### PR TITLE
test/new-e2e/tests/autoscaling/spot: Increase timeout and recreate stack on retry

### DIFF
--- a/test/e2e-framework/testing/utils/infra/retriable_errors.go
+++ b/test/e2e-framework/testing/utils/infra/retriable_errors.go
@@ -91,5 +91,12 @@ func getKnownErrors() []knownError {
 			retryType:    ReCreate,
 			maxRetry:     stackUpMaxRetry,
 		},
+		{
+			// Helm release timed out waiting for the deployment to become ready.
+			// Re-upgrading a stuck cluster never recovers; recreate for a clean environment.
+			errorMessage: `Helm Release .+: context deadline exceeded`,
+			retryType:    ReCreate,
+			maxRetry:     stackUpMaxRetry,
+		},
 	}
 }

--- a/test/new-e2e/tests/autoscaling/spot/suite_test.go
+++ b/test/new-e2e/tests/autoscaling/spot/suite_test.go
@@ -179,6 +179,7 @@ func TestSpotSchedulingKindCI(t *testing.T) {
 			kindvmscen.WithAgentOptions(
 				kubernetesagentparams.WithHelmChartVersion(helmChartVersion),
 				kubernetesagentparams.WithHelmValues(makeHelmValues("IfNotPresent")),
+				kubernetesagentparams.WithTimeout(600),
 			),
 		),
 	)))


### PR DESCRIPTION
### What does this PR do?

Increases the timeout of `TestSpotSchedulingKindCI` and add an entry for the error on `retriable_errors` so that the stack gets recreated instead of `ReUp`-ed.

### Motivation

We're seeing flakes such as this: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1684972434

[CI visibility link](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A%22new-e2e-autoscaling%22&agg_m=%40ci.job.name&agg_m_source=base&agg_t=cardinality&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cipipeline_explorer_sort=timestamp%2Cdesc&colorByAttr=meta%5B%27ci.stage.name%27%5D&cols=%40git.branch%2C%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40ci.stage.name%2C%40ci.job.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.commit.message&currentTab=trace&fromUser=true&graphType=flamegraph&index=cipipeline&mode=sliding&refresh_mode=paused&sort=time&spanViewType=metadata&step=86400000&tab=overview&viz=stream&start=1778663727835&end=1778836527835&paused=true)

Note, from this [job run](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1685286872#L216), it says `Stack up took 4m56.381060881s at attempt 1`, which is a successful attempt very close in duration to the default 5 min timeout that this PR overrides.

### Describe how you validated your changes

CI.

### Additional Notes
