### PR TITLE
[ddqa/config.toml] Exclude olivielpeau from AMP members

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -16,7 +16,7 @@ jira_issue_type = "Task"
 jira_statuses = ["To Do", "In Progress", "Done"]
 github_team = "agent-metric-pipelines"
 github_labels = ["team/agent-metric-pipelines"]
-exclude_members = [""]
+exclude_members = ["olivielpeau"]
 
 [teams."Agent Data Plane"]
 jira_project = "DADP"


### PR DESCRIPTION
### What does this PR do?

Exclude olivielpeau from AMP members in ddqa/config.toml

### Motivation

olivielpeau is part of the agent-metric-pipelines github team but shouldn't be assigned QA tickets of the team

### Describe how you validated your changes

(didn't validate the change)

### Additional Notes
