### PR TITLE
[WP] Add config flag for retval tracking

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -166,6 +166,11 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.user_sessions.ssh.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.user_sessions.cache_size", 1024)
 
+	// CWS - Capture all syscall errors
+	// When enabled, the eBPF IS_UNHANDLED_ERROR filter treats every negative syscall
+	// return as handled (constant patched at probe load). Defaults to false.
+	cfg.BindEnvAndSetDefault("runtime_security_config.syscalls.capture_all_errors.enabled", false)
+
 	// CWS -eBPF Less
 	cfg.BindEnvAndSetDefault("runtime_security_config.ebpfless.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.ebpfless.socket", constants.DefaultEBPFLessProbeAddr)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -400,6 +400,10 @@ type RuntimeSecurityConfig struct {
 	// SSHUserSessionsEnabled defines if SSH user session features should be enabled
 	SSHUserSessionsEnabled bool
 
+	// CaptureAllSyscallErrorsEnabled, when true, sets the eBPF load-time constant so
+	// IS_UNHANDLED_ERROR treats every negative syscall return as handled.
+	CaptureAllSyscallErrorsEnabled bool
+
 	// EBPFLessEnabled enables the ebpfless probe
 	EBPFLessEnabled bool
 	// EBPFLessSocket defines the socket used for the communication between system-probe and the ebpfless source
@@ -670,6 +674,9 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		// User Sessions
 		SSHUserSessionsEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.user_sessions.ssh.enabled"),
 		UserSessionsCacheSize:  pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.user_sessions.cache_size"),
+
+		// Capture all syscall errors
+		CaptureAllSyscallErrorsEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.syscalls.capture_all_errors.enabled"),
 
 		// ebpf less
 		EBPFLessEnabled: IsEBPFLessModeEnabled(),

--- a/pkg/security/ebpf/c/include/constants/macros.h
+++ b/pkg/security/ebpf/c/include/constants/macros.h
@@ -3,7 +3,7 @@
 
 #define LOAD_CONSTANT(param, var) asm("%0 = " param " ll" \
                                       : "=r"(var))
-#define IS_UNHANDLED_ERROR(retval) retval < 0 && retval != -EACCES && retval != -EPERM
+#define IS_UNHANDLED_ERROR(retval) !capture_all_errors_enabled() && retval < 0 && retval != -EACCES && retval != -EPERM
 #define IS_ERR(ptr) ((unsigned long)(ptr) > (unsigned long)(-1000))
 #define IS_KTHREADD(pid) (pid == 2)
 #define IS_KERNEL_THREAD(pid) (IS_KTHREADD(pid) || bpf_map_lookup_elem(&kernel_thread_pids, &pid)) // will be reported as kworker userspace side

--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -256,4 +256,9 @@ static struct syscall_cache_t *__attribute__((always_inline)) pop_current_or_imp
     return syscall;
 }
 
+static __attribute__((always_inline)) int capture_all_errors_enabled(void) {
+    u64 captured;
+    LOAD_CONSTANT("capture_all_errors_enabled", captured);
+    return captured != 0;
+}
 #endif

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2791,6 +2791,10 @@ func (p *EBPFProbe) initManagerOptionsConstants() {
 			Value: utils.BoolTouint64(p.probe.Opts.SyscallsMonitorEnabled),
 		},
 		manager.ConstantEditor{
+			Name:  "capture_all_errors_enabled",
+			Value: utils.BoolTouint64(p.config.RuntimeSecurity.CaptureAllSyscallErrorsEnabled),
+		},
+		manager.ConstantEditor{
 			Name:  "imds_ip",
 			Value: uint64(p.config.RuntimeSecurity.IMDSIPv4),
 		},

--- a/pkg/security/tests/capture_all_syscall_errors_test.go
+++ b/pkg/security/tests/capture_all_syscall_errors_test.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && functionaltests
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+// To access the path, we need to use the syscall context instead of the chmod event
+var (
+	chmodEnoentRule = &rules.RuleDefinition{
+		ID:         "test_chmod_capture_enoent",
+		Expression: `chmod.syscall.path == "{{.Root}}/does-not-exist" && chmod.retval == ENOENT`,
+	}
+	openEnoentRule = &rules.RuleDefinition{
+		ID:         "test_open_capture_enoent",
+		Expression: `open.syscall.path == "{{.Root}}/does-not-exist" && open.retval == ENOENT`,
+	}
+)
+
+// TestCaptureAllSyscallErrors verifies that with
+// runtime_security_config.syscalls.capture_all_errors.enabled set to true,
+// chmod() and open() syscalls failing with ENOENT (normally filtered by
+// IS_UNHANDLED_ERROR) still produce events in userspace.
+func TestCaptureAllSyscallErrors(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	ruleDefs := []*rules.RuleDefinition{
+		chmodEnoentRule,
+		openEnoentRule,
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{
+		captureAllSyscallErrorsEnabled: true,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(test.Root(), "does-not-exist")
+
+	t.Run("chmod-enoent", func(t *testing.T) {
+		test.WaitSignalFromRule(t, func() error {
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "chmod-error", path)
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_chmod_capture_enoent")
+			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
+			assert.Equal(t, -int64(syscall.ENOENT), event.Chmod.Retval, "wrong retval")
+			// When the file does not exist, the dentry resolution should return an empty string here
+			assert.Equal(t, "", event.Chmod.File.PathnameStr)
+		}, "test_chmod_capture_enoent")
+	})
+	t.Run("open-enoent", func(t *testing.T) {
+		// On CentOS 7.9, dentry resolution for a missing file returns an empty path instead of
+		// the first existing parent, so the event is flagged as Error and the rule never matches.
+		checkKernelCompatibility(t, "open ENOENT capture on CentOS 7.9", func(kv *kernel.Version) bool {
+			return kv.IsRH7Kernel()
+		})
+
+		test.WaitSignalFromRule(t, func() error {
+			_, err := os.Open(path)
+			if err == nil {
+				t.Errorf("should fail with ENOENT: %v", err)
+				return err
+			}
+			return nil
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_open_capture_enoent")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
+			assert.Equal(t, -int64(syscall.ENOENT), event.Open.Retval, "wrong retval")
+			// When the file does not exist, the dentry resolution should return the first existing parent
+			assert.Equal(t, test.Root(), event.Open.File.PathnameStr)
+		}, "test_open_capture_enoent")
+	})
+
+}
+
+func TestCaptureAllSyscallErrorsDisabledByDefault(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	ruleDefs := []*rules.RuleDefinition{
+		chmodEnoentRule,
+		openEnoentRule,
+	}
+
+	// captureAllSyscallErrorsEnabled is intentionally left at its zero value (false)
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(test.Root(), "does-not-exist")
+
+	t.Run("chmod-enoent-dropped", func(t *testing.T) {
+		_ = test.GetSignal(t, func() error {
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "chmod-error", path)
+		}, func(_ *model.Event, rule *rules.Rule) {
+			t.Errorf("unexpected event for chmod ENOENT (rule %q): the kernel should have dropped it", rule.ID)
+		})
+	})
+
+	t.Run("open-enoent-dropped", func(t *testing.T) {
+		_ = test.GetSignal(t, func() error {
+			_, err := os.Open(path)
+			if err == nil {
+				t.Errorf("should fail with ENOENT: %v", err)
+				return err
+			}
+			return nil
+		}, func(_ *model.Event, rule *rules.Rule) {
+			t.Errorf("unexpected event for open ENOENT (rule %q): the kernel should have dropped it", rule.ID)
+		})
+	})
+}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -850,6 +850,7 @@ func genTestConfigs(t testing.TB, cfgDir string, opts testOpts) (*emconfig.Confi
 		"EnableSelfTests":                            opts.enableSelfTests,
 		"NetworkFlowMonitorEnabled":                  opts.networkFlowMonitorEnabled,
 		"CapabilitiesMonitoringEnabled":              opts.capabilitiesMonitoringEnabled,
+		"CaptureAllSyscallErrorsEnabled":             opts.captureAllSyscallErrorsEnabled,
 	}); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -215,6 +215,9 @@ runtime_security_config:
         period: {{.EnforcementDisarmerExecutablePeriod}}
   file_metadata_resolver:
     enabled: true
+  syscalls:
+    capture_all_errors:
+      enabled: {{ .CaptureAllSyscallErrorsEnabled }}
 `
 
 const (

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -1326,6 +1326,25 @@ int test_chmod(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+// test_chmod_error chmods a path that must not exist; expects ENOENT (used by capture_all_errors test).
+int test_chmod_error(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Please specify a file name\n");
+        return EXIT_FAILURE;
+    }
+
+    if (chmod(argv[1], 0644) < 0) {
+        if (errno != ENOENT) {
+            fprintf(stderr, "chmod(%s) failed with errno %d, expected ENOENT\n", argv[1], errno);
+            return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
+    }
+
+    fprintf(stderr, "chmod(%s) unexpectedly succeeded\n", argv[1]);
+    return EXIT_FAILURE;
+}
+
 int test_chown(int argc, char **argv) {
     if (argc != 4) {
         fprintf(stderr, "Please specify a file name, a user ID, and a group ID\n");
@@ -2154,6 +2173,8 @@ int main(int argc, char **argv) {
             exit_code = test_slow_write(sub_argc, sub_argv);
         } else if (strcmp(cmd, "network_flow_send_udp4") == 0) {
             exit_code = test_network_flow_send_udp4(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "chmod-error") == 0) {
+            exit_code = test_chmod_error(sub_argc, sub_argv);
         } else if (strcmp(cmd, "chmod") == 0) {
             exit_code = test_chmod(sub_argc, sub_argv);
         } else if (strcmp(cmd, "chown") == 0) {

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -74,6 +74,7 @@ type testOpts struct {
 	dnsPort                                    uint16
 	traceSystemdCgroups                        bool
 	capabilitiesMonitoringEnabled              bool
+	captureAllSyscallErrorsEnabled             bool
 }
 
 type dynamicTestOpts struct {


### PR DESCRIPTION
### What does this PR do?
When `runtime_security_config.capture_all_syscall_errors.enabled` is true, the kernel-side `IS_UNHANDLED_ERROR` filter is disabled , so negative return values are treated as handled and events are sent to userspace. When disabled (default), behavior is unchanged: most errors are still filtered out, as it was before.

Syscalls using `IS_UNHANDLED_ERROR` and impacted by the PR: 
- chdir
- chmod
- link
- mkdir
- open
- rename
- rmdir
- setxaddr
- signal
- utimes
- bind
- connect

### Motivation
By default, CWS ignores most syscall failures at the eBPF exit hook to reduce noise and cost. Some use cases need visibility into errors such as `ENOENT`, `EINVAL`, or `ENOTDIR` (failed opens, chmod on missing paths, etc.). This flag makes that behavior configurable without changing the default for existing deployments.

### Describe how you validated your changes
Add 2 tests for chmod and open.