### PR TITLE
Fix partial logs agent restart

### DIFF
--- a/comp/logs-library/pipeline/provider.go
+++ b/comp/logs-library/pipeline/provider.go
@@ -75,6 +75,7 @@ type provider struct {
 	routerChannels     []chan *message.Message
 	currentRouterIndex *atomic.Uint32
 	forwarderWaitGroup sync.WaitGroup
+	stopOnce           sync.Once
 }
 
 // NewProvider returns a new Provider.
@@ -280,23 +281,26 @@ func (p *provider) Start() {
 // Stop stops all pipelines in parallel. This call blocks until all pipelines are stopped.
 // If failover is enabled, closes all router channels and waits for forwarder goroutines
 // to finish draining before stopping pipelines.
+// Stop is idempotent; subsequent calls are no-ops.
 func (p *provider) Stop() {
-	stopper := startstop.NewParallelStopper()
+	p.stopOnce.Do(func() {
+		stopper := startstop.NewParallelStopper()
 
-	for _, ch := range p.routerChannels {
-		close(ch)
-	}
-	p.forwarderWaitGroup.Wait()
+		for _, ch := range p.routerChannels {
+			close(ch)
+		}
+		p.forwarderWaitGroup.Wait()
 
-	// close the pipelines
-	for _, pipeline := range p.pipelines {
-		stopper.Add(pipeline)
-	}
+		// close the pipelines
+		for _, pipeline := range p.pipelines {
+			stopper.Add(pipeline)
+		}
 
-	stopper.Stop()
-	p.sender.Stop()
-	p.pipelines = p.pipelines[:0]
-	p.routerChannels = nil
+		stopper.Stop()
+		p.sender.Stop()
+		p.pipelines = p.pipelines[:0]
+		p.routerChannels = nil
+	})
 }
 
 // NextPipelineChan returns a channel for sending log messages to the pipeline.

--- a/comp/logs-library/pipeline/provider.go
+++ b/comp/logs-library/pipeline/provider.go
@@ -75,7 +75,6 @@ type provider struct {
 	routerChannels     []chan *message.Message
 	currentRouterIndex *atomic.Uint32
 	forwarderWaitGroup sync.WaitGroup
-	stopOnce           sync.Once
 }
 
 // NewProvider returns a new Provider.
@@ -281,26 +280,23 @@ func (p *provider) Start() {
 // Stop stops all pipelines in parallel. This call blocks until all pipelines are stopped.
 // If failover is enabled, closes all router channels and waits for forwarder goroutines
 // to finish draining before stopping pipelines.
-// Stop is idempotent; subsequent calls are no-ops.
 func (p *provider) Stop() {
-	p.stopOnce.Do(func() {
-		stopper := startstop.NewParallelStopper()
+	stopper := startstop.NewParallelStopper()
 
-		for _, ch := range p.routerChannels {
-			close(ch)
-		}
-		p.forwarderWaitGroup.Wait()
+	for _, ch := range p.routerChannels {
+		close(ch)
+	}
+	p.forwarderWaitGroup.Wait()
 
-		// close the pipelines
-		for _, pipeline := range p.pipelines {
-			stopper.Add(pipeline)
-		}
+	// close the pipelines
+	for _, pipeline := range p.pipelines {
+		stopper.Add(pipeline)
+	}
 
-		stopper.Stop()
-		p.sender.Stop()
-		p.pipelines = p.pipelines[:0]
-		p.routerChannels = nil
-	})
+	stopper.Stop()
+	p.sender.Stop()
+	p.pipelines = p.pipelines[:0]
+	p.routerChannels = nil
 }
 
 // NextPipelineChan returns a channel for sending log messages to the pipeline.

--- a/pkg/logs/launchers/channel/launcher.go
+++ b/pkg/logs/launchers/channel/launcher.go
@@ -7,6 +7,8 @@
 package channel
 
 import (
+	"sync"
+
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
@@ -26,6 +28,7 @@ type Launcher struct {
 	sourcesDone      chan struct{}
 	tailers          []*tailer.Tailer
 	stop             chan struct{}
+	stopOnce         sync.Once
 }
 
 // NewLauncher returns an initialized Launcher
@@ -64,9 +67,11 @@ func (l *Launcher) run() {
 
 // Stop waits for any running tailer to be flushed.
 func (l *Launcher) Stop() {
-	for _, tailer := range l.tailers {
-		tailer.WaitFlush()
-	}
-	close(l.sourcesDone)
-	l.stop <- struct{}{}
+	l.stopOnce.Do(func() {
+		for _, tailer := range l.tailers {
+			tailer.WaitFlush()
+		}
+		close(l.sourcesDone)
+		l.stop <- struct{}{}
+	})
 }

--- a/pkg/logs/launchers/channel/launcher.go
+++ b/pkg/logs/launchers/channel/launcher.go
@@ -23,6 +23,7 @@ import (
 type Launcher struct {
 	pipelineProvider pipeline.Provider
 	sources          chan *sources.LogSource
+	sourcesDone      chan struct{}
 	tailers          []*tailer.Tailer
 	stop             chan struct{}
 }
@@ -30,14 +31,15 @@ type Launcher struct {
 // NewLauncher returns an initialized Launcher
 func NewLauncher() *Launcher {
 	return &Launcher{
-		stop: make(chan struct{}),
+		sourcesDone: make(chan struct{}),
+		stop:        make(chan struct{}),
 	}
 }
 
 // Start starts the launcher.
 func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, _ auditor.Registry, _ *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
-	l.sources = sourceProvider.GetAddedForType(config.StringChannelType)
+	l.sources = sourceProvider.GetAddedForType(config.StringChannelType, l.sourcesDone)
 	go l.run()
 }
 
@@ -65,5 +67,6 @@ func (l *Launcher) Stop() {
 	for _, tailer := range l.tailers {
 		tailer.WaitFlush()
 	}
+	close(l.sourcesDone)
 	l.stop <- struct{}{}
 }

--- a/pkg/logs/launchers/container/launcher.go
+++ b/pkg/logs/launchers/container/launcher.go
@@ -51,6 +51,11 @@ type Launcher struct {
 	// (temporary)
 	sources *sourcesPkg.LogSources
 
+	// addedSourcesDone and removedSourcesDone are closed in Stop() to unblock
+	// any pending sends from LogSources.AddSource/RemoveSource.
+	addedSourcesDone   chan struct{}
+	removedSourcesDone chan struct{}
+
 	// tailerFactory builds tailers for sources
 	tailerFactory tailerfactory.Factory
 
@@ -65,10 +70,12 @@ type Launcher struct {
 // NewLauncher returns a new launcher
 func NewLauncher(sources *sourcesPkg.LogSources, wmeta option.Option[workloadmeta.Component], tagger tagger.Component) *Launcher {
 	launcher := &Launcher{
-		sources: sources,
-		tailers: make(map[*sourcesPkg.LogSource]tailerfactory.Tailer),
-		wmeta:   wmeta,
-		tagger:  tagger,
+		sources:            sources,
+		addedSourcesDone:   make(chan struct{}),
+		removedSourcesDone: make(chan struct{}),
+		tailers:            make(map[*sourcesPkg.LogSource]tailerfactory.Tailer),
+		wmeta:              wmeta,
+		tagger:             tagger,
 	}
 	return launcher
 }
@@ -87,6 +94,8 @@ func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvid
 // Stop stops the Launcher. This call returns when the launcher has stopped.
 func (l *Launcher) Stop() {
 	if l.cancel != nil {
+		close(l.addedSourcesDone)
+		close(l.removedSourcesDone)
 		l.cancel()
 		l.cancel = nil
 		<-l.stopped
@@ -99,7 +108,7 @@ func (l *Launcher) Stop() {
 func (l *Launcher) run(ctx context.Context, sourceProvider launchers.SourceProvider) {
 	log.Info("Starting Container launcher")
 
-	addedSources, removedSources := sourceProvider.SubscribeAll()
+	addedSources, removedSources := sourceProvider.SubscribeAll(l.addedSourcesDone, l.removedSourcesDone)
 
 	for {
 		if !l.loop(ctx, addedSources, removedSources) {

--- a/pkg/logs/launchers/container/launcher.go
+++ b/pkg/logs/launchers/container/launcher.go
@@ -10,6 +10,7 @@ package container
 
 import (
 	"context"
+	"sync"
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -64,7 +65,8 @@ type Launcher struct {
 
 	wmeta option.Option[workloadmeta.Component]
 
-	tagger tagger.Component
+	tagger   tagger.Component
+	stopOnce sync.Once
 }
 
 // NewLauncher returns a new launcher
@@ -93,14 +95,16 @@ func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvid
 
 // Stop stops the Launcher. This call returns when the launcher has stopped.
 func (l *Launcher) Stop() {
-	if l.cancel != nil {
-		close(l.addedSourcesDone)
-		close(l.removedSourcesDone)
-		l.cancel()
-		l.cancel = nil
-		<-l.stopped
-		l.stopped = nil
-	}
+	l.stopOnce.Do(func() {
+		if l.cancel != nil {
+			close(l.addedSourcesDone)
+			close(l.removedSourcesDone)
+			l.cancel()
+			l.cancel = nil
+			<-l.stopped
+			l.stopped = nil
+		}
+	})
 }
 
 // run is the main loop for this launcher.  It monitors for sources added or

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -43,6 +43,8 @@ type Launcher struct {
 	addedSources        chan *sources.LogSource
 	removedSources      chan *sources.LogSource
 	activeSources       []*sources.LogSource
+	addedSourcesDone    chan struct{}
+	removedSourcesDone  chan struct{}
 	tailingLimit        int
 	fileProvider        *fileprovider.FileProvider
 	tailers             *tailers.TailerContainer[*tailer.Tailer]
@@ -103,6 +105,8 @@ func NewLauncher(
 	}
 
 	return &Launcher{
+		addedSourcesDone:       make(chan struct{}),
+		removedSourcesDone:     make(chan struct{}),
 		tailingLimit:           tailingLimit,
 		fileProvider:           fileprovider.NewFileProvider(tailingLimit, wildcardStrategy),
 		tailers:                tailers.NewTailerContainer[*tailer.Tailer](),
@@ -124,7 +128,7 @@ func NewLauncher(
 // Start starts the Launcher
 func (s *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
 	s.pipelineProvider = pipelineProvider
-	s.addedSources, s.removedSources = sourceProvider.SubscribeForType(config.FileType)
+	s.addedSources, s.removedSources = sourceProvider.SubscribeForType(config.FileType, s.addedSourcesDone, s.removedSourcesDone)
 	s.registry = registry
 	tracker.Add(s.tailers)
 	go s.run()
@@ -133,6 +137,10 @@ func (s *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvid
 // Stop stops the Scanner and its tailers in parallel,
 // this call returns only when all the tailers are stopped
 func (s *Launcher) Stop() {
+	// stop the launcher source subscriptions from blocking
+	close(s.addedSourcesDone)
+	close(s.removedSourcesDone)
+
 	s.stop <- struct{}{}
 	<-s.done
 }

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"regexp"
 	"slices"
+	"sync"
 	"time"
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -66,6 +67,7 @@ type Launcher struct {
 	oldInfoMap    map[string]*oldTailerInfo
 	fileOpener    opener.FileOpener
 	fingerprinter tailer.Fingerprinter
+	stopOnce      sync.Once
 }
 
 const (
@@ -137,12 +139,14 @@ func (s *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvid
 // Stop stops the Scanner and its tailers in parallel,
 // this call returns only when all the tailers are stopped
 func (s *Launcher) Stop() {
-	// stop the launcher source subscriptions from blocking
-	close(s.addedSourcesDone)
-	close(s.removedSourcesDone)
+	s.stopOnce.Do(func() {
+		// stop the launcher source subscriptions from blocking
+		close(s.addedSourcesDone)
+		close(s.removedSourcesDone)
 
-	s.stop <- struct{}{}
-	<-s.done
+		s.stop <- struct{}{}
+		<-s.done
+	})
 }
 
 // run checks periodically if there are new files to tail and the state of its tailers until stop

--- a/pkg/logs/launchers/journald/launcher.go
+++ b/pkg/logs/launchers/journald/launcher.go
@@ -10,6 +10,7 @@ package journald
 
 import (
 	"os"
+	"sync"
 
 	"github.com/coreos/go-systemd/v22/sdjournal"
 
@@ -50,6 +51,7 @@ type Launcher struct {
 	journalFactory   tailer.JournalFactory
 	fc               *flareController.FlareController
 	tagger           tagger.Component
+	stopOnce         sync.Once
 }
 
 // NewLauncher returns a new Launcher.
@@ -118,14 +120,16 @@ func (l *Launcher) run() {
 
 // Stop stops all active tailers
 func (l *Launcher) Stop() {
-	close(l.sourcesDone)
-	l.stop <- struct{}{}
-	stopper := startstop.NewParallelStopper()
-	for identifier, tailer := range l.tailers {
-		stopper.Add(tailer)
-		delete(l.tailers, identifier)
-	}
-	stopper.Stop()
+	l.stopOnce.Do(func() {
+		close(l.sourcesDone)
+		l.stop <- struct{}{}
+		stopper := startstop.NewParallelStopper()
+		for identifier, tailer := range l.tailers {
+			stopper.Add(tailer)
+			delete(l.tailers, identifier)
+		}
+		stopper.Stop()
+	})
 }
 
 // setupTailer configures and starts a new tailer,

--- a/pkg/logs/launchers/journald/launcher.go
+++ b/pkg/logs/launchers/journald/launcher.go
@@ -42,6 +42,7 @@ func (s *SDJournalFactory) NewJournalFromPath(path string) (tailer.Journal, erro
 // Launcher is in charge of starting and stopping new journald tailers
 type Launcher struct {
 	sources          chan *sources.LogSource
+	sourcesDone      chan struct{}
 	pipelineProvider pipeline.Provider
 	registry         auditor.Registry
 	tailers          map[string]*tailer.Tailer
@@ -60,6 +61,7 @@ func NewLauncher(fc *flareController.FlareController, tagger tagger.Component) *
 func NewLauncherWithFactory(journalFactory tailer.JournalFactory, fc *flareController.FlareController, tagger tagger.Component) *Launcher {
 	return &Launcher{
 		tailers:        make(map[string]*tailer.Tailer),
+		sourcesDone:    make(chan struct{}),
 		stop:           make(chan struct{}),
 		journalFactory: journalFactory,
 		fc:             fc,
@@ -69,7 +71,7 @@ func NewLauncherWithFactory(journalFactory tailer.JournalFactory, fc *flareContr
 
 // Start starts the launcher.
 func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, _ *tailers.TailerTracker) {
-	l.sources = sourceProvider.GetAddedForType(config.JournaldType)
+	l.sources = sourceProvider.GetAddedForType(config.JournaldType, l.sourcesDone)
 	l.pipelineProvider = pipelineProvider
 	l.registry = registry
 	go l.run()
@@ -116,6 +118,7 @@ func (l *Launcher) run() {
 
 // Stop stops all active tailers
 func (l *Launcher) Stop() {
+	close(l.sourcesDone)
 	l.stop <- struct{}{}
 	stopper := startstop.NewParallelStopper()
 	for identifier, tailer := range l.tailers {

--- a/pkg/logs/launchers/listener/launcher.go
+++ b/pkg/logs/launchers/listener/launcher.go
@@ -6,6 +6,8 @@
 package listener
 
 import (
+	"sync"
+
 	"github.com/DataDog/datadog-agent/comp/logs-library/pipeline"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
@@ -26,6 +28,7 @@ type Launcher struct {
 	udpSourcesDone   chan struct{}
 	listeners        []startstop.StartStoppable
 	stop             chan struct{}
+	stopOnce         sync.Once
 }
 
 // NewLauncher returns an initialized Launcher
@@ -76,12 +79,14 @@ func (l *Launcher) run() {
 
 // Stop stops all listeners
 func (l *Launcher) Stop() {
-	close(l.tcpSourcesDone)
-	close(l.udpSourcesDone)
-	l.stop <- struct{}{}
-	stopper := startstop.NewParallelStopper()
-	for _, l := range l.listeners {
-		stopper.Add(l)
-	}
-	stopper.Stop()
+	l.stopOnce.Do(func() {
+		close(l.tcpSourcesDone)
+		close(l.udpSourcesDone)
+		l.stop <- struct{}{}
+		stopper := startstop.NewParallelStopper()
+		for _, l := range l.listeners {
+			stopper.Add(l)
+		}
+		stopper.Stop()
+	})
 }

--- a/pkg/logs/launchers/listener/launcher.go
+++ b/pkg/logs/launchers/listener/launcher.go
@@ -21,7 +21,9 @@ type Launcher struct {
 	pipelineProvider pipeline.Provider
 	frameSize        int
 	tcpSources       chan *sources.LogSource
+	tcpSourcesDone   chan struct{}
 	udpSources       chan *sources.LogSource
+	udpSourcesDone   chan struct{}
 	listeners        []startstop.StartStoppable
 	stop             chan struct{}
 }
@@ -29,16 +31,18 @@ type Launcher struct {
 // NewLauncher returns an initialized Launcher
 func NewLauncher(frameSize int) *Launcher {
 	return &Launcher{
-		frameSize: frameSize,
-		stop:      make(chan struct{}),
+		frameSize:      frameSize,
+		tcpSourcesDone: make(chan struct{}),
+		udpSourcesDone: make(chan struct{}),
+		stop:           make(chan struct{}),
 	}
 }
 
 // Start starts the listener.
 func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, _ auditor.Registry, _ *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
-	l.tcpSources = sourceProvider.GetAddedForType(config.TCPType)
-	l.udpSources = sourceProvider.GetAddedForType(config.UDPType)
+	l.tcpSources = sourceProvider.GetAddedForType(config.TCPType, l.tcpSourcesDone)
+	l.udpSources = sourceProvider.GetAddedForType(config.UDPType, l.udpSourcesDone)
 	go l.run()
 }
 
@@ -72,6 +76,8 @@ func (l *Launcher) run() {
 
 // Stop stops all listeners
 func (l *Launcher) Stop() {
+	close(l.tcpSourcesDone)
+	close(l.udpSourcesDone)
 	l.stop <- struct{}{}
 	stopper := startstop.NewParallelStopper()
 	for _, l := range l.listeners {

--- a/pkg/logs/launchers/mock_source_provider.go
+++ b/pkg/logs/launchers/mock_source_provider.go
@@ -26,16 +26,16 @@ func NewMockSourceProvider() *MockSourceProvider {
 }
 
 // SubscribeAll implements SourceProvider#SubscribeAll.
-func (sp *MockSourceProvider) SubscribeAll() (chan *sources.LogSource, chan *sources.LogSource) {
+func (sp *MockSourceProvider) SubscribeAll(_, _ chan struct{}) (chan *sources.LogSource, chan *sources.LogSource) {
 	return sp.SourceChan, sp.SourceChan
 }
 
 // SubscribeForType implements SourceProvider#SubscribeForType.
-func (sp *MockSourceProvider) SubscribeForType(_ string) (chan *sources.LogSource, chan *sources.LogSource) {
+func (sp *MockSourceProvider) SubscribeForType(_ string, _, _ chan struct{}) (chan *sources.LogSource, chan *sources.LogSource) {
 	return sp.SourceChan, sp.SourceChan
 }
 
 // GetAddedForType implements SourceProvider#GetAddedForType.
-func (sp *MockSourceProvider) GetAddedForType(_ string) chan *sources.LogSource {
+func (sp *MockSourceProvider) GetAddedForType(_ string, _ chan struct{}) chan *sources.LogSource {
 	return sp.SourceChan
 }

--- a/pkg/logs/launchers/types.go
+++ b/pkg/logs/launchers/types.go
@@ -37,11 +37,11 @@ type SourceProvider interface {
 	//
 	// Sources are not automatically removed when the agent shuts down.  Consumers should handle any
 	// required shutdwon of running sources in their own Stop methods.
-	SubscribeForType(sourceType string) (added chan *sources.LogSource, removed chan *sources.LogSource)
+	SubscribeForType(sourceType string, addedDone, removedDone chan struct{}) (added chan *sources.LogSource, removed chan *sources.LogSource)
 
 	// SubscribeAll returns channels containing all added and removed sources.
-	SubscribeAll() (added chan *sources.LogSource, removed chan *sources.LogSource)
+	SubscribeAll(addedDone, removedDone chan struct{}) (added chan *sources.LogSource, removed chan *sources.LogSource)
 
 	// GetAddedForType returns channels containing the new added sources matching the provided type.
-	GetAddedForType(sourceType string) chan *sources.LogSource
+	GetAddedForType(sourceType string, addedDone chan struct{}) chan *sources.LogSource
 }

--- a/pkg/logs/launchers/windowsevent/launcher.go
+++ b/pkg/logs/launchers/windowsevent/launcher.go
@@ -33,6 +33,7 @@ type tailer interface {
 // Launcher is in charge of starting and stopping windows event logs tailers
 type Launcher struct {
 	sources                chan *sources.LogSource
+	sourcesDone            chan struct{}
 	pipelineProvider       pipeline.Provider
 	registry               auditor.Registry
 	tailers                map[string]tailer
@@ -45,6 +46,7 @@ func NewLauncher() *Launcher {
 	cache := publishermetadatacache.New(winevtapi.New())
 	return &Launcher{
 		tailers:                make(map[string]tailer),
+		sourcesDone:            make(chan struct{}),
 		stop:                   make(chan struct{}),
 		publisherMetadataCache: cache,
 	}
@@ -53,7 +55,7 @@ func NewLauncher() *Launcher {
 // Start starts the launcher by setting up Windows event log sources and beginning to tail them.
 func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, _ *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
-	l.sources = sourceProvider.GetAddedForType(config.WindowsEventType)
+	l.sources = sourceProvider.GetAddedForType(config.WindowsEventType, l.sourcesDone)
 	l.registry = registry
 	availableChannels, err := EnumerateChannels()
 	if err != nil {
@@ -88,6 +90,7 @@ func (l *Launcher) run() {
 
 // Stop stops all active tailers
 func (l *Launcher) Stop() {
+	close(l.sourcesDone)
 	l.stop <- struct{}{}
 	stopper := startstop.NewParallelStopper()
 	for _, tailer := range l.tailers {

--- a/pkg/logs/launchers/windowsevent/launcher.go
+++ b/pkg/logs/launchers/windowsevent/launcher.go
@@ -9,6 +9,8 @@
 package windowsevent
 
 import (
+	"sync"
+
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	winevtapi "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api/windows"
 
@@ -39,6 +41,7 @@ type Launcher struct {
 	tailers                map[string]tailer
 	stop                   chan struct{}
 	publisherMetadataCache publishermetadatacachedef.Component
+	stopOnce               sync.Once
 }
 
 // NewLauncher returns a new Launcher.
@@ -90,15 +93,17 @@ func (l *Launcher) run() {
 
 // Stop stops all active tailers
 func (l *Launcher) Stop() {
-	close(l.sourcesDone)
-	l.stop <- struct{}{}
-	stopper := startstop.NewParallelStopper()
-	for _, tailer := range l.tailers {
-		stopper.Add(tailer)
-		delete(l.tailers, tailer.Identifier())
-	}
-	stopper.Stop()
-	l.publisherMetadataCache.Flush()
+	l.stopOnce.Do(func() {
+		close(l.sourcesDone)
+		l.stop <- struct{}{}
+		stopper := startstop.NewParallelStopper()
+		for _, tailer := range l.tailers {
+			stopper.Add(tailer)
+			delete(l.tailers, tailer.Identifier())
+		}
+		stopper.Stop()
+		l.publisherMetadataCache.Flush()
+	})
 }
 
 // sanitizedConfig sets default values for the config

--- a/pkg/logs/sources/config_source.go
+++ b/pkg/logs/sources/config_source.go
@@ -25,16 +25,20 @@ func (s *ConfigSources) AddSource(source *LogSource) {
 }
 
 // SubscribeAll is required for the SourceProvider interface
-func (s *ConfigSources) SubscribeAll() (added chan *LogSource, _ chan *LogSource) {
+func (s *ConfigSources) SubscribeAll(_, _ chan struct{}) (added chan *LogSource, _ chan *LogSource) {
 	return
 }
 
 // SubscribeForType returns a channel carrying LogSources for a given source type
-func (s *ConfigSources) SubscribeForType(sourceType string) (added chan *LogSource, _ chan *LogSource) {
+func (s *ConfigSources) SubscribeForType(sourceType string, addedDone, _ chan struct{}) (added chan *LogSource, _ chan *LogSource) {
 	added = make(chan *LogSource)
 	go func() {
 		for _, logSource := range s.addedByType[sourceType] {
-			added <- logSource
+			select {
+			case added <- logSource:
+			case <-addedDone:
+				return
+			}
 		}
 	}()
 
@@ -42,6 +46,6 @@ func (s *ConfigSources) SubscribeForType(sourceType string) (added chan *LogSour
 }
 
 // GetAddedForType is required for the SourceProvider interface
-func (s *ConfigSources) GetAddedForType(_ string) chan *LogSource {
+func (s *ConfigSources) GetAddedForType(_ string, _ chan struct{}) chan *LogSource {
 	return nil
 }

--- a/pkg/logs/sources/config_source_test.go
+++ b/pkg/logs/sources/config_source_test.go
@@ -73,7 +73,7 @@ func TestSubscribeForTypeAndAddFileSource(t *testing.T) {
 		configSource.AddSource(source)
 	}
 
-	addedChan, _ := configSource.SubscribeForType("file")
+	addedChan, _ := configSource.SubscribeForType("file", make(chan struct{}), make(chan struct{}))
 	added := <-addedChan
 	assert.NotNil(t, added)
 	assert.Equal(t, "file", added.Config.Type)

--- a/pkg/logs/sources/sources.go
+++ b/pkg/logs/sources/sources.go
@@ -12,12 +12,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+type subscription struct {
+	ch   chan *LogSource
+	done chan struct{}
+}
+
 // LogSources serves as the interface between Schedulers and Launchers, distributing
 // notifications of added/removed LogSources to subscribed Launchers.
 //
 // Each subscription receives its own unbuffered channel for sources, and should
-// consume from the channel quickly to avoid blocking other goroutines.  There is
-// no means to unsubscribe.
+// consume from the channel quickly to avoid blocking other goroutines.
+// Callers must provide a done channel and close it when they stop consuming,
+// so that blocked sends can be skipped.
 //
 // If any sources have been added when GetAddedForType is called, then those sources
 // are immediately sent to the channel.
@@ -26,17 +32,17 @@ import (
 type LogSources struct {
 	mu            sync.Mutex
 	sources       []*LogSource
-	added         []chan *LogSource
-	addedByType   map[string][]chan *LogSource
-	removed       []chan *LogSource
-	removedByType map[string][]chan *LogSource
+	added         []*subscription
+	addedByType   map[string][]*subscription
+	removed       []*subscription
+	removedByType map[string][]*subscription
 }
 
 // NewLogSources creates a new log sources.
 func NewLogSources() *LogSources {
 	return &LogSources{
-		addedByType:   make(map[string][]chan *LogSource),
-		removedByType: make(map[string][]chan *LogSource),
+		addedByType:   make(map[string][]*subscription),
+		removedByType: make(map[string][]*subscription),
 	}
 }
 
@@ -57,11 +63,17 @@ func (s *LogSources) AddSource(source *LogSource) {
 	s.mu.Unlock()
 
 	for _, stream := range streams {
-		stream <- source
+		select {
+		case stream.ch <- source:
+		case <-stream.done:
+		}
 	}
 
 	for _, stream := range streamsForType {
-		stream <- source
+		select {
+		case stream.ch <- source:
+		case <-stream.done:
+		}
 	}
 }
 
@@ -86,10 +98,16 @@ func (s *LogSources) RemoveSource(source *LogSource) {
 
 	if sourceFound {
 		for _, stream := range streams {
-			stream <- source
+			select {
+			case stream.ch <- source:
+			case <-stream.done:
+			}
 		}
 		for _, stream := range streamsForType {
-			stream <- source
+			select {
+			case stream.ch <- source:
+			case <-stream.done:
+			}
 		}
 	}
 }
@@ -99,12 +117,12 @@ func (s *LogSources) RemoveSource(source *LogSource) {
 // added or removed concurrently.
 //
 // Any sources added before this call are delivered from a new goroutine.
-func (s *LogSources) SubscribeAll() (added chan *LogSource, removed chan *LogSource) {
+func (s *LogSources) SubscribeAll(addedDone, removedDone chan struct{}) (chan *LogSource, chan *LogSource) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	added = make(chan *LogSource)
-	removed = make(chan *LogSource)
+	added := &subscription{ch: make(chan *LogSource), done: addedDone}
+	removed := &subscription{ch: make(chan *LogSource), done: removedDone}
 
 	s.added = append(s.added, added)
 	s.removed = append(s.removed, removed)
@@ -112,11 +130,15 @@ func (s *LogSources) SubscribeAll() (added chan *LogSource, removed chan *LogSou
 	existingSources := slices.Clone(s.sources) // clone for goroutine
 	go func() {
 		for _, source := range existingSources {
-			added <- source
+			select {
+			case added.ch <- source:
+			case <-addedDone:
+				return
+			}
 		}
 	}()
 
-	return
+	return added.ch, removed.ch
 }
 
 // SubscribeForType returns two channels carrying notifications of added and
@@ -124,20 +146,20 @@ func (s *LogSources) SubscribeAll() (added chan *LogSource, removed chan *LogSou
 // consistency if sources are added or removed concurrently.
 //
 // Any sources added before this call are delivered from a new goroutine.
-func (s *LogSources) SubscribeForType(sourceType string) (added chan *LogSource, removed chan *LogSource) {
+func (s *LogSources) SubscribeForType(sourceType string, addedDone, removedDone chan struct{}) (chan *LogSource, chan *LogSource) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	added = make(chan *LogSource)
-	removed = make(chan *LogSource)
+	added := &subscription{ch: make(chan *LogSource), done: addedDone}
+	removed := &subscription{ch: make(chan *LogSource), done: removedDone}
 
 	if _, exists := s.addedByType[sourceType]; !exists {
-		s.addedByType[sourceType] = []chan *LogSource{}
+		s.addedByType[sourceType] = []*subscription{}
 	}
 	s.addedByType[sourceType] = append(s.addedByType[sourceType], added)
 
 	if _, exists := s.removedByType[sourceType]; !exists {
-		s.removedByType[sourceType] = []chan *LogSource{}
+		s.removedByType[sourceType] = []*subscription{}
 	}
 	s.removedByType[sourceType] = append(s.removedByType[sourceType], removed)
 
@@ -145,40 +167,48 @@ func (s *LogSources) SubscribeForType(sourceType string) (added chan *LogSource,
 	go func() {
 		for _, source := range existingSources {
 			if source.Config.Type == sourceType {
-				added <- source
+				select {
+				case added.ch <- source:
+				case <-addedDone:
+					return
+				}
 			}
 		}
 	}()
 
-	return
+	return added.ch, removed.ch
 }
 
 // GetAddedForType returns a channel carrying notifications of new sources
 // with the given type.
 //
 // Any sources added before this call are delivered from a new goroutine.
-func (s *LogSources) GetAddedForType(sourceType string) chan *LogSource {
+func (s *LogSources) GetAddedForType(sourceType string, addedDone chan struct{}) chan *LogSource {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	_, exists := s.addedByType[sourceType]
 	if !exists {
-		s.addedByType[sourceType] = []chan *LogSource{}
+		s.addedByType[sourceType] = []*subscription{}
 	}
 
-	stream := make(chan *LogSource)
+	stream := &subscription{ch: make(chan *LogSource), done: addedDone}
 	s.addedByType[sourceType] = append(s.addedByType[sourceType], stream)
 
 	existingSources := slices.Clone(s.sources) // clone for goroutine
 	go func() {
 		for _, source := range existingSources {
 			if source.Config.Type == sourceType {
-				stream <- source
+				select {
+				case stream.ch <- source:
+				case <-addedDone:
+					return
+				}
 			}
 		}
 	}()
 
-	return stream
+	return stream.ch
 }
 
 // GetSources returns all the sources currently held.  The result is copied and

--- a/pkg/logs/sources/sources_test.go
+++ b/pkg/logs/sources/sources_test.go
@@ -56,10 +56,10 @@ func TestGetAddedForType(t *testing.T) {
 	sources := NewLogSources()
 	source := NewLogSource("foo", &config.LogsConfig{Type: "foo"})
 
-	stream1 := sources.GetAddedForType("foo")
+	stream1 := sources.GetAddedForType("foo", make(chan struct{}))
 	assert.NotNil(t, stream1)
 
-	stream2 := sources.GetAddedForType("foo")
+	stream2 := sources.GetAddedForType("foo", make(chan struct{}))
 	assert.NotNil(t, stream2)
 
 	go func() { sources.AddSource(source) }()
@@ -82,7 +82,7 @@ func TestGetAddedForTypeExistingSources(t *testing.T) {
 		sources.AddSource(source1)
 	}()
 
-	streamA := sources.GetAddedForType("foo")
+	streamA := sources.GetAddedForType("foo", make(chan struct{}))
 	assert.NotNil(t, streamA)
 	sa1 := <-streamA
 	assert.Equal(t, sa1, source1)
@@ -94,7 +94,7 @@ func TestGetAddedForTypeExistingSources(t *testing.T) {
 	sa2 := <-streamA
 	assert.Equal(t, sa2, source2)
 
-	streamB := sources.GetAddedForType("foo")
+	streamB := sources.GetAddedForType("foo", make(chan struct{}))
 	assert.NotNil(t, streamB)
 	sb1 := <-streamB
 	sb2 := <-streamB
@@ -115,7 +115,7 @@ func TestSubscribeAll(t *testing.T) {
 
 	go func() { sources.AddSource(source1) }()
 
-	addA, removeA := sources.SubscribeAll()
+	addA, removeA := sources.SubscribeAll(make(chan struct{}), make(chan struct{}))
 	assert.NotNil(t, addA)
 	sa1 := <-addA
 	assert.Equal(t, sa1, source1)
@@ -127,7 +127,7 @@ func TestSubscribeAll(t *testing.T) {
 	assert.Equal(t, sa2, source2)
 	assert.Equal(t, 0, len(removeA))
 
-	addB, removeB := sources.SubscribeAll()
+	addB, removeB := sources.SubscribeAll(make(chan struct{}), make(chan struct{}))
 	assert.NotNil(t, addB)
 	sb1 := <-addB
 	sb2 := <-addB
@@ -165,7 +165,7 @@ func TestSubscribeForType(t *testing.T) {
 		sources.AddSource(source1)
 	}()
 
-	addA, removeA := sources.SubscribeForType("foo")
+	addA, removeA := sources.SubscribeForType("foo", make(chan struct{}), make(chan struct{}))
 	assert.NotNil(t, addA)
 	sa1 := <-addA
 	assert.Equal(t, sa1, source1)
@@ -179,7 +179,7 @@ func TestSubscribeForType(t *testing.T) {
 	sa2 := <-addA
 	assert.Equal(t, sa2, source2)
 
-	addB, removeB := sources.SubscribeForType("foo")
+	addB, removeB := sources.SubscribeForType("foo", make(chan struct{}), make(chan struct{}))
 	assert.NotNil(t, addB)
 	sb1 := <-addB
 	sb2 := <-addB

--- a/pkg/logs/sources/sources_test.go
+++ b/pkg/logs/sources/sources_test.go
@@ -7,6 +7,7 @@ package sources
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -202,4 +203,44 @@ func TestSubscribeForType(t *testing.T) {
 	sb1 = <-removeB
 	assert.Equal(t, sa1, source1)
 	assert.Equal(t, sb1, source1)
+}
+
+// TestPartialRestart verifies that AddSource does not block after a launcher
+// stops (closes its done channel) while a new launcher is subscribed.
+//
+// This covers the partial pipeline restart scenario: LogSources is reused
+// across restarts, so dead subscriptions from the old launcher must not
+// block sends to new subscribers.
+func TestPartialRestart(t *testing.T) {
+	logSources := NewLogSources()
+	source := NewLogSource("foo", &config.LogsConfig{Type: "foo"})
+
+	// Simulate old launcher: subscribe but never consume, then stop.
+	oldDone := make(chan struct{})
+	_ = logSources.GetAddedForType("foo", oldDone)
+	close(oldDone) // old launcher stopped; its channel is now dead
+
+	// Simulate new launcher: subscribe and consume.
+	newDone := make(chan struct{})
+	newStream := logSources.GetAddedForType("foo", newDone)
+
+	addSourceDone := make(chan struct{})
+	go func() {
+		logSources.AddSource(source)
+		close(addSourceDone)
+	}()
+
+	select {
+	case received := <-newStream:
+		assert.Equal(t, source, received)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for new subscriber to receive source")
+	}
+
+	select {
+	case <-addSourceDone:
+		// AddSource completed without blocking on the dead subscription
+	case <-time.After(time.Second):
+		t.Fatal("AddSource blocked on dead subscription")
+	}
 }

--- a/pkg/logs/util/testutils/test_utils.go
+++ b/pkg/logs/util/testutils/test_utils.go
@@ -12,7 +12,7 @@ import "github.com/DataDog/datadog-agent/pkg/logs/sources"
 // the producer to get stuck.
 func consumeSources(sources *sources.LogSources) {
 	go func() {
-		sources := sources.GetAddedForType("foo")
+		sources := sources.GetAddedForType("foo", make(chan struct{}))
 		for source := range sources {
 			// Consume from channel to prevent blocking
 			_ = source


### PR DESCRIPTION
### What does this PR do?
The `LogSources` struct tracks its source subscriptions internally using a slice of unbuffered channels e.g.

```go
// Old state before this PR
LogSources{
  addedByType   map[string][]chan *LogSource // ["file"] = [chan1, chan2]
  removedByType map[string][]chan *LogSource
}
```
When the log pipeline is partially restarted to upgrade from TCP to HTTP forwarding, the existing launcher is stopped and a new launcher is created that uses the _pre-existing_  LogSources. This leaves the unbuffered channels without a consumer.

`AddSource()` iterates over the slice of channels and attempts to send them to all subscribers but because the original launcher [subscriber] was removed, _this will block forever_.

This PR introduces a complementary "done" channel for added/removed sources that can be closed during the `Stop()` process and avoid deadlock.

```go
// New type pairs subscription channels with their done channels
type subscription struct {
  ch chan *LogSource // subscription channel
  done chan struct{} // done channel
}

LogSources{
  addedByType   map[string][]*subscription
  removedByType map[string][]*subscription
}
```

### Motivation
Address a deadlock issue when new log sources are added after the logs agent has been partially restarted. 

### Describe how you validated your changes
#### 1. Deploy netpol that blocks 443 egress for node agent

#### 2. Deploy custom node agent with fix

```bash
NAME                                           READY   STATUS    RESTARTS   AGE                    IMAGE
datadog-agent-76wdv                            true    Running   0          2026-05-15T14:12:53Z   justinlesko689/agent:partial-logs-agent-restart-v0
datadog-agent-cluster-agent-548bdb4f55-2gg6l   true    Running   0          2026-05-15T14:12:53Z   registry.datadoghq.com/cluster-agent:7.78.3
datadog-agent-operator-7b47bdb497-dk98t        true    Running   0          2026-05-15T14:12:53Z   registry.datadoghq.com/operator:1.26.0
```

#### 3. Observe agent fallback to TCP
```bash
❯ k exec -it datadog-agent-76wdv -c agent -- agent status | grep -A20 "Logs Agent"

Logs Agent
==========
    Reliable: Sending uncompressed logs in SSL encrypted TCP to agent-intake.logs.datadoghq.com. on port 10516 (API Key: ****************************)

    You are currently sending Logs to Datadog through TCP (either because logs_config.force_use_tcp or logs_config.socks5_proxy_address is set or the HTTP connectivity test has failed). To benefit from increased reliability and better network performances, we strongly encourage switching over to compressed HTTPS which is now the default protocol.

    BytesSent: 0
    EncodedBytesSent: 74
    LogsProcessed: 0
    LogsSent: 0
    LogsTruncated: 0
    RetryCount: 0
    RetryTimeSpent: 0s
    CoreAgentProcessOpenFiles: 34
    OSFileLimit: 1048576
```

#### 4. Delete netpol and observe agent upgrade its connection to HTTPS
```bash
Logs Agent
==========

    Reliable: Sending compressed logs in HTTPS to agent-http-intake.logs.datadoghq.com. on port 443 (API Key: ****************************)
    BytesSent: 1430327
    EncodedBytesSent: 1272147
    LogsProcessed: 1250
    LogsSent: 1247
    LogsTruncated: 0
    RetryCount: 0
    RetryTimeSpent: 0s
    CoreAgentProcessOpenFiles: 49
    OSFileLimit: 1048576
```

#### 5. Deploy another workload trigger `AddSource` 

#### 6. Observe that the agent does not restart from AD healthcheck failing due to deadlock detection
```
NAME                                           READY   STATUS    RESTARTS   AGE                    IMAGE
datadog-agent-76wdv                            true    Running   0          2026-05-15T14:12:53Z   justinlesko689/agent:partial-logs-agent-restart-v0
datadog-agent-cluster-agent-548bdb4f55-2gg6l   true    Running   0          2026-05-15T14:12:53Z   registry.datadoghq.com/cluster-agent:7.78.3
datadog-agent-operator-7b47bdb497-dk98t        true    Running   0          2026-05-15T14:12:53Z   registry.datadoghq.com/operator:1.26.0
log-generator-5bb5786894-vlqsz                 true    Running   0          2026-05-15T14:21:04Z   busybox
```
### Additional Notes
