### PR TITLE
 [CONTP-1651] ncclprofiler: decouple host and in-workload socket paths

### DIFF
--- a/pkg/clusteragent/admission/mutate/ncclprofiler/mutator.go
+++ b/pkg/clusteragent/admission/mutate/ncclprofiler/mutator.go
@@ -65,9 +65,10 @@ const (
 //  3. Mounting the .so volume and the agent socket directory into every app container.
 //  4. Setting NCCL env vars (incl. NCCL_DD_SOCKET_PATH from the agent config).
 //
-// hostSocketPath is the host directory containing the agent's Unix socket
-// (mounted into pods at the same path). socketPath is the full in-container
-// socket path the wrapper connects to. Both come from gpu.nccl.{host_socket_path,socket_path}.
+// Mirrors `mutate/config` (APM/DSD): bind-mounts the socket file itself
+// with HostPathSocket, composing host file = hostSocketDir+"/"+filename
+// and in-workload file = clientSocketDir+"/"+filename. NCCL_DD_SOCKET_PATH
+// is set to the in-workload file.
 // initResources is the optional resource requirements applied to the injected
 // init container. nil means no Resources block is set (cluster default applies);
 // operators with a LimitRange or strict QoS requirements override via
@@ -75,21 +76,25 @@ const (
 //
 // Pod-level opt-in policy (label + mutate_unlabelled) is enforced by the
 // webhook objectSelector at the K8s API server, not re-checked here.
-func mutatePod(pod *corev1.Pod, injectorImage, hostSocketPath, socketPath string, initResources *corev1.ResourceRequirements) (bool, error) {
+func mutatePod(pod *corev1.Pod, injectorImage, hostSocketDir, clientSocketDir, socketFilename string, initResources *corev1.ResourceRequirements) (bool, error) {
 	soVolume := corev1.Volume{
 		Name:         soVolumeName,
 		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 	}
 	soMount := corev1.VolumeMount{Name: soVolumeName, MountPath: soMountPath, ReadOnly: true}
 
-	hostPathType := corev1.HostPathDirectoryOrCreate
+	// Pod paths are POSIX regardless of where the cluster-agent runs; do
+	// not use path/filepath here (it'd produce backslashes on Windows).
+	hostFile := hostSocketDir + "/" + socketFilename
+	clientFile := clientSocketDir + "/" + socketFilename
+	hostPathType := corev1.HostPathSocket
 	socketVolume := corev1.Volume{
 		Name: socketVolumeName,
 		VolumeSource: corev1.VolumeSource{
-			HostPath: &corev1.HostPathVolumeSource{Path: hostSocketPath, Type: &hostPathType},
+			HostPath: &corev1.HostPathVolumeSource{Path: hostFile, Type: &hostPathType},
 		},
 	}
-	socketMount := corev1.VolumeMount{Name: socketVolumeName, MountPath: hostSocketPath, ReadOnly: true}
+	socketMount := corev1.VolumeMount{Name: socketVolumeName, MountPath: clientFile, ReadOnly: true}
 
 	// Inject volumes + mounts into all app containers using shared helpers.
 	soVolAdded, soMountAdded := mutatecommon.InjectVolume(pod, soVolume, soMount)
@@ -97,7 +102,7 @@ func mutatePod(pod *corev1.Pod, injectorImage, hostSocketPath, socketPath string
 
 	// Inject NCCL env vars into all app containers.
 	envAdded := mutatecommon.InjectEnv(pod, corev1.EnvVar{Name: "NCCL_PROFILER_PLUGIN", Value: soDestPath})
-	envAdded = mutatecommon.InjectEnv(pod, corev1.EnvVar{Name: "NCCL_DD_SOCKET_PATH", Value: socketPath}) || envAdded
+	envAdded = mutatecommon.InjectEnv(pod, corev1.EnvVar{Name: "NCCL_DD_SOCKET_PATH", Value: clientFile}) || envAdded
 	envAdded = mutatecommon.InjectEnv(pod, corev1.EnvVar{Name: "NCCL_DD_INSPECTOR_PATH", Value: soMountPath + "/libnccl-profiler-inspector.so"}) || envAdded
 	envAdded = mutatecommon.InjectEnv(pod, corev1.EnvVar{Name: "NCCL_INSPECTOR_ENABLE", Value: "1"}) || envAdded
 

--- a/pkg/clusteragent/admission/mutate/ncclprofiler/mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/ncclprofiler/mutator_test.go
@@ -18,7 +18,9 @@ import (
 
 const (
 	testInjectorImage  = "registry.example/nccl-profiler-injector:latest"
-	testHostSocketPath = "/var/run/datadog"
+	testHostSocketDir  = "/var/run/datadog"
+	testClientDir      = "/var/run/datadog"
+	testSocketFilename = "nccl.socket"
 	testSocketPath     = "/var/run/datadog/nccl.socket"
 )
 
@@ -40,7 +42,7 @@ func newTestPod() *corev1.Pod {
 func TestMutatePod_HappyPath(t *testing.T) {
 	pod := newTestPod()
 
-	mutated, err := mutatePod(pod, testInjectorImage, testHostSocketPath, testSocketPath, nil)
+	mutated, err := mutatePod(pod, testInjectorImage, testHostSocketDir, testClientDir, testSocketFilename, nil)
 
 	require.NoError(t, err)
 	assert.True(t, mutated, "mutatePod should report it mutated the pod")
@@ -61,7 +63,10 @@ func TestMutatePod_HappyPath(t *testing.T) {
 			sawSoVol = true
 		case socketVolumeName:
 			require.NotNil(t, v.HostPath, "socket volume should be hostPath")
-			assert.Equal(t, testHostSocketPath, v.HostPath.Path)
+			assert.Equal(t, testSocketPath, v.HostPath.Path,
+				"with default config, host file == hostSocketPath+/+filepath.Base(socketPath)")
+			require.NotNil(t, v.HostPath.Type)
+			assert.Equal(t, corev1.HostPathSocket, *v.HostPath.Type)
 			sawSocketVol = true
 		}
 	}
@@ -71,12 +76,14 @@ func TestMutatePod_HappyPath(t *testing.T) {
 	// Trainer container has both volume mounts and 4 NCCL env vars.
 	require.Len(t, pod.Spec.Containers, 1)
 	trainer := pod.Spec.Containers[0]
-	mountNames := map[string]bool{}
+	mounts := map[string]string{}
 	for _, m := range trainer.VolumeMounts {
-		mountNames[m.Name] = true
+		mounts[m.Name] = m.MountPath
 	}
-	assert.True(t, mountNames[soVolumeName])
-	assert.True(t, mountNames[socketVolumeName])
+	assert.Contains(t, mounts, soVolumeName)
+	assert.Contains(t, mounts, socketVolumeName)
+	assert.Equal(t, testSocketPath, mounts[socketVolumeName],
+		"socket mount destination must equal socketPath (file mount)")
 
 	envs := map[string]string{}
 	for _, e := range trainer.Env {
@@ -86,4 +93,45 @@ func TestMutatePod_HappyPath(t *testing.T) {
 	assert.Equal(t, testSocketPath, envs["NCCL_DD_SOCKET_PATH"])
 	assert.Equal(t, soMountPath+"/libnccl-profiler-inspector.so", envs["NCCL_DD_INSPECTOR_PATH"])
 	assert.Equal(t, "1", envs["NCCL_INSPECTOR_ENABLE"])
+}
+
+// TestMutatePod_DecoupledHostAndContainerPaths: host and in-container
+// directories can differ. Host file = hostDir+/+filename, in-workload
+// file = clientDir+/+filename, NCCL_DD_SOCKET_PATH = in-workload file.
+func TestMutatePod_DecoupledHostAndContainerPaths(t *testing.T) {
+	pod := newTestPod()
+	hostDir := "/var/run/datadog-agent"
+	clientDir := "/var/run/datadog"
+	filename := "nccl.socket"
+
+	mutated, err := mutatePod(pod, testInjectorImage, hostDir, clientDir, filename, nil)
+	require.NoError(t, err)
+	assert.True(t, mutated)
+
+	var socketVol *corev1.Volume
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == socketVolumeName {
+			socketVol = &pod.Spec.Volumes[i]
+		}
+	}
+	require.NotNil(t, socketVol)
+	require.NotNil(t, socketVol.HostPath)
+	assert.Equal(t, "/var/run/datadog-agent/nccl.socket", socketVol.HostPath.Path)
+	require.NotNil(t, socketVol.HostPath.Type)
+	assert.Equal(t, corev1.HostPathSocket, *socketVol.HostPath.Type)
+
+	trainer := pod.Spec.Containers[0]
+	var mountPath string
+	for _, m := range trainer.VolumeMounts {
+		if m.Name == socketVolumeName {
+			mountPath = m.MountPath
+		}
+	}
+	assert.Equal(t, "/var/run/datadog/nccl.socket", mountPath)
+
+	for _, e := range trainer.Env {
+		if e.Name == "NCCL_DD_SOCKET_PATH" {
+			assert.Equal(t, "/var/run/datadog/nccl.socket", e.Value)
+		}
+	}
 }

--- a/pkg/clusteragent/admission/mutate/ncclprofiler/webhook.go
+++ b/pkg/clusteragent/admission/mutate/ncclprofiler/webhook.go
@@ -11,7 +11,7 @@
 package ncclprofiler
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 
 	admiv1 "k8s.io/api/admission/v1"
@@ -46,37 +46,39 @@ type Webhook struct {
 	isEnabled        bool
 	mutateUnlabelled bool
 	injectorImage    string
-	hostSocketPath   string
-	socketPath       string
+	hostSocketDir    string
+	socketFilename   string
+	clientSocketDir  string
 	initResources    *corev1.ResourceRequirements
 }
 
 // NewWebhook creates a new NCCL profiler webhook from agent config.
 // The injector_image config is required when enabled; if empty the webhook
 // is disabled with a warning so pods are not mutated with a broken image ref.
-// hostSocketPath and socketPath default to the agent's gpu.nccl config so the
-// injected pod's NCCL_DD_SOCKET_PATH matches where the agent listens.
-// Self-disables if socketPath does not live under hostSocketPath, since that
-// mismatch silently breaks delivery (mounted dir doesn't contain the socket).
+// Mirrors `mutate/config` (APM/DSD): hostSocketDir + socketFilename describe
+// the host bind-mount source, clientSocketDir + socketFilename describe the
+// workload's in-container view. Self-disables on pathological inputs.
 func NewWebhook(datadogConfig config.Component) *Webhook {
 	enabled := datadogConfig.GetBool("admission_controller.nccl_profiler.enabled")
 	image := datadogConfig.GetString("admission_controller.nccl_profiler.injector_image")
-	hostSocketPath := datadogConfig.GetString("gpu.nccl.host_socket_path")
+	hostSocketDir := datadogConfig.GetString("gpu.nccl.host_socket_path")
 	socketPath := datadogConfig.GetString("gpu.nccl.socket_path")
+	clientSocketDir := datadogConfig.GetString("admission_controller.nccl_profiler.socket_dir")
 	if enabled && image == "" {
 		log.Errorf("NCCL profiler webhook is enabled but admission_controller.nccl_profiler.injector_image is not set; disabling webhook")
 		enabled = false
 	}
-	if enabled && !socketPathUnderHost(socketPath, hostSocketPath) {
-		log.Errorf("NCCL profiler webhook: gpu.nccl.socket_path=%q is not under gpu.nccl.host_socket_path=%q; injected pods would write to a location not mounted from the host. Disabling webhook.", socketPath, hostSocketPath)
+	if enabled && !validSocketConfig(hostSocketDir, clientSocketDir, socketPath) {
+		log.Errorf("NCCL profiler webhook: invalid gpu.nccl.host_socket_path=%q, admission_controller.nccl_profiler.socket_dir=%q, or gpu.nccl.socket_path=%q; both directories must be absolute and non-root, and socket_path must be an absolute file path with a non-empty basename (no trailing separator). Disabling webhook.", hostSocketDir, clientSocketDir, socketPath)
 		enabled = false
 	}
 	return &Webhook{
 		isEnabled:        enabled,
 		mutateUnlabelled: mutateUnlabelledEnabled(datadogConfig),
 		injectorImage:    image,
-		hostSocketPath:   hostSocketPath,
-		socketPath:       socketPath,
+		hostSocketDir:    hostSocketDir,
+		socketFilename:   path.Base(socketPath),
+		clientSocketDir:  clientSocketDir,
 		initResources:    parseInitResources(datadogConfig),
 	}
 }
@@ -139,19 +141,35 @@ func objectSelector(mutateUnlabelled bool) *metav1.LabelSelector {
 	return &metav1.LabelSelector{MatchLabels: map[string]string{EnabledLabel: "true"}}
 }
 
-// socketPathUnderHost returns true if socketPath is the same as or a
-// descendant of hostSocketPath. Both inputs are cleaned before comparison
-// to handle trailing slashes and `.` segments.
-func socketPathUnderHost(socketPath, hostSocketPath string) bool {
-	if socketPath == "" || hostSocketPath == "" {
+// validSocketConfig rejects empty/relative paths, root dirs, and
+// socket_path values that don't resolve to a real file basename
+// (e.g. relative names or trailing-separator directory paths).
+//
+// Uses path (POSIX) rather than path/filepath because injected pod paths
+// are always POSIX even when the cluster-agent runs on Windows.
+func validSocketConfig(hostDir, clientDir, socketPath string) bool {
+	if socketPath == "" || !path.IsAbs(socketPath) {
 		return false
 	}
-	host := filepath.Clean(hostSocketPath)
-	sock := filepath.Clean(socketPath)
-	if !strings.HasSuffix(host, string(filepath.Separator)) {
-		host += string(filepath.Separator)
+	// Trailing separator => the configured value is a directory, not a
+	// file. path.Clean strips the slash, so check the raw input.
+	if strings.HasSuffix(socketPath, "/") {
+		return false
 	}
-	return strings.HasPrefix(sock, host)
+	base := path.Base(path.Clean(socketPath))
+	if base == "." || base == "/" {
+		return false
+	}
+	for _, d := range []string{hostDir, clientDir} {
+		if d == "" {
+			return false
+		}
+		c := path.Clean(d)
+		if !path.IsAbs(c) || c == "/" {
+			return false
+		}
+	}
+	return true
 }
 
 // Name returns the name of the webhook.
@@ -219,7 +237,7 @@ func (w *Webhook) WebhookFunc() admission.WebhookFunc {
 			w.Name(),
 			func(pod *corev1.Pod, _ string, _ dynamic.Interface) (bool, error) {
 				log.Debugf("Injecting NCCL profiler plugin into pod %s", mutatecommon.PodString(pod))
-				return mutatePod(pod, w.injectorImage, w.hostSocketPath, w.socketPath, w.initResources)
+				return mutatePod(pod, w.injectorImage, w.hostSocketDir, w.clientSocketDir, w.socketFilename, w.initResources)
 			},
 			request.DynamicClient,
 		))

--- a/pkg/clusteragent/admission/mutate/ncclprofiler/webhook_test.go
+++ b/pkg/clusteragent/admission/mutate/ncclprofiler/webhook_test.go
@@ -92,6 +92,53 @@ func TestWebhook_LabelSelector_FallbackFailsClosed(t *testing.T) {
 		"fallback selector must not match any real namespace")
 }
 
+func TestValidSocketConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		hostDir    string
+		clientDir  string
+		socketPath string
+		want       bool
+	}{
+		{"defaults", "/var/run/datadog", "/var/run/datadog", "/var/run/datadog/nccl.socket", true},
+		{"decoupled dirs", "/var/run/datadog-agent", "/var/run/datadog", "/var/run/datadog/nccl.socket", true},
+		{"empty hostDir", "", "/var/run/datadog", "/var/run/datadog/nccl.socket", false},
+		{"empty clientDir", "/var/run/datadog", "", "/var/run/datadog/nccl.socket", false},
+		{"empty socket_path", "/var/run/datadog", "/var/run/datadog", "", false},
+		{"relative hostDir", "var/run/datadog", "/var/run/datadog", "/var/run/datadog/nccl.socket", false},
+		{"relative clientDir", "/var/run/datadog", "var/run/datadog", "/var/run/datadog/nccl.socket", false},
+		{"hostDir is /", "/", "/var/run/datadog", "/var/run/datadog/nccl.socket", false},
+		{"clientDir is /", "/var/run/datadog", "/", "/var/run/datadog/nccl.socket", false},
+		{"socket_path relative (basename-only)", "/var/run/datadog", "/var/run/datadog", "nccl.socket", false},
+		{"socket_path trailing slash", "/var/run/datadog", "/var/run/datadog", "/var/run/datadog/", false},
+		{"socket_path is /", "/var/run/datadog", "/var/run/datadog", "/", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, validSocketConfig(tc.hostDir, tc.clientDir, tc.socketPath))
+		})
+	}
+}
+
+func TestWebhook_InvalidSocketConfigDisablesItself(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  string
+		val  string
+	}{
+		{"relative socket_path", "gpu.nccl.socket_path", "nccl.socket"},
+		{"trailing-slash socket_path", "gpu.nccl.socket_path", "/var/run/datadog/"},
+		{"root client socket_dir", "admission_controller.nccl_profiler.socket_dir", "/"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := configmock.New(t)
+			cfg.SetWithoutSource("admission_controller.nccl_profiler.enabled", true)
+			cfg.SetWithoutSource("admission_controller.nccl_profiler.injector_image", "registry.example/img:tag")
+			cfg.SetWithoutSource(tc.key, tc.val)
+			assert.False(t, NewWebhook(cfg).IsEnabled())
+		})
+	}
+}
+
 // TestWebhook_LabelSelector_MutateUnlabelled covers blanket mode: when the
 // per-webhook (or global) mutate_unlabelled knob is set, the objectSelector
 // flips from "label=true required" to "label!=false". cwsinstrumentation has

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -476,6 +476,11 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	// to mount /var/run/datadog into the agent pod. For DSD/APM-enabled deployments
 	// the directory is already mounted; this setting matters for NCCL-only setups.
 	config.BindEnvAndSetDefault("gpu.nccl.host_socket_path", "/var/run/datadog")
+	// In-container directory at which the agent's NCCL socket is mounted in
+	// injected workload pods. Composed with filepath.Base(gpu.nccl.socket_path)
+	// to build the mount destination and NCCL_DD_SOCKET_PATH. Same shape as
+	// admission_controller.inject_config.socket_path used by APM/DSD injection.
+	config.BindEnvAndSetDefault("admission_controller.nccl_profiler.socket_dir", "/var/run/datadog")
 
 	// Cloud Foundry BBS
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.url", "https://bbs.service.cf.internal:8889")


### PR DESCRIPTION
## Summary

Add admission_controller.nccl_profiler.socket_dir config

This align the NCCL profiler admission webhook with the APM SSI / DSD socket injection in `pkg/clusteragent/admission/mutate/config/`: bind-mount the agent's socket file directly with `HostPathSocket`, and let the host directory and the in-workload directory be configured **independently**.

| Concept | APM/DSD (existing) | NCCL profiler (this PR) |
|---|---|---|
| Host directory | `trace_agent_host_socket_path`, `dogstatsd_host_socket_path` | `gpu.nccl.host_socket_path` (existing) |
| Socket filename | `filepath.Base(apm_config.receiver_socket)`, `filepath.Base(dogstatsd_socket)` | `filepath.Base(gpu.nccl.socket_path)` (existing) |
| In-workload directory | `admission_controller.inject_config.socket_path` | `admission_controller.nccl_profiler.socket_dir` (**new**) |
| Volume helper | `buildHostPathVolume` with `HostPathSocket` | inline, same shape |

## What this unlocks

Previously the webhook bind-mounted the agent socket directory at the same in-container path as on the host. Deployments that place the agent's socket at a non-default host directory had no way to express that to the webhook without also changing the in-container path that every workload's `NCCL_DD_SOCKET_PATH` references.

After this PR, host and in-workload paths are configured independently:

| Knob | Purpose |
|---|---|
| `gpu.nccl.host_socket_path` | Where the agent's socket actually lives on the node (bind-mount source) |
| `admission_controller.nccl_profiler.socket_dir` | Where the workload sees the socket inside its container (defaults to `/var/run/datadog`) |
| `gpu.nccl.socket_path` | Read for its basename only — defines the socket filename |

User can now override `gpu.nccl.host_socket_path` alone, and `NCCL_DD_SOCKET_PATH` inside workload pods stays at its default. Workloads remain portable across deployment styles without per-pod overrides.

## Tests
unit test
