### PR TITLE
[AGNTLOG-632] Skip directory matches in logs file tailer glob

### DIFF
--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -270,9 +270,12 @@ func (p *FileProvider) FilesToTail(ctx context.Context, validatePodContainerID b
 // with ordering defined by 'wildcardOrder'
 func (p *FileProvider) CollectFiles(source *sources.LogSource) ([]*tailer.File, error) {
 	path := source.Config.Path
-	_, err := opener.StatLogFile(path)
+	fi, err := opener.StatLogFile(path)
 	switch {
 	case err == nil:
+		if fi.IsDir() {
+			return nil, fmt.Errorf("path %s is a directory, not a file; specify a file path or a glob (e.g. %s) to tail files inside it", path, filepath.Join(path, "*"))
+		}
 		return []*tailer.File{
 			tailer.NewFile(path, source, false),
 		}, nil
@@ -303,6 +306,40 @@ func (p *FileProvider) filesMatchingSource(source *sources.LogSource) ([]*tailer
 	}
 	if err != nil {
 		return nil, fmt.Errorf("malformed pattern, could not find any file: %s", pattern)
+	}
+	// Filter out directories that the glob matched. Opening a directory as a file
+	// produces misleading errors (e.g. "Access is denied" on Windows). The most
+	// common cause is a glob that is not deep enough (e.g. C:\Logs\* against a
+	// tree of subdirectories), and the user typically wants C:\Logs\*\* instead.
+	filteredPaths := paths[:0]
+	skippedDirCount := 0
+	var firstSkippedDir string
+	for _, path := range paths {
+		fi, statErr := opener.StatLogFile(path)
+		if statErr != nil {
+			// can't stat; let downstream logic surface a clear error
+			filteredPaths = append(filteredPaths, path)
+			continue
+		}
+		if fi.IsDir() {
+			if skippedDirCount == 0 {
+				firstSkippedDir = path
+			}
+			skippedDirCount++
+			continue
+		}
+		filteredPaths = append(filteredPaths, path)
+	}
+	paths = filteredPaths
+	dirsMessageKey := "directory-matches:" + pattern
+	if skippedDirCount > 0 {
+		if p.shouldLogErrors {
+			log.Warnf("Pattern %q matched %d director(ies) (e.g. %q); these were skipped because directories cannot be tailed. To tail files inside them, use a deeper glob such as %q.",
+				pattern, skippedDirCount, firstSkippedDir, filepath.Join(pattern, "*"))
+		}
+		source.Messages.AddMessage(dirsMessageKey, fmt.Sprintf("%d entries matching %s resolved to directories and were skipped; use a deeper glob to tail files inside them", skippedDirCount, pattern))
+	} else {
+		source.Messages.RemoveMessage(dirsMessageKey)
 	}
 	if len(paths) == 0 {
 		// no file was found, its parent directories might have wrong permissions or it just does not exist

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -308,12 +308,10 @@ func (p *FileProvider) filesMatchingSource(source *sources.LogSource) ([]*tailer
 		return nil, fmt.Errorf("malformed pattern, could not find any file: %s", pattern)
 	}
 	// Filter out directories that the glob matched. Opening a directory as a file
-	// produces misleading errors (e.g. "Access is denied" on Windows). The most
-	// common cause is a glob that is not deep enough (e.g. C:\Logs\* against a
-	// tree of subdirectories), and the user typically wants C:\Logs\*\* instead.
+	// produces misleading errors (e.g. "Access is denied" on Windows). Mixing
+	// files and subdirectories in the same parent is normal, so this is silent
+	// at the info level; trace level is available for debugging.
 	filteredPaths := paths[:0]
-	skippedDirCount := 0
-	var firstSkippedDir string
 	for _, path := range paths {
 		fi, statErr := opener.StatLogFile(path)
 		if statErr != nil {
@@ -322,25 +320,12 @@ func (p *FileProvider) filesMatchingSource(source *sources.LogSource) ([]*tailer
 			continue
 		}
 		if fi.IsDir() {
-			if skippedDirCount == 0 {
-				firstSkippedDir = path
-			}
-			skippedDirCount++
+			log.Tracef("Skipping directory %q matched by pattern %q", path, pattern)
 			continue
 		}
 		filteredPaths = append(filteredPaths, path)
 	}
 	paths = filteredPaths
-	dirsMessageKey := "directory-matches:" + pattern
-	if skippedDirCount > 0 {
-		if p.shouldLogErrors {
-			log.Warnf("Pattern %q matched %d director(ies) (e.g. %q); these were skipped because directories cannot be tailed. To tail files inside them, use a deeper glob such as %q.",
-				pattern, skippedDirCount, firstSkippedDir, filepath.Join(pattern, "*"))
-		}
-		source.Messages.AddMessage(dirsMessageKey, fmt.Sprintf("%d entries matching %s resolved to directories and were skipped; use a deeper glob to tail files inside them", skippedDirCount, pattern))
-	} else {
-		source.Messages.RemoveMessage(dirsMessageKey)
-	}
 	if len(paths) == 0 {
 		// no file was found, its parent directories might have wrong permissions or it just does not exist
 		return nil, fmt.Errorf("could not find any file matching pattern %s, check that all its subdirectories are executable", pattern)

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -381,6 +381,55 @@ func TestCollectFiles(t *testing.T) {
 		assert.Equal(t, fs.path("t.log"), files[2].Path)
 		assert.Equal(t, fs.path("z.log"), files[3].Path)
 	})
+
+	t.Run("LiteralPathToDirectoryReturnsError", func(t *testing.T) {
+		fs := newTempFs(t)
+		fs.mkDir("logsdir")
+
+		fileProvider := NewFileProvider(2, WildcardUseFileName)
+		source := sources.NewLogSource("dir", &config.LogsConfig{Type: config.FileType, Path: fs.path("logsdir")})
+		files, err := fileProvider.CollectFiles(source)
+		assert.Empty(t, files)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "is a directory")
+	})
+
+	t.Run("WildcardMatchingOnlyDirectoriesReturnsError", func(t *testing.T) {
+		fs := newTempFs(t)
+		fs.mkDir("alpha")
+		fs.mkDir("beta")
+
+		fileProvider := NewFileProvider(2, WildcardUseFileName)
+		source := sources.NewLogSource("dir-only", &config.LogsConfig{Type: config.FileType, Path: fs.path("*")})
+		files, err := fileProvider.CollectFiles(source)
+		assert.Empty(t, files)
+		assert.Error(t, err)
+		// Source should be annotated so the status page makes the situation obvious.
+		messages := source.Messages.GetMessages()
+		assert.Len(t, messages, 1)
+		assert.Contains(t, messages[0], "resolved to directories")
+	})
+
+	t.Run("WildcardSkipsDirectoriesAndKeepsFiles", func(t *testing.T) {
+		fs := newTempFs(t)
+		fs.mkDir("subdir")     // glob match that must be skipped
+		fs.createFile("a.log") // real file
+		fs.createFile("b.log") // real file
+
+		fileProvider := NewFileProvider(5, WildcardUseFileName)
+		source := sources.NewLogSource("mixed", &config.LogsConfig{Type: config.FileType, Path: fs.path("*")})
+		files, err := fileProvider.CollectFiles(source)
+		assert.NoError(t, err)
+		assert.Len(t, files, 2)
+		paths := []string{files[0].Path, files[1].Path}
+		assert.Contains(t, paths, fs.path("a.log"))
+		assert.Contains(t, paths, fs.path("b.log"))
+		assert.NotContains(t, paths, fs.path("subdir"))
+
+		messages := source.Messages.GetMessages()
+		assert.Len(t, messages, 1)
+		assert.Contains(t, messages[0], "resolved to directories")
+	})
 }
 
 func TestFilesToTail(t *testing.T) {

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -404,10 +404,9 @@ func TestCollectFiles(t *testing.T) {
 		files, err := fileProvider.CollectFiles(source)
 		assert.Empty(t, files)
 		assert.Error(t, err)
-		// Source should be annotated so the status page makes the situation obvious.
-		messages := source.Messages.GetMessages()
-		assert.Len(t, messages, 1)
-		assert.Contains(t, messages[0], "resolved to directories")
+		// Directories are filtered silently — a mix of files and subdirectories
+		// is a normal layout and shouldn't generate per-scan noise.
+		assert.Empty(t, source.Messages.GetMessages())
 	})
 
 	t.Run("WildcardSkipsDirectoriesAndKeepsFiles", func(t *testing.T) {
@@ -426,9 +425,7 @@ func TestCollectFiles(t *testing.T) {
 		assert.Contains(t, paths, fs.path("b.log"))
 		assert.NotContains(t, paths, fs.path("subdir"))
 
-		messages := source.Messages.GetMessages()
-		assert.Len(t, messages, 1)
-		assert.Contains(t, messages[0], "resolved to directories")
+		assert.Empty(t, source.Messages.GetMessages())
 	})
 }
 

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -427,6 +427,31 @@ func TestCollectFiles(t *testing.T) {
 
 		assert.Empty(t, source.Messages.GetMessages())
 	})
+
+	t.Run("RecursiveGlobSkipsDirectoriesAndKeepsFiles", func(t *testing.T) {
+		mockConfig := configmock.New(t)
+		mockConfig.SetInTest("logs_config.enable_recursive_glob", true)
+
+		fs := newTempFs(t)
+		fs.mkDir("alpha")
+		fs.createFile("alpha/a.log")
+		fs.mkDir("alpha/beta")
+		fs.createFile("alpha/beta/b.log")
+
+		fileProvider := NewFileProvider(5, WildcardUseFileName)
+		source := sources.NewLogSource("recursive", &config.LogsConfig{Type: config.FileType, Path: fs.path("**")})
+		files, err := fileProvider.CollectFiles(source)
+		assert.NoError(t, err)
+
+		paths := make([]string, 0, len(files))
+		for _, f := range files {
+			paths = append(paths, f.Path)
+		}
+		assert.Contains(t, paths, fs.path("alpha/a.log"))
+		assert.Contains(t, paths, fs.path("alpha/beta/b.log"))
+		assert.NotContains(t, paths, fs.path("alpha"))
+		assert.NotContains(t, paths, fs.path("alpha/beta"))
+	})
 }
 
 func TestFilesToTail(t *testing.T) {

--- a/releasenotes/notes/Fix-logs-tailer-directory-glob-error-fad591706d0d106a.yaml
+++ b/releasenotes/notes/Fix-logs-tailer-directory-glob-error-fad591706d0d106a.yaml
@@ -1,0 +1,17 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Logs file tailer: when a configured ``path`` glob matches directories
+    (for example ``E:\Logs\*`` against a tree of subdirectories on Windows),
+    the directory entries are now skipped instead of being opened as files.
+    Previously the tailer surfaced a bare ``Access is denied`` from the OS,
+    which misled troubleshooting toward permissions. The agent now logs a
+    clear warning explaining that the glob matched directories and suggesting
+    a deeper pattern (for example ``E:\Logs\*\*``).

--- a/releasenotes/notes/Fix-logs-tailer-directory-glob-error-fad591706d0d106a.yaml
+++ b/releasenotes/notes/Fix-logs-tailer-directory-glob-error-fad591706d0d106a.yaml
@@ -8,10 +8,10 @@
 ---
 fixes:
   - |
-    Logs file tailer: when a configured ``path`` glob matches directories
-    (for example ``E:\Logs\*`` against a tree of subdirectories on Windows),
-    the directory entries are now skipped instead of being opened as files.
-    Previously the tailer surfaced a bare ``Access is denied`` from the OS,
-    which misled troubleshooting toward permissions. The agent now logs a
-    clear warning explaining that the glob matched directories and suggesting
-    a deeper pattern (for example ``E:\Logs\*\*``).
+    Logs file tailer: directory entries returned by a configured ``path``
+    glob are now skipped instead of being opened as files. Previously the
+    tailer attempted to open the directory and surfaced a misleading
+    ``Access is denied`` error from the OS (on Windows in particular),
+    which sent troubleshooting toward permissions. A non-wildcard
+    ``path`` that resolves to a directory now returns a descriptive
+    error explaining that a file or glob is required.


### PR DESCRIPTION
## Summary

Fixes [AGNTLOG-632](https://datadoghq.atlassian.net/browse/AGNTLOG-632).

When a configured `path` glob matched directories (e.g. `E:\Logs\*` against a tree of subdirectories on Windows), the file tailer opened the directory as a file and surfaced a bare `Access is denied` error from the OS — sending users (and Support) down an incorrect troubleshooting path (permissions / ACLs).

This change:

- In [`pkg/logs/launchers/file/provider/file_provider.go`](pkg/logs/launchers/file/provider/file_provider.go) `filesMatchingSource`, silently drops directory entries from glob results. A folder containing a mix of files and subdirectories is a normal layout, so this stays at trace level rather than warning per scan.
- In `CollectFiles`, a non-wildcard `path` that resolves to a directory now returns a descriptive error (file or glob required) instead of being handed to the tailer.
- Applies uniformly across Linux/macOS/Windows.

## Test plan

### QA Report — AGNTLOG-632

**PR:** [datadog-agent#50827](https://github.com/DataDog/datadog-agent/pull/50827)
**Platform:** macOS. Windows is the motivating case but the fix sits
before the syscall, so platform differences past it don't apply.

#### Summary

Drove `fileprovider.CollectFiles` (the entry point the launcher calls
per source) against real macOS tempdir fixtures matching the bug's
shape. Observed behavior matched expectations across literal paths,
mixed file/directory globs, recursive globs, and the customer's exact
"glob matches only subdirs" tree. No misleading errors, directories
no longer reach the tailer's `os.Open`.

#### Setup (to reproduce)

For each scenario: create a real tempdir, populate it as listed
below, build a `LogSource` with the given `Path`, call
`fileProvider.CollectFiles(source)`, and check `(files, err)` plus
`source.Messages.GetMessages()`.

| Setup | `Path` | Expected | Observed |
|---|---|---|---|
| `mkdir logsdir` | `<tmp>/logsdir` | error containing "is a directory"; no files | matches |
| `mkdir alpha; mkdir beta` (customer's tree shape) | `<tmp>/*` | error "could not find any file matching pattern …"; no source messages | matches |
| `mkdir subdir; touch a.log; touch b.log` | `<tmp>/*` | 2 files (`a.log`, `b.log`); `subdir` filtered; no source messages | matches |
| `mkdir -p alpha/beta; touch alpha/a.log; touch alpha/beta/b.log` (with `logs_config.enable_recursive_glob=true`) | `<tmp>/**` | both `.log` files returned; `alpha/` and `alpha/beta/` filtered | matches |
| 4 files at root, no subdirs | `<tmp>/*` | all 4 files returned, ordering preserved (control case — pre-fix behavior) | matches |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGNTLOG-632]: https://datadoghq.atlassian.net/browse/AGNTLOG-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ