### PR TITLE
[AGTMETRICS-504] Make API keys named

### DIFF
--- a/comp/core/agenttelemetry/fx/go.mod
+++ b/comp/core/agenttelemetry/fx/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000 // indirect

--- a/comp/core/agenttelemetry/impl/go.mod
+++ b/comp/core/agenttelemetry/impl/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/comp/core/configsync/go.mod
+++ b/comp/core/configsync/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.76.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/mock v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.72.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.76.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/api v0.76.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.76.0-devel // indirect

--- a/comp/core/delegatedauth/api/cloudauth/aws/go.mod
+++ b/comp/core/delegatedauth/api/cloudauth/aws/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/buildschema v0.0.0-00010101000000-000000000000 // indirect

--- a/comp/core/delegatedauth/go.mod
+++ b/comp/core/delegatedauth/go.mod
@@ -19,6 +19,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.73.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/comp/core/ipc/impl/go.mod
+++ b/comp/core/ipc/impl/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.72.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.73.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/comp/core/ipc/mock/go.mod
+++ b/comp/core/ipc/mock/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.72.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.73.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/comp/core/tagger/impl-remote/go.mod
+++ b/comp/core/tagger/impl-remote/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/ipc/httphelpers v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.72.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/api v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/comp/forwarder/defaultforwarder/default_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder_test.go
@@ -36,11 +36,11 @@ func TestDefaultForwarderUpdateAPIKey(t *testing.T) {
 	// starting API Keys, before the update
 	keysPerDomains := map[string][]utils.APIKeys{
 		"example1.com": {
-			utils.NewAPIKeys("api_key", "api_key1"),
-			utils.NewAPIKeys("additional_endpoints", "api_key2"),
+			utils.NewAPIKeys("api_key", "example1.com", "api_key1"),
+			utils.NewAPIKeys("additional_endpoints", "example1.com", "api_key2"),
 		},
 		"example2.com": {
-			utils.NewAPIKeys("additional_endpoints", "api_key3"),
+			utils.NewAPIKeys("additional_endpoints", "example2.com", "api_key3"),
 		},
 	}
 	forwarderOptions, err := NewOptions(mockConfig, log, keysPerDomains)
@@ -76,11 +76,11 @@ func TestDefaultForwarderUpdateAdditionalEndpointAPIKey(t *testing.T) {
 	// main api_key is a duplicate of the additional_endpoints one
 	keysPerDomains := map[string][]utils.APIKeys{
 		"example1.com": {
-			utils.NewAPIKeys("api_key", "api_key1"),
-			utils.NewAPIKeys("additional_endpoints", "api_key1"),
+			utils.NewAPIKeys("api_key", "example1.com", "api_key1"),
+			utils.NewAPIKeys("additional_endpoints", "example1.com", "api_key1"),
 		},
 		"example2.com": {
-			utils.NewAPIKeys("additional_endpoints", "api_key3"),
+			utils.NewAPIKeys("additional_endpoints", "example2.com", "api_key3"),
 		},
 	}
 	forwarderOptions, err := NewOptions(mockConfig, log, keysPerDomains)

--- a/comp/forwarder/defaultforwarder/forwarder_health_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health_test.go
@@ -39,11 +39,11 @@ func TestCheckValidAPIKey(t *testing.T) {
 
 	keysPerDomains := map[string][]utils.APIKeys{
 		ts1.URL: {
-			utils.NewAPIKeys("path", "api_key1"),
-			utils.NewAPIKeys("path", "api_key2"),
+			utils.NewAPIKeys("path", ts1.URL, "api_key1"),
+			utils.NewAPIKeys("path", ts1.URL, "api_key2"),
 		},
 		ts2.URL: {
-			utils.NewAPIKeys("path", "key3"),
+			utils.NewAPIKeys("path", ts2.URL, "key3"),
 		},
 	}
 	log := logmock.New(t)
@@ -62,20 +62,20 @@ func TestCheckValidAPIKey(t *testing.T) {
 
 func TestComputeDomainsURL(t *testing.T) {
 	keysPerDomains := map[string][]utils.APIKeys{
-		"https://app.datadoghq.com":              {utils.NewAPIKeys("path", "api_key1")},
-		"https://custom.datadoghq.com":           {utils.NewAPIKeys("path", "api_key2")},
-		"https://custom.agent.datadoghq.com":     {utils.NewAPIKeys("path", "api_key3")},
-		"https://app.datadoghq.eu":               {utils.NewAPIKeys("path", "api_key4")},
-		"https://app.us2.datadoghq.com":          {utils.NewAPIKeys("path", "api_key5")},
-		"https://app.xx9.datadoghq.com":          {utils.NewAPIKeys("path", "api_key5")},
-		"https://app.xxxx99.datadoghq.com":       {utils.NewAPIKeys("path", "api_key5")},
-		"https://custom.agent.us2.datadoghq.com": {utils.NewAPIKeys("path", "api_key6")},
+		"https://app.datadoghq.com":              {utils.NewAPIKeys("path", "https://app.datadoghq.com", "api_key1")},
+		"https://custom.datadoghq.com":           {utils.NewAPIKeys("path", "https://custom.datadoghq.com", "api_key2")},
+		"https://custom.agent.datadoghq.com":     {utils.NewAPIKeys("path", "https://custom.agent.datadoghq.com", "api_key3")},
+		"https://app.datadoghq.eu":               {utils.NewAPIKeys("path", "https://app.datadoghq.eu", "api_key4")},
+		"https://app.us2.datadoghq.com":          {utils.NewAPIKeys("path", "https://app.us2.datadoghq.com", "api_key5")},
+		"https://app.xx9.datadoghq.com":          {utils.NewAPIKeys("path", "https://app.xx9.datadoghq.com", "api_key5")},
+		"https://app.xxxx99.datadoghq.com":       {utils.NewAPIKeys("path", "https://app.xxxx99.datadoghq.com", "api_key5")},
+		"https://custom.agent.us2.datadoghq.com": {utils.NewAPIKeys("path", "https://custom.agent.us2.datadoghq.com", "api_key6")},
 		// debatable whether the next one should be changed to `api.`, preserve pre-existing behavior for now
-		"https://app.datadoghq.internal":  {utils.NewAPIKeys("path", "api_key7")},
-		"https://app.myproxy.com":         {utils.NewAPIKeys("path", "api_key8")},
-		"https://app.ddog-gov.com":        {utils.NewAPIKeys("path", "api_key9")},
-		"https://custom.ddog-gov.com":     {utils.NewAPIKeys("path", "api_key10")},
-		"https://app.xxxx99.ddog-gov.com": {utils.NewAPIKeys("path", "api_key11")},
+		"https://app.datadoghq.internal":  {utils.NewAPIKeys("path", "https://app.datadoghq.internal", "api_key7")},
+		"https://app.myproxy.com":         {utils.NewAPIKeys("path", "https://app.myproxy.com", "api_key8")},
+		"https://app.ddog-gov.com":        {utils.NewAPIKeys("path", "https://app.ddog-gov.com", "api_key9")},
+		"https://custom.ddog-gov.com":     {utils.NewAPIKeys("path", "https://custom.ddog-gov.com", "api_key10")},
+		"https://app.xxxx99.ddog-gov.com": {utils.NewAPIKeys("path", "https://app.xxxx99.ddog-gov.com", "api_key11")},
 	}
 
 	expectedMap := map[string][]string{
@@ -181,8 +181,8 @@ func TestUpdateAPIKey(t *testing.T) {
 
 	// starting API Keys, before the update
 	keysPerDomains := map[string][]utils.APIKeys{
-		ts1.URL: {utils.NewAPIKeys("path1", "api_key1"), utils.NewAPIKeys("path2", "api_key2")},
-		ts2.URL: {utils.NewAPIKeys("path", "api_key3")},
+		ts1.URL: {utils.NewAPIKeys("path1", ts1.URL, "api_key1"), utils.NewAPIKeys("path2", ts1.URL, "api_key2")},
+		ts2.URL: {utils.NewAPIKeys("path", ts2.URL, "api_key3")},
 	}
 
 	log := logmock.New(t)
@@ -201,7 +201,7 @@ func TestUpdateAPIKey(t *testing.T) {
 	assert.Equal(t, expect, string(data))
 
 	// update the resolver first since the health checker will load the new keys from the resolver
-	r[ts1.URL].UpdateAPIKeys("path1", []utils.APIKeys{utils.NewAPIKeys("path1", "api_key4")})
+	r[ts1.URL].UpdateAPIKeys("path1", []utils.APIKeys{utils.NewAPIKeys("path1", ts1.URL, "api_key4")})
 	// update the API Key
 	fh.UpdateAPIKeys(ts1.URL, []string{"api_key1"}, []string{"api_key4"})
 
@@ -252,10 +252,10 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 
 	// starting API Keys, before the update
 	keysPerDomains := map[string][]utils.APIKeys{
-		ts1.URL: {utils.NewAPIKeys("api_key", "api_key1")},
+		ts1.URL: {utils.NewAPIKeys("api_key", ts1.URL, "api_key1")},
 		ts2.URL: {
-			utils.NewAPIKeys("process.additional_endpoints", "api_key1", "api_key2"),
-			utils.NewAPIKeys("additional_endpoints", keysBefore...),
+			utils.NewAPIKeys("process.additional_endpoints", ts2.URL, "api_key1", "api_key2"),
+			utils.NewAPIKeys("additional_endpoints", ts2.URL, keysBefore...),
 		},
 	}
 
@@ -399,9 +399,9 @@ func TestOneEndpointNoAPIKeys(t *testing.T) {
 	// additional endpoints has no API keys, but endpoint should still
 	// be valid because the main endpoint does.
 	keysPerDomains := map[string][]utils.APIKeys{
-		ts1.URL: {utils.NewAPIKeys("api_key", "api_key1")},
+		ts1.URL: {utils.NewAPIKeys("api_key", ts1.URL, "api_key1")},
 		ts2.URL: {
-			utils.NewAPIKeys("additional_endpoints"),
+			utils.NewAPIKeys("additional_endpoints", ts2.URL),
 		},
 	}
 
@@ -434,9 +434,9 @@ func TestOneEndpointInvalid(t *testing.T) {
 	// additional endpoints has no API keys, but endpoint should still
 	// be valid because the main endpoint does.
 	keysPerDomains := map[string][]utils.APIKeys{
-		ts1.URL: {utils.NewAPIKeys("api_key", "api_key1")},
+		ts1.URL: {utils.NewAPIKeys("api_key", ts1.URL, "api_key1")},
 		ts2.URL: {
-			utils.NewAPIKeys("additional_endpoints", "api_key2"),
+			utils.NewAPIKeys("additional_endpoints", ts2.URL, "api_key2"),
 		},
 	}
 
@@ -491,7 +491,7 @@ func TestUpdateAPIKeyAfterSetBaseDomain(t *testing.T) {
 	originalDomain := "https://app.datadoghq.com."
 
 	keysPerDomains := map[string][]utils.APIKeys{
-		originalDomain: {utils.NewAPIKeys("api_key", "old_key")},
+		originalDomain: {utils.NewAPIKeys("api_key", originalDomain, "old_key")},
 	}
 	resolvers, err := resolver.NewSingleDomainResolvers(keysPerDomains)
 	require.NoError(t, err)

--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -44,20 +44,20 @@ var (
 	testDomain           = "http://app.datadoghq.com"
 	testVersionDomain, _ = configUtils.AddAgentVersionToDomain(testDomain, "app")
 	monoKeysDomains      = map[string][]configUtils.APIKeys{
-		testVersionDomain: {configUtils.NewAPIKeys("path", "monokey")},
+		testVersionDomain: {configUtils.NewAPIKeys("path", testVersionDomain, "monokey")},
 	}
 	keysPerDomains = map[string][]configUtils.APIKeys{
 		testDomain: {
-			configUtils.NewAPIKeys("path", "api-key-1", "api-key-2"),
+			configUtils.NewAPIKeys("path", testDomain, "api-key-1", "api-key-2"),
 		},
 		"datadog.bar": nil,
 	}
 	keysWithMultipleDomains = map[string][]configUtils.APIKeys{
 		testDomain: {
-			configUtils.NewAPIKeys("path", "api-key-1"),
-			configUtils.NewAPIKeys("path", "api-key-2"),
+			configUtils.NewAPIKeys("path", testDomain, "api-key-1"),
+			configUtils.NewAPIKeys("path", testDomain, "api-key-2"),
 		},
-		"datadog.bar": {configUtils.NewAPIKeys("path", "api-key-3")},
+		"datadog.bar": {configUtils.NewAPIKeys("path", "datadog.bar", "api-key-3")},
 	}
 	validKeys = []string{"api-key-1", "api-key-2"}
 )
@@ -294,7 +294,7 @@ func TestCreateHTTPTransactionsWithMultipleDomains(t *testing.T) {
 func TestCreateHTTPTransactionsWithDifferentResolvers(t *testing.T) {
 	resolvers, err := resolver.NewSingleDomainResolvers(keysWithMultipleDomains)
 	require.NoError(t, err)
-	additionalResolver, err := resolver.NewMultiDomainResolver("datadog.vector", []configUtils.APIKeys{configUtils.NewAPIKeys("path", "api-key-4")})
+	additionalResolver, err := resolver.NewMultiDomainResolver("datadog.vector", []configUtils.APIKeys{configUtils.NewAPIKeys("path", "datadog.vector", "api-key-4")})
 	require.NoError(t, err)
 	additionalResolver.RegisterAlternateDestination("diversion.domain", "diverted_name", resolver.Vector)
 	resolvers["datadog.vector"] = additionalResolver
@@ -344,7 +344,7 @@ func TestCreateHTTPTransactionsWithDifferentResolvers(t *testing.T) {
 
 func TestCreateHTTPTransactionsWithOverrides(t *testing.T) {
 	resolvers := make(map[string]resolver.DomainResolver)
-	r, err := resolver.NewMultiDomainResolver(testDomain, []configUtils.APIKeys{configUtils.NewAPIKeys("path", "api-key-1")})
+	r, err := resolver.NewMultiDomainResolver(testDomain, []configUtils.APIKeys{configUtils.NewAPIKeys("path", testDomain, "api-key-1")})
 	require.NoError(t, err)
 	r.RegisterAlternateDestination("observability_pipelines_worker.tld", "diverted", resolver.Vector)
 	resolvers[testDomain] = r
@@ -474,7 +474,7 @@ func TestForwarderEndtoEnd(t *testing.T) {
 	mockConfig.SetWithoutSource("dd_url", ts.URL)
 
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", "api_key1", "api_key2")}, "invalid": {}, "invalid2": nil})
+	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", ts.URL, "api_key1", "api_key2")}, "invalid": {}, "invalid2": nil})
 	require.NoError(t, err)
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
@@ -551,7 +551,7 @@ func TestTransactionEventHandlers(t *testing.T) {
 	mockConfig.SetWithoutSource("dd_url", ts.URL)
 
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", ts.URL, "api_key1")}})
 	require.NoError(t, err)
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
@@ -606,7 +606,7 @@ func syncTestTransactionEventHandlersOnRetry(t *testing.T) {
 
 	mockConfig := mock.New(t)
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "http://test.invalid", "api_key1")}})
 	require.NoError(t, err)
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
@@ -664,7 +664,7 @@ func TestTransactionEventHandlersNotRetryable(t *testing.T) {
 	mockConfig.SetWithoutSource("dd_url", ts.URL)
 
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{ts.URL: {configUtils.NewAPIKeys("path", ts.URL, "api_key1")}})
 	require.NoError(t, err)
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
@@ -714,7 +714,7 @@ func syncTestProcessLikePayloadResponseTimeout(t *testing.T) {
 	mockConfig.SetWithoutSource("forwarder_num_workers", 0) // Set the number of workers to 0 so the txn goes nowhere
 
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "http://test.invalid", "api_key1")}})
 	require.NoError(t, err)
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
@@ -775,7 +775,7 @@ func syncTestHighPriorityTransactionTendency(t *testing.T) {
 	mockConfig.SetWithoutSource("forwarder_max_concurrent_requests", 10)
 
 	log := logmock.New(t)
-	r, _ := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, _ := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "http://test.invalid", "api_key1")}})
 	secrets := secretsmock.New(t)
 	options := NewOptionsWithResolvers(mockConfig, log, r)
 	options.DisableAPIKeyChecking = true // Disable API key checking so no health check goroutine is started
@@ -849,7 +849,7 @@ func syncTestHighPriorityTransaction(t *testing.T) {
 	mockConfig.SetWithoutSource("forwarder_max_concurrent_requests", 1)
 
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "api_key1")}})
+	r, err := resolver.NewSingleDomainResolvers(map[string][]configUtils.APIKeys{"http://test.invalid": {configUtils.NewAPIKeys("path", "http://test.invalid", "api_key1")}})
 	require.NoError(t, err)
 
 	secrets := secretsmock.New(t)

--- a/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer.go
@@ -439,8 +439,8 @@ func createReplacers(apiKeys []utils.APIKeys, currentAPIKeyPlaceholder []*string
 	for path := range apiKeys {
 		for _, key := range apiKeys[path].Keys {
 			placeholder := fmt.Sprintf(placeHolderFormat, index)
-			apiKeyPlaceholder = append(apiKeyPlaceholder, key, placeholder)
-			placeholderToAPIKey = append(placeholderToAPIKey, placeholder, key)
+			apiKeyPlaceholder = append(apiKeyPlaceholder, key.Key, placeholder)
+			placeholderToAPIKey = append(placeholderToAPIKey, placeholder, key.Key)
 			index++
 		}
 	}

--- a/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer_test.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/http_transactions_serializer_test.go
@@ -39,12 +39,12 @@ const domain = "domain"
 const vectorDomain = "vectorDomain"
 
 func TestHTTPSerializeDeserialize(t *testing.T) {
-	r, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2)})
+	r, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2)})
 	require.NoError(t, err)
 	runTestHTTPSerializeDeserializeWithResolver(t, domain, r)
 }
 func TestHTTPSerializeDeserializeWithResolverOverride(t *testing.T) {
-	r, err := resolver.NewMultiDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2)})
+	r, err := resolver.NewMultiDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2)})
 	require.NoError(t, err)
 	r.RegisterAlternateDestination(vectorDomain, "name", resolver.Vector)
 	runTestHTTPSerializeDeserializeWithResolver(t, vectorDomain, r)
@@ -107,7 +107,7 @@ func TestPartialDeserialize(t *testing.T) {
 func TestHTTPTransactionSerializerMissingAPIKey(t *testing.T) {
 	r := require.New(t)
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2)})
 	require.NoError(t, err)
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
@@ -125,7 +125,7 @@ func TestHTTPTransactionSerializerMissingAPIKey(t *testing.T) {
 
 	// Deserializing with a resolver that only has apiKey1: the transaction is dropped
 	// because APIKeyIndex 1 is out of range for a single-key resolver.
-	res2, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1)})
+	res2, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1)})
 	require.NoError(t, err)
 	serializerSmaller := NewHTTPTransactionsSerializer(log, res2)
 	txns2, errorCount, err := serializerSmaller.Deserialize(bytes)
@@ -140,7 +140,7 @@ func TestHTTPTransactionSerializerMissingAPIKey(t *testing.T) {
 func TestHTTPTransactionSerializerUpdateAPIKey(t *testing.T) {
 	r := require.New(t)
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", apiKey1, apiKey2)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", domain, apiKey1, apiKey2)})
 	r.NoError(err)
 
 	serializer := NewHTTPTransactionsSerializer(log, res)
@@ -153,7 +153,7 @@ func TestHTTPTransactionSerializerUpdateAPIKey(t *testing.T) {
 	r.NotContains(string(bytes), apiKey1, "Serialized data should not contain %s", apiKey1)
 
 	// Update the API keys so index 1 now resolves to apiKey2 (unchanged).
-	res.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", apiKey4, apiKey2, apiKey3)})
+	res.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", domain, apiKey4, apiKey2, apiKey3)})
 
 	tr2 := createHTTPTransactionTests(domain)
 	tr2.APIKeyIndex = 2 // apiKey3
@@ -175,8 +175,8 @@ func TestHTTPTransactionSerializerUpdateDedupedAPIKey(t *testing.T) {
 
 	// apiKey1 is duplicated across two config paths.
 	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{
-		utils.NewAPIKeys("api_key", apiKey1),
-		utils.NewAPIKeys("additional_endpoints", apiKey1, apiKey2),
+		utils.NewAPIKeys("api_key", domain, apiKey1),
+		utils.NewAPIKeys("additional_endpoints", domain, apiKey1, apiKey2),
 	})
 	r.NoError(err)
 
@@ -190,8 +190,8 @@ func TestHTTPTransactionSerializerUpdateDedupedAPIKey(t *testing.T) {
 	r.NotContains(string(bytes), apiKey1, "Serialized data should not contain %s", apiKey1)
 
 	// Rotate keys so there are no longer any duplicates.
-	res.UpdateAPIKeys("api_key", []utils.APIKeys{utils.NewAPIKeys("api_key", apiKey3)})
-	res.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", apiKey4, apiKey5)})
+	res.UpdateAPIKeys("api_key", []utils.APIKeys{utils.NewAPIKeys("api_key", domain, apiKey3)})
+	res.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", domain, apiKey4, apiKey5)})
 
 	// The stored index (0) is preserved; the actual key resolved at send time may differ.
 	transactions, _, err := serializer.Deserialize(bytes)
@@ -205,7 +205,7 @@ func TestHTTPTransactionSerializerUpdateDedupedAPIKey(t *testing.T) {
 func TestHTTPTransactionSerializerUpdateAPIKeyBeforeSerializing(t *testing.T) {
 	r := require.New(t)
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", apiKey1, apiKey2)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", domain, apiKey1, apiKey2)})
 	r.NoError(err)
 
 	serializer := NewHTTPTransactionsSerializer(log, res)
@@ -214,7 +214,7 @@ func TestHTTPTransactionSerializerUpdateAPIKeyBeforeSerializing(t *testing.T) {
 	txn.APIKeyIndex = 0 // originally points to apiKey1
 
 	// Rotate keys before calling Add (apiKey4 replaces apiKey1 at index 0).
-	res.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", apiKey4, apiKey2)})
+	res.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", domain, apiKey4, apiKey2)})
 
 	r.NoError(serializer.Add(txn))
 	bytes, err := serializer.GetBytesAndReset()
@@ -276,7 +276,7 @@ func assertTransactionEqual(a *assert.Assertions, tr1 *transaction.HTTPTransacti
 // so Authorize() can be called without panicking.
 func TestDeserializedTransactionHasResolver(t *testing.T) {
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2)})
 	require.NoError(t, err)
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
@@ -298,7 +298,7 @@ func TestDeserializedTransactionHasResolver(t *testing.T) {
 // serialization is correctly restored so the transaction uses the same API key after restart.
 func TestDeserializedTransactionAPIKeyIndexPreserved(t *testing.T) {
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2, apiKey3)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2, apiKey3)})
 	require.NoError(t, err)
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
@@ -325,7 +325,7 @@ func TestDeserializedTransactionAPIKeyIndexPreserved(t *testing.T) {
 // transaction correctly sets the DD-Api-Key header based on the stored APIKeyIndex.
 func TestDeserializedTransactionAuthorize(t *testing.T) {
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2)})
 	require.NoError(t, err)
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
@@ -353,7 +353,7 @@ func TestDeserializedTransactionAuthorize(t *testing.T) {
 // with different APIKeyIndex values each gets the correct key after deserialization.
 func TestDeserializedTransactionAuthorizeMultipleKeys(t *testing.T) {
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2, apiKey3)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2, apiKey3)})
 	require.NoError(t, err)
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
@@ -393,7 +393,7 @@ func TestDeserializedTransactionAuthorizeMultipleKeys(t *testing.T) {
 func TestDeserializeV2BackwardCompat(t *testing.T) {
 	r := require.New(t)
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", apiKey1, apiKey2)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", domain, apiKey1, apiKey2)})
 	r.NoError(err)
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
@@ -450,7 +450,7 @@ func TestDeserializeV2MissingAPIKey(t *testing.T) {
 	}
 
 	// Two-key resolver: the blob is valid (index 1 → apiKey2).
-	res2, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2)})
+	res2, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2)})
 	r.NoError(err)
 	serializerFull := NewHTTPTransactionsSerializer(log, res2)
 	txns, errorCount, err := serializerFull.Deserialize(v2Bytes)
@@ -459,7 +459,7 @@ func TestDeserializeV2MissingAPIKey(t *testing.T) {
 	r.Len(txns, 1)
 
 	// One-key resolver: index 1 is out of range — transaction must be dropped.
-	res1, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1)})
+	res1, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1)})
 	r.NoError(err)
 	serializerSmaller := NewHTTPTransactionsSerializer(log, res1)
 	txns, errorCount, err = serializerSmaller.Deserialize(v2Bytes)
@@ -494,7 +494,7 @@ func TestExtractPlaceholderIndex(t *testing.T) {
 // APIKeyIndex derived from the embedded placeholder rather than a restored key value.
 func TestV2IndexExtraction(t *testing.T) {
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2, apiKey3)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2, apiKey3)})
 	require.NoError(t, err)
 	serializer := NewHTTPTransactionsSerializer(log, res)
 
@@ -525,7 +525,7 @@ func TestV1IndexExtraction(t *testing.T) {
 	// Config order (deduped): [apiKey3, apiKey1, apiKey2]
 	// Sorted order:           [apiKey1, apiKey2, apiKey3]
 	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{
-		utils.NewAPIKeys("path", apiKey3, apiKey1, apiKey2),
+		utils.NewAPIKeys("path", domain, apiKey3, apiKey1, apiKey2),
 	})
 	require.NoError(t, err)
 
@@ -580,7 +580,7 @@ func TestV1IndexExtraction(t *testing.T) {
 // header value does, the index is still extracted correctly (V2 format).
 func TestV2IndexFromHeaderPlaceholder(t *testing.T) {
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", apiKey1, apiKey2)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("path", domain, apiKey1, apiKey2)})
 	require.NoError(t, err)
 
 	serializer := NewHTTPTransactionsSerializer(log, res)
@@ -621,7 +621,7 @@ func TestV2IndexFromHeaderPlaceholder(t *testing.T) {
 func TestDeserializeV2(t *testing.T) {
 	r := require.New(t)
 	log := logmock.New(t)
-	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", apiKey1, apiKey2)})
+	res, err := resolver.NewSingleDomainResolver(domain, []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", domain, apiKey1, apiKey2)})
 	r.NoError(err)
 	serializer := NewHTTPTransactionsSerializer(log, res)
 

--- a/comp/forwarder/defaultforwarder/internal/retry/on_disk_retry_queue_test.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/on_disk_retry_queue_test.go
@@ -51,7 +51,7 @@ func TestOnDiskRetryQueueMaxSize(t *testing.T) {
 	a := assert.New(t)
 	path := t.TempDir()
 
-	maxSizeInBytes := int64(100)
+	maxSizeInBytes := int64(200)
 	pointDropped := fileStoragePointDroppedCountTelemetry.expvar.Value()
 	q := newTestOnDiskRetryQueue(t, a, path, maxSizeInBytes)
 
@@ -135,7 +135,7 @@ func newTestOnDiskRetryQueue(t *testing.T, a *assert.Assertions, path string, ma
 		}}
 	diskUsageLimit := NewDiskUsageLimit("", disk, maxSizeInBytes, 1)
 	log := logmock.New(t)
-	r, _ := resolver.NewSingleDomainResolver(domainName, []utils.APIKeys{utils.NewAPIKeys("path", "api-key-1")})
+	r, _ := resolver.NewSingleDomainResolver(domainName, []utils.APIKeys{utils.NewAPIKeys("path", domainName, "api-key-1")})
 	storage, err := newOnDiskRetryQueue(log, NewHTTPTransactionsSerializer(log, r), path, diskUsageLimit, telemetry, NewPointCountTelemetryMock())
 	a.NoError(err)
 	return storage

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue_test.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue_test.go
@@ -182,7 +182,7 @@ func newOnDiskRetryQueueTest(t *testing.T, a *assert.Assertions) *onDiskRetryQue
 		}}
 	diskUsageLimit := NewDiskUsageLimit("", disk, 1000, 1)
 	log := logmock.New(t)
-	r, err := resolver.NewSingleDomainResolver("", []utils.APIKeys{utils.NewAPIKeys("path", "api-key-1")})
+	r, err := resolver.NewSingleDomainResolver("", []utils.APIKeys{utils.NewAPIKeys("path", "", "api-key-1")})
 	require.NoError(t, err)
 	q, err := newOnDiskRetryQueue(
 		log,

--- a/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
+++ b/comp/forwarder/defaultforwarder/resolver/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     deps = [
         "//comp/core/log/mock",
         "//pkg/config/mock",
+        "//pkg/config/model",
         "//pkg/config/utils",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -53,7 +53,7 @@ type domainResolver struct {
 	domain          string
 	apiKeys         []utils.APIKeys
 	keyVersion      int
-	dedupedAPIKeys  []string
+	dedupedKeys     []utils.APIKey
 	mu              sync.Mutex
 	healthChecker   ForwarderHealth
 	destinationType DestinationType
@@ -122,8 +122,15 @@ func OnUpdateConfig(resolver DomainResolver, log log.Component, config config.Co
 // will not know exactly which api key has been updated so we reload the whole list from the config and insert this
 // into our list before deduping.
 func updateAdditionalEndpoints(resolver DomainResolver, setting string, config config.Component, log log.Component) {
-	additionalEndpoints := utils.MakeEndpoints(config.GetStringMapStringSlice(setting), setting)
+	additionalEndpoints := utils.MakeNamedEndpoints(
+		config.GetStringMapStringSlice(setting),
+		utils.RawStringMapStringSlice(config, setting),
+		setting,
+	)
 	endpoints, ok := additionalEndpoints[resolver.GetBaseDomain()]
+	if !ok {
+		endpoints, ok = additionalEndpoints[resolver.GetConfigName()]
+	}
 	if !ok {
 		log.Errorf("error: the domain in additional_endpoints changed at runtime for '%s', discarding update.", resolver.GetBaseDomain())
 		return
@@ -165,16 +172,14 @@ func NewSingleDomainResolver2(descriptor utils.EndpointDescriptor) (DomainResolv
 		}
 	}
 
-	deduped := utils.DedupAPIKeys(descriptor.APIKeySet)
-
 	return &domainResolver{
-		configName:     descriptor.BaseURL,
-		domain:         descriptor.BaseURL,
-		apiKeys:        descriptor.APIKeySet,
-		keyVersion:     0,
-		dedupedAPIKeys: deduped,
-		mu:             sync.Mutex{},
-		isMRF:          descriptor.IsMRF,
+		configName:  descriptor.BaseURL,
+		domain:      descriptor.BaseURL,
+		apiKeys:     descriptor.APIKeySet,
+		keyVersion:  0,
+		dedupedKeys: utils.DedupAPIKeys(descriptor.APIKeySet),
+		mu:          sync.Mutex{},
+		isMRF:       descriptor.IsMRF,
 	}, nil
 }
 
@@ -201,11 +206,61 @@ func (r *domainResolver) GetBaseDomain() string {
 	return r.domain
 }
 
-// GetAPIKeys returns the slice of API keys associated with this SingleDomainResolver
+// GetAPIKeys returns the deduplicated API key values associated with this resolver.
 func (r *domainResolver) GetAPIKeys() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.dedupedAPIKeys
+	keys := make([]string, len(r.dedupedKeys))
+	for i, k := range r.dedupedKeys {
+		keys[i] = k.Key
+	}
+	return keys
+}
+
+// GetAPIKeyNames returns the stable API key names associated with this resolver.
+func (r *domainResolver) GetAPIKeyNames() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	names := make([]string, len(r.dedupedKeys))
+	for i, k := range r.dedupedKeys {
+		names[i] = k.Name
+	}
+	return names
+}
+
+// GetAPIKeyName returns the stable name for the given legacy API key index.
+func (r *domainResolver) GetAPIKeyName(apiKeyIdx uint) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.IsLocal() {
+		if apiKeyIdx == 0 {
+			return localAPIKeyName, true
+		}
+		return "", false
+	}
+	if apiKeyIdx >= uint(len(r.dedupedKeys)) {
+		return "", false
+	}
+	name := r.dedupedKeys[apiKeyIdx].Name
+	return name, name != ""
+}
+
+// GetAPIKeyIndex returns the current legacy API key index for a stable key name.
+func (r *domainResolver) GetAPIKeyIndex(apiKeyName string) (uint, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.IsLocal() {
+		if apiKeyName == localAPIKeyName {
+			return 0, true
+		}
+		return 0, false
+	}
+	for idx, k := range r.dedupedKeys {
+		if k.Name == apiKeyName {
+			return uint(idx), true
+		}
+	}
+	return 0, false
 }
 
 // GetAPIKeyVersion get the version of the keys.
@@ -246,12 +301,19 @@ func (r *domainResolver) GetAPIKeysInfo() ([]utils.APIKeys, int) {
 	return r.apiKeys, r.keyVersion
 }
 
-// SetBaseDomain sets the only destination available for a SingleDomainResolver
+// SetBaseDomain sets the only destination available for a SingleDomainResolver.
+// API key names are not regenerated: identity is decoupled from the routing
+// domain so that endpoint changes do not invalidate retry-queue identifiers.
 func (r *domainResolver) SetBaseDomain(domain string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.domain = domain
 }
 
-// UpdateAPIKeys updates the api keys at the given config path and sets the deduped keys to the new list.
+// UpdateAPIKeys updates the api keys at the given config path and sets the
+// deduped keys to the new list. New keys without a name are named against the
+// resolver's original config URL so identifiers stay stable even after
+// SetBaseDomain has rerouted the resolver to a different host.
 func (r *domainResolver) UpdateAPIKeys(configPath string, newKeys []utils.APIKeys) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -263,31 +325,31 @@ func (r *domainResolver) UpdateAPIKeys(configPath string, newKeys []utils.APIKey
 	}
 
 	r.apiKeys = append(newAPIKeys, newKeys...)
-	r.dedupedAPIKeys = utils.DedupAPIKeys(r.apiKeys)
+	r.dedupedKeys = utils.DedupAPIKeys(r.apiKeys)
 	r.keyVersion++
 }
 
-// UpdateAPIKey replaces instances of the oldKey with the newKey
+// UpdateAPIKey replaces instances of the oldKey with the newKey. Names are
+// preserved across rotation: only the key material changes.
 func (r *domainResolver) UpdateAPIKey(configPath, oldKey, newKey string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	for idx := range r.apiKeys {
 		if r.apiKeys[idx].ConfigSettingPath == configPath {
-			replace := make([]string, 0, len(r.apiKeys[idx].Keys))
+			replace := make([]utils.APIKey, 0, len(r.apiKeys[idx].Keys))
 			for _, key := range r.apiKeys[idx].Keys {
-				if key == oldKey {
-					replace = append(replace, newKey)
-				} else {
-					replace = append(replace, key)
+				if key.Key == oldKey {
+					key.Key = newKey
 				}
+				replace = append(replace, key)
 			}
 
 			r.apiKeys[idx].Keys = replace
 		}
 	}
 
-	r.dedupedAPIKeys = utils.DedupAPIKeys(r.apiKeys)
+	r.dedupedKeys = utils.DedupAPIKeys(r.apiKeys)
 	r.keyVersion++
 }
 
@@ -323,14 +385,12 @@ func NewMultiDomainResolver(domain string, apiKeys []utils.APIKeys) (DomainResol
 		}
 	}
 
-	deduped := utils.DedupAPIKeys(apiKeys)
-
 	return &domainResolver{
 		configName:          domain,
 		domain:              domain,
 		apiKeys:             apiKeys,
 		keyVersion:          0,
-		dedupedAPIKeys:      deduped,
+		dedupedKeys:         utils.DedupAPIKeys(apiKeys),
 		overrides:           make(map[string]destination),
 		alternateDomainList: []string{},
 		mu:                  sync.Mutex{},
@@ -392,7 +452,7 @@ func NewLocalDomainResolver(domain string, authToken string) DomainResolver {
 
 // IsUsable returns true if the resolver has valid configuration.
 func (r *domainResolver) IsUsable() bool {
-	return r.IsLocal() || len(r.dedupedAPIKeys) > 0
+	return r.IsLocal() || len(r.dedupedKeys) > 0
 }
 
 // IsLocal returns true if the domain corresponds to another agent.
@@ -408,6 +468,8 @@ func (r *domainResolver) IsMRF() bool {
 type authHeader struct {
 	key, value string
 }
+
+const localAPIKeyName = "local"
 
 // Authorize sets the auth header on the provided headers map.
 func (ah authHeader) Authorize(headers http.Header) {
@@ -440,6 +502,16 @@ func (r *domainResolver) Authorize(apiKeyIdx uint, headers http.Header, log log.
 	} else {
 		authorizers[apiKeyIdx].Authorize(headers)
 	}
+}
+
+// AuthorizeByName sets the auth header for the provided stable API key name.
+func (r *domainResolver) AuthorizeByName(apiKeyName string, headers http.Header, log log.Component) {
+	apiKeyIdx, ok := r.GetAPIKeyIndex(apiKeyName)
+	if !ok {
+		log.Errorf("API key name %q is not available for domain %q", apiKeyName, r.GetBaseDomain())
+		return
+	}
+	r.Authorize(apiKeyIdx, headers, log)
 }
 
 // GetConfigName returns the base url as it was originally written in the config.

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
@@ -30,8 +30,8 @@ func assertKeys(t *testing.T, expect []string, resolver DomainResolver) {
 func TestSingleDomainResolverDedupedKey(t *testing.T) {
 	// Note key2 exists twice in the list.
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("additional_endpoints", "example.com", "key1", "key2"),
-		utils.NewAPIKeys("multi_region_failover.api_key", "example.com", "key2"),
+		utils.NewAPIKeys("additional_endpoints", "app.datadoghq.com", "key1", "key2"),
+		utils.NewAPIKeys("multi_region_failover.api_key", "app.datadoghq.eu", "key2"),
 	}
 
 	resolver, err := NewSingleDomainResolver("example.com", apiKeys)
@@ -42,14 +42,14 @@ func TestSingleDomainResolverDedupedKey(t *testing.T) {
 
 func TestSingleDomainUpdateAPIKeys(t *testing.T) {
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("api_key", "example.com", "key1"),
-		utils.NewAPIKeys("additional_endpoints", "example.com", "key1", "key2", "key3"),
+		utils.NewAPIKeys("api_key", "app.datadoghq.com", "key1"),
+		utils.NewAPIKeys("additional_endpoints", "app.datadoghq.com", "key1", "key2", "key3"),
 	}
 
 	resolver, err := NewSingleDomainResolver("example.com", apiKeys)
 	require.NoError(t, err)
 
-	resolver.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", "example.com", "key4", "key2", "key3")})
+	resolver.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", "app.datadoghq.com", "key4", "key2", "key3")})
 
 	assertKeys(t, []string{"key1", "key4", "key2", "key3"}, resolver)
 }
@@ -151,8 +151,8 @@ func TestAuthorizeUnknownIndex(t *testing.T) {
 
 func TestSingleDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("api_key", "example.com", "key1"),
-		utils.NewAPIKeys("additional_endpoints", "example.com", "key1", "key2", "key3"),
+		utils.NewAPIKeys("api_key", "app.datadoghq.com", "key1"),
+		utils.NewAPIKeys("additional_endpoints", "app.datadoghq.com", "key1", "key2", "key3"),
 	}
 	resolver, err := NewSingleDomainResolver("example.com", apiKeys)
 	require.NoError(t, err)
@@ -183,8 +183,8 @@ func TestSingleDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 
 func TestMultiDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("api_key", "example.com", "key1"),
-		utils.NewAPIKeys("additional_endpoints", "example.com", "key1", "key2", "key3"),
+		utils.NewAPIKeys("api_key", "app.datadoghq.com", "key1"),
+		utils.NewAPIKeys("additional_endpoints", "app.datadoghq.com", "key1", "key2", "key3"),
 	}
 	resolver, err := NewMultiDomainResolver("example.com", apiKeys)
 	require.NoError(t, err)

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
@@ -7,10 +7,12 @@ package resolver
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -209,6 +211,59 @@ func TestMultiDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 	updateAdditionalEndpoints(resolver, "additional_endpoints", mockConfig, log)
 
 	assertKeys(t, []string{"key1", "key4", "key3"}, resolver)
+}
+
+// TestUpdateAdditionalEndpointsPreservesEncName verifies that secret rotation
+// does not change the stable enc_-prefixed name of an ENC-backed additional
+// endpoint key. Before the fix, updateAdditionalEndpoints passed nil for the
+// raw-config view so MakeNamedEndpoints only saw resolved key material and
+// regenerated the name as idx_..., breaking persisted enc_ references.
+func TestUpdateAdditionalEndpointsPreservesEncName(t *testing.T) {
+	const (
+		endpoint   = "https://app.datadoghq.com"
+		setting    = "additional_endpoints"
+		initialKey = "initial_key_material"
+		rotatedKey = "rotated_key_material"
+	)
+
+	// YAML load populates the file layer with the raw ENC[...] handle,
+	// mirroring how the agent reads datadog.yaml before secret resolution.
+	mockCfg := configmock.NewFromYAML(t, `
+additional_endpoints:
+  "https://app.datadoghq.com":
+  - ENC[my_api_handle]
+`)
+	// Secret resolution writes the resolved material into the secrets layer.
+	mockCfg.Set(setting, map[string]interface{}{
+		endpoint: []interface{}{initialKey},
+	}, model.SourceSecret)
+
+	// Build the initial resolver the same way GetEndpointsFromConfig does:
+	// resolved view for key material, raw view to preserve the enc_ name.
+	apiKeysByDomain := utils.MakeNamedEndpoints(
+		mockCfg.GetStringMapStringSlice(setting),
+		utils.RawStringMapStringSlice(mockCfg, setting),
+		setting,
+	)
+	resolver, err := NewSingleDomainResolver(endpoint, apiKeysByDomain[endpoint])
+	require.NoError(t, err)
+
+	initialName, ok := resolver.GetAPIKeyName(0)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(initialName, "enc_"), "expected enc_ prefix before rotation, got %q", initialName)
+
+	// Rotate: file layer (ENC[...] handle) is unchanged; only the secrets
+	// layer is updated with the new key material.
+	mockCfg.Set(setting, map[string]interface{}{
+		endpoint: []interface{}{rotatedKey},
+	}, model.SourceSecret)
+
+	log := logmock.New(t)
+	updateAdditionalEndpoints(resolver, setting, mockCfg, log)
+
+	rotatedName, ok := resolver.GetAPIKeyName(0)
+	require.True(t, ok)
+	assert.Equal(t, initialName, rotatedName, "ENC-backed key name must not change on secret rotation")
 }
 
 func TestScrubKeys(t *testing.T) {

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
@@ -6,6 +6,7 @@
 package resolver
 
 import (
+	"net/http"
 	"testing"
 
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
@@ -27,35 +28,129 @@ func assertKeys(t *testing.T, expect []string, resolver DomainResolver) {
 func TestSingleDomainResolverDedupedKey(t *testing.T) {
 	// Note key2 exists twice in the list.
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("additional_endpoints", "key1", "key2"),
-		utils.NewAPIKeys("multi_region_failover.api_key", "key2"),
+		utils.NewAPIKeys("additional_endpoints", "example.com", "key1", "key2"),
+		utils.NewAPIKeys("multi_region_failover.api_key", "example.com", "key2"),
 	}
 
 	resolver, err := NewSingleDomainResolver("example.com", apiKeys)
 	require.NoError(t, err)
 
-	assert.Equal(t, resolver.dedupedAPIKeys,
-		[]string{"key1", "key2"})
+	assert.Equal(t, []string{"key1", "key2"}, resolver.GetAPIKeys())
 }
 
 func TestSingleDomainUpdateAPIKeys(t *testing.T) {
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("api_key", "key1"),
-		utils.NewAPIKeys("additional_endpoints", "key1", "key2", "key3"),
+		utils.NewAPIKeys("api_key", "example.com", "key1"),
+		utils.NewAPIKeys("additional_endpoints", "example.com", "key1", "key2", "key3"),
 	}
 
 	resolver, err := NewSingleDomainResolver("example.com", apiKeys)
 	require.NoError(t, err)
 
-	resolver.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", "key4", "key2", "key3")})
+	resolver.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", "example.com", "key4", "key2", "key3")})
 
 	assertKeys(t, []string{"key1", "key4", "key2", "key3"}, resolver)
 }
 
+func TestSingleDomainResolverAPIKeyNameRotation(t *testing.T) {
+	apiKeys := []utils.APIKeys{
+		utils.NewAPIKeys("additional_endpoints", "https://app.datadoghq.com", "key1", "key2"),
+	}
+
+	resolver, err := NewSingleDomainResolver("https://app.datadoghq.com", apiKeys)
+	require.NoError(t, err)
+	resolver.SetBaseDomain("https://7-0-0-agent.datadoghq.com")
+
+	name, ok := resolver.GetAPIKeyName(0)
+	require.True(t, ok)
+
+	resolver.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", "https://app.datadoghq.com", "rotated-key1", "key2")})
+
+	rotatedName, ok := resolver.GetAPIKeyName(0)
+	require.True(t, ok)
+	assert.Equal(t, name, rotatedName)
+	idx, ok := resolver.GetAPIKeyIndex(name)
+	require.True(t, ok)
+	assert.Equal(t, uint(0), idx)
+}
+
+// TestSingleDomainResolverSetBaseDomainStableNames verifies that calling
+// SetBaseDomain after construction does not rewrite already-stable names —
+// once a key has a name, the name survives endpoint reassignment.
+func TestSingleDomainResolverSetBaseDomainStableNames(t *testing.T) {
+	apiKeys := []utils.APIKeys{
+		utils.NewAPIKeys("additional_endpoints", "https://app.datadoghq.com", "key1", "key2"),
+	}
+
+	resolver, err := NewSingleDomainResolver("https://app.datadoghq.com", apiKeys)
+	require.NoError(t, err)
+
+	before := append([]string(nil), resolver.GetAPIKeyNames()...)
+
+	resolver.SetBaseDomain("https://different.example.com")
+	after := resolver.GetAPIKeyNames()
+
+	assert.Equal(t, before, after,
+		"SetBaseDomain must not rewrite existing API key names; identity must be stable")
+}
+
+// TestSingleDomainResolverPrimaryAndAdditionalShareKey verifies the dedup
+// behavior when api_key shares its value with an additional_endpoints entry.
+// The first occurrence wins, and the surviving name resolves back to index 0.
+func TestSingleDomainResolverPrimaryAndAdditionalShareKey(t *testing.T) {
+	apiKeys := []utils.APIKeys{
+		utils.NewAPIKeys("api_key", "https://app.datadoghq.com", "shared"),
+		utils.NewAPIKeys("additional_endpoints", "https://app.datadoghq.com", "shared", "other"),
+	}
+
+	resolver, err := NewSingleDomainResolver("https://app.datadoghq.com", apiKeys)
+	require.NoError(t, err)
+
+	assertKeys(t, []string{"shared", "other"}, resolver)
+
+	primaryName, ok := resolver.GetAPIKeyName(0)
+	require.True(t, ok)
+	require.NotEmpty(t, primaryName)
+	idx, ok := resolver.GetAPIKeyIndex(primaryName)
+	require.True(t, ok)
+	assert.Equal(t, uint(0), idx)
+}
+
+// TestAuthorizeByNameUnknown verifies that an unknown name produces a clean
+// error path and does not set the DD-Api-Key header.
+func TestAuthorizeByNameUnknown(t *testing.T) {
+	apiKeys := []utils.APIKeys{
+		utils.NewAPIKeys("api_key", "https://app.datadoghq.com", "key1"),
+	}
+	resolver, err := NewSingleDomainResolver("https://app.datadoghq.com", apiKeys)
+	require.NoError(t, err)
+
+	mockLog := logmock.New(t)
+	headers := make(http.Header)
+	resolver.AuthorizeByName("does-not-exist", headers, mockLog)
+	assert.Empty(t, headers.Get("DD-Api-Key"),
+		"unknown name must not authorize a request")
+}
+
+// TestAuthorizeUnknownIndex verifies the index-based path also fails cleanly
+// when the index is out of range.
+func TestAuthorizeUnknownIndex(t *testing.T) {
+	apiKeys := []utils.APIKeys{
+		utils.NewAPIKeys("api_key", "https://app.datadoghq.com", "key1"),
+	}
+	resolver, err := NewSingleDomainResolver("https://app.datadoghq.com", apiKeys)
+	require.NoError(t, err)
+
+	mockLog := logmock.New(t)
+	headers := make(http.Header)
+	resolver.Authorize(99, headers, mockLog)
+	assert.Empty(t, headers.Get("DD-Api-Key"))
+}
+
 func TestSingleDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("api_key", "key1"),
-		utils.NewAPIKeys("additional_endpoints", "key1", "key2", "key3"),
+		utils.NewAPIKeys("api_key", "example.com", "key1"),
+		utils.NewAPIKeys("additional_endpoints", "example.com", "key1", "key2", "key3"),
 	}
 	resolver, err := NewSingleDomainResolver("example.com", apiKeys)
 	require.NoError(t, err)
@@ -86,8 +181,8 @@ func TestSingleDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 
 func TestMultiDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("api_key", "key1"),
-		utils.NewAPIKeys("additional_endpoints", "key1", "key2", "key3"),
+		utils.NewAPIKeys("api_key", "example.com", "key1"),
+		utils.NewAPIKeys("additional_endpoints", "example.com", "key1", "key2", "key3"),
 	}
 	resolver, err := NewMultiDomainResolver("example.com", apiKeys)
 	require.NoError(t, err)

--- a/comp/forwarder/orchestrator/orchestratorinterface/go.mod
+++ b/comp/forwarder/orchestrator/orchestratorinterface/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.73.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.73.0-rc.5 // indirect

--- a/comp/logs-library/go.mod
+++ b/comp/logs-library/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.73.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.75.4 // indirect

--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/comp/otelcol/collector-contrib/impl/go.mod
+++ b/comp/otelcol/collector-contrib/impl/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.77.0-devel.0.20260213154712-e02b9359151a // indirect

--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -68,6 +68,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.78.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.72.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.78.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/buildschema v0.0.0-00010101000000-000000000000 // indirect

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -73,6 +73,7 @@ require (
 )
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostport v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/go-acl v1.0.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.78.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.73.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.78.1 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.78.1 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.78.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.77.0-devel.0.20260213154712-e02b9359151a // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
@@ -140,6 +140,7 @@ func createTestServer(t *testing.T, c chan payload.HostMetadata) *httptest.Serve
 func createTestFactory(t *testing.T, serverAddr string) exporter.Factory {
 	params := exportertest.NewNopSettings(Type)
 	scfg := &serializerexporter.ExporterConfig{}
+	scfg.API.Key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	scfg.API.Site = serverAddr
 	scfg.Metrics.Metrics.TCPAddrConfig.Endpoint = serverAddr
 	srlz, fwd, err := serializerexporter.InitSerializer(params.Logger, scfg, &sourceProvider)

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -41,6 +41,7 @@ require (
 require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.77.0-devel.0.20260213154712-e02b9359151a // indirect

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -53,6 +53,7 @@ require (
 require github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/pkg/config/buildschema v0.0.0-00010101000000-000000000000 // indirect

--- a/comp/otelcol/status/impl/go.mod
+++ b/comp/otelcol/status/impl/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.72.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.73.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/api v0.72.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.72.0-rc.5 // indirect

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -54,7 +54,7 @@ func benchmarkAddBucket(bucketValue int64, b *testing.B) {
 	mockConfig := configmock.New(b)
 	deps := fxutil.Test[benchmarkDeps](b, core.MockBundle(), hostnameimpl.MockModule())
 	taggerComponent := taggerfxmock.SetupFakeTagger(b)
-	resolver, _ := resolver.NewSingleDomainResolvers(map[string][]utils.APIKeys{"hello": {utils.NewAPIKeys("", "world")}})
+	resolver, _ := resolver.NewSingleDomainResolvers(map[string][]utils.APIKeys{"hello": {utils.NewAPIKeys("", "hello", "world")}})
 	forwarderOpts := forwarder.NewOptionsWithResolvers(mockConfig, deps.Log, resolver)
 	options := DefaultAgentDemultiplexerOptions()
 	options.DontStartForwarders = true

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -20,6 +20,7 @@ require gopkg.in/yaml.v3 v3.0.1 // indirect
 require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/buildschema v0.0.0-00010101000000-000000000000 // indirect

--- a/pkg/config/utils/BUILD.bazel
+++ b/pkg/config/utils/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/pkg/config/utils",
     visibility = ["//visibility:public"],
     deps = [
+        "//comp/core/secrets/utils",
         "//pkg/config/model",
         "//pkg/config/setup",
         "//pkg/config/structure",

--- a/pkg/config/utils/endpoints.go
+++ b/pkg/config/utils/endpoints.go
@@ -236,6 +236,42 @@ func RawStringMapStringSlice(c pkgconfigmodel.Reader, setting string) map[string
 	return getStringMapStringSlice(c.AllSettingsWithoutSecrets()[setting])
 }
 
+// newAPIKeysFromConfig builds an APIKeys for a config setting that holds
+// either a single string or a string slice (e.g. api_key or
+// multi_region_failover.api_key). It reads both the resolved form (via
+// c.GetStringSlice) and the pre-secret-resolution form (from
+// AllSettingsWithoutSecrets) so ENC-backed keys receive enc_-prefixed stable
+// names. Works for settings with one key or several.
+func newAPIKeysFromConfig(c pkgconfigmodel.Reader, path, endpoint string) APIKeys {
+	raw := rawLeafSlice(c.AllSettingsWithoutSecrets(), path)
+	return APIKeys{
+		ConfigSettingPath: path,
+		Keys:              makeNamedAPIKeys(endpoint, path, c.GetStringSlice(path), raw),
+	}
+}
+
+// rawLeafSlice traverses a nested AllSettingsWithoutSecrets map using
+// dot-notation and normalises the leaf value (string or []interface{}) to
+// []string. Returns nil when the key is absent or the value has an unexpected
+// type.
+func rawLeafSlice(m map[string]interface{}, dotKey string) []string {
+	parts := strings.SplitN(dotKey, ".", 2)
+	for len(parts) == 2 {
+		nested, ok := m[parts[0]].(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		m = nested
+		parts = strings.SplitN(parts[1], ".", 2)
+	}
+	leaf := m[parts[0]]
+	if s, ok := leaf.(string); ok {
+		return []string{s}
+	}
+	result, _ := interfaceToStringSlice(leaf)
+	return result
+}
+
 // getStringMapStringSlice normalizes a setting value to map[string][]string.
 // Both viper and nodetreemodel normalize YAML's map[interface{}]interface{}
 // to map[string]interface{} at parse time, and env-var JSON parsing produces
@@ -318,7 +354,7 @@ func GetMultipleEndpoints(c pkgconfigmodel.Reader) (EndpointDescriptorSet, error
 	}
 
 	keysPerDomain := map[string][]APIKeys{
-		ddURL: {NewAPIKeys("api_key", ddURL, c.GetString("api_key"))},
+		ddURL: {newAPIKeysFromConfig(c, "api_key", ddURL)},
 	}
 
 	additionalEndpoints := MakeNamedEndpoints(
@@ -351,7 +387,7 @@ func GetMultipleEndpoints(c pkgconfigmodel.Reader) (EndpointDescriptorSet, error
 		}
 		eds[haURL] = EndpointDescriptor{
 			BaseURL:   haURL,
-			APIKeySet: []APIKeys{NewAPIKeys("multi_region_failover.api_key", haURL, c.GetString("multi_region_failover.api_key"))},
+			APIKeySet: []APIKeys{newAPIKeysFromConfig(c, "multi_region_failover.api_key", haURL)},
 			IsMRF:     true,
 		}
 	}

--- a/pkg/config/utils/endpoints.go
+++ b/pkg/config/utils/endpoints.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/net/idna"
 
+	secretutils "github.com/DataDog/datadog-agent/comp/core/secrets/utils"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -31,12 +33,23 @@ const (
 	MRFInfraPrefix = "mrf."
 )
 
-func getResolvedDDUrl(c pkgconfigmodel.Reader, urlKey string) string {
-	resolvedDDURL := c.GetString(urlKey)
-	if c.IsSet("site") {
-		log.Debugf("'site' and '%s' are both set in config: setting main endpoint to '%s': \"%s\"", urlKey, urlKey, c.GetString(urlKey))
+// getResolvedURL returns the URL stored at urlKey, logging a notice when
+// siteKey is also set so users see that the explicit URL is taking precedence.
+func getResolvedURL(c pkgconfigmodel.Reader, urlKey, siteKey string) string {
+	resolved := c.GetString(urlKey)
+	if c.IsSet(siteKey) {
+		log.Debugf("'%s' and '%s' are both set in config: setting main endpoint to '%s': %q", siteKey, urlKey, urlKey, resolved)
 	}
-	return resolvedDDURL
+	return resolved
+}
+
+// APIKey contains one API key value and its stable, non-secret identity.
+type APIKey struct {
+	// Key is the API key material to use for this endpoint.
+	Key string
+
+	// Name is the stable, non-secret identity for Key.
+	Name string
 }
 
 // APIKeys contains a list of API keys together with the path within the config that this API key were configured.
@@ -45,83 +58,235 @@ type APIKeys struct {
 	// the config.
 	ConfigSettingPath string
 
-	// the apiKey to use for this endpoint
-	Keys []string
+	// Keys contains the API keys to use for this endpoint.
+	Keys []APIKey
 }
 
-// NewAPIKeys creates an endpoint
-func NewAPIKeys(path string, keys ...string) APIKeys {
+// NewAPIKeys creates an APIKeys for the given config setting path and endpoint.
+// Each returned APIKey gets a stable name derived from endpoint and its
+// position in keys (see apiKeyNameForIndex), with ENC[...]
+// handles preserved when present. Empty/whitespace-only keys are dropped, and
+// indexes in the remaining names reflect the original list positions so adding
+// or removing empty entries does not renumber the survivors.
+func NewAPIKeys(path, endpoint string, keys ...string) APIKeys {
 	return APIKeys{
 		ConfigSettingPath: path,
-		Keys:              keys,
+		Keys:              makeNamedAPIKeys(endpoint, path, keys, nil),
 	}
 }
 
-func newAPIKeyset(path string, keys ...string) []APIKeys {
-	return []APIKeys{NewAPIKeys(path, keys...)}
+// makeNamedAPIKeys builds the APIKey list for one endpoint at a single config
+// setting path. rawKeys is the unresolved (pre-secret-resolution) form of
+// keys; pass nil when not available. Secret-backed entries (ENC[handle])
+// receive enc_<endpoint>_<path>_<handle> names so rotation preserves identity;
+// plain entries receive idx_<endpoint>_<path>_<position>. Duplicate key values
+// within keys are collapsed to a single entry, keeping the first occurrence's
+// name.
+func makeNamedAPIKeys(endpoint, path string, keys, rawKeys []string) []APIKey {
+	result := make([]APIKey, 0, len(keys))
+	seen := make(map[string]bool, len(keys))
+	for index, key := range keys {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		result = append(result, APIKey{
+			Key:  trimmed,
+			Name: additionalEndpointAPIKeyName(endpoint, path, index, key, rawKeys),
+		})
+	}
+	return result
+}
+
+const (
+	plainAPIKeyNamePrefix  = "idx"
+	secretAPIKeyNamePrefix = "enc"
+	apiKeyNameSeparator    = "_"
+)
+
+// apiKeyNameForIndex returns the stable name for a plain API key at original
+// list position index, scoped by endpoint and config setting path. The
+// endpoint is canonicalized so equivalent spellings produce the same
+// identifier; the agent-version prefix is intentionally not applied so the
+// name stays stable across upgrades. Including path disambiguates names when
+// two APIKeys sets (e.g. api_key and additional_endpoints) target the same
+// endpoint.
+func apiKeyNameForIndex(endpoint, path string, index int) string {
+	return strings.Join([]string{
+		plainAPIKeyNamePrefix,
+		canonicalEndpoint(endpoint),
+		path,
+		strconv.Itoa(index),
+	}, apiKeyNameSeparator)
+}
+
+// apiKeyNameForSecret returns the stable name for an API key backed by the
+// given ENC[handle], scoped by endpoint and config setting path.
+func apiKeyNameForSecret(endpoint, path, handle string) string {
+	return strings.Join([]string{
+		secretAPIKeyNamePrefix,
+		canonicalEndpoint(endpoint),
+		path,
+		handle,
+	}, apiKeyNameSeparator)
+}
+
+// canonicalEndpoint normalizes a user-configured endpoint so that equivalent
+// spellings (with/without scheme, trailing slash, scheme/host case) share the
+// same identifier. The agent-version prefix added by AddAgentVersionToDomain
+// is a request-time concern and is intentionally not applied here.
+func canonicalEndpoint(endpoint string) string {
+	trimmed := strings.TrimSpace(endpoint)
+	if trimmed == "" {
+		return ""
+	}
+	raw := trimmed
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return trimmed
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme == "" {
+		scheme = "https"
+	}
+	host := strings.ToLower(u.Host)
+	path := strings.TrimRight(u.Path, "/")
+	return scheme + "://" + host + path
 }
 
 // GetMainEndpointBackwardCompatible implements the logic to extract the DD URL from a config, based on `site`,ddURLKey and a backward compatible key
 func GetMainEndpointBackwardCompatible(c pkgconfigmodel.Reader, prefix string, ddURLKey string, backwardKey string) string {
 	if c.IsSet(ddURLKey) && c.GetString(ddURLKey) != "" {
 		// value under ddURLKey takes precedence over backwardKey and 'site'
-		return getResolvedDDUrl(c, ddURLKey)
+		return getResolvedURL(c, ddURLKey, "site")
 	} else if c.IsSet(backwardKey) && c.GetString(backwardKey) != "" {
 		// value under backwardKey takes precedence over 'site'
-		return getResolvedDDUrl(c, backwardKey)
+		return getResolvedURL(c, backwardKey, "site")
 	} else if c.GetString("site") != "" {
 		return prefix + strings.TrimSpace(c.GetString("site"))
 	}
 	return prefix + pkgconfigsetup.DefaultSite
 }
 
-// MakeEndpoints takes a map of domain to apikeys and a config path root and converts this to
-// a map of domain to Endpoint structs.
-func MakeEndpoints(endpoints map[string][]string, root string) map[string][]APIKeys {
+// MakeNamedEndpoints takes a map of domain to apikeys and a config path root
+// and produces one APIKeys per non-empty domain. rawEndpoints can carry the
+// original unresolved config values so secret-backed names keep their ENC[...]
+// handle across rotation; pass nil when not available. Endpoints with only
+// empty/whitespace keys are dropped with a log line.
+func MakeNamedEndpoints(endpoints map[string][]string, rawEndpoints map[string][]string, root string) map[string][]APIKeys {
 	result := map[string][]APIKeys{}
 	for url, keys := range endpoints {
-		// Remove any empty API keys.
-		// We don't need to hold on to an endpoint with an empty API key to track if a
-		// secret has been updated since secrets can never be empty in the first place.
-		trimmed := []string{}
-		for _, key := range keys {
-			trimmedAPIKey := strings.TrimSpace(key)
-			if trimmedAPIKey != "" {
-				trimmed = append(trimmed, trimmedAPIKey)
-			}
-		}
-
-		if len(trimmed) > 0 {
-			result[url] = []APIKeys{{
-				ConfigSettingPath: root,
-				Keys:              trimmed,
-			}}
-		} else {
+		named := makeNamedAPIKeys(url, root, keys, rawEndpoints[url])
+		if len(named) == 0 {
 			log.Infof("No API key provided for domain %q, removing domain from endpoints", url)
+			continue
 		}
+		result[url] = []APIKeys{{ConfigSettingPath: root, Keys: named}}
 	}
-
 	return result
 }
 
-// DedupAPIKeys takes a single array of endpoints and returns an array of unique
-// api keys that they contain.
-// This needs to be a separate process to loading because we need to keep track
-// of the endpoints with the API config location to know when they have been
-// refreshed.
-func DedupAPIKeys(endpoints []APIKeys) []string {
-	dedupedAPIKeys := make([]string, 0)
-	seen := make(map[string]bool)
-	for _, endpoint := range endpoints {
-		for _, apiKey := range endpoint.Keys {
-			if _, ok := seen[apiKey]; !ok {
-				seen[apiKey] = true
-				dedupedAPIKeys = append(dedupedAPIKeys, apiKey)
+// additionalEndpointAPIKeyName returns the stable name for the API key at
+// list position index on endpoint+path. It prefers the raw config value (which
+// still contains ENC[handle] before secret resolution), and falls back to the
+// resolved value when no raw config is available. This keeps secret-backed
+// names stable across rotation.
+func additionalEndpointAPIKeyName(endpoint, path string, index int, resolvedKey string, rawKeys []string) string {
+	source := resolvedKey
+	if index < len(rawKeys) {
+		source = rawKeys[index]
+	}
+	if ok, handle := secretutils.IsEnc(source); ok {
+		return apiKeyNameForSecret(endpoint, path, handle)
+	}
+	return apiKeyNameForIndex(endpoint, path, index)
+}
+
+// AdditionalEndpointsWithNames returns configstream's serialized shape for
+// additional_endpoints: endpoint -> [{"name": stableName, "key": resolvedKey}].
+func AdditionalEndpointsWithNames(c pkgconfigmodel.Reader, setting string, value interface{}) map[string][]map[string]string {
+	resolved := getStringMapStringSlice(value)
+	if resolved == nil {
+		resolved = c.GetStringMapStringSlice(setting)
+	}
+	named := MakeNamedEndpoints(resolved, RawStringMapStringSlice(c, setting), setting)
+
+	result := make(map[string][]map[string]string, len(named))
+	for endpoint, apiKeys := range named {
+		for _, set := range apiKeys {
+			for _, k := range set.Keys {
+				result[endpoint] = append(result[endpoint], map[string]string{
+					"name": k.Name,
+					"key":  k.Key,
+				})
 			}
 		}
 	}
+	return result
+}
 
-	return dedupedAPIKeys
+// RawStringMapStringSlice returns the user-configured value of setting with
+// the secret layer excluded, so callers can see ENC[handle] entries as the
+// user wrote them instead of the resolved key material.
+func RawStringMapStringSlice(c pkgconfigmodel.Reader, setting string) map[string][]string {
+	return getStringMapStringSlice(c.AllSettingsWithoutSecrets()[setting])
+}
+
+// getStringMapStringSlice normalizes a setting value to map[string][]string.
+// Both viper and nodetreemodel normalize YAML's map[interface{}]interface{}
+// to map[string]interface{} at parse time, and env-var JSON parsing produces
+// the same shape natively, so a single case covers both sources.
+func getStringMapStringSlice(value interface{}) map[string][]string {
+	raw, ok := value.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	result := make(map[string][]string, len(raw))
+	for endpoint, rawKeys := range raw {
+		keys, ok := interfaceToStringSlice(rawKeys)
+		if !ok {
+			continue
+		}
+		result[endpoint] = keys
+	}
+	return result
+}
+
+func interfaceToStringSlice(value interface{}) ([]string, bool) {
+	raw, ok := value.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	keys := make([]string, 0, len(raw))
+	for _, rawKey := range raw {
+		key, ok := rawKey.(string)
+		if !ok {
+			return nil, false
+		}
+		keys = append(keys, key)
+	}
+	return keys, true
+}
+
+// DedupAPIKeys returns the unique APIKey entries across all endpoints,
+// preserving the first occurrence of each key value. Names ride along on the
+// APIKey struct so callers don't manage parallel slices.
+func DedupAPIKeys(endpoints []APIKeys) []APIKey {
+	result := make([]APIKey, 0)
+	seen := make(map[string]bool)
+	for _, endpoint := range endpoints {
+		for _, apiKey := range endpoint.Keys {
+			if !seen[apiKey.Key] {
+				seen[apiKey.Key] = true
+				result = append(result, apiKey)
+			}
+		}
+	}
+	return result
 }
 
 // EndpointDescriptor holds configuration about a single endpoint (aka domain) for infra pipelines.
@@ -131,13 +296,6 @@ type EndpointDescriptor struct {
 	IsMRF     bool
 }
 
-func newEndpointDescriptor(baseURL string, apiKeySet []APIKeys) EndpointDescriptor {
-	return EndpointDescriptor{
-		BaseURL:   baseURL,
-		APIKeySet: apiKeySet,
-	}
-}
-
 // EndpointDescriptorSet is a collection of all endpoints for infra pipelines keyed by base URL.
 type EndpointDescriptorSet = map[string]EndpointDescriptor
 
@@ -145,7 +303,7 @@ type EndpointDescriptorSet = map[string]EndpointDescriptor
 func EndpointDescriptorSetFromKeysPerDomain(keysPerDomain map[string][]APIKeys) EndpointDescriptorSet {
 	eds := EndpointDescriptorSet{}
 	for domain, keyset := range keysPerDomain {
-		eds[domain] = newEndpointDescriptor(domain, keyset)
+		eds[domain] = EndpointDescriptor{BaseURL: domain, APIKeySet: keyset}
 	}
 
 	return eds
@@ -160,10 +318,14 @@ func GetMultipleEndpoints(c pkgconfigmodel.Reader) (EndpointDescriptorSet, error
 	}
 
 	keysPerDomain := map[string][]APIKeys{
-		ddURL: newAPIKeyset("api_key", c.GetString("api_key")),
+		ddURL: {NewAPIKeys("api_key", ddURL, c.GetString("api_key"))},
 	}
 
-	additionalEndpoints := MakeEndpoints(c.GetStringMapStringSlice("additional_endpoints"), "additional_endpoints")
+	additionalEndpoints := MakeNamedEndpoints(
+		c.GetStringMapStringSlice("additional_endpoints"),
+		RawStringMapStringSlice(c, "additional_endpoints"),
+		"additional_endpoints",
+	)
 
 	for domain, apiKeys := range additionalEndpoints {
 		// Validating domain
@@ -187,11 +349,11 @@ func GetMultipleEndpoints(c pkgconfigmodel.Reader) (EndpointDescriptorSet, error
 		if err != nil {
 			return nil, fmt.Errorf("could not parse MRF endpoint: %s", err)
 		}
-		ed := newEndpointDescriptor(
-			haURL,
-			newAPIKeyset("multi_region_failover.api_key", c.GetString("multi_region_failover.api_key")))
-		ed.IsMRF = true
-		eds[haURL] = ed
+		eds[haURL] = EndpointDescriptor{
+			BaseURL:   haURL,
+			APIKeySet: []APIKeys{NewAPIKeys("multi_region_failover.api_key", haURL, c.GetString("multi_region_failover.api_key"))},
+			IsMRF:     true,
+		}
 	}
 
 	return eds, nil
@@ -260,7 +422,7 @@ func BuildURLWithPrefix(prefix, site string) string {
 func GetMainEndpoint(c pkgconfigmodel.Reader, prefix string, ddURLKey string) string {
 	// value under ddURLKey takes precedence over 'site'
 	if c.IsSet(ddURLKey) && c.GetString(ddURLKey) != "" {
-		return getResolvedDDUrl(c, ddURLKey)
+		return getResolvedURL(c, ddURLKey, "site")
 	} else if c.GetString("site") != "" {
 		return BuildURLWithPrefix(prefix, c.GetString("site"))
 	}
@@ -274,7 +436,7 @@ func GetMainEndpoint(c pkgconfigmodel.Reader, prefix string, ddURLKey string) st
 // precedence over `multi_region_failover.site`.
 func GetMRFEndpoint(c pkgconfigmodel.Reader, prefix, ddMRFURLKey string) (string, error) {
 	if c.IsConfigured(ddMRFURLKey) && c.GetString(ddMRFURLKey) != "" {
-		return getResolvedMRFDDURL(c, ddMRFURLKey), nil
+		return getResolvedURL(c, ddMRFURLKey, "multi_region_failover.site"), nil
 	} else if c.GetString("multi_region_failover.site") != "" {
 		return BuildURLWithPrefix(prefix, c.GetString("multi_region_failover.site")), nil
 	}
@@ -296,14 +458,6 @@ func GetMRFLogsEndpoint(c pkgconfigmodel.Reader, prefix string) (string, error) 
 	}
 
 	return GetMRFEndpoint(c, logsSpecificPrefix, "multi_region_failover.dd_url")
-}
-
-func getResolvedMRFDDURL(c pkgconfigmodel.Reader, mrfURLKey string) string {
-	resolvedMRFDDURL := c.GetString(mrfURLKey)
-	if c.IsConfigured("multi_region_failover.site") {
-		log.Infof("'multi_region_failover.site' and '%s' are both set in config: setting main endpoint to '%s': \"%s\"", mrfURLKey, mrfURLKey, resolvedMRFDDURL)
-	}
-	return resolvedMRFDDURL
 }
 
 // GetInfraEndpoint returns the main DD Infra URL defined in config, based on the value of `site` and `dd_url`

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -24,11 +24,13 @@ func TestSecretBackendWithMultipleEndpoints(t *testing.T) {
 	conf := mock.NewFromFile(t, "./tests/datadog_secrets.yaml")
 
 	expectedKeysPerDomain := EndpointDescriptorSet{
-		"https://app.datadoghq.com.": newEndpointDescriptor(
-			"https://app.datadoghq.com.", []APIKeys{
-				NewAPIKeys("api_key", "someapikey"),
-				NewAPIKeys("additional_endpoints", "someotherapikey"),
-			}),
+		"https://app.datadoghq.com.": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com.",
+			APIKeySet: []APIKeys{
+				NewAPIKeys("api_key", "https://app.datadoghq.com.", "someapikey"),
+				NewAPIKeys("additional_endpoints", "https://app.datadoghq.com.", "someotherapikey"),
+			},
+		},
 	}
 	keysPerDomain, err := GetMultipleEndpoints(conf)
 	assert.NoError(t, err)
@@ -52,11 +54,14 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", newAPIKeyset("additional_endpoints", "someapikey")),
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", []APIKeys{
-			NewAPIKeys("api_key", "fakeapikey"),
-			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
-		}),
+		"https://foo.datadoghq.com.": EndpointDescriptor{BaseURL: "https://foo.datadoghq.com.", APIKeySet: []APIKeys{NewAPIKeys("additional_endpoints", "https://foo.datadoghq.com.", "someapikey")}},
+		"https://app.datadoghq.com.": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com.",
+			APIKeySet: []APIKeys{
+				NewAPIKeys("api_key", "https://app.datadoghq.com.", "fakeapikey"),
+				NewAPIKeys("additional_endpoints", "https://app.datadoghq.com.", "fakeapikey2", "fakeapikey3"),
+			},
+		},
 	}
 
 	assert.NoError(t, err)
@@ -81,11 +86,14 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey")),
-		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
-			NewAPIKeys("api_key", "fakeapikey"),
-			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey3"),
-		}),
+		"https://foo.datadoghq.com": EndpointDescriptor{BaseURL: "https://foo.datadoghq.com", APIKeySet: []APIKeys{NewAPIKeys("additional_endpoints", "https://foo.datadoghq.com", "someapikey")}},
+		"https://app.datadoghq.com": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com",
+			APIKeySet: []APIKeys{
+				NewAPIKeys("api_key", "https://app.datadoghq.com", "fakeapikey"),
+				NewAPIKeys("additional_endpoints", "https://app.datadoghq.com", "fakeapikey2", "fakeapikey3"),
+			},
+		},
 	}
 
 	assert.NoError(t, err)
@@ -101,8 +109,8 @@ func TestGetMultipleEndpointsEnvVar(t *testing.T) {
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", newAPIKeyset("additional_endpoints", "someapikey")),
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", newAPIKeyset("api_key", "fakeapikey")),
+		"https://foo.datadoghq.com.": EndpointDescriptor{BaseURL: "https://foo.datadoghq.com.", APIKeySet: []APIKeys{NewAPIKeys("additional_endpoints", "https://foo.datadoghq.com.", "someapikey")}},
+		"https://app.datadoghq.com.": EndpointDescriptor{BaseURL: "https://app.datadoghq.com.", APIKeySet: []APIKeys{NewAPIKeys("api_key", "https://app.datadoghq.com.", "fakeapikey")}},
 	}
 
 	assert.NoError(t, err)
@@ -127,9 +135,9 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu.":  newEndpointDescriptor("https://app.datadoghq.eu.", newAPIKeyset("api_key", "fakeapikey")),
-		"https://foo.datadoghq.com.": newEndpointDescriptor("https://foo.datadoghq.com.", newAPIKeyset("additional_endpoints", "someapikey")),
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", newAPIKeyset("additional_endpoints", "fakeapikey2", "fakeapikey3")),
+		"https://app.datadoghq.eu.":  EndpointDescriptor{BaseURL: "https://app.datadoghq.eu.", APIKeySet: []APIKeys{NewAPIKeys("api_key", "https://app.datadoghq.eu.", "fakeapikey")}},
+		"https://foo.datadoghq.com.": EndpointDescriptor{BaseURL: "https://foo.datadoghq.com.", APIKeySet: []APIKeys{NewAPIKeys("additional_endpoints", "https://foo.datadoghq.com.", "someapikey")}},
+		"https://app.datadoghq.com.": EndpointDescriptor{BaseURL: "https://app.datadoghq.com.", APIKeySet: []APIKeys{NewAPIKeys("additional_endpoints", "https://app.datadoghq.com.", "fakeapikey2", "fakeapikey3")}},
 	}
 
 	assert.NoError(t, err)
@@ -147,7 +155,7 @@ api_key: fakeapikey
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", newAPIKeyset("api_key", "fakeapikey")),
+		"https://app.datadoghq.com": EndpointDescriptor{BaseURL: "https://app.datadoghq.com", APIKeySet: []APIKeys{NewAPIKeys("api_key", "https://app.datadoghq.com", "fakeapikey")}},
 	}
 
 	assert.NoError(t, err)
@@ -173,11 +181,14 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
-			NewAPIKeys("api_key", "fakeapikey"),
-			NewAPIKeys("additional_endpoints", "fakeapikey2"),
-		}),
-		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey")),
+		"https://app.datadoghq.com": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com",
+			APIKeySet: []APIKeys{
+				NewAPIKeys("api_key", "https://app.datadoghq.com", "fakeapikey"),
+				NewAPIKeys("additional_endpoints", "https://app.datadoghq.com", "fakeapikey2"),
+			},
+		},
+		"https://foo.datadoghq.com": EndpointDescriptor{BaseURL: "https://foo.datadoghq.com", APIKeySet: []APIKeys{NewAPIKeys("additional_endpoints", "https://foo.datadoghq.com", "someapikey")}},
 	}
 
 	assert.NoError(t, err)
@@ -204,16 +215,182 @@ additional_endpoints:
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", []APIKeys{
-			NewAPIKeys("api_key", "fakeapikey"),
-			NewAPIKeys("additional_endpoints", "fakeapikey2", "fakeapikey"),
-		}),
-		"https://foo.datadoghq.com": newEndpointDescriptor("https://foo.datadoghq.com", newAPIKeyset("additional_endpoints", "someapikey", "someotherapikey", "someapikey")),
+		// "fakeapikey" appears in both api_key and additional_endpoints; both sets
+		// keep their copy so each config path can track independent key rotations.
+		// Cross-set dedup happens later in the resolver via DedupAPIKeys.
+		"https://app.datadoghq.com": EndpointDescriptor{
+			BaseURL: "https://app.datadoghq.com",
+			APIKeySet: []APIKeys{
+				NewAPIKeys("api_key", "https://app.datadoghq.com", "fakeapikey"),
+				NewAPIKeys("additional_endpoints", "https://app.datadoghq.com", "fakeapikey2", "fakeapikey"),
+			},
+		},
+		// "someapikey" appears twice in config — collapsed to one entry at construction.
+		"https://foo.datadoghq.com": EndpointDescriptor{BaseURL: "https://foo.datadoghq.com", APIKeySet: []APIKeys{
+			NewAPIKeys("additional_endpoints", "https://foo.datadoghq.com", "someapikey", "someotherapikey"),
+		}},
 	}
 
 	assert.NoError(t, err)
-
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
+}
+
+// TestAdditionalEndpointMixedPlainAndSecretKeys verifies that a single
+// additional endpoint configured with one plain key and one ENC[handle] key
+// produces both entries side by side: each carries the resolved key material
+// in Key, the plain entry gets an idx_-prefixed name keyed on its list
+// position, and the ENC entry gets an enc_-prefixed name keyed on its handle.
+func TestAdditionalEndpointMixedPlainAndSecretKeys(t *testing.T) {
+	const endpoint = "https://app.datadoghq.com"
+
+	testConfig := mock.NewFromYAML(t, `
+api_key: main_key
+additional_endpoints:
+  "https://app.datadoghq.com":
+  - plain_extra_key
+  - ENC[secret_handle]
+`)
+	// Secret resolution writes the resolved value for the ENC entry back to the
+	// SourceSecret layer; the plain entry is unchanged.
+	testConfig.Set("additional_endpoints", map[string]interface{}{
+		endpoint: []interface{}{"plain_extra_key", "resolved_secret_value"},
+	}, pkgconfigmodel.SourceSecret)
+
+	endpoints, err := GetMultipleEndpoints(testConfig)
+	require.NoError(t, err)
+
+	descriptor, ok := endpoints[endpoint]
+	require.True(t, ok, "endpoint %q must be present in the result", endpoint)
+
+	// One APIKeys entry for additional_endpoints (the api_key set lives under
+	// the same endpoint and is a separate APIKeys entry).
+	var additional APIKeys
+	for _, set := range descriptor.APIKeySet {
+		if set.ConfigSettingPath == "additional_endpoints" {
+			additional = set
+			break
+		}
+	}
+	require.Len(t, additional.Keys, 2, "additional endpoint must keep both keys")
+
+	assert.Equal(t, "plain_extra_key", additional.Keys[0].Key)
+	assert.Equal(t, "idx_https://app.datadoghq.com_additional_endpoints_0", additional.Keys[0].Name)
+
+	assert.Equal(t, "resolved_secret_value", additional.Keys[1].Key)
+	assert.Equal(t, "enc_https://app.datadoghq.com_additional_endpoints_secret_handle", additional.Keys[1].Name)
+}
+
+// TestAdditionalEndpointAPIKeyNamesTrimAndDedup verifies that empty keys are
+// dropped and duplicate key values within one endpoint are collapsed at
+// construction. The surviving entry keeps the first occurrence's name, and
+// later entries' positions are reflected in their names (positions 0 and 4
+// here, with the repeat at position 3 dropped).
+func TestAdditionalEndpointAPIKeyNamesTrimAndDedup(t *testing.T) {
+	endpoints := map[string][]string{
+		"https://app.datadoghq.com": {"key1", "", "  ", "key1", "key2"},
+	}
+	result := MakeNamedEndpoints(endpoints, nil, "additional_endpoints")
+
+	require.Len(t, result["https://app.datadoghq.com"], 1)
+	keys := result["https://app.datadoghq.com"][0].Keys
+	require.Len(t, keys, 2, "empty/whitespace keys must be trimmed and duplicate values collapsed")
+
+	assert.Equal(t, "key1", keys[0].Key)
+	assert.Equal(t, "idx_https://app.datadoghq.com_additional_endpoints_0", keys[0].Name)
+
+	assert.Equal(t, "key2", keys[1].Key)
+	assert.Equal(t, "idx_https://app.datadoghq.com_additional_endpoints_4", keys[1].Name)
+}
+
+// TestCanonicalEndpoint verifies superficial spelling differences collapse to
+// the same identifier.
+func TestCanonicalEndpoint(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://app.datadoghq.com", "https://app.datadoghq.com"},
+		{"app.datadoghq.com", "https://app.datadoghq.com"},
+		{"https://app.datadoghq.com/", "https://app.datadoghq.com"},
+		{"HTTPS://APP.DATADOGHQ.COM/", "https://app.datadoghq.com"},
+		{"  https://app.datadoghq.com  ", "https://app.datadoghq.com"},
+		{"https://app.datadoghq.com/path/", "https://app.datadoghq.com/path"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, canonicalEndpoint(tc.in), "input=%q", tc.in)
+	}
+
+	// Distinct endpoints stay distinct.
+	assert.NotEqual(t, canonicalEndpoint("https://app.datadoghq.com"), canonicalEndpoint("https://app.datadoghq.eu"))
+	assert.NotEqual(t, canonicalEndpoint("https://app.datadoghq.com"), canonicalEndpoint("https://app.datadoghq.com/path"))
+
+	// Edge cases: empty input, whitespace-only, and unparseable strings fall
+	// back gracefully.
+	assert.Equal(t, "", canonicalEndpoint(""))
+	assert.Equal(t, "", canonicalEndpoint("   "))
+	// A bare non-URL string parses without a host; we return it verbatim
+	// (after trimming) rather than mangling it.
+	assert.Equal(t, "https://not a url", canonicalEndpoint("https://not a url"))
+}
+
+// TestAdditionalEndpointsWithNamesFallsBackToConfig verifies that an
+// unrecognized value (e.g. nil from an unset OnUpdate path) makes the helper
+// fetch the current setting from the config Reader.
+func TestAdditionalEndpointsWithNamesFallsBackToConfig(t *testing.T) {
+	testConfig := mock.NewFromYAML(t, `
+additional_endpoints:
+  "https://app.datadoghq.com":
+  - the_key
+`)
+
+	got := AdditionalEndpointsWithNames(testConfig, "additional_endpoints", nil)
+
+	require.Len(t, got["https://app.datadoghq.com"], 1)
+	assert.Equal(t, "the_key", got["https://app.datadoghq.com"][0]["key"])
+}
+
+// TestGetStringMapStringSliceRejectsBadShape verifies that values with a
+// non-[]interface{} inner type and inner non-string elements are dropped
+// instead of producing partial results.
+func TestGetStringMapStringSliceRejectsBadShape(t *testing.T) {
+	// Inner slice contains a non-string element: that endpoint is dropped.
+	mixed := map[string]interface{}{
+		"https://bad.example.com":  []interface{}{"k1", 42},
+		"https://good.example.com": []interface{}{"k2"},
+	}
+	assert.Equal(t, map[string][]string{
+		"https://good.example.com": {"k2"},
+	}, getStringMapStringSlice(mixed))
+
+	// Value is not a map at all: returns nil.
+	assert.Nil(t, getStringMapStringSlice("not a map"))
+	assert.Nil(t, getStringMapStringSlice(nil))
+}
+
+func TestAdditionalEndpointsWithNamesShape(t *testing.T) {
+	datadogYaml := `
+additional_endpoints:
+  "https://app.datadoghq.com":
+  - ENC[api_key_handle]
+`
+	testConfig := mock.NewFromYAML(t, datadogYaml)
+	testConfig.Set("additional_endpoints", map[string]interface{}{
+		"https://app.datadoghq.com": []interface{}{"resolved_api_key"},
+	}, pkgconfigmodel.SourceSecret)
+
+	got := AdditionalEndpointsWithNames(
+		testConfig,
+		"additional_endpoints",
+		testConfig.Get("additional_endpoints"),
+	)
+
+	assert.Equal(t, map[string][]map[string]string{
+		"https://app.datadoghq.com": {
+			{
+				"name": "enc_https://app.datadoghq.com_additional_endpoints_api_key_handle",
+				"key":  "resolved_api_key",
+			},
+		},
+	}, got)
 }
 
 func TestSiteEnvVar(t *testing.T) {
@@ -240,7 +417,7 @@ func TestSiteEnvVar(t *testing.T) {
 			externalAgentURL := GetMainEndpoint(testConfig, tc.prefix, "external_config.external_agent_dd_url")
 
 			expectedMultipleEndpoints := EndpointDescriptorSet{
-				tc.expectedSiteURL: newEndpointDescriptor(tc.expectedSiteURL, newAPIKeyset("api_key", "fakeapikey")),
+				tc.expectedSiteURL: EndpointDescriptor{BaseURL: tc.expectedSiteURL, APIKeySet: []APIKeys{NewAPIKeys("api_key", tc.expectedSiteURL, "fakeapikey")}},
 			}
 
 			assert.NoError(t, err)
@@ -261,7 +438,7 @@ api_key: fakeapikey
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com.": newEndpointDescriptor("https://app.datadoghq.com.", newAPIKeyset("api_key", "fakeapikey")),
+		"https://app.datadoghq.com.": EndpointDescriptor{BaseURL: "https://app.datadoghq.com.", APIKeySet: []APIKeys{NewAPIKeys("api_key", "https://app.datadoghq.com.", "fakeapikey")}},
 	}
 
 	assert.NoError(t, err)
@@ -308,7 +485,7 @@ convert_dd_site_fqdn.enabled: false
 			externalAgentURL := GetMainEndpoint(testConfig, tc.externalPrefix, tc.externalConfig)
 
 			expectedMultipleEndpoints := EndpointDescriptorSet{
-				tc.expectedSite: newEndpointDescriptor(tc.expectedSite, newAPIKeyset("api_key", "fakeapikey")),
+				tc.expectedSite: EndpointDescriptor{BaseURL: tc.expectedSite, APIKeySet: []APIKeys{NewAPIKeys("api_key", tc.expectedSite, "fakeapikey")}},
 			}
 
 			assert.NoError(t, err)
@@ -330,7 +507,7 @@ func TestDDURLEnvVar(t *testing.T) {
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", newAPIKeyset("api_key", "fakeapikey")),
+		"https://app.datadoghq.eu": EndpointDescriptor{BaseURL: "https://app.datadoghq.eu", APIKeySet: []APIKeys{NewAPIKeys("api_key", "https://app.datadoghq.eu", "fakeapikey")}},
 	}
 
 	assert.NoError(t, err)
@@ -350,7 +527,7 @@ func TestDDDDURLEnvVar(t *testing.T) {
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", newAPIKeyset("api_key", "fakeapikey")),
+		"https://app.datadoghq.eu": EndpointDescriptor{BaseURL: "https://app.datadoghq.eu", APIKeySet: []APIKeys{NewAPIKeys("api_key", "https://app.datadoghq.eu", "fakeapikey")}},
 	}
 
 	assert.NoError(t, err)
@@ -374,7 +551,7 @@ func TestDDURLAndDDDDURLEnvVar(t *testing.T) {
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.dd_dd_url.eu": newEndpointDescriptor("https://app.datadoghq.dd_dd_url.eu", newAPIKeyset("api_key", "fakeapikey")),
+		"https://app.datadoghq.dd_dd_url.eu": EndpointDescriptor{BaseURL: "https://app.datadoghq.dd_dd_url.eu", APIKeySet: []APIKeys{NewAPIKeys("api_key", "https://app.datadoghq.dd_dd_url.eu", "fakeapikey")}},
 	}
 
 	assert.NoError(t, err)
@@ -397,7 +574,7 @@ external_config:
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.com": newEndpointDescriptor("https://app.datadoghq.com", newAPIKeyset("api_key", "fakeapikey")),
+		"https://app.datadoghq.com": EndpointDescriptor{BaseURL: "https://app.datadoghq.com", APIKeySet: []APIKeys{NewAPIKeys("api_key", "https://app.datadoghq.com", "fakeapikey")}},
 	}
 
 	assert.NoError(t, err)
@@ -419,7 +596,7 @@ external_config:
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := EndpointDescriptorSet{
-		"https://app.datadoghq.eu": newEndpointDescriptor("https://app.datadoghq.eu", newAPIKeyset("api_key", "fakeapikey")),
+		"https://app.datadoghq.eu": EndpointDescriptor{BaseURL: "https://app.datadoghq.eu", APIKeySet: []APIKeys{NewAPIKeys("api_key", "https://app.datadoghq.eu", "fakeapikey")}},
 	}
 
 	assert.NoError(t, err)

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -280,6 +280,39 @@ additional_endpoints:
 	assert.Equal(t, "enc_https://app.datadoghq.com_additional_endpoints_secret_handle", additional.Keys[1].Name)
 }
 
+// TestMainAPIKeyEncBackedName verifies that an ENC-backed api_key gets an
+// enc_-prefixed stable name from GetMultipleEndpoints, matching the behaviour
+// already in place for additional_endpoints. Without this, a user who swaps
+// which ENC handle is api_key vs. an additional endpoint between agent restarts
+// would produce transactions that resolve to idx_-based names on both sides,
+// making the two keys indistinguishable in the retry queue.
+func TestMainAPIKeyEncBackedName(t *testing.T) {
+	ddURL := "https://app.datadoghq.com"
+
+	testConfig := mock.NewFromYAML(t, `
+api_key: ENC[main_key_handle]
+dd_url: https://app.datadoghq.com
+`)
+	testConfig.Set("api_key", "resolved_main_key", pkgconfigmodel.SourceSecret)
+
+	endpoints, err := GetMultipleEndpoints(testConfig)
+	require.NoError(t, err)
+
+	descriptor, ok := endpoints[ddURL]
+	require.True(t, ok)
+
+	var primary APIKeys
+	for _, set := range descriptor.APIKeySet {
+		if set.ConfigSettingPath == "api_key" {
+			primary = set
+			break
+		}
+	}
+	require.Len(t, primary.Keys, 1)
+	assert.Equal(t, "resolved_main_key", primary.Keys[0].Key)
+	assert.Equal(t, "enc_https://app.datadoghq.com_api_key_main_key_handle", primary.Keys[0].Name)
+}
+
 // TestAdditionalEndpointAPIKeyNamesTrimAndDedup verifies that empty keys are
 // dropped and duplicate key values within one endpoint are collapsed at
 // construction. The surviving entry keeps the first occurrence's name, and

--- a/pkg/config/utils/go.mod
+++ b/pkg/config/utils/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/config/utils
 go 1.25.0
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.77.2
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.61.0

--- a/pkg/logs/diagnostic/go.mod
+++ b/pkg/logs/diagnostic/go.mod
@@ -16,6 +16,7 @@ require gopkg.in/yaml.v3 v3.0.1 // indirect
 require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.75.4 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.75.4 // indirect

--- a/pkg/logs/message/go.mod
+++ b/pkg/logs/message/go.mod
@@ -15,6 +15,7 @@ require gopkg.in/yaml.v3 v3.0.1 // indirect
 require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.75.4 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/pkg/logs/sources/go.mod
+++ b/pkg/logs/sources/go.mod
@@ -15,6 +15,7 @@ require gopkg.in/yaml.v3 v3.0.1 // indirect
 require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.75.4 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/pkg/logs/util/testutils/go.mod
+++ b/pkg/logs/util/testutils/go.mod
@@ -7,6 +7,7 @@ require github.com/DataDog/datadog-agent/pkg/logs/sources v0.75.4
 require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.75.4 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.75.4 // indirect

--- a/pkg/process/util/api/config/endpoint.go
+++ b/pkg/process/util/api/config/endpoint.go
@@ -29,10 +29,7 @@ func KeysPerDomains(endpoints []Endpoint) map[string][]utils.APIKeys {
 
 	for _, ep := range endpoints {
 		domain := removePathIfPresent(ep.Endpoint)
-		keysPerDomains[domain] = append(keysPerDomains[domain], utils.APIKeys{
-			ConfigSettingPath: ep.ConfigSettingPath,
-			Keys:              []string{ep.APIKey},
-		})
+		keysPerDomains[domain] = append(keysPerDomains[domain], utils.NewAPIKeys(ep.ConfigSettingPath, domain, ep.APIKey))
 	}
 
 	return keysPerDomains

--- a/pkg/process/util/api/config/endpoint_test.go
+++ b/pkg/process/util/api/config/endpoint_test.go
@@ -46,7 +46,7 @@ func TestKeysPerDomain(t *testing.T) {
 				{APIKey: "key1", Endpoint: getEndpoint(t, "http://foo.com"), ConfigSettingPath: "path"},
 			},
 			expected: map[string][]utils.APIKeys{
-				"http://foo.com": {utils.NewAPIKeys("path", "key1")},
+				"http://foo.com": {utils.NewAPIKeys("path", "http://foo.com", "key1")},
 			},
 		},
 		{
@@ -56,8 +56,8 @@ func TestKeysPerDomain(t *testing.T) {
 			},
 			expected: map[string][]utils.APIKeys{
 				"http://foo.com": {
-					utils.NewAPIKeys("path1", "key1"),
-					utils.NewAPIKeys("path2", "key2"),
+					utils.NewAPIKeys("path1", "http://foo.com", "key1"),
+					utils.NewAPIKeys("path2", "http://foo.com", "key2"),
 				},
 			},
 		},
@@ -67,8 +67,8 @@ func TestKeysPerDomain(t *testing.T) {
 				{APIKey: "key2", Endpoint: getEndpoint(t, "http://bar.com"), ConfigSettingPath: "path2"},
 			},
 			expected: map[string][]utils.APIKeys{
-				"http://foo.com": {utils.NewAPIKeys("path1", "key1")},
-				"http://bar.com": {utils.NewAPIKeys("path2", "key2")},
+				"http://foo.com": {utils.NewAPIKeys("path1", "http://foo.com", "key1")},
+				"http://bar.com": {utils.NewAPIKeys("path2", "http://bar.com", "key2")},
 			},
 		},
 		{
@@ -79,10 +79,10 @@ func TestKeysPerDomain(t *testing.T) {
 			},
 			expected: map[string][]utils.APIKeys{
 				"http://foo.com": {
-					utils.NewAPIKeys("path1", "key1"),
-					utils.NewAPIKeys("path3", "key3"),
+					utils.NewAPIKeys("path1", "http://foo.com", "key1"),
+					utils.NewAPIKeys("path3", "http://foo.com", "key3"),
 				},
-				"http://bar.com": {utils.NewAPIKeys("path2", "key2")},
+				"http://bar.com": {utils.NewAPIKeys("path2", "http://bar.com", "key2")},
 			},
 		},
 	} {

--- a/pkg/process/util/api/go.mod
+++ b/pkg/process/util/api/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.73.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.73.0-rc.5 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.62.0-rc.7 // indirect

--- a/pkg/serializer/internal/metrics/pipeline_test.go
+++ b/pkg/serializer/internal/metrics/pipeline_test.go
@@ -32,14 +32,14 @@ func TestPipelineSendValidate(t *testing.T) {
 	res1, err := resolver.NewSingleDomainResolver2(utils.EndpointDescriptor{
 		BaseURL: "http://example.test",
 		APIKeySet: []utils.APIKeys{
-			utils.NewAPIKeys("api_key", "1"),
+			utils.NewAPIKeys("api_key", "http://example.test", "1"),
 		},
 	})
 	require.NoError(t, err)
 	res2, err := resolver.NewSingleDomainResolver2(utils.EndpointDescriptor{
 		BaseURL: "http://another.test",
 		APIKeySet: []utils.APIKeys{
-			utils.NewAPIKeys("api_key", "2"),
+			utils.NewAPIKeys("api_key", "http://another.test", "2"),
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/serializer/metrics_test.go
+++ b/pkg/serializer/metrics_test.go
@@ -191,6 +191,7 @@ func TestBuildPipelinesWithMRFActive(t *testing.T) {
 	config.SetWithoutSource("multi_region_failover.enabled", true)
 	config.SetWithoutSource("multi_region_failover.failover_metrics", true)
 	config.SetWithoutSource("multi_region_failover.dd_url", "http://mrf.example.test")
+	config.SetWithoutSource("multi_region_failover.api_key", "mrf_test_key")
 
 	f, err := defaultforwarder.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)
@@ -228,6 +229,7 @@ func TestBuildPipelinesWithMRFActiveFilter(t *testing.T) {
 	config.SetWithoutSource("multi_region_failover.failover_metrics", true)
 	config.SetWithoutSource("multi_region_failover.metric_allowlist", []string{"datadog.agent.running"})
 	config.SetWithoutSource("multi_region_failover.dd_url", "http://mrf.example.test")
+	config.SetWithoutSource("multi_region_failover.api_key", "mrf_test_key")
 
 	f, err := defaultforwarder.NewTestForwarder(defaultforwarder.Params{}, config, logger, &secretnooptypes.SecretNoop{})
 	require.NoError(t, err)

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -369,7 +369,7 @@ func TestSendV1Series(t *testing.T) {
 
 func setupMockForwarder(t *testing.T) *forwarder.MockedForwarder {
 	r, err := resolver.NewSingleDomainResolver("https://localhost", []configutils.APIKeys{
-		configutils.NewAPIKeys("api_key", "foobar"),
+		configutils.NewAPIKeys("api_key", "https://localhost", "foobar"),
 	})
 	require.NoError(t, err)
 

--- a/pkg/status/endpoints/status.go
+++ b/pkg/status/endpoints/status.go
@@ -27,13 +27,16 @@ func PopulateStatus(stats map[string]interface{}) {
 
 	// obfuscate the api keys
 	for endpoint, eps := range endpoints {
-		keys := utils.DedupAPIKeys(eps.APIKeySet)
-		for i, key := range keys {
-			if len(key) > 4 {
-				keys[i] = key[len(key)-4:]
+		deduped := utils.DedupAPIKeys(eps.APIKeySet)
+		obfuscated := make([]string, len(deduped))
+		for i, k := range deduped {
+			if len(k.Key) > 4 {
+				obfuscated[i] = k.Key[len(k.Key)-4:]
+			} else {
+				obfuscated[i] = k.Key
 			}
 		}
-		endpointsInfos[endpoint] = keys
+		endpointsInfos[endpoint] = obfuscated
 	}
 	stats["endpointsInfos"] = endpointsInfos
 }

--- a/pkg/util/aws/creds/go.mod
+++ b/pkg/util/aws/creds/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/buildschema v0.0.0-00010101000000-000000000000 // indirect

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.72.0-rc.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.78.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
+	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.77.0-devel.0.20260213154712-e02b9359151a // indirect
 	github.com/DataDog/datadog-agent/comp/logs-library v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.78.1 // indirect


### PR DESCRIPTION
### What does this PR do?
Add a stable name to every API key.

Generate stable names for API keys in use. Names use the scheme:
- `idx_<canonical_endpoint>_<config_path>_<index>`   (plain keys)
- `enc_<canonical_endpoint>_<config_path>_<handle>`  (ENC-backed secrets)

Extend the domain resolver with stable-name lookup methods: `GetAPIKeyName(idx)`, `GetAPIKeyIndex(name)`, `AuthorizeByName(name)`.

### Motivation
Downstream components (retry serializer, configstream) need a stable, non-secret identifier per key so identity survives rotation and upgrades. The numeric index is fragile once the key list can change.

To illustrate this problem, let’s take a user who has configured an additional endpoint with two keys: A and B. We succeeded with sending the transaction with A, but failed to send it with B, so we serialize this transaction for later with index 1 (keys are referred via their indexes in the list of keys, so A has index 0, and B has index 1). Then the user performs a configuration update which swaps the key order, now B has index 0, and A has index 1. We deserialize our stored transaction and retry it with a key in slot 1, which is A, which works fine. So A has received the data twice, while B has lost the data completely.

Additionally, Remote Agents (e.g. ADP) get a fully resolved config which means that they cannot distinguish between plain non-updateable keys and keys which can get dynamic updates via the secrets management utilities. When they get a configuration update, they don't know if a new API key is related to the old ones or not, which might lead them to drop serialized transactions because they don't know which new key to use. We add API key names as a mechanism to correctly identify the keys and make this (endpoint, key) mapping stable.

### Describe how you validated your changes

Added new test cases to check the key name generation and handling logic.

### Additional Notes

This PR focuses on the way we generate and store the API key names. We will do the integration with the other parts of the Agent in follow-up PRs.