### PR TITLE
process-agent: rename LookupIdProbe to LookupIDProbe

### DIFF
--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -57,7 +57,7 @@ func NewProcessCheck(config pkgconfigmodel.Reader, sysprobeYamlConfig pkgconfigm
 		config:              config,
 		sysConfig:           sysprobeYamlConfig,
 		scrubber:            procutil.NewDefaultDataScrubber(),
-		lookupIdProbe:       NewLookupIDProbe(config),
+		lookupIDProbe:       NewLookupIDProbe(config),
 		serviceExtractor:    parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm),
 		wmeta:               wmeta,
 		gpuSubscriber:       gpuSubscriber,
@@ -122,8 +122,7 @@ type ProcessCheck struct {
 	checkCount uint32
 	skipAmount uint32
 
-	//nolint:revive // TODO(PROC) Fix revive linter
-	lookupIdProbe *LookupIdProbe
+	lookupIDProbe *LookupIDProbe
 
 	extractors []metadata.Extractor
 
@@ -311,7 +310,7 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, erro
 
 	pidToGPUTags := p.gpuSubscriber.GetGPUTags()
 
-	procsByCtr := fmtProcesses(p.scrubber, p.disallowList, procs, p.lastProcs, pidToCid, cpuTimes[0], p.lastCPUTime, p.lastRun, p.lookupIdProbe, p.ignoreZombieProcesses, p.serviceExtractor, pidToGPUTags, p.tagger, time.Now())
+	procsByCtr := fmtProcesses(p.scrubber, p.disallowList, procs, p.lastProcs, pidToCid, cpuTimes[0], p.lastCPUTime, p.lastRun, p.lookupIDProbe, p.ignoreZombieProcesses, p.serviceExtractor, pidToGPUTags, p.tagger, time.Now())
 	messages, totalProcs, totalContainers := createProcCtrMessages(p.hostInfo, procsByCtr, containers, p.maxBatchSize, p.maxBatchBytes, groupID, p.networkID, collectorProcHints)
 
 	// Store the last state for comparison on the next run.
@@ -478,8 +477,7 @@ func fmtProcesses(
 	ctrByProc map[int]string,
 	syst2, syst1 cpu.TimesStat,
 	lastRun time.Time,
-	//nolint:revive // TODO(PROC) Fix revive linter
-	lookupIdProbe *LookupIdProbe,
+	lookupIDProbe *LookupIDProbe,
 	zombiesIgnored bool,
 	serviceExtractor *parser.ServiceExtractor,
 	pidToGPUTags map[int32][]string,
@@ -504,7 +502,7 @@ func fmtProcesses(
 			Pid:                    fp.Pid,
 			NsPid:                  fp.NsPid,
 			Command:                formatCommand(fp),
-			User:                   formatUser(fp, lookupIdProbe),
+			User:                   formatUser(fp, lookupIDProbe),
 			Memory:                 formatMemory(fp.Stats),
 			Cpu:                    formatCPU(fp.Stats, lastProcs[fp.Pid].Stats, syst2, syst1),
 			CreateTime:             fp.Stats.CreateTime,

--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -39,7 +39,7 @@ type ProcessDiscoveryCheck struct {
 
 	probe      procutil.Probe
 	scrubber   *procutil.DataScrubber
-	userProbe  *LookupIdProbe
+	userProbe  *LookupIDProbe
 	info       *HostInfo
 	initCalled bool
 
@@ -137,7 +137,7 @@ func (d *ProcessDiscoveryCheck) Run(nextGroupID func() int32, options *RunOption
 // Cleanup frees any resource held by the ProcessDiscoveryCheck before the agent exits
 func (d *ProcessDiscoveryCheck) Cleanup() {}
 
-func pidMapToProcDiscoveries(pidMap map[int32]*procutil.Process, userProbe *LookupIdProbe, scrubber *procutil.DataScrubber) []*model.ProcessDiscovery {
+func pidMapToProcDiscoveries(pidMap map[int32]*procutil.Process, userProbe *LookupIDProbe, scrubber *procutil.DataScrubber) []*model.ProcessDiscovery {
 	pd := make([]*model.ProcessDiscovery, 0, len(pidMap))
 	for _, proc := range pidMap {
 		proc.Cmdline = scrubber.ScrubProcessCommand(proc)

--- a/pkg/process/checks/process_discovery_check_test.go
+++ b/pkg/process/checks/process_discovery_check_test.go
@@ -37,7 +37,7 @@ func processDiscoveryCheckWithMockProbe(t *testing.T) (*ProcessDiscoveryCheck, *
 		probe:      probe,
 		scrubber:   procutil.NewDefaultDataScrubber(),
 		info:       info,
-		userProbe:  &LookupIdProbe{},
+		userProbe:  &LookupIDProbe{},
 		initCalled: true,
 	}, probe
 }

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -24,7 +24,7 @@ var (
 	hostCPUCount = system.HostCPUCount
 )
 
-func formatUser(fp *procutil.Process, uidProbe *LookupIdProbe) *model.ProcessUser {
+func formatUser(fp *procutil.Process, uidProbe *LookupIDProbe) *model.ProcessUser {
 	var username string
 	var uid, gid int32
 	if len(fp.Uids) > 0 {
@@ -33,10 +33,10 @@ func formatUser(fp *procutil.Process, uidProbe *LookupIdProbe) *model.ProcessUse
 			err error
 		)
 		if uidProbe == nil {
-			// If the probe is nil, skip it and just call `LookupId` directly
+			// If the probe is nil, skip it and just call `user.LookupId` directly
 			u, err = user.LookupId(strconv.Itoa(int(fp.Uids[0])))
 		} else {
-			u, err = uidProbe.LookupId(strconv.Itoa(int(fp.Uids[0])))
+			u, err = uidProbe.LookupID(strconv.Itoa(int(fp.Uids[0])))
 		}
 		if err == nil {
 			username = u.Username

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -23,7 +23,7 @@ var (
 	numCPU = runtime.NumCPU
 )
 
-func formatUser(fp *procutil.Process, _ *LookupIdProbe) *model.ProcessUser {
+func formatUser(fp *procutil.Process, _ *LookupIDProbe) *model.ProcessUser {
 	return &model.ProcessUser{
 		Name: fp.Username,
 	}

--- a/pkg/process/checks/user_nix.go
+++ b/pkg/process/checks/user_nix.go
@@ -17,39 +17,37 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-//nolint:revive // TODO(PROC) Fix revive linter
-type LookupIdProbe struct {
+// LookupIDProbe wraps user.LookupId with an optional cache.
+type LookupIDProbe struct {
 	config pkgconfigmodel.Reader
 
-	lookupIdCache *cache.Cache
-	//nolint:revive // TODO(PROC) Fix revive linter
-	lookupId func(uid string) (*user.User, error)
+	lookupIDCache *cache.Cache
+	lookupID      func(uid string) (*user.User, error)
 }
 
-// NewLookupIDProbe returns a new LookupIdProbe from the config
-func NewLookupIDProbe(coreConfig pkgconfigmodel.Reader) *LookupIdProbe {
+// NewLookupIDProbe returns a new LookupIDProbe from the config
+func NewLookupIDProbe(coreConfig pkgconfigmodel.Reader) *LookupIDProbe {
 	if coreConfig.GetBool("process_config.cache_lookupid") {
 		log.Debug("Using cached calls to `user.LookupID`")
 	}
-	return &LookupIdProbe{
+	return &LookupIDProbe{
 		// Inject global logger and config to make it easy to use components
 		config: coreConfig,
 
-		lookupIdCache: cache.New(time.Hour, time.Hour), // Used by lookupIdWithCache
-		lookupId:      user.LookupId,
+		lookupIDCache: cache.New(time.Hour, time.Hour), // Used by lookupIDWithCache
+		lookupID:      user.LookupId,
 	}
 }
 
-//nolint:revive // TODO(PROC) Fix revive linter
-func (p *LookupIdProbe) lookupIdWithCache(uid string) (*user.User, error) {
-	result, ok := p.lookupIdCache.Get(uid)
+func (p *LookupIDProbe) lookupIDWithCache(uid string) (*user.User, error) {
+	result, ok := p.lookupIDCache.Get(uid)
 	if !ok {
 		var err error
-		u, err := p.lookupId(uid)
+		u, err := p.lookupID(uid)
 		if err == nil {
-			p.lookupIdCache.SetDefault(uid, u)
+			p.lookupIDCache.SetDefault(uid, u)
 		} else {
-			p.lookupIdCache.SetDefault(uid, err)
+			p.lookupIDCache.SetDefault(uid, err)
 		}
 		return u, err
 	}
@@ -60,14 +58,14 @@ func (p *LookupIdProbe) lookupIdWithCache(uid string) (*user.User, error) {
 	case error:
 		return nil, v
 	default:
-		return nil, log.Error("Unknown value cached in lookupIdCache for uid:", uid)
+		return nil, log.Error("Unknown value cached in lookupIDCache for uid:", uid)
 	}
 }
 
-//nolint:revive // TODO(PROC) Fix revive linter
-func (p *LookupIdProbe) LookupId(uid string) (*user.User, error) {
+// LookupID returns the user.User for the given uid, using a cache if configured.
+func (p *LookupIDProbe) LookupID(uid string) (*user.User, error) {
 	if p.config.GetBool("process_config.cache_lookupid") {
-		return p.lookupIdWithCache(uid)
+		return p.lookupIDWithCache(uid)
 	}
-	return p.lookupId(uid)
+	return p.lookupID(uid)
 }

--- a/pkg/process/checks/user_nix_test.go
+++ b/pkg/process/checks/user_nix_test.go
@@ -68,39 +68,38 @@ func TestLookupUserWithId(t *testing.T) {
 			}
 
 			var timesCalled int
-			p.lookupId = func(inputUid string) (*user.User, error) {
-				// Make sure this function is called once despite the fact that we call `lookupIdWithCache`.
+			p.lookupID = func(inputUID string) (*user.User, error) {
+				// Make sure this function is called once despite the fact that we call `lookupIDWithCache`.
 				// This should simulate a cache hit vs a miss.
 				timesCalled++
 				assert.Equal(t, 1, timesCalled)
 
-				assert.Equal(t, testUID, inputUid)
+				assert.Equal(t, testUID, inputUID)
 				if tc.expectedError != nil {
 					return nil, tc.expectedError
 				}
 				return tc.expectedUser, nil
 			}
 
-			checkResult(p.LookupId(testUID))
-			checkCacheResult(p.lookupIdCache.Get(testUID))
-			checkResult(p.LookupId(testUID))
+			checkResult(p.LookupID(testUID))
+			checkCacheResult(p.lookupIDCache.Get(testUID))
+			checkResult(p.LookupID(testUID))
 		})
 	}
 }
 
-func TestLookupIdConfigSetting(t *testing.T) {
-	//nolint:revive // TODO(PROC) Fix revive linter
-	testLookupIdFunc := func(_ string) (*user.User, error) { return &user.User{Name: "jojo"}, nil }
+func TestLookupIDConfigSetting(t *testing.T) {
+	testLookupIDFunc := func(_ string) (*user.User, error) { return &user.User{Name: "jojo"}, nil }
 
 	t.Run("enabled", func(t *testing.T) {
 		cfg := configmock.New(t)
 		cfg.SetWithoutSource("process_config.cache_lookupid", true)
 
 		p := NewLookupIDProbe(cfg)
-		p.lookupId = testLookupIdFunc
+		p.lookupID = testLookupIDFunc
 
-		_, _ = p.LookupId("1234") // testLookupIdFunc should be called and "1234" added to the cache
-		u, ok := p.lookupIdCache.Get("1234")
+		_, _ = p.LookupID("1234") // testLookupIDFunc should be called and "1234" added to the cache
+		u, ok := p.lookupIDCache.Get("1234")
 		assert.Equal(t, "jojo", u.(*user.User).Name)
 		assert.True(t, ok)
 	})
@@ -110,10 +109,10 @@ func TestLookupIdConfigSetting(t *testing.T) {
 		cfg.SetWithoutSource("process_config.cache_lookupid", false)
 
 		p := NewLookupIDProbe(cfg)
-		p.lookupId = testLookupIdFunc
+		p.lookupID = testLookupIDFunc
 
-		_, _ = p.LookupId("1234")
-		_, ok := p.lookupIdCache.Get("1234")
+		_, _ = p.LookupID("1234")
+		_, ok := p.lookupIDCache.Get("1234")
 		assert.False(t, ok)
 	})
 }

--- a/pkg/process/checks/user_windows.go
+++ b/pkg/process/checks/user_windows.go
@@ -11,14 +11,10 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
-// On Windows the LookupIdProbe does nothing since we get the user info from the process itself.
-//
-//nolint:revive // TODO(PROC) Fix revive linter
-type LookupIdProbe struct{}
+// LookupIDProbe is a no-op on Windows since user info is obtained from the process itself.
+type LookupIDProbe struct{}
 
-// NewLookupIDProbe returns a new LookupIdProbe
-//
-//nolint:revive // TODO(PROC) Fix revive linter
-func NewLookupIDProbe(pkgconfigmodel.Reader) *LookupIdProbe {
-	return &LookupIdProbe{}
+// NewLookupIDProbe returns a new LookupIDProbe
+func NewLookupIDProbe(pkgconfigmodel.Reader) *LookupIDProbe {
+	return &LookupIDProbe{}
 }


### PR DESCRIPTION
## What does this PR do?

Renames the `LookupIdProbe` symbol set in `pkg/process/checks` to use the idiomatic [Go initialism](https://go.dev/wiki/CodeReviewComments#initialisms) `ID`:

| Before | After |
|---|---|
| `LookupIdProbe` (type) | `LookupIDProbe` |
| `LookupId` (method) | `LookupID` |
| `lookupIdWithCache` (method) | `lookupIDWithCache` |
| `lookupId` / `lookupIdCache` (fields) | `lookupID` / `lookupIDCache` |
| `lookupIdProbe` (field/param) | `lookupIDProbe` |

Drops the corresponding `//nolint:revive // TODO(PROC) Fix revive linter` suppressions in `user_nix.go`, `user_windows.go`, and `process.go`. Renames the test helper `TestLookupIdConfigSetting` and `testLookupIdFunc` to match.


## Motivation
fix the naming issues to remove the linter exclusions

## Describe how you validated your changes

- `dda inv linter.go --targets=./pkg/process/checks` — 0 issues
- `dda inv test --targets=./pkg/process/checks -x '-count=1'` — 194 passed
- `grep -rn 'LookupId\|lookupId' pkg/process/checks/` returns only `user.LookupId` (stdlib) references

## Possible Drawbacks / Trade-offs

None — package-internal rename.

## Additional Notes

`changelog/no-changelog` — internal refactor, no user-visible change.