### PR TITLE
[ABLD-476] Change default rtloader build to use bazel

### DIFF
--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -91,8 +91,7 @@
     - !reference [.install_python_dependencies]
     # See there is no virtualization, we need to clean the environment regularly
     - !reference [.macos_runner_maintenance]
-    - dda inv -- -e rtloader.make
-    - dda inv -- -e rtloader.install
+    - bazel run -- //rtloader:install --destdir=dev
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e install-tools --verbose

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -7,6 +7,7 @@
     - !reference [.except_disable_unit_tests]
     - !reference [.fast_on_dev_branch_only]
   script:
+    - bazel test //rtloader/...
     - dda inv -- -e rtloader.make --install-prefix=$CI_PROJECT_DIR/dev
     - dda inv -- -e rtloader.install
     - dda inv -- -e rtloader.format --raise-if-changed

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -87,7 +87,7 @@ def build(
     agent_bin=None,
     run_on=None,  # noqa: U100, F841. Used by the run_on_devcontainer decorator
     glibc=True,
-    enable_bazel=False,
+    enable_bazel=True,
 ):
     """
     Build the agent. If the bits to include in the build are not specified,

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -33,9 +33,13 @@ def run_make_command(ctx, command=""):
 
 
 @task
-def make(ctx, install_prefix=None, cmake_options=''):
+def make(ctx, install_prefix=None, cmake_options='', enable_bazel=True):
     dev_path = get_dev_path()
     prefix = install_prefix or dev_path
+
+    if enable_bazel:
+        bazel(ctx, "build", "//rtloader:all_files")
+        return
 
     if cmake_options.find("-G") == -1:
         cmake_options += " -G \"Unix Makefiles\""
@@ -90,8 +94,11 @@ def clean(_):
 
 
 @task
-def install(ctx):
+def install(ctx, enable_bazel=True):
     with gitlab_section("Install rtloader", collapsed=True):
+        if enable_bazel:
+            install_with_bazel(ctx)
+            return
         run_make_command(ctx, "install")
 
 
@@ -151,8 +158,11 @@ def install_with_bazel(ctx):
 
 
 @task
-def test(ctx):
+def test(ctx, enable_bazel=True):
     with gitlab_section("Run rtloader tests", collapsed=True):
+        if enable_bazel:
+            bazel(ctx, "test", "//rtloader/...")
+            return
         ctx.run(f"make -C {get_rtloader_build_path()}/test run", err_stream=sys.stdout)
 
 


### PR DESCRIPTION
Agent build should default to building rtloader with bazel.

### What this does

- Changes the defaults for `inv agent.build` to --exclude_rtloader and `--enable_bazel`.
- Changes the default in `inv rtloader.build` to use bazel
- Have the .gitlab jobs that call `dda inv rtloader.*` use bazel commands directly

For CI:
- This will be a no-op for CI, where we first explicitly build rtloader with bazel, and then build agent with `--exclude_rtloader`.

For developer builds.
- Developer workflows will use bazel instead of cmake. This brings them in line with what the product does.
- You can no longer build for a particular install_dir. If you need that, you must do
```
bazel run -- //rtloader:install --destdir=/some/dir
```

### Next step
- Find a replacement for the clang-format call - or remove it temporarily and add it back later
- drop the cmake calls from rtloader entirely.