### PR TITLE
dyninst/irgen: dynamically discover context.Context implementations

### DIFF
--- a/pkg/dyninst/irgen/go_context.go
+++ b/pkg/dyninst/irgen/go_context.go
@@ -8,40 +8,27 @@
 package irgen
 
 import (
-	"slices"
-
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 )
 
-var ddTraceGoContextTypes = []string{
-	"context.Context",
-	"*context.afterFuncCtx",
-	"*context.cancelCtx",
-	"*context.stopCtx",
-	"*context.timerCtx",
-	"*context.valueCtx",
-	"*context.withoutCancelCtx",
-	"*os/signal.signalCtx",
-	"context.afterFuncCtx",
-	"context.backgroundCtx",
-	"context.cancelCtx",
-	"context.emptyCtx",
-	"context.stopCtx",
-	"context.timerCtx",
-	"context.todoCtx",
-	"context.valueCtx",
-	"context.withoutCancelCtx",
-	"os/signal.signalCtx",
-	"*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span",
+// ddTraceSpanTypeNames are dd-trace-go span types whose layout the BPF chain
+// walk needs to know about for trace-correlation. These are not
+// context.Context implementations in their own right; they get the
+// DDTraceSpanType annotation. They're listed explicitly because they live
+// outside the standard library, are not discoverable as
+// context.Context implementations, and carry per-version layout that the
+// runtime needs.
+var ddTraceSpanTypeNames = []string{
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span",
+	"*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span",
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext",
-	"*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span",
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span",
+	"*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span",
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext",
 }
 
-func addDDTraceGoContextTypes(typeNames map[string]struct{}) {
-	for _, name := range ddTraceGoContextTypes {
+func addDDTraceSpanTypeNames(typeNames map[string]struct{}) {
+	for _, name := range ddTraceSpanTypeNames {
 		typeNames[name] = struct{}{}
 	}
 }
@@ -61,12 +48,20 @@ func analyzedProbesContainGoContext(analyzedProbes []analyzedProbe) bool {
 // typeCatalog with dedicated wrapper IR types that carry the metadata the
 // BPF chain walk needs:
 //
-//   - context.{cancelCtx, valueCtx, …} → GoContextImplementationType
+//   - Every concrete context.Context implementation → GoContextImplementationType
 //   - dd-trace-go tracer.span (v1) / tracer.Span (v2) → DDTraceSpanType
+//
+// contextImplIRTypeIDs is the set of IR type IDs known to be concrete
+// context.Context implementations, discovered dynamically by walking the
+// method index for implementors of the context.Context interface.
 //
 // Wrapping (rather than mutating GoTypeAttributes on every IR type) keeps
 // the metadata off types that don't need it.
-func annotateSpecialGoTypes(tc *typeCatalog, enabled bool) {
+func annotateSpecialGoTypes(
+	tc *typeCatalog,
+	enabled bool,
+	contextImplIRTypeIDs map[ir.TypeID]struct{},
+) {
 	if !enabled {
 		return
 	}
@@ -75,32 +70,11 @@ func annotateSpecialGoTypes(tc *typeCatalog, enabled bool) {
 		if !ok {
 			continue
 		}
+		// dd-trace-go span types are special: they implement context.Context
+		// but the chain walk needs DDTrace-specific layout instead of the
+		// generic context impl wrapping. Match them first by their canonical
+		// names.
 		switch st.Name {
-		case "context.valueCtx":
-			attrs := goContextAttributes(st)
-			if key, ok := st.FieldByName("key"); ok {
-				attrs.KeyOffset = int32(key.Offset)
-			}
-			if val, ok := st.FieldByName("val"); ok {
-				attrs.ValueOffset = int32(val.Offset)
-			}
-			tc.typesByID[id] = &ir.GoContextImplementationType{
-				StructureType:       st,
-				GoContextAttributes: attrs,
-			}
-		case "context.afterFuncCtx",
-			"context.backgroundCtx",
-			"context.cancelCtx",
-			"context.emptyCtx",
-			"context.stopCtx",
-			"context.timerCtx",
-			"context.todoCtx",
-			"context.withoutCancelCtx",
-			"os/signal.signalCtx":
-			tc.typesByID[id] = &ir.GoContextImplementationType{
-				StructureType:       st,
-				GoContextAttributes: goContextAttributes(st),
-			}
 		case "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span":
 			if attrs, ok := ddTraceSpanLayout(tc, st, ir.DDTraceSpanV1); ok {
 				tc.typesByID[id] = &ir.DDTraceSpanType{
@@ -108,6 +82,7 @@ func annotateSpecialGoTypes(tc *typeCatalog, enabled bool) {
 					DDTraceAttributes: attrs,
 				}
 			}
+			continue
 		case "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span":
 			if attrs, ok := ddTraceSpanLayout(tc, st, ir.DDTraceSpanV2); ok {
 				tc.typesByID[id] = &ir.DDTraceSpanType{
@@ -115,26 +90,67 @@ func annotateSpecialGoTypes(tc *typeCatalog, enabled bool) {
 					DDTraceAttributes: attrs,
 				}
 			}
+			continue
+		}
+		if _, isCtxImpl := contextImplIRTypeIDs[id]; !isCtxImpl {
+			continue
+		}
+		attrs := goContextAttributes(st, contextImplIRTypeIDs)
+		// context.valueCtx is the one concrete context impl whose extra
+		// payload (key/val) the chain walk needs to read out. Match it by
+		// canonical name; no other Go context implementation exposes a
+		// key/value pair in this shape.
+		if st.Name == "context.valueCtx" {
+			if key, ok := st.FieldByName("key"); ok {
+				attrs.KeyOffset = int32(key.Offset)
+			}
+			if val, ok := st.FieldByName("val"); ok {
+				attrs.ValueOffset = int32(val.Offset)
+			}
+		}
+		tc.typesByID[id] = &ir.GoContextImplementationType{
+			StructureType:       st,
+			GoContextAttributes: attrs,
 		}
 	}
 }
 
-func goContextAttributes(st *ir.StructureType) ir.GoContextAttributes {
+func goContextAttributes(
+	st *ir.StructureType, contextImplIRTypeIDs map[ir.TypeID]struct{},
+) ir.GoContextAttributes {
 	attrs := ir.GoContextAttributes{
 		ContextOffset: ir.GoContextNoOffset,
 		KeyOffset:     ir.GoContextNoOffset,
 		ValueOffset:   ir.GoContextNoOffset,
 	}
-	if off, ok := embeddedContextOffset(st); ok {
+	visited := make(map[ir.TypeID]struct{})
+	if off, ok := embeddedContextOffset(st, contextImplIRTypeIDs, visited); ok {
 		attrs.ContextOffset = int32(off)
 	}
 	return attrs
 }
 
-func embeddedContextOffset(st *ir.StructureType) (uint32, bool) {
-	for _, name := range []string{"Context", "c"} {
-		if f, ok := st.FieldByName(name); ok &&
-			!isPlaceholderIRType(f.Type) &&
+// embeddedContextOffset finds the offset of the first field of type
+// context.Context (the interface) reachable from st, descending through
+// nested struct fields that are themselves concrete context implementations
+// (per contextImplIRTypeIDs). This generalizes the rule "the parent context
+// is the first field of type context.Context", which the BPF chain walk
+// relies on to step from one context to the next. The visited set guards
+// against cycles where impls embed each other.
+func embeddedContextOffset(
+	st *ir.StructureType,
+	contextImplIRTypeIDs map[ir.TypeID]struct{},
+	visited map[ir.TypeID]struct{},
+) (uint32, bool) {
+	if _, seen := visited[st.ID]; seen {
+		return 0, false
+	}
+	visited[st.ID] = struct{}{}
+	for _, f := range st.RawFields {
+		if isPlaceholderIRType(f.Type) {
+			continue
+		}
+		if _, ok := f.Type.(*ir.GoInterfaceType); ok &&
 			f.Type.GetName() == "context.Context" {
 			return f.Offset, true
 		}
@@ -144,26 +160,17 @@ func embeddedContextOffset(st *ir.StructureType) (uint32, bool) {
 			continue
 		}
 		nested, ok := f.Type.(*ir.StructureType)
-		if !ok || !isGoContextImplName(nested.Name) {
+		if !ok {
 			continue
 		}
-		if off, ok := embeddedContextOffset(nested); ok {
+		if _, ok := contextImplIRTypeIDs[nested.ID]; !ok {
+			continue
+		}
+		if off, ok := embeddedContextOffset(nested, contextImplIRTypeIDs, visited); ok {
 			return f.Offset + off, true
 		}
 	}
 	return 0, false
-}
-
-func isGoContextImplName(name string) bool {
-	return slices.Contains([]string{
-		"context.afterFuncCtx",
-		"context.cancelCtx",
-		"context.stopCtx",
-		"context.timerCtx",
-		"context.valueCtx",
-		"context.withoutCancelCtx",
-		"os/signal.signalCtx",
-	}, name)
 }
 
 func ddTraceSpanLayout(

--- a/pkg/dyninst/irgen/go_context_test.go
+++ b/pkg/dyninst/irgen/go_context_test.go
@@ -48,7 +48,9 @@ func TestAnnotateSpecialGoTypesContextValueCtx(t *testing.T) {
 		valueCtx.ID:     valueCtx,
 	}}
 
-	annotateSpecialGoTypes(tc, true)
+	annotateSpecialGoTypes(tc, true, map[ir.TypeID]struct{}{
+		valueCtx.ID: {},
+	})
 
 	wrapped, ok := tc.typesByID[valueCtx.ID].(*ir.GoContextImplementationType)
 	require.True(t, ok, "valueCtx should be wrapped as GoContextImplementationType")
@@ -113,7 +115,7 @@ func TestAnnotateSpecialGoTypesDDTraceSpan(t *testing.T) {
 		span.ID:           span,
 	}}
 
-	annotateSpecialGoTypes(tc, true)
+	annotateSpecialGoTypes(tc, true, nil)
 
 	spanWrapped, ok := tc.typesByID[span.ID].(*ir.DDTraceSpanType)
 	require.True(t, ok, "tracer.Span should be wrapped as DDTraceSpanType")

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -253,8 +253,18 @@ func generateIR(
 		additionalTypeSet[name] = struct{}{}
 	}
 	specialAdditionalTypeSet := make(map[string]struct{})
-	addDDTraceGoContextTypes(specialAdditionalTypeSet)
+	addDDTraceSpanTypeNames(specialAdditionalTypeSet)
+	specialAdditionalTypeSet["context.Context"] = struct{}{}
 	specialAdditionalTypeOffsets := make(map[string]dwarf.Offset, len(specialAdditionalTypeSet))
+
+	// Context.Context's gotype TypeID, captured while iterating gotypes
+	// below, is used after the method index is built to dynamically
+	// enumerate every context.Context implementation in the binary via
+	// the implementor iterator.
+	var contextInterfaceMethods []gotype.IMethod
+	// DWARF offsets of every concrete context.Context implementation
+	// discovered dynamically via the implementor iterator.
+	var contextImplDwarfOffsets []dwarf.Offset
 
 	var additionalTypeRoots []explorationRoot
 	var methodBuf []gotype.Method
@@ -311,6 +321,17 @@ func generateIR(
 				specialAdditionalTypeOffsets[matchName] = dwarfOffset
 			}
 		}
+		if contextInterfaceMethods == nil && name == "context.Context" {
+			if iface, ok := goType.Interface(); ok {
+				ms, err := iface.Methods(nil)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"failed to get methods for context.Context: %w", err,
+					)
+				}
+				contextInterfaceMethods = ms
+			}
+		}
 		if len(additionalTypeSet) > 0 {
 			if _, requested := additionalTypeSet[name]; requested {
 				if dwarfOffset, ok := typeIndex.resolveDwarfOffset(tid); ok {
@@ -350,6 +371,22 @@ func generateIR(
 		return nil, fmt.Errorf("failed to build method index: %w", err)
 	}
 	defer cleanupCloser(methodIndex, "method index")()
+
+	// Discover every concrete context.Context implementation in the binary
+	// by enumerating types that satisfy context.Context's method set via
+	// the method index. This replaces hardcoding the set of known
+	// implementations and lets custom user types participate in
+	// context-chain decoding.
+	if len(contextInterfaceMethods) > 0 {
+		ii := makeImplementorIterator(methodIndex)
+		for ii.seek(contextInterfaceMethods); ii.valid(); ii.next() {
+			dwarfOffset, ok := typeIndex.resolveDwarfOffset(ii.cur())
+			if !ok {
+				continue
+			}
+			contextImplDwarfOffsets = append(contextImplDwarfOffsets, dwarfOffset)
+		}
+	}
 
 	// Collect line information about subprograms. It's important for
 	// performance to batch analysis of each compilation unit, and do it in
@@ -444,16 +481,37 @@ func generateIR(
 			needsGoContextSupport = true
 		}
 	}
+	// IR type IDs of every concrete context.Context implementation pulled
+	// into the type catalog. Passed to annotateSpecialGoTypes so it knows
+	// which structures to wrap as GoContextImplementationType.
+	contextImplIRTypeIDs := make(map[ir.TypeID]struct{})
 	if needsGoContextSupport {
-		// Pull every dd-trace-go support type and the context.Context
-		// interface itself into the catalog now, so that the unified
-		// expansion below has them as roots. context.Context gets budget
-		// 2 (enough to dereference the interface to its impl pointer and
-		// then dereference that pointer to the impl struct, materializing
-		// the struct as a real StructureType rather than a placeholder).
-		// All other special types get budget 1 — they're either directly
-		// captured or reached via valueCtx's value field at runtime.
-		for _, name := range ddTraceGoContextTypes {
+		// Pull the context.Context interface itself into the catalog now,
+		// so that the unified expansion below has it as a root.
+		// context.Context gets budget 2 (enough to dereference the
+		// interface to its impl pointer and then dereference that pointer
+		// to the impl struct, materializing the struct as a real
+		// StructureType rather than a placeholder).
+		if dwarfOffset, ok := specialAdditionalTypeOffsets["context.Context"]; ok {
+			t, addErr := typeCatalog.addType(dwarfOffset)
+			if addErr != nil {
+				log.Debugf(
+					"failed to add context.Context at offset %#x: %v",
+					dwarfOffset, addErr,
+				)
+			} else {
+				additionalTypeRoots = append(additionalTypeRoots, explorationRoot{
+					typeID: t.GetID(),
+					budget: 2,
+				})
+			}
+		}
+		// Pull every dd-trace-go span type into the catalog. These are
+		// not discovered as context.Context implementations (they need
+		// DDTraceSpan annotation rather than GoContext annotation) but
+		// the chain walk still needs them present so it can attach
+		// trace-correlation layout.
+		for _, name := range ddTraceSpanTypeNames {
 			dwarfOffset, ok := specialAdditionalTypeOffsets[name]
 			if !ok {
 				continue
@@ -461,18 +519,56 @@ func generateIR(
 			t, addErr := typeCatalog.addType(dwarfOffset)
 			if addErr != nil {
 				log.Debugf(
-					"failed to add context support type %q at offset %#x: %v",
+					"failed to add dd-trace-go support type %q at offset %#x: %v",
 					name, dwarfOffset, addErr,
 				)
 				continue
 			}
-			budget := uint32(1)
-			if name == "context.Context" {
-				budget = 2
+			additionalTypeRoots = append(additionalTypeRoots, explorationRoot{
+				typeID: t.GetID(),
+				budget: 1,
+			})
+		}
+		// Pull every dynamically discovered context.Context implementation
+		// into the catalog. The iterator returns both value-form impls
+		// (e.g. emptyCtx) and pointer-form impls (e.g. *cancelCtx); the
+		// latter is what shows up when the methods have pointer
+		// receivers. In both cases what we want as a budget-1 root is
+		// the impl *struct*, so that the struct's fields are explored at
+		// budget 1 and any interface-typed fields (e.g. cancelCtx.err
+		// error, cancelCtx.children map[canceler]struct{}) fire
+		// processInterface to pull in their implementors. For pointer
+		// forms, root the pointee struct directly rather than the
+		// pointer — equivalent to giving the pointer budget 2, but
+		// states the intent.
+		for _, dwarfOffset := range contextImplDwarfOffsets {
+			t, addErr := typeCatalog.addType(dwarfOffset)
+			if addErr != nil {
+				log.Debugf(
+					"failed to add context impl at offset %#x: %v",
+					dwarfOffset, addErr,
+				)
+				continue
+			}
+			if ptr, ok := t.(*ir.PointerType); ok {
+				if placeholder, ok := ptr.Pointee.(*pointeePlaceholderType); ok {
+					pointee, addErr := typeCatalog.addType(placeholder.offset)
+					if addErr != nil {
+						log.Debugf(
+							"failed to add pointee for context impl at offset %#x: %v",
+							placeholder.offset, addErr,
+						)
+						continue
+					}
+					ptr.Pointee = pointee
+					t = pointee
+				} else {
+					t = ptr.Pointee
+				}
 			}
 			additionalTypeRoots = append(additionalTypeRoots, explorationRoot{
 				typeID: t.GetID(),
-				budget: budget,
+				budget: 1,
 			})
 		}
 	}
@@ -511,7 +607,29 @@ func generateIR(
 	if err := finalizeTypes(typeCatalog, materializedSubprograms); err != nil {
 		return nil, err
 	}
-	annotateSpecialGoTypes(typeCatalog, needsGoContextSupport)
+	// Resolve each dynamically discovered context.Context implementation
+	// to an IR struct type ID. We do this after expansion so that
+	// pointer-form impls (e.g. *cancelCtx) have had their pointee struct
+	// materialized — at the moment addType was called above, the pointee
+	// was still a placeholder.
+	for _, dwarfOffset := range contextImplDwarfOffsets {
+		id, ok := typeCatalog.typesByDwarfType[dwarfOffset]
+		if !ok {
+			continue
+		}
+		t := typeCatalog.typesByID[id]
+		switch tt := t.(type) {
+		case *ir.StructureType:
+			contextImplIRTypeIDs[tt.ID] = struct{}{}
+		case *ir.PointerType:
+			if tt.Pointee != nil && !isPlaceholderIRType(tt.Pointee) {
+				if _, isStruct := tt.Pointee.(*ir.StructureType); isStruct {
+					contextImplIRTypeIDs[tt.Pointee.GetID()] = struct{}{}
+				}
+			}
+		}
+	}
+	annotateSpecialGoTypes(typeCatalog, needsGoContextSupport, contextImplIRTypeIDs)
 
 	// Populate event root expressions for every probe.
 	probes, eventIssues := populateProbeEventsExpressions(

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -702,10 +702,10 @@ Types:
       ByteSize: 8
       Pointee: 726 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 159
+      ID: 151
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 158 GoSliceDataType []os.Signal.array
+      Pointee: 150 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -731,15 +731,15 @@ Types:
       ByteSize: 8
       Pointee: 476 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 161
+      ID: 165
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 160 GoSliceDataType []time.zone.array
+      Pointee: 164 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 163
+      ID: 167
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []time.zoneTrans.array
+      Pointee: 166 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1036
       Name: '*[]uint16.array'
@@ -753,15 +753,15 @@ Types:
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 143
+      ID: 147
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 142 GoSliceDataType []uint8.array
+      Pointee: 146 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 145
+      ID: 149
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 144 GoSliceDataType []uintptr.array
+      Pointee: 148 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 890
       Name: '*[]vendor/golang.org/x/net/http2/hpack.HeaderField.array'
@@ -790,10 +790,10 @@ Types:
       ByteSize: 8
       Pointee: 846 GoHMapBucketType bucket<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 125
+      ID: 133
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 126 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 134 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1020
       Name: '*bucket<crypto/x509.sum224,bool>'
@@ -893,19 +893,19 @@ Types:
       GoKind: 22
       Pointee: 504 StructureType bytes.Reader
     - __kind: PointerType
-      ID: 170
+      ID: 117
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 279936
       GoKind: 22
-      Pointee: 117 StructureType context.backgroundCtx
+      Pointee: 118 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 107
+      ID: 126
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 330240
       GoKind: 22
-      Pointee: 108 StructureType context.cancelCtx
+      Pointee: 127 StructureType context.cancelCtx
     - __kind: PointerType
       ID: 308
       Name: '*context.deadlineExceededError'
@@ -914,12 +914,12 @@ Types:
       GoKind: 22
       Pointee: 309 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 167
+      ID: 107
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 244608
       GoKind: 22
-      Pointee: 118 StructureType context.emptyCtx
+      Pointee: 108 StructureType context.emptyCtx
     - __kind: PointerType
       ID: 109
       Name: '*context.stopCtx'
@@ -928,19 +928,19 @@ Types:
       GoKind: 22
       Pointee: 110 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 111
+      ID: 137
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 330432
       GoKind: 22
-      Pointee: 112 StructureType context.timerCtx
+      Pointee: 138 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 279616
       GoKind: 22
-      Pointee: 114 StructureType context.valueCtx
+      Pointee: 115 StructureType context.valueCtx
     - __kind: PointerType
       ID: 260
       Name: '*crypto/aes.KeySizeError'
@@ -1372,10 +1372,10 @@ Types:
       ByteSize: 8
       Pointee: 844 GoHMapHeaderType hash<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 123
+      ID: 131
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 124 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 132 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1018
       Name: '*hash<crypto/x509.sum224,bool>'
@@ -1831,12 +1831,12 @@ Types:
       GoKind: 22
       Pointee: 204 StructureType net.notFoundError
     - __kind: PointerType
-      ID: 168
+      ID: 112
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 245248
       GoKind: 22
-      Pointee: 169 StructureType net.onlyValuesCtx
+      Pointee: 113 StructureType net.onlyValuesCtx
     - __kind: PointerType
       ID: 205
       Name: '*net.result·2'
@@ -2576,12 +2576,12 @@ Types:
       GoKind: 22
       Pointee: 286 StructureType os.LinkError
     - __kind: PointerType
-      ID: 137
+      ID: 123
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 82304
       GoKind: 22
-      Pointee: 138 GoInterfaceType os.Signal
+      Pointee: 124 GoInterfaceType os.Signal
     - __kind: PointerType
       ID: 317
       Name: '*os.SyscallError'
@@ -2625,12 +2625,12 @@ Types:
       GoKind: 22
       Pointee: 601 StructureType os.noWriteTo
     - __kind: PointerType
-      ID: 115
+      ID: 119
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 295488
       GoKind: 22
-      Pointee: 116 StructureType os/signal.signalCtx
+      Pointee: 120 StructureType os/signal.signalCtx
     - __kind: PointerType
       ID: 229
       Name: '*reflect.ValueError'
@@ -2728,12 +2728,12 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 127
+      ID: 135
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 88128
       GoKind: 22
-      Pointee: 128 UnresolvedPointeeType runtime.mapextra
+      Pointee: 136 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 294
       Name: '*runtime.plainError'
@@ -2782,10 +2782,10 @@ Types:
       GoKind: 22
       Pointee: 12 GoStringHeaderType string
     - __kind: PointerType
-      ID: 141
+      ID: 145
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 140 GoStringDataType string.str
+      Pointee: 144 GoStringDataType string.str
     - __kind: PointerType
       ID: 587
       Name: '*strings.Reader'
@@ -2825,7 +2825,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 282016
       GoKind: 22
-      Pointee: 119 StructureType sync.Mutex
+      Pointee: 128 StructureType sync.Mutex
     - __kind: PointerType
       ID: 981
       Name: '*sync.RWMutex'
@@ -2862,19 +2862,19 @@ Types:
       GoKind: 22
       Pointee: 475 StructureType syscall.Iovec
     - __kind: PointerType
-      ID: 166
+      ID: 170
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 201856
       GoKind: 22
-      Pointee: 165 BaseType syscall.Signal
+      Pointee: 169 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 133
+      ID: 142
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 296448
       GoKind: 22
-      Pointee: 134 StructureType time.Location
+      Pointee: 143 StructureType time.Location
     - __kind: PointerType
       ID: 223
       Name: '*time.ParseError'
@@ -2883,12 +2883,12 @@ Types:
       GoKind: 22
       Pointee: 224 StructureType time.ParseError
     - __kind: PointerType
-      ID: 130
+      ID: 139
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 198016
       GoKind: 22
-      Pointee: 131 StructureType time.Timer
+      Pointee: 140 StructureType time.Timer
     - __kind: PointerType
       ID: 222
       Name: '*time.fileSizeError'
@@ -2902,19 +2902,19 @@ Types:
       ByteSize: 8
       Pointee: 185 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 153
+      ID: 159
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 82944
       GoKind: 22
-      Pointee: 154 StructureType time.zone
+      Pointee: 160 StructureType time.zone
     - __kind: PointerType
-      ID: 156
+      ID: 162
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 83008
       GoKind: 22
-      Pointee: 157 StructureType time.zoneTrans
+      Pointee: 163 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 101
       Name: '*uint'
@@ -3033,7 +3033,7 @@ Types:
       GoRuntimeType: 118464
       GoKind: 18
     - __kind: GoChannelType
-      ID: 164
+      ID: 168
       Name: <-chan time.Time
       GoRuntimeType: 120576
       GoKind: 18
@@ -3582,7 +3582,7 @@ Types:
       HasCount: true
       Element: 13 BaseType uint64
     - __kind: ArrayType
-      ID: 146
+      ID: 152
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 125568
@@ -3802,11 +3802,11 @@ Types:
       ByteSize: 80
       Element: 846 GoHMapBucketType bucket<*net/http.http2serverConn,struct {}>
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 157
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 126 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 134 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
       ID: 1032
       Name: '[]bucket<crypto/x509.sum224,bool>.array'
@@ -4235,12 +4235,12 @@ Types:
       HasCount: true
       Element: 803 PointerType *net/http.http2serverConn
     - __kind: ArrayType
-      ID: 147
+      ID: 153
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 148 GoInterfaceType context.canceler
+      Element: 154 GoInterfaceType context.canceler
     - __kind: ArrayType
       ID: 1029
       Name: '[]key<crypto/x509.sum224>'
@@ -4415,7 +4415,7 @@ Types:
       ByteSize: 24
       Element: 725 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 122
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 99136
@@ -4423,20 +4423,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType *os.Signal
+          Type: 123 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 158 GoSliceDataType []os.Signal.array
+      Data: 150 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 158
+      ID: 150
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 138 GoInterfaceType os.Signal
+      Element: 124 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -4488,7 +4488,7 @@ Types:
       ByteSize: 16
       Element: 475 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 158
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 103616
@@ -4496,22 +4496,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 153 PointerType *time.zone
+          Type: 159 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 160 GoSliceDataType []time.zone.array
+      Data: 164 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 164
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 154 StructureType time.zone
+      Element: 160 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 161
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 103680
@@ -4519,20 +4519,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType *time.zoneTrans
+          Type: 162 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 162 GoSliceDataType []time.zoneTrans.array
+      Data: 166 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 166
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 157 StructureType time.zoneTrans
+      Element: 163 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 536
       Name: '[]uint16'
@@ -4572,9 +4572,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 142 GoSliceDataType []uint8.array
+      Data: 146 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 142
+      ID: 146
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4595,9 +4595,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 144 GoSliceDataType []uintptr.array
+      Data: 148 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 144
+      ID: 148
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4687,11 +4687,11 @@ Types:
       HasCount: true
       Element: 12 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 149
+      ID: 155
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
-      Element: 150 StructureType struct {}
+      Element: 156 StructureType struct {}
     - __kind: ArrayType
       ID: 904
       Name: '[]val<uint64>'
@@ -4735,18 +4735,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 748 ArrayType []key<*net.Listener>
         - Name: values
           Offset: 72
-          Type: 149 ArrayType []val<struct {}>
+          Type: 155 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 670 PointerType *bucket<*net.Listener,struct {}>
       KeyType: 749 PointerType *net.Listener
-      ValueType: 150 StructureType struct {}
+      ValueType: 156 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 676
       Name: bucket<*net/http.conn,struct {}>
@@ -4754,18 +4754,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 752 ArrayType []key<*net/http.conn>
         - Name: values
           Offset: 72
-          Type: 149 ArrayType []val<struct {}>
+          Type: 155 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 675 PointerType *bucket<*net/http.conn,struct {}>
       KeyType: 630 PointerType *net/http.conn
-      ValueType: 150 StructureType struct {}
+      ValueType: 156 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 846
       Name: bucket<*net/http.http2serverConn,struct {}>
@@ -4773,37 +4773,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 847 ArrayType []key<*net/http.http2serverConn>
         - Name: values
           Offset: 72
-          Type: 149 ArrayType []val<struct {}>
+          Type: 155 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 845 PointerType *bucket<*net/http.http2serverConn,struct {}>
       KeyType: 803 PointerType *net/http.http2serverConn
-      ValueType: 150 StructureType struct {}
+      ValueType: 156 StructureType struct {}
     - __kind: GoHMapBucketType
-      ID: 126
+      ID: 134
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 147 ArrayType []key<context.canceler>
+          Type: 153 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 149 ArrayType []val<struct {}>
+          Type: 155 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 125 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 148 GoInterfaceType context.canceler
-      ValueType: 150 StructureType struct {}
+          Type: 133 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 154 GoInterfaceType context.canceler
+      ValueType: 156 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 1021
       Name: bucket<crypto/x509.sum224,bool>
@@ -4811,7 +4811,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 1029 ArrayType []key<crypto/x509.sum224>
@@ -4830,7 +4830,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 733 ArrayType []key<net/http.routingIndexKey>
@@ -4849,7 +4849,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4868,7 +4868,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4887,7 +4887,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4906,7 +4906,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4925,7 +4925,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4944,7 +4944,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4963,7 +4963,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4982,7 +4982,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -5001,7 +5001,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -5020,7 +5020,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 927 ArrayType []key<uint32>
@@ -5039,7 +5039,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 927 ArrayType []key<uint32>
@@ -5058,7 +5058,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 906 ArrayType []key<vendor/golang.org/x/net/http2/hpack.pairNameValue>
@@ -5191,7 +5191,7 @@ Types:
       GoRuntimeType: 120960
       GoKind: 18
     - __kind: GoChannelType
-      ID: 139
+      ID: 125
       Name: chan os.Signal
       GoRuntimeType: 121728
       GoKind: 18
@@ -5213,7 +5213,7 @@ Types:
       GoRuntimeType: 115904
       GoKind: 15
     - __kind: GoSubroutineType
-      ID: 135
+      ID: 121
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 124800
@@ -5232,19 +5232,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 117
+      ID: 118
       Name: context.backgroundCtx
       GoRuntimeType: 351392
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 118 StructureType context.emptyCtx
+          Type: 108 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 108
+      ID: 127
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 385344
@@ -5255,13 +5255,13 @@ Types:
           Type: 106 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 120 StructureType sync/atomic.Value
+          Type: 129 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 122 GoMapType map[context.canceler]struct {}
+          Type: 130 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -5271,7 +5271,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 148
+      ID: 154
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 214240
@@ -5290,7 +5290,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 118
+      ID: 108
       Name: context.emptyCtx
       GoRuntimeType: 289056
       GoKind: 25
@@ -5310,11 +5310,11 @@ Types:
           Type: 106 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 129 GoSubroutineType func() bool
+          Type: 111 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 112
+      ID: 138
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 290688
@@ -5322,17 +5322,17 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 108 StructureType context.cancelCtx
+          Type: 127 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 130 PointerType *time.Timer
+          Type: 139 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 132 GoTimeType time.Time
+          Type: 141 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 114
+      ID: 115
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 357664
@@ -5343,10 +5343,10 @@ Types:
           Type: 106 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: BaseType
@@ -5443,7 +5443,7 @@ Types:
           Type: 518 GoInterfaceType io.Reader
         - Name: mu
           Offset: 16
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: used
           Offset: 24
           Type: 606 StructureType sync/atomic.Uint32
@@ -5709,7 +5709,7 @@ Types:
           Type: 481 StructureType sync/atomic.Bool
         - Name: handshakeMutex
           Offset: 44
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: handshakeErr
           Offset: 56
           Type: 20 GoInterfaceType error
@@ -6107,7 +6107,7 @@ Types:
       RawFields:
         - Name: Mutex
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: err
           Offset: 8
           Type: 20 GoInterfaceType error
@@ -6116,19 +6116,19 @@ Types:
           Type: 9 BaseType uint16
         - Name: cipher
           Offset: 32
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: mac
           Offset: 48
           Type: 499 GoInterfaceType hash.Hash
         - Name: seq
           Offset: 64
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: scratchBuf
           Offset: 72
           Type: 500 ArrayType [13]uint8
         - Name: nextCipher
           Offset: 88
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: nextMac
           Offset: 104
           Type: 499 GoInterfaceType hash.Hash
@@ -6178,7 +6178,7 @@ Types:
           Type: 515 GoChannelType <-chan struct {}
         - Name: cancel
           Offset: 512
-          Type: 135 GoSubroutineType context.CancelFunc
+          Type: 121 GoSubroutineType context.CancelFunc
         - Name: waitingForDrain
           Offset: 520
           Type: 6 BaseType bool
@@ -6206,7 +6206,7 @@ Types:
           Type: 506 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 132 GoTimeType time.Time
+          Type: 141 GoTimeType time.Time
     - __kind: StructureType
       ID: 534
       Name: crypto/x509.CertPool
@@ -6259,7 +6259,7 @@ Types:
           Type: 392 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 11 BaseType int
@@ -6274,10 +6274,10 @@ Types:
           Type: 395 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 132 GoTimeType time.Time
+          Type: 141 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 132 GoTimeType time.Time
+          Type: 141 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 400 BaseType crypto/x509.KeyUsage
@@ -6518,7 +6518,7 @@ Types:
           Type: 406 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 403
       Name: crypto/x509/pkix.Extension
@@ -6760,7 +6760,7 @@ Types:
           Type: 1059 GoSliceHeaderType fmt.buffer
         - Name: arg
           Offset: 24
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: value
           Offset: 40
           Type: 1060 StructureType reflect.Value
@@ -6836,7 +6836,7 @@ Types:
       GoRuntimeType: 134592
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 129
+      ID: 111
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 118720
@@ -7035,7 +7035,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 671 GoHMapBucketType bucket<*net.Listener,struct {}>
       BucketsType: 751 GoSliceDataType []bucket<*net.Listener,struct {}>.array
     - __kind: GoHMapHeaderType
@@ -7069,7 +7069,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 676 GoHMapBucketType bucket<*net/http.conn,struct {}>
       BucketsType: 753 GoSliceDataType []bucket<*net/http.conn,struct {}>.array
     - __kind: GoHMapHeaderType
@@ -7103,11 +7103,11 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 846 GoHMapBucketType bucket<*net/http.http2serverConn,struct {}>
       BucketsType: 848 GoSliceDataType []bucket<*net/http.http2serverConn,struct {}>.array
     - __kind: GoHMapHeaderType
-      ID: 124
+      ID: 132
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -7128,18 +7128,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 125 PointerType *bucket<context.canceler,struct {}>
+          Type: 133 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 125 PointerType *bucket<context.canceler,struct {}>
+          Type: 133 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
-      BucketType: 126 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 151 GoSliceDataType []bucket<context.canceler,struct {}>.array
+          Type: 135 PointerType *runtime.mapextra
+      BucketType: 134 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 157 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 1019
       Name: hash<crypto/x509.sum224,bool>
@@ -7171,7 +7171,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 1021 GoHMapBucketType bucket<crypto/x509.sum224,bool>
       BucketsType: 1032 GoSliceDataType []bucket<crypto/x509.sum224,bool>.array
     - __kind: GoHMapHeaderType
@@ -7205,7 +7205,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 711 GoHMapBucketType bucket<net/http.routingIndexKey,[]*net/http.pattern>
       BucketsType: 736 GoSliceDataType []bucket<net/http.routingIndexKey,[]*net/http.pattern>.array
     - __kind: GoHMapHeaderType
@@ -7239,7 +7239,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 527 GoHMapBucketType bucket<string,*crypto/tls.Certificate>
       BucketsType: 1006 GoSliceDataType []bucket<string,*crypto/tls.Certificate>.array
     - __kind: GoHMapHeaderType
@@ -7273,7 +7273,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 704 GoHMapBucketType bucket<string,*net/http.routingNode>
       BucketsType: 732 GoSliceDataType []bucket<string,*net/http.routingNode>.array
     - __kind: GoHMapHeaderType
@@ -7307,7 +7307,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 784 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
       BucketsType: 789 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
@@ -7341,7 +7341,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 1013 GoHMapBucketType bucket<string,[]int>
       BucketsType: 1024 GoSliceDataType []bucket<string,[]int>.array
     - __kind: GoHMapHeaderType
@@ -7375,7 +7375,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 641 GoHMapBucketType bucket<string,[]string>
       BucketsType: 778 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
@@ -7409,7 +7409,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 660 GoHMapBucketType bucket<string,func(*net/http.Server, *crypto/tls.Conn, net/http.Handler)>
       BucketsType: 745 GoSliceDataType []bucket<string,func(*net/http.Server, *crypto/tls.Conn, net/http.Handler)>.array
     - __kind: GoHMapHeaderType
@@ -7443,7 +7443,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 719 GoHMapBucketType bucket<string,net/http.muxEntry>
       BucketsType: 740 GoSliceDataType []bucket<string,net/http.muxEntry>.array
     - __kind: GoHMapHeaderType
@@ -7477,7 +7477,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 776 GoHMapBucketType bucket<string,string>
       BucketsType: 795 GoSliceDataType []bucket<string,string>.array
     - __kind: GoHMapHeaderType
@@ -7511,7 +7511,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 897 GoHMapBucketType bucket<string,uint64>
       BucketsType: 905 GoSliceDataType []bucket<string,uint64>.array
     - __kind: GoHMapHeaderType
@@ -7545,7 +7545,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 831 GoHMapBucketType bucket<uint32,*net/http.http2stream>
       BucketsType: 961 GoSliceDataType []bucket<uint32,*net/http.http2stream>.array
     - __kind: GoHMapHeaderType
@@ -7579,7 +7579,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 920 GoHMapBucketType bucket<uint32,*net/http.http2writeQueue>
       BucketsType: 929 GoSliceDataType []bucket<uint32,*net/http.http2writeQueue>.array
     - __kind: GoHMapHeaderType
@@ -7613,7 +7613,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 902 GoHMapBucketType bucket<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>
       BucketsType: 908 GoSliceDataType []bucket<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>.array
     - __kind: BaseType
@@ -7660,7 +7660,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoEmptyInterfaceType
-      ID: 121
+      ID: 116
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 159552
@@ -8062,7 +8062,7 @@ Types:
       RawFields:
         - Name: outMu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: out
           Offset: 8
           Type: 544 GoInterfaceType io.Writer
@@ -8123,12 +8123,12 @@ Types:
       GoKind: 21
       HeaderType: 844 GoHMapHeaderType hash<*net/http.http2serverConn,struct {}>
     - __kind: GoMapType
-      ID: 122
+      ID: 130
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 178272
       GoKind: 21
-      HeaderType: 124 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 132 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 1017
       Name: map[crypto/x509.sum224]bool
@@ -8323,7 +8323,7 @@ Types:
       RawFields:
         - Name: lk
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: s
           Offset: 8
           Type: 986 PointerType *math/rand.rngSource
@@ -8352,7 +8352,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
     - __kind: StructureType
       ID: 790
       Name: mime/multipart.FileHeader
@@ -8859,8 +8859,8 @@ Types:
         - Name: s
           Offset: 0
           Type: 12 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 169
+    - __kind: GoContextImplementationType
+      ID: 113
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 336384
@@ -8872,6 +8872,8 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 106 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
       ID: 206
       Name: net.result·2
@@ -9205,7 +9207,7 @@ Types:
           Type: 20 GoInterfaceType error
         - Name: mu
           Offset: 168
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: listeners
           Offset: 176
           Type: 667 GoMapType map[*net.Listener]struct {}
@@ -9230,7 +9232,7 @@ Types:
           Type: 518 GoInterfaceType io.Reader
         - Name: hdr
           Offset: 16
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: r
           Offset: 32
           Type: 592 PointerType *bufio.Reader
@@ -9242,7 +9244,7 @@ Types:
           Type: 6 BaseType bool
         - Name: mu
           Offset: 44
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: sawEOF
           Offset: 52
           Type: 6 BaseType bool
@@ -9306,7 +9308,7 @@ Types:
           Type: 646 PointerType *net/http.Server
         - Name: cancelCtx
           Offset: 8
-          Type: 135 GoSubroutineType context.CancelFunc
+          Type: 121 GoSubroutineType context.CancelFunc
         - Name: rwc
           Offset: 16
           Type: 349 GoInterfaceType net.Conn
@@ -9339,7 +9341,7 @@ Types:
           Type: 652 StructureType sync/atomic.Uint64
         - Name: mu
           Offset: 128
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: hijackedv
           Offset: 136
           Type: 6 BaseType bool
@@ -9355,7 +9357,7 @@ Types:
           Type: 630 PointerType *net/http.conn
         - Name: mu
           Offset: 8
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: hasByte
           Offset: 16
           Type: 6 BaseType bool
@@ -9652,7 +9654,7 @@ Types:
           Type: 858 StructureType net/http.http2FrameHeader
         - Name: Data
           Offset: 12
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
     - __kind: StructureType
       ID: 868
       Name: net/http.http2PriorityFrame
@@ -10050,7 +10052,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: c
           Offset: 8
           Type: 973 StructureType sync.Cond
@@ -10190,7 +10192,7 @@ Types:
           Type: 15 BaseType int64
         - Name: closeNotifierMu
           Offset: 104
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: closeNotifierCh
           Offset: 112
           Type: 645 GoChannelType chan bool
@@ -10382,7 +10384,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: activeConns
           Offset: 8
           Type: 842 GoMapType map[*net/http.http2serverConn]struct {}
@@ -10478,7 +10480,7 @@ Types:
       RawFields:
         - Name: Timer
           Offset: 0
-          Type: 130 PointerType *time.Timer
+          Type: 139 PointerType *time.Timer
     - __kind: StructureType
       ID: 834
       Name: net/http.http2unstartedHandler
@@ -10836,7 +10838,7 @@ Types:
           Type: 629 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 135 GoSubroutineType context.CancelFunc
+          Type: 121 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -10848,7 +10850,7 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
           Type: 481 StructureType sync/atomic.Bool
@@ -11272,7 +11274,7 @@ Types:
           Offset: 48
           Type: 20 GoInterfaceType error
     - __kind: GoInterfaceType
-      ID: 138
+      ID: 124
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 216160
@@ -11306,7 +11308,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: buf
           Offset: 8
           Type: 487 PointerType *[]uint8
@@ -11380,7 +11382,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 116
+      ID: 120
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 385600
@@ -11391,13 +11393,13 @@ Types:
           Type: 106 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 135 GoSubroutineType context.CancelFunc
+          Type: 121 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 136 GoSliceHeaderType []os.Signal
+          Type: 122 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 139 GoChannelType chan os.Signal
+          Type: 125 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
@@ -12144,7 +12146,7 @@ Types:
           Offset: 24
           Type: 30 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 128
+      ID: 136
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -12313,13 +12315,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 141 PointerType *string.str
+          Type: 145 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 140 GoStringDataType string.str
+      Data: 144 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 140
+      ID: 144
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -12376,7 +12378,7 @@ Types:
           Offset: 16
           Type: 580 GoInterfaceType io.WriterTo
     - __kind: StructureType
-      ID: 150
+      ID: 156
       Name: struct {}
       GoRuntimeType: 157504
       GoKind: 25
@@ -12414,7 +12416,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 119
+      ID: 128
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 262656
@@ -12438,7 +12440,7 @@ Types:
           Type: 606 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
     - __kind: StructureType
       ID: 545
       Name: sync.RWMutex
@@ -12448,7 +12450,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -12615,7 +12617,7 @@ Types:
           Offset: 0
           Type: 13 BaseType uint64
     - __kind: StructureType
-      ID: 120
+      ID: 129
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 226144
@@ -12623,7 +12625,7 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 653
       Name: sync/atomic.align64
@@ -12656,7 +12658,7 @@ Types:
           Offset: 8
           Type: 13 BaseType uint64
     - __kind: BaseType
-      ID: 165
+      ID: 169
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 188192
@@ -12668,7 +12670,7 @@ Types:
       GoRuntimeType: 377920
       GoKind: 6
     - __kind: StructureType
-      ID: 134
+      ID: 143
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 387584
@@ -12679,10 +12681,10 @@ Types:
           Type: 12 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 152 GoSliceHeaderType []time.zone
+          Type: 158 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 155 GoSliceHeaderType []time.zoneTrans
+          Type: 161 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 12 GoStringHeaderType string
@@ -12694,7 +12696,7 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 153 PointerType *time.zone
+          Type: 159 PointerType *time.zone
     - __kind: StructureType
       ID: 224
       Name: time.ParseError
@@ -12718,7 +12720,7 @@ Types:
           Offset: 64
           Type: 12 GoStringHeaderType string
     - __kind: GoTimeType
-      ID: 132
+      ID: 141
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 456160
@@ -12732,7 +12734,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 133 PointerType *time.Location
+          Type: 142 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -12742,7 +12744,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 131
+      ID: 140
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 263936
@@ -12750,7 +12752,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 164 GoChannelType <-chan time.Time
+          Type: 168 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -12774,7 +12776,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 154
+      ID: 160
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 296256
@@ -12790,7 +12792,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 157
+      ID: 163
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 340992

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -564,10 +564,10 @@ Types:
       ByteSize: 8
       Pointee: 901 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 132
+      ID: 140
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 133 PointerType *table<context.canceler,struct {}>
+      Pointee: 141 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1112
       Name: '**table<crypto/x509.sum224,bool>'
@@ -795,10 +795,10 @@ Types:
       ByteSize: 8
       Pointee: 729 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 168
+      ID: 156
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []os.Signal.array
+      Pointee: 155 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -824,15 +824,15 @@ Types:
       ByteSize: 8
       Pointee: 494 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 170
+      ID: 174
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType []time.zone.array
+      Pointee: 173 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 172
+      ID: 176
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []time.zoneTrans.array
+      Pointee: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1139
       Name: '*[]uint16.array'
@@ -846,15 +846,15 @@ Types:
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 148
+      ID: 152
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 147 GoSliceDataType []uint8.array
+      Pointee: 151 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 150
+      ID: 154
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 149 GoSliceDataType []uintptr.array
+      Pointee: 153 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 951
       Name: '*[]vendor/golang.org/x/net/http2/hpack.HeaderField.array'
@@ -896,19 +896,19 @@ Types:
       GoKind: 22
       Pointee: 523 StructureType bytes.Reader
     - __kind: PointerType
-      ID: 179
+      ID: 122
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 325472
       GoKind: 22
-      Pointee: 122 StructureType context.backgroundCtx
+      Pointee: 123 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 112
+      ID: 131
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 365312
       GoKind: 22
-      Pointee: 113 StructureType context.cancelCtx
+      Pointee: 132 StructureType context.cancelCtx
     - __kind: PointerType
       ID: 319
       Name: '*context.deadlineExceededError'
@@ -917,12 +917,12 @@ Types:
       GoKind: 22
       Pointee: 320 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 176
+      ID: 112
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 287136
       GoKind: 22
-      Pointee: 123 StructureType context.emptyCtx
+      Pointee: 113 StructureType context.emptyCtx
     - __kind: PointerType
       ID: 114
       Name: '*context.stopCtx'
@@ -931,19 +931,19 @@ Types:
       GoKind: 22
       Pointee: 115 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 116
+      ID: 142
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 365504
       GoKind: 22
-      Pointee: 117 StructureType context.timerCtx
+      Pointee: 143 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 325152
       GoKind: 22
-      Pointee: 119 StructureType context.valueCtx
+      Pointee: 120 StructureType context.valueCtx
     - __kind: PointerType
       ID: 270
       Name: '*crypto/aes.KeySizeError'
@@ -1485,7 +1485,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 330112
       GoKind: 22
-      Pointee: 126 StructureType internal/sync.Mutex
+      Pointee: 135 StructureType internal/sync.Mutex
     - __kind: PointerType
       ID: 570
       Name: '*io.LimitedReader'
@@ -1558,10 +1558,10 @@ Types:
       ByteSize: 8
       Pointee: 899 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 130
+      ID: 138
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 131 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 139 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1110
       Name: '*map<crypto/x509.sum224,bool>'
@@ -1877,12 +1877,12 @@ Types:
       GoKind: 22
       Pointee: 214 StructureType net.notFoundError
     - __kind: PointerType
-      ID: 177
+      ID: 117
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 287776
       GoKind: 22
-      Pointee: 178 StructureType net.onlyValuesCtx
+      Pointee: 118 StructureType net.onlyValuesCtx
     - __kind: PointerType
       ID: 215
       Name: '*net.result·2'
@@ -2665,10 +2665,10 @@ Types:
       ByteSize: 8
       Pointee: 905 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: PointerType
-      ID: 153
+      ID: 159
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 160 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
       ID: 1129
       Name: '*noalg.map.group[crypto/x509.sum224]bool'
@@ -2754,12 +2754,12 @@ Types:
       GoKind: 22
       Pointee: 297 StructureType os.LinkError
     - __kind: PointerType
-      ID: 142
+      ID: 128
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 91584
       GoKind: 22
-      Pointee: 143 GoInterfaceType os.Signal
+      Pointee: 129 GoInterfaceType os.Signal
     - __kind: PointerType
       ID: 328
       Name: '*os.SyscallError'
@@ -2803,12 +2803,12 @@ Types:
       GoKind: 22
       Pointee: 619 StructureType os.noWriteTo
     - __kind: PointerType
-      ID: 120
+      ID: 124
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 342464
       GoKind: 22
-      Pointee: 121 StructureType os/signal.signalCtx
+      Pointee: 125 StructureType os/signal.signalCtx
     - __kind: PointerType
       ID: 239
       Name: '*reflect.ValueError'
@@ -2960,10 +2960,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 146
+      ID: 150
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 145 GoStringDataType string.str
+      Pointee: 149 GoStringDataType string.str
     - __kind: PointerType
       ID: 605
       Name: '*strings.Reader'
@@ -3003,7 +3003,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 250112
       GoKind: 22
-      Pointee: 124 StructureType sync.Mutex
+      Pointee: 133 StructureType sync.Mutex
     - __kind: PointerType
       ID: 1069
       Name: '*sync.RWMutex'
@@ -3017,7 +3017,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 213728
       GoKind: 22
-      Pointee: 125 StructureType sync.noCopy
+      Pointee: 134 StructureType sync.noCopy
     - __kind: PointerType
       ID: 1065
       Name: '*sync/atomic.noCopy'
@@ -3040,12 +3040,12 @@ Types:
       GoKind: 22
       Pointee: 493 StructureType syscall.Iovec
     - __kind: PointerType
-      ID: 175
+      ID: 179
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 217824
       GoKind: 22
-      Pointee: 174 BaseType syscall.Signal
+      Pointee: 178 BaseType syscall.Signal
     - __kind: PointerType
       ID: 673
       Name: '*table<*net.Listener,struct {}>'
@@ -3062,10 +3062,10 @@ Types:
       ByteSize: 8
       Pointee: 902 StructureType table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 133
+      ID: 141
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 151 StructureType table<context.canceler,struct {}>
+      Pointee: 157 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1113
       Name: '*table<crypto/x509.sum224,bool>'
@@ -3137,12 +3137,12 @@ Types:
       ByteSize: 8
       Pointee: 973 StructureType table<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>
     - __kind: PointerType
-      ID: 138
+      ID: 147
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 343616
       GoKind: 22
-      Pointee: 139 StructureType time.Location
+      Pointee: 148 StructureType time.Location
     - __kind: PointerType
       ID: 233
       Name: '*time.ParseError'
@@ -3151,12 +3151,12 @@ Types:
       GoKind: 22
       Pointee: 234 StructureType time.ParseError
     - __kind: PointerType
-      ID: 135
+      ID: 144
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 213984
       GoKind: 22
-      Pointee: 136 StructureType time.Timer
+      Pointee: 145 StructureType time.Timer
     - __kind: PointerType
       ID: 232
       Name: '*time.fileSizeError'
@@ -3170,19 +3170,19 @@ Types:
       ByteSize: 8
       Pointee: 194 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 162
+      ID: 168
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 92160
       GoKind: 22
-      Pointee: 163 StructureType time.zone
+      Pointee: 169 StructureType time.zone
     - __kind: PointerType
-      ID: 165
+      ID: 171
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 92224
       GoKind: 22
-      Pointee: 166 StructureType time.zoneTrans
+      Pointee: 172 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 106
       Name: '*uint'
@@ -3287,7 +3287,7 @@ Types:
       GoRuntimeType: 132480
       GoKind: 18
     - __kind: GoChannelType
-      ID: 173
+      ID: 177
       Name: <-chan time.Time
       GoRuntimeType: 134528
       GoKind: 18
@@ -4017,11 +4017,11 @@ Types:
       ByteSize: 8
       Element: 901 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 165
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 133 PointerType *table<context.canceler,struct {}>
+      Element: 141 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
       ID: 1134
       Name: '[]*table<crypto/x509.sum224,bool>.array'
@@ -4677,11 +4677,11 @@ Types:
       ByteSize: 136
       Element: 905 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 166
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 154 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 160 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
       ID: 1135
       Name: '[]noalg.map.group[crypto/x509.sum224]bool.array'
@@ -4767,7 +4767,7 @@ Types:
       ByteSize: 328
       Element: 976 StructureType noalg.map.group[vendor/golang.org/x/net/http2/hpack.pairNameValue]uint64
     - __kind: GoSliceHeaderType
-      ID: 141
+      ID: 127
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 109248
@@ -4775,20 +4775,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 142 PointerType *os.Signal
+          Type: 128 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 167 GoSliceDataType []os.Signal.array
+      Data: 155 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 155
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 143 GoInterfaceType os.Signal
+      Element: 129 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -4840,7 +4840,7 @@ Types:
       ByteSize: 16
       Element: 493 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 167
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 115072
@@ -4848,22 +4848,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *time.zone
+          Type: 168 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 169 GoSliceDataType []time.zone.array
+      Data: 173 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 173
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 163 StructureType time.zone
+      Element: 169 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 170
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 115136
@@ -4871,20 +4871,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *time.zoneTrans
+          Type: 171 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 171 GoSliceDataType []time.zoneTrans.array
+      Data: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 175
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 166 StructureType time.zoneTrans
+      Element: 172 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 555
       Name: '[]uint16'
@@ -4924,9 +4924,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 147 GoSliceDataType []uint8.array
+      Data: 151 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 147
+      ID: 151
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4947,9 +4947,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 149 GoSliceDataType []uintptr.array
+      Data: 153 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 153
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -5104,7 +5104,7 @@ Types:
       GoRuntimeType: 134912
       GoKind: 18
     - __kind: GoChannelType
-      ID: 144
+      ID: 130
       Name: chan os.Signal
       GoRuntimeType: 135744
       GoKind: 18
@@ -5126,7 +5126,7 @@ Types:
       GoRuntimeType: 129792
       GoKind: 15
     - __kind: GoSubroutineType
-      ID: 140
+      ID: 126
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 141312
@@ -5145,19 +5145,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 123
       Name: context.backgroundCtx
       GoRuntimeType: 386688
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 123 StructureType context.emptyCtx
+          Type: 113 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 113
+      ID: 132
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 427360
@@ -5168,13 +5168,13 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 127 StructureType sync/atomic.Value
+          Type: 136 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 129 GoMapType map[context.canceler]struct {}
+          Type: 137 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 15 GoInterfaceType error
@@ -5184,7 +5184,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 163
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 230464
@@ -5203,7 +5203,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 113
       Name: context.emptyCtx
       GoRuntimeType: 335872
       GoKind: 25
@@ -5223,11 +5223,11 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 134 GoSubroutineType func() bool
+          Type: 116 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 117
+      ID: 143
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 337664
@@ -5235,17 +5235,17 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 113 StructureType context.cancelCtx
+          Type: 132 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 135 PointerType *time.Timer
+          Type: 144 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 137 GoTimeType time.Time
+          Type: 146 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 120
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 394432
@@ -5256,10 +5256,10 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoEmptyInterfaceType
@@ -5695,7 +5695,7 @@ Types:
           Type: 499 StructureType sync/atomic.Bool
         - Name: handshakeMutex
           Offset: 44
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: handshakeErr
           Offset: 56
           Type: 15 GoInterfaceType error
@@ -6109,7 +6109,7 @@ Types:
       RawFields:
         - Name: Mutex
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: err
           Offset: 8
           Type: 15 GoInterfaceType error
@@ -6118,7 +6118,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: cipher
           Offset: 32
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: mac
           Offset: 48
           Type: 517 GoInterfaceType hash.Hash
@@ -6130,7 +6130,7 @@ Types:
           Type: 519 ArrayType [13]uint8
         - Name: nextCipher
           Offset: 88
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: nextMac
           Offset: 104
           Type: 517 GoInterfaceType hash.Hash
@@ -6186,7 +6186,7 @@ Types:
           Type: 534 GoChannelType <-chan struct {}
         - Name: cancel
           Offset: 512
-          Type: 140 GoSubroutineType context.CancelFunc
+          Type: 126 GoSubroutineType context.CancelFunc
         - Name: waitingForDrain
           Offset: 520
           Type: 6 BaseType bool
@@ -6214,7 +6214,7 @@ Types:
           Type: 525 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 137 GoTimeType time.Time
+          Type: 146 GoTimeType time.Time
     - __kind: StructureType
       ID: 553
       Name: crypto/x509.CertPool
@@ -6267,7 +6267,7 @@ Types:
           Type: 403 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
@@ -6282,10 +6282,10 @@ Types:
           Type: 406 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 137 GoTimeType time.Time
+          Type: 146 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 137 GoTimeType time.Time
+          Type: 146 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 411 BaseType crypto/x509.KeyUsage
@@ -6560,7 +6560,7 @@ Types:
           Type: 417 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 414
       Name: crypto/x509/pkix.Extension
@@ -6802,7 +6802,7 @@ Types:
           Type: 1187 GoSliceHeaderType fmt.buffer
         - Name: arg
           Offset: 24
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: value
           Offset: 40
           Type: 1188 StructureType reflect.Value
@@ -6878,7 +6878,7 @@ Types:
       GoRuntimeType: 151168
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 134
+      ID: 116
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 132736
@@ -7070,19 +7070,19 @@ Types:
       GroupType: 905 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
       GroupSliceType: 909 GoSliceDataType []noalg.map.group[*net/http.http2serverConn]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 158
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 159 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 160 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 160 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 166 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
       ID: 1128
       Name: groupReference<crypto/x509.sum224,bool>
@@ -7336,7 +7336,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoEmptyInterfaceType
-      ID: 128
+      ID: 121
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 178816
@@ -7623,7 +7623,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 126
+      ID: 135
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 316992
@@ -7751,7 +7751,7 @@ Types:
       RawFields:
         - Name: outMu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: out
           Offset: 8
           Type: 563 GoInterfaceType io.Writer
@@ -7887,7 +7887,7 @@ Types:
       TablePtrSliceType: 908 GoSliceDataType []*table<*net/http.http2serverConn,struct {}>.array
       GroupType: 905 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 131
+      ID: 139
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -7900,7 +7900,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 132 PointerType **table<context.canceler,struct {}>
+          Type: 140 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -7916,8 +7916,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 159 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 154 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 165 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 160 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 1111
       Name: map<crypto/x509.sum224,bool>
@@ -8388,12 +8388,12 @@ Types:
       GoKind: 21
       HeaderType: 899 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: GoMapType
-      ID: 129
+      ID: 137
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 235072
       GoKind: 21
-      HeaderType: 131 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 139 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 1109
       Name: map[crypto/x509.sum224]bool
@@ -8588,7 +8588,7 @@ Types:
       RawFields:
         - Name: lk
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: s
           Offset: 8
           Type: 1074 PointerType *math/rand.rngSource
@@ -8617,7 +8617,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
     - __kind: StructureType
       ID: 840
       Name: mime/multipart.FileHeader
@@ -9124,8 +9124,8 @@ Types:
         - Name: s
           Offset: 0
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 178
+    - __kind: GoContextImplementationType
+      ID: 118
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 370880
@@ -9137,6 +9137,8 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 111 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
       ID: 216
       Name: net.result·2
@@ -9520,7 +9522,7 @@ Types:
           Type: 15 GoInterfaceType error
         - Name: mu
           Offset: 184
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: listeners
           Offset: 192
           Type: 669 GoMapType map[*net.Listener]struct {}
@@ -9545,7 +9547,7 @@ Types:
           Type: 537 GoInterfaceType io.Reader
         - Name: hdr
           Offset: 16
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: r
           Offset: 32
           Type: 610 PointerType *bufio.Reader
@@ -9557,7 +9559,7 @@ Types:
           Type: 6 BaseType bool
         - Name: mu
           Offset: 44
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: sawEOF
           Offset: 52
           Type: 6 BaseType bool
@@ -9621,7 +9623,7 @@ Types:
           Type: 643 PointerType *net/http.Server
         - Name: cancelCtx
           Offset: 8
-          Type: 140 GoSubroutineType context.CancelFunc
+          Type: 126 GoSubroutineType context.CancelFunc
         - Name: rwc
           Offset: 16
           Type: 360 GoInterfaceType net.Conn
@@ -9654,7 +9656,7 @@ Types:
           Type: 649 StructureType sync/atomic.Uint64
         - Name: mu
           Offset: 128
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: hijackedv
           Offset: 136
           Type: 6 BaseType bool
@@ -9670,7 +9672,7 @@ Types:
           Type: 627 PointerType *net/http.conn
         - Name: mu
           Offset: 8
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: hasByte
           Offset: 16
           Type: 6 BaseType bool
@@ -10402,7 +10404,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: c
           Offset: 8
           Type: 1060 StructureType sync.Cond
@@ -10542,7 +10544,7 @@ Types:
           Type: 14 BaseType int64
         - Name: closeNotifierMu
           Offset: 104
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: closeNotifierCh
           Offset: 112
           Type: 642 GoChannelType chan bool
@@ -10755,7 +10757,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: activeConns
           Offset: 8
           Type: 897 GoMapType map[*net/http.http2serverConn]struct {}
@@ -10851,7 +10853,7 @@ Types:
       RawFields:
         - Name: Timer
           Offset: 0
-          Type: 135 PointerType *time.Timer
+          Type: 144 PointerType *time.Timer
     - __kind: StructureType
       ID: 890
       Name: net/http.http2unstartedHandler
@@ -11219,7 +11221,7 @@ Types:
           Type: 626 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 140 GoSubroutineType context.CancelFunc
+          Type: 126 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -11231,7 +11233,7 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
           Type: 499 StructureType sync/atomic.Bool
@@ -11682,14 +11684,14 @@ Types:
       HasCount: true
       Element: 907 StructureType noalg.struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: ArrayType
-      ID: 155
+      ID: 161
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 143424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 162 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
       ID: 1131
       Name: noalg.[8]struct { key crypto/x509.sum224; elem bool }
@@ -11856,7 +11858,7 @@ Types:
           Offset: 8
           Type: 906 ArrayType noalg.[8]struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: StructureType
-      ID: 154
+      ID: 160
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 266624
@@ -11867,7 +11869,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 161 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
       ID: 1130
       Name: noalg.map.group[crypto/x509.sum224]bool
@@ -12062,7 +12064,7 @@ Types:
           Type: 780 PointerType *net.Listener
         - Name: elem
           Offset: 8
-          Type: 158 StructureType struct {}
+          Type: 164 StructureType struct {}
     - __kind: StructureType
       ID: 789
       Name: noalg.struct { key *net/http.conn; elem struct {} }
@@ -12075,7 +12077,7 @@ Types:
           Type: 627 PointerType *net/http.conn
         - Name: elem
           Offset: 8
-          Type: 158 StructureType struct {}
+          Type: 164 StructureType struct {}
     - __kind: StructureType
       ID: 907
       Name: noalg.struct { key *net/http.http2serverConn; elem struct {} }
@@ -12088,9 +12090,9 @@ Types:
           Type: 859 PointerType *net/http.http2serverConn
         - Name: elem
           Offset: 8
-          Type: 158 StructureType struct {}
+          Type: 164 StructureType struct {}
     - __kind: StructureType
-      ID: 156
+      ID: 162
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 266496
@@ -12098,10 +12100,10 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 157 GoInterfaceType context.canceler
+          Type: 163 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 158 StructureType struct {}
+          Type: 164 StructureType struct {}
     - __kind: StructureType
       ID: 1132
       Name: noalg.struct { key crypto/x509.sum224; elem bool }
@@ -12314,7 +12316,7 @@ Types:
           Offset: 48
           Type: 15 GoInterfaceType error
     - __kind: GoInterfaceType
-      ID: 143
+      ID: 129
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 232384
@@ -12348,7 +12350,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: buf
           Offset: 8
           Type: 505 PointerType *[]uint8
@@ -12422,7 +12424,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 125
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 427616
@@ -12433,13 +12435,13 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 140 GoSubroutineType context.CancelFunc
+          Type: 126 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 141 GoSliceHeaderType []os.Signal
+          Type: 127 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 144 GoChannelType chan os.Signal
+          Type: 130 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
@@ -13389,13 +13391,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 146 PointerType *string.str
+          Type: 150 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 145 GoStringDataType string.str
+      Data: 149 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 145
+      ID: 149
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -13452,7 +13454,7 @@ Types:
           Offset: 16
           Type: 598 GoInterfaceType io.WriterTo
     - __kind: StructureType
-      ID: 158
+      ID: 164
       Name: struct {}
       GoRuntimeType: 176480
       GoKind: 25
@@ -13466,7 +13468,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 125 StructureType sync.noCopy
+          Type: 134 StructureType sync.noCopy
         - Name: L
           Offset: 0
           Type: 1061 GoInterfaceType sync.Locker
@@ -13490,7 +13492,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 124
+      ID: 133
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 305312
@@ -13498,10 +13500,10 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 125 StructureType sync.noCopy
+          Type: 134 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 126 StructureType internal/sync.Mutex
+          Type: 135 StructureType internal/sync.Mutex
     - __kind: StructureType
       ID: 667
       Name: sync.Once
@@ -13511,13 +13513,13 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 125 StructureType sync.noCopy
+          Type: 134 StructureType sync.noCopy
         - Name: done
           Offset: 0
           Type: 668 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
     - __kind: StructureType
       ID: 567
       Name: sync.RWMutex
@@ -13527,7 +13529,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -13549,7 +13551,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 125 StructureType sync.noCopy
+          Type: 134 StructureType sync.noCopy
         - Name: state
           Offset: 0
           Type: 649 StructureType sync/atomic.Uint64
@@ -13563,7 +13565,7 @@ Types:
       GoRuntimeType: 128896
       GoKind: 12
     - __kind: StructureType
-      ID: 125
+      ID: 134
       Name: sync.noCopy
       GoRuntimeType: 202336
       GoKind: 25
@@ -13694,7 +13696,7 @@ Types:
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 127
+      ID: 136
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 250752
@@ -13702,7 +13704,7 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 650
       Name: sync/atomic.align64
@@ -13735,7 +13737,7 @@ Types:
           Offset: 8
           Type: 10 BaseType uint64
     - __kind: BaseType
-      ID: 174
+      ID: 178
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 203680
@@ -13813,7 +13815,7 @@ Types:
           Offset: 16
           Type: 903 GoSwissMapGroupsType groupReference<*net/http.http2serverConn,struct {}>
     - __kind: StructureType
-      ID: 151
+      ID: 157
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -13835,7 +13837,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 158 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
       ID: 1127
       Name: table<crypto/x509.sum224,bool>
@@ -14179,7 +14181,7 @@ Types:
       GoRuntimeType: 417376
       GoKind: 6
     - __kind: StructureType
-      ID: 139
+      ID: 148
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 429312
@@ -14190,10 +14192,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 161 GoSliceHeaderType []time.zone
+          Type: 167 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 164 GoSliceHeaderType []time.zoneTrans
+          Type: 170 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -14205,7 +14207,7 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 162 PointerType *time.zone
+          Type: 168 PointerType *time.zone
     - __kind: StructureType
       ID: 234
       Name: time.ParseError
@@ -14229,7 +14231,7 @@ Types:
           Offset: 64
           Type: 11 GoStringHeaderType string
     - __kind: GoTimeType
-      ID: 137
+      ID: 146
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 502112
@@ -14243,7 +14245,7 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 138 PointerType *time.Location
+          Type: 147 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -14253,7 +14255,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 136
+      ID: 145
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 306432
@@ -14261,7 +14263,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 173 GoChannelType <-chan time.Time
+          Type: 177 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -14285,7 +14287,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 163
+      ID: 169
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 343424
@@ -14301,7 +14303,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 166
+      ID: 172
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 375488

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -580,10 +580,10 @@ Types:
       ByteSize: 8
       Pointee: 1008 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 134
+      ID: 142
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 135 PointerType *table<context.canceler,struct {}>
+      Pointee: 143 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1218
       Name: '**table<crypto/x509.sum224,bool>'
@@ -698,10 +698,10 @@ Types:
       ByteSize: 8
       Pointee: 454 GoSliceDataType []*runtime._defer.array
     - __kind: PointerType
-      ID: 155
+      ID: 159
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 154 GoSliceDataType []*runtime.p.array
+      Pointee: 158 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 457
       Name: '*[]*runtime.sudog.array'
@@ -828,10 +828,10 @@ Types:
       ByteSize: 8
       Pointee: 836 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 173
+      ID: 161
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType []os.Signal.array
+      Pointee: 160 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -867,15 +867,15 @@ Types:
       ByteSize: 8
       Pointee: 603 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 175
+      ID: 179
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zone.array
+      Pointee: 178 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 177
+      ID: 181
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []time.zoneTrans.array
+      Pointee: 180 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1245
       Name: '*[]uint16.array'
@@ -889,15 +889,15 @@ Types:
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 150
+      ID: 154
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 149 GoSliceDataType []uint8.array
+      Pointee: 153 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 152
+      ID: 156
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 151 GoSliceDataType []uintptr.array
+      Pointee: 155 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 462
       Name: '*[]unsafe.Pointer.array'
@@ -944,19 +944,19 @@ Types:
       GoKind: 22
       Pointee: 630 StructureType bytes.Reader
     - __kind: PointerType
-      ID: 184
+      ID: 124
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 328928
       GoKind: 22
-      Pointee: 124 StructureType context.backgroundCtx
+      Pointee: 125 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 114
+      ID: 133
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 371168
       GoKind: 22
-      Pointee: 115 StructureType context.cancelCtx
+      Pointee: 134 StructureType context.cancelCtx
     - __kind: PointerType
       ID: 334
       Name: '*context.deadlineExceededError'
@@ -965,12 +965,12 @@ Types:
       GoKind: 22
       Pointee: 335 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 181
+      ID: 114
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 289472
       GoKind: 22
-      Pointee: 125 StructureType context.emptyCtx
+      Pointee: 115 StructureType context.emptyCtx
     - __kind: PointerType
       ID: 116
       Name: '*context.stopCtx'
@@ -979,19 +979,19 @@ Types:
       GoKind: 22
       Pointee: 117 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 118
+      ID: 144
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 371360
       GoKind: 22
-      Pointee: 119 StructureType context.timerCtx
+      Pointee: 145 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 328608
       GoKind: 22
-      Pointee: 121 StructureType context.valueCtx
+      Pointee: 122 StructureType context.valueCtx
     - __kind: PointerType
       ID: 283
       Name: '*crypto/aes.KeySizeError'
@@ -1558,7 +1558,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 333568
       GoKind: 22
-      Pointee: 128 StructureType internal/sync.Mutex
+      Pointee: 137 StructureType internal/sync.Mutex
     - __kind: PointerType
       ID: 678
       Name: '*io.LimitedReader'
@@ -1631,10 +1631,10 @@ Types:
       ByteSize: 8
       Pointee: 1006 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 132
+      ID: 140
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 133 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 141 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1216
       Name: '*map<crypto/x509.sum224,bool>'
@@ -1950,12 +1950,12 @@ Types:
       GoKind: 22
       Pointee: 222 StructureType net.notFoundError
     - __kind: PointerType
-      ID: 182
+      ID: 119
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 290112
       GoKind: 22
-      Pointee: 183 StructureType net.onlyValuesCtx
+      Pointee: 120 StructureType net.onlyValuesCtx
     - __kind: PointerType
       ID: 223
       Name: '*net.result·2'
@@ -2738,10 +2738,10 @@ Types:
       ByteSize: 8
       Pointee: 1012 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: PointerType
-      ID: 158
+      ID: 164
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 159 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 165 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
       ID: 1235
       Name: '*noalg.map.group[crypto/x509.sum224]bool'
@@ -2827,12 +2827,12 @@ Types:
       GoKind: 22
       Pointee: 310 StructureType os.LinkError
     - __kind: PointerType
-      ID: 144
+      ID: 130
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 93152
       GoKind: 22
-      Pointee: 145 GoInterfaceType os.Signal
+      Pointee: 131 GoInterfaceType os.Signal
     - __kind: PointerType
       ID: 343
       Name: '*os.SyscallError'
@@ -2876,12 +2876,12 @@ Types:
       GoKind: 22
       Pointee: 727 StructureType os.noWriteTo
     - __kind: PointerType
-      ID: 122
+      ID: 126
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 346400
       GoKind: 22
-      Pointee: 123 StructureType os/signal.signalCtx
+      Pointee: 127 StructureType os/signal.signalCtx
     - __kind: PointerType
       ID: 247
       Name: '*reflect.ValueError'
@@ -3047,7 +3047,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 220384
       GoKind: 22
-      Pointee: 153 StructureType runtime.p
+      Pointee: 157 StructureType runtime.p
     - __kind: PointerType
       ID: 415
       Name: '*runtime.pinner'
@@ -3145,10 +3145,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 148
+      ID: 152
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 147 GoStringDataType string.str
+      Pointee: 151 GoStringDataType string.str
     - __kind: PointerType
       ID: 713
       Name: '*strings.Reader'
@@ -3188,7 +3188,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 253088
       GoKind: 22
-      Pointee: 126 StructureType sync.Mutex
+      Pointee: 135 StructureType sync.Mutex
     - __kind: PointerType
       ID: 1176
       Name: '*sync.RWMutex'
@@ -3202,7 +3202,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 217312
       GoKind: 22
-      Pointee: 127 StructureType sync.noCopy
+      Pointee: 136 StructureType sync.noCopy
     - __kind: PointerType
       ID: 1172
       Name: '*sync/atomic.noCopy'
@@ -3225,12 +3225,12 @@ Types:
       GoKind: 22
       Pointee: 602 StructureType syscall.Iovec
     - __kind: PointerType
-      ID: 180
+      ID: 184
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 221408
       GoKind: 22
-      Pointee: 179 BaseType syscall.Signal
+      Pointee: 183 BaseType syscall.Signal
     - __kind: PointerType
       ID: 780
       Name: '*table<*net.Listener,struct {}>'
@@ -3247,10 +3247,10 @@ Types:
       ByteSize: 8
       Pointee: 1009 StructureType table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 135
+      ID: 143
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 156 StructureType table<context.canceler,struct {}>
+      Pointee: 162 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1219
       Name: '*table<crypto/x509.sum224,bool>'
@@ -3322,12 +3322,12 @@ Types:
       ByteSize: 8
       Pointee: 1080 StructureType table<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>
     - __kind: PointerType
-      ID: 140
+      ID: 149
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 347552
       GoKind: 22
-      Pointee: 141 StructureType time.Location
+      Pointee: 150 StructureType time.Location
     - __kind: PointerType
       ID: 241
       Name: '*time.ParseError'
@@ -3336,12 +3336,12 @@ Types:
       GoKind: 22
       Pointee: 242 StructureType time.ParseError
     - __kind: PointerType
-      ID: 137
+      ID: 146
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 217568
       GoKind: 22
-      Pointee: 138 StructureType time.Timer
+      Pointee: 147 StructureType time.Timer
     - __kind: PointerType
       ID: 240
       Name: '*time.fileSizeError'
@@ -3355,19 +3355,19 @@ Types:
       ByteSize: 8
       Pointee: 199 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 167
+      ID: 173
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 93728
       GoKind: 22
-      Pointee: 168 StructureType time.zone
+      Pointee: 174 StructureType time.zone
     - __kind: PointerType
-      ID: 170
+      ID: 176
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 93792
       GoKind: 22
-      Pointee: 171 StructureType time.zoneTrans
+      Pointee: 177 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 108
       Name: '*uint'
@@ -3479,7 +3479,7 @@ Types:
       GoRuntimeType: 135008
       GoKind: 18
     - __kind: GoChannelType
-      ID: 178
+      ID: 182
       Name: <-chan time.Time
       GoRuntimeType: 136992
       GoKind: 18
@@ -4316,9 +4316,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 154 GoSliceDataType []*runtime.p.array
+      Data: 158 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 154
+      ID: 158
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4365,11 +4365,11 @@ Types:
       ByteSize: 8
       Element: 1008 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 170
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 135 PointerType *table<context.canceler,struct {}>
+      Element: 143 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
       ID: 1240
       Name: '[]*table<crypto/x509.sum224,bool>.array'
@@ -5025,11 +5025,11 @@ Types:
       ByteSize: 136
       Element: 1012 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 171
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 159 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 165 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
       ID: 1241
       Name: '[]noalg.map.group[crypto/x509.sum224]bool.array'
@@ -5115,7 +5115,7 @@ Types:
       ByteSize: 328
       Element: 1083 StructureType noalg.map.group[vendor/golang.org/x/net/http2/hpack.pairNameValue]uint64
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 129
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 110752
@@ -5123,20 +5123,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *os.Signal
+          Type: 130 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 172 GoSliceDataType []os.Signal.array
+      Data: 160 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 160
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 145 GoInterfaceType os.Signal
+      Element: 131 GoInterfaceType os.Signal
     - __kind: GoSliceHeaderType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -5230,7 +5230,7 @@ Types:
       ByteSize: 16
       Element: 602 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 172
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 116640
@@ -5238,22 +5238,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *time.zone
+          Type: 173 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 174 GoSliceDataType []time.zone.array
+      Data: 178 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 178
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 168 StructureType time.zone
+      Element: 174 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 175
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 116704
@@ -5261,20 +5261,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *time.zoneTrans
+          Type: 176 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 176 GoSliceDataType []time.zoneTrans.array
+      Data: 180 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 180
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 171 StructureType time.zoneTrans
+      Element: 177 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 662
       Name: '[]uint16'
@@ -5314,9 +5314,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 149 GoSliceDataType []uint8.array
+      Data: 153 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 153
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -5337,9 +5337,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 151 GoSliceDataType []uintptr.array
+      Data: 155 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 155
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -5517,7 +5517,7 @@ Types:
       GoRuntimeType: 137376
       GoKind: 18
     - __kind: GoChannelType
-      ID: 146
+      ID: 132
       Name: chan os.Signal
       GoRuntimeType: 138272
       GoKind: 18
@@ -5539,7 +5539,7 @@ Types:
       GoRuntimeType: 132320
       GoKind: 15
     - __kind: GoSubroutineType
-      ID: 142
+      ID: 128
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 143488
@@ -5558,19 +5558,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 125
       Name: context.backgroundCtx
       GoRuntimeType: 392928
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 125 StructureType context.emptyCtx
+          Type: 115 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 115
+      ID: 134
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 434304
@@ -5581,23 +5581,23 @@ Types:
           Type: 113 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 129 StructureType sync/atomic.Value
+          Type: 138 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 131 GoMapType map[context.canceler]struct {}
+          Type: 139 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 129 StructureType sync/atomic.Value
+          Type: 138 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 15 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 162
+      ID: 168
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 234272
@@ -5616,7 +5616,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 115
       Name: context.emptyCtx
       GoRuntimeType: 339328
       GoKind: 25
@@ -5636,11 +5636,11 @@ Types:
           Type: 113 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 136 GoSubroutineType func() bool
+          Type: 118 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 145
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 341600
@@ -5648,17 +5648,17 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 115 StructureType context.cancelCtx
+          Type: 134 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 137 PointerType *time.Timer
+          Type: 146 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 139 GoTimeType time.Time
+          Type: 148 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 122
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 401440
@@ -5669,10 +5669,10 @@ Types:
           Type: 113 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoEmptyInterfaceType
@@ -6098,7 +6098,7 @@ Types:
           Type: 608 StructureType sync/atomic.Bool
         - Name: handshakeMutex
           Offset: 44
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: handshakeErr
           Offset: 56
           Type: 15 GoInterfaceType error
@@ -6515,7 +6515,7 @@ Types:
       RawFields:
         - Name: Mutex
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: err
           Offset: 8
           Type: 15 GoInterfaceType error
@@ -6524,7 +6524,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: cipher
           Offset: 32
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: mac
           Offset: 48
           Type: 624 GoInterfaceType hash.Hash
@@ -6536,7 +6536,7 @@ Types:
           Type: 626 ArrayType [13]uint8
         - Name: nextCipher
           Offset: 88
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: nextMac
           Offset: 104
           Type: 624 GoInterfaceType hash.Hash
@@ -6592,7 +6592,7 @@ Types:
           Type: 641 GoChannelType <-chan struct {}
         - Name: cancel
           Offset: 512
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 128 GoSubroutineType context.CancelFunc
         - Name: waitingForDrain
           Offset: 520
           Type: 6 BaseType bool
@@ -6620,7 +6620,7 @@ Types:
           Type: 632 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 139 GoTimeType time.Time
+          Type: 148 GoTimeType time.Time
     - __kind: StructureType
       ID: 660
       Name: crypto/x509.CertPool
@@ -6673,7 +6673,7 @@ Types:
           Type: 512 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
@@ -6688,10 +6688,10 @@ Types:
           Type: 515 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 139 GoTimeType time.Time
+          Type: 148 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 139 GoTimeType time.Time
+          Type: 148 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 520 BaseType crypto/x509.KeyUsage
@@ -6966,7 +6966,7 @@ Types:
           Type: 526 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 523
       Name: crypto/x509/pkix.Extension
@@ -7208,7 +7208,7 @@ Types:
           Type: 1292 GoSliceHeaderType fmt.buffer
         - Name: arg
           Offset: 24
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: value
           Offset: 40
           Type: 1293 StructureType reflect.Value
@@ -7284,7 +7284,7 @@ Types:
       GoRuntimeType: 153344
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 136
+      ID: 118
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 135264
@@ -7494,19 +7494,19 @@ Types:
       GroupType: 1012 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
       GroupSliceType: 1016 GoSliceDataType []noalg.map.group[*net/http.http2serverConn]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 157
+      ID: 163
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 158 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 164 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 159 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 165 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 165 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 171 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
       ID: 1234
       Name: groupReference<crypto/x509.sum224,bool>
@@ -7760,7 +7760,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoEmptyInterfaceType
-      ID: 130
+      ID: 123
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 180640
@@ -8143,7 +8143,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 128
+      ID: 137
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 320160
@@ -8271,7 +8271,7 @@ Types:
       RawFields:
         - Name: outMu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: out
           Offset: 8
           Type: 670 GoInterfaceType io.Writer
@@ -8416,7 +8416,7 @@ Types:
       TablePtrSliceType: 1015 GoSliceDataType []*table<*net/http.http2serverConn,struct {}>.array
       GroupType: 1012 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 133
+      ID: 141
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -8429,7 +8429,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 134 PointerType **table<context.canceler,struct {}>
+          Type: 142 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -8448,8 +8448,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 164 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 159 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 170 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 165 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 1217
       Name: map<crypto/x509.sum224,bool>
@@ -8962,12 +8962,12 @@ Types:
       GoKind: 21
       HeaderType: 1006 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: GoMapType
-      ID: 131
+      ID: 139
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 238880
       GoKind: 21
-      HeaderType: 133 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 141 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 1215
       Name: map[crypto/x509.sum224]bool
@@ -9162,7 +9162,7 @@ Types:
       RawFields:
         - Name: lk
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: s
           Offset: 8
           Type: 1181 PointerType *math/rand.rngSource
@@ -9191,7 +9191,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
     - __kind: StructureType
       ID: 947
       Name: mime/multipart.FileHeader
@@ -9698,8 +9698,8 @@ Types:
         - Name: s
           Offset: 0
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 183
+    - __kind: GoContextImplementationType
+      ID: 120
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 377312
@@ -9711,6 +9711,8 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 113 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
       ID: 224
       Name: net.result·2
@@ -10094,7 +10096,7 @@ Types:
           Type: 15 GoInterfaceType error
         - Name: mu
           Offset: 184
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: listeners
           Offset: 192
           Type: 776 GoMapType map[*net.Listener]struct {}
@@ -10119,7 +10121,7 @@ Types:
           Type: 644 GoInterfaceType io.Reader
         - Name: hdr
           Offset: 16
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: r
           Offset: 32
           Type: 718 PointerType *bufio.Reader
@@ -10131,7 +10133,7 @@ Types:
           Type: 6 BaseType bool
         - Name: mu
           Offset: 44
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: sawEOF
           Offset: 52
           Type: 6 BaseType bool
@@ -10195,7 +10197,7 @@ Types:
           Type: 751 PointerType *net/http.Server
         - Name: cancelCtx
           Offset: 8
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 128 GoSubroutineType context.CancelFunc
         - Name: rwc
           Offset: 16
           Type: 377 GoInterfaceType net.Conn
@@ -10228,7 +10230,7 @@ Types:
           Type: 757 StructureType sync/atomic.Uint64
         - Name: mu
           Offset: 128
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: hijackedv
           Offset: 136
           Type: 6 BaseType bool
@@ -10244,7 +10246,7 @@ Types:
           Type: 377 GoInterfaceType net.Conn
         - Name: mu
           Offset: 16
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: conn
           Offset: 24
           Type: 735 PointerType *net/http.conn
@@ -10979,7 +10981,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: c
           Offset: 8
           Type: 1167 StructureType sync.Cond
@@ -11119,7 +11121,7 @@ Types:
           Type: 14 BaseType int64
         - Name: closeNotifierMu
           Offset: 104
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: closeNotifierCh
           Offset: 112
           Type: 750 GoChannelType chan bool
@@ -11332,7 +11334,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: activeConns
           Offset: 8
           Type: 1004 GoMapType map[*net/http.http2serverConn]struct {}
@@ -11428,7 +11430,7 @@ Types:
       RawFields:
         - Name: Timer
           Offset: 0
-          Type: 137 PointerType *time.Timer
+          Type: 146 PointerType *time.Timer
     - __kind: StructureType
       ID: 997
       Name: net/http.http2unstartedHandler
@@ -11796,7 +11798,7 @@ Types:
           Type: 734 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 128 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -11808,7 +11810,7 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
           Type: 608 StructureType sync/atomic.Bool
@@ -11859,7 +11861,7 @@ Types:
           Type: 749 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
           Type: 750 GoChannelType chan bool
@@ -12262,14 +12264,14 @@ Types:
       HasCount: true
       Element: 1014 StructureType noalg.struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: ArrayType
-      ID: 160
+      ID: 166
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 145696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 161 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 167 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
       ID: 1237
       Name: noalg.[8]struct { key crypto/x509.sum224; elem bool }
@@ -12436,7 +12438,7 @@ Types:
           Offset: 8
           Type: 1013 ArrayType noalg.[8]struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: StructureType
-      ID: 159
+      ID: 165
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 269472
@@ -12447,7 +12449,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 160 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 166 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
       ID: 1236
       Name: noalg.map.group[crypto/x509.sum224]bool
@@ -12642,7 +12644,7 @@ Types:
           Type: 887 PointerType *net.Listener
         - Name: elem
           Offset: 8
-          Type: 163 StructureType struct {}
+          Type: 169 StructureType struct {}
     - __kind: StructureType
       ID: 896
       Name: noalg.struct { key *net/http.conn; elem struct {} }
@@ -12655,7 +12657,7 @@ Types:
           Type: 735 PointerType *net/http.conn
         - Name: elem
           Offset: 8
-          Type: 163 StructureType struct {}
+          Type: 169 StructureType struct {}
     - __kind: StructureType
       ID: 1014
       Name: noalg.struct { key *net/http.http2serverConn; elem struct {} }
@@ -12668,9 +12670,9 @@ Types:
           Type: 966 PointerType *net/http.http2serverConn
         - Name: elem
           Offset: 8
-          Type: 163 StructureType struct {}
+          Type: 169 StructureType struct {}
     - __kind: StructureType
-      ID: 161
+      ID: 167
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 269344
@@ -12678,10 +12680,10 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 162 GoInterfaceType context.canceler
+          Type: 168 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 163 StructureType struct {}
+          Type: 169 StructureType struct {}
     - __kind: StructureType
       ID: 1238
       Name: noalg.struct { key crypto/x509.sum224; elem bool }
@@ -12894,7 +12896,7 @@ Types:
           Offset: 48
           Type: 15 GoInterfaceType error
     - __kind: GoInterfaceType
-      ID: 145
+      ID: 131
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 236192
@@ -12928,7 +12930,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: buf
           Offset: 8
           Type: 615 PointerType *[]uint8
@@ -13002,7 +13004,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 127
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 434560
@@ -13013,13 +13015,13 @@ Types:
           Type: 113 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 128 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 143 GoSliceHeaderType []os.Signal
+          Type: 129 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 146 GoChannelType chan os.Signal
+          Type: 132 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
@@ -13154,7 +13156,7 @@ Types:
           Type: 16 VoidPointerType unsafe.Pointer
         - Name: arg
           Offset: 8
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: link
           Offset: 24
           Type: 26 PointerType *runtime._panic
@@ -14318,7 +14320,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: StructureType
-      ID: 153
+      ID: 157
       Name: runtime.p
       ByteSize: 9512
       GoRuntimeType: 512896
@@ -14813,7 +14815,7 @@ Types:
           Type: 477 GoSubroutineType func(interface {}, uintptr, int64)
         - Name: arg
           Offset: 48
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: seq
           Offset: 64
           Type: 3 BaseType uintptr
@@ -15022,13 +15024,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 148 PointerType *string.str
+          Type: 152 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 147 GoStringDataType string.str
+      Data: 151 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 147
+      ID: 151
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15098,7 +15100,7 @@ Types:
           Offset: 8
           Type: 412 ArrayType [128]*runtime.mspan
     - __kind: StructureType
-      ID: 163
+      ID: 169
       Name: struct {}
       GoRuntimeType: 178208
       GoKind: 25
@@ -15112,7 +15114,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 127 StructureType sync.noCopy
+          Type: 136 StructureType sync.noCopy
         - Name: L
           Offset: 0
           Type: 1168 GoInterfaceType sync.Locker
@@ -15136,7 +15138,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 126
+      ID: 135
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 308000
@@ -15144,10 +15146,10 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 127 StructureType sync.noCopy
+          Type: 136 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 128 StructureType internal/sync.Mutex
+          Type: 137 StructureType internal/sync.Mutex
     - __kind: StructureType
       ID: 775
       Name: sync.Once
@@ -15157,13 +15159,13 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 127 StructureType sync.noCopy
+          Type: 136 StructureType sync.noCopy
         - Name: done
           Offset: 0
           Type: 608 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
     - __kind: StructureType
       ID: 675
       Name: sync.RWMutex
@@ -15173,7 +15175,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -15195,7 +15197,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 127 StructureType sync.noCopy
+          Type: 136 StructureType sync.noCopy
         - Name: state
           Offset: 0
           Type: 757 StructureType sync/atomic.Uint64
@@ -15209,7 +15211,7 @@ Types:
       GoRuntimeType: 131424
       GoKind: 12
     - __kind: StructureType
-      ID: 127
+      ID: 136
       Name: sync.noCopy
       GoRuntimeType: 205408
       GoKind: 25
@@ -15327,7 +15329,7 @@ Types:
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 129
+      ID: 138
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 253600
@@ -15335,7 +15337,7 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 758
       Name: sync/atomic.align64
@@ -15368,7 +15370,7 @@ Types:
           Offset: 8
           Type: 10 BaseType uint64
     - __kind: BaseType
-      ID: 179
+      ID: 183
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 206848
@@ -15446,7 +15448,7 @@ Types:
           Offset: 16
           Type: 1010 GoSwissMapGroupsType groupReference<*net/http.http2serverConn,struct {}>
     - __kind: StructureType
-      ID: 156
+      ID: 162
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -15468,7 +15470,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 157 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 163 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
       ID: 1233
       Name: table<crypto/x509.sum224,bool>
@@ -15812,7 +15814,7 @@ Types:
       GoRuntimeType: 423552
       GoKind: 6
     - __kind: StructureType
-      ID: 141
+      ID: 150
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 436256
@@ -15823,10 +15825,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 166 GoSliceHeaderType []time.zone
+          Type: 172 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 169 GoSliceHeaderType []time.zoneTrans
+          Type: 175 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -15838,7 +15840,7 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 167 PointerType *time.zone
+          Type: 173 PointerType *time.zone
     - __kind: StructureType
       ID: 242
       Name: time.ParseError
@@ -15862,7 +15864,7 @@ Types:
           Offset: 64
           Type: 11 GoStringHeaderType string
     - __kind: GoTimeType
-      ID: 139
+      ID: 148
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 508800
@@ -15876,7 +15878,7 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 140 PointerType *time.Location
+          Type: 149 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -15886,7 +15888,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 138
+      ID: 147
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 309120
@@ -15894,7 +15896,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 178 GoChannelType <-chan time.Time
+          Type: 182 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -15918,7 +15920,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 168
+      ID: 174
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 347360
@@ -15934,7 +15936,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 171
+      ID: 177
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 381920

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=amd64,toolchain=go1.26rc1.yaml
@@ -580,10 +580,10 @@ Types:
       ByteSize: 8
       Pointee: 1034 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 139
+      ID: 147
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<context.canceler,struct {}>
+      Pointee: 148 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1245
       Name: '**table<crypto/x509.sum224,bool>'
@@ -698,10 +698,10 @@ Types:
       ByteSize: 8
       Pointee: 481 GoSliceDataType []*runtime._defer.array
     - __kind: PointerType
-      ID: 165
+      ID: 169
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 164 GoSliceDataType []*runtime.p.array
+      Pointee: 168 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 484
       Name: '*[]*runtime.sudog.array'
@@ -828,10 +828,10 @@ Types:
       ByteSize: 8
       Pointee: 866 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 183
+      ID: 171
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []os.Signal.array
+      Pointee: 170 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -867,15 +867,15 @@ Types:
       ByteSize: 8
       Pointee: 632 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 185
+      ID: 189
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []time.zone.array
+      Pointee: 188 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 187
+      ID: 191
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []time.zoneTrans.array
+      Pointee: 190 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1272
       Name: '*[]uint16.array'
@@ -889,15 +889,15 @@ Types:
       GoKind: 22
       Pointee: 41 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 160
+      ID: 164
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 159 GoSliceDataType []uint8.array
+      Pointee: 163 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 162
+      ID: 166
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []uintptr.array
+      Pointee: 165 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 489
       Name: '*[]unsafe.Pointer.array'
@@ -944,26 +944,26 @@ Types:
       GoKind: 22
       Pointee: 657 StructureType bytes.Reader
     - __kind: PointerType
-      ID: 119
+      ID: 156
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 388128
       GoKind: 22
-      Pointee: 120 StructureType context.afterFuncCtx
+      Pointee: 157 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 194
+      ID: 129
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 341856
       GoKind: 22
-      Pointee: 144 StructureType context.backgroundCtx
+      Pointee: 130 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 121
+      ID: 138
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 387552
       GoKind: 22
-      Pointee: 122 StructureType context.cancelCtx
+      Pointee: 139 StructureType context.cancelCtx
     - __kind: PointerType
       ID: 350
       Name: '*context.deadlineExceededError'
@@ -972,33 +972,33 @@ Types:
       GoKind: 22
       Pointee: 351 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 191
+      ID: 119
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 300480
       GoKind: 22
-      Pointee: 145 StructureType context.emptyCtx
+      Pointee: 120 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 123
+      ID: 121
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 300640
       GoKind: 22
-      Pointee: 124 StructureType context.stopCtx
+      Pointee: 122 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 125
+      ID: 149
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 387744
       GoKind: 22
-      Pointee: 126 StructureType context.timerCtx
+      Pointee: 150 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 127
+      ID: 126
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 341536
       GoKind: 22
-      Pointee: 128 StructureType context.valueCtx
+      Pointee: 127 StructureType context.valueCtx
     - __kind: PointerType
       ID: 297
       Name: '*crypto/aes.KeySizeError'
@@ -1586,7 +1586,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 347136
       GoKind: 22
-      Pointee: 133 StructureType internal/sync.Mutex
+      Pointee: 142 StructureType internal/sync.Mutex
     - __kind: PointerType
       ID: 706
       Name: '*io.LimitedReader'
@@ -1659,10 +1659,10 @@ Types:
       ByteSize: 8
       Pointee: 1032 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 137
+      ID: 145
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 146 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1243
       Name: '*map<crypto/x509.sum224,bool>'
@@ -1978,12 +1978,12 @@ Types:
       GoKind: 22
       Pointee: 236 StructureType net.notFoundError
     - __kind: PointerType
-      ID: 192
+      ID: 124
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 301120
       GoKind: 22
-      Pointee: 193 StructureType net.onlyValuesCtx
+      Pointee: 125 StructureType net.onlyValuesCtx
     - __kind: PointerType
       ID: 237
       Name: '*net.result·2'
@@ -2759,10 +2759,10 @@ Types:
       ByteSize: 8
       Pointee: 1040 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: PointerType
-      ID: 168
+      ID: 174
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 169 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 175 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
       ID: 1262
       Name: '*noalg.map.group[crypto/x509.sum224]bool'
@@ -2848,12 +2848,12 @@ Types:
       GoKind: 22
       Pointee: 324 StructureType os.LinkError
     - __kind: PointerType
-      ID: 154
+      ID: 135
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 97600
       GoKind: 22
-      Pointee: 155 GoInterfaceType os.Signal
+      Pointee: 136 GoInterfaceType os.Signal
     - __kind: PointerType
       ID: 359
       Name: '*os.SyscallError'
@@ -2897,12 +2897,12 @@ Types:
       GoKind: 22
       Pointee: 758 StructureType os.noWriteTo
     - __kind: PointerType
-      ID: 129
+      ID: 131
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 360864
       GoKind: 22
-      Pointee: 130 StructureType os/signal.signalCtx
+      Pointee: 132 StructureType os/signal.signalCtx
     - __kind: PointerType
       ID: 254
       Name: '*os/signal.signalError'
@@ -3087,7 +3087,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 229600
       GoKind: 22
-      Pointee: 163 StructureType runtime.p
+      Pointee: 167 StructureType runtime.p
     - __kind: PointerType
       ID: 430
       Name: '*runtime.pinner'
@@ -3199,10 +3199,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 158
+      ID: 162
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 157 GoStringDataType string.str
+      Pointee: 161 GoStringDataType string.str
     - __kind: PointerType
       ID: 744
       Name: '*strings.Reader'
@@ -3242,7 +3242,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 261792
       GoKind: 22
-      Pointee: 131 StructureType sync.Mutex
+      Pointee: 140 StructureType sync.Mutex
     - __kind: PointerType
       ID: 1203
       Name: '*sync.RWMutex'
@@ -3256,14 +3256,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 226656
       GoKind: 22
-      Pointee: 132 StructureType sync.noCopy
+      Pointee: 141 StructureType sync.noCopy
     - __kind: PointerType
       ID: 1199
       Name: '*sync/atomic.noCopy'
       ByteSize: 8
       GoRuntimeType: 227040
       GoKind: 22
-      Pointee: 143 StructureType sync/atomic.noCopy
+      Pointee: 160 StructureType sync/atomic.noCopy
     - __kind: PointerType
       ID: 378
       Name: '*syscall.Errno'
@@ -3279,12 +3279,12 @@ Types:
       GoKind: 22
       Pointee: 631 StructureType syscall.Iovec
     - __kind: PointerType
-      ID: 190
+      ID: 194
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 230880
       GoKind: 22
-      Pointee: 189 BaseType syscall.Signal
+      Pointee: 193 BaseType syscall.Signal
     - __kind: PointerType
       ID: 810
       Name: '*table<*net.Listener,struct {}>'
@@ -3301,10 +3301,10 @@ Types:
       ByteSize: 8
       Pointee: 1037 StructureType table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 140
+      ID: 148
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 166 StructureType table<context.canceler,struct {}>
+      Pointee: 172 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1246
       Name: '*table<crypto/x509.sum224,bool>'
@@ -3376,12 +3376,12 @@ Types:
       ByteSize: 8
       Pointee: 1108 StructureType table<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>
     - __kind: PointerType
-      ID: 150
+      ID: 154
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 362016
       GoKind: 22
-      Pointee: 151 StructureType time.Location
+      Pointee: 155 StructureType time.Location
     - __kind: PointerType
       ID: 256
       Name: '*time.ParseError'
@@ -3390,12 +3390,12 @@ Types:
       GoKind: 22
       Pointee: 257 StructureType time.ParseError
     - __kind: PointerType
-      ID: 147
+      ID: 151
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 226912
       GoKind: 22
-      Pointee: 148 StructureType time.Timer
+      Pointee: 152 StructureType time.Timer
     - __kind: PointerType
       ID: 255
       Name: '*time.fileSizeError'
@@ -3409,19 +3409,19 @@ Types:
       ByteSize: 8
       Pointee: 212 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 177
+      ID: 183
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 98176
       GoKind: 22
-      Pointee: 178 StructureType time.zone
+      Pointee: 184 StructureType time.zone
     - __kind: PointerType
-      ID: 180
+      ID: 186
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 98240
       GoKind: 22
-      Pointee: 181 StructureType time.zoneTrans
+      Pointee: 187 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 113
       Name: '*uint'
@@ -3533,7 +3533,7 @@ Types:
       GoRuntimeType: 140640
       GoKind: 18
     - __kind: GoChannelType
-      ID: 188
+      ID: 192
       Name: <-chan time.Time
       GoRuntimeType: 144096
       GoKind: 18
@@ -4388,9 +4388,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 164 GoSliceDataType []*runtime.p.array
+      Data: 168 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 168
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4437,11 +4437,11 @@ Types:
       ByteSize: 8
       Element: 1034 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 180
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 140 PointerType *table<context.canceler,struct {}>
+      Element: 148 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
       ID: 1267
       Name: '[]*table<crypto/x509.sum224,bool>.array'
@@ -5097,11 +5097,11 @@ Types:
       ByteSize: 136
       Element: 1040 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 181
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 169 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 175 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
       ID: 1268
       Name: '[]noalg.map.group[crypto/x509.sum224]bool.array'
@@ -5187,7 +5187,7 @@ Types:
       ByteSize: 328
       Element: 1111 StructureType noalg.map.group[vendor/golang.org/x/net/http2/hpack.pairNameValue]uint64
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 134
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 116032
@@ -5195,20 +5195,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType *os.Signal
+          Type: 135 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 182 GoSliceDataType []os.Signal.array
+      Data: 170 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 170
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 155 GoInterfaceType os.Signal
+      Element: 136 GoInterfaceType os.Signal
     - __kind: GoSliceHeaderType
       ID: 43
       Name: '[]runtime.ancestorInfo'
@@ -5302,7 +5302,7 @@ Types:
       ByteSize: 16
       Element: 631 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 182
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 122176
@@ -5310,22 +5310,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *time.zone
+          Type: 183 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []time.zone.array
+      Data: 188 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 188
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 178 StructureType time.zone
+      Element: 184 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 185
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 122240
@@ -5333,20 +5333,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 180 PointerType *time.zoneTrans
+          Type: 186 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType []time.zoneTrans.array
+      Data: 190 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 190
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 181 StructureType time.zoneTrans
+      Element: 187 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 690
       Name: '[]uint16'
@@ -5386,9 +5386,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 159 GoSliceDataType []uint8.array
+      Data: 163 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 163
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -5409,9 +5409,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 161 GoSliceDataType []uintptr.array
+      Data: 165 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 165
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -5589,7 +5589,7 @@ Types:
       GoRuntimeType: 143456
       GoKind: 18
     - __kind: GoChannelType
-      ID: 156
+      ID: 137
       Name: chan os.Signal
       GoRuntimeType: 144416
       GoKind: 18
@@ -5611,7 +5611,7 @@ Types:
       GoRuntimeType: 138016
       GoKind: 15
     - __kind: GoSubroutineType
-      ID: 152
+      ID: 133
       Name: context.CancelCauseFunc
       ByteSize: 8
       GoRuntimeType: 181216
@@ -5636,7 +5636,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 120
+      ID: 157
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 387936
@@ -5644,29 +5644,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 122 StructureType context.cancelCtx
+          Type: 139 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 144
+      ID: 130
       Name: context.backgroundCtx
       GoRuntimeType: 410656
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 145 StructureType context.emptyCtx
+          Type: 120 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 139
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 452928
@@ -5677,23 +5677,23 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 134 StructureType sync/atomic.Value
+          Type: 143 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 136 GoMapType map[context.canceler]struct {}
+          Type: 144 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 134 StructureType sync/atomic.Value
+          Type: 143 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 15 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 172
+      ID: 178
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 243680
@@ -5712,7 +5712,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 145
+      ID: 120
       Name: context.emptyCtx
       GoRuntimeType: 353536
       GoKind: 25
@@ -5721,7 +5721,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 122
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 417824
@@ -5732,11 +5732,11 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 146 GoSubroutineType func() bool
+          Type: 123 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 126
+      ID: 150
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 356448
@@ -5744,17 +5744,17 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 122 StructureType context.cancelCtx
+          Type: 139 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 149 GoTimeType time.Time
+          Type: 153 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 127
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 418944
@@ -5765,10 +5765,10 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoEmptyInterfaceType
@@ -6207,10 +6207,10 @@ Types:
           Type: 635 PointerType *crypto/tls.quicState
         - Name: isHandshakeComplete
           Offset: 40
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: handshakeMutex
           Offset: 44
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: handshakeErr
           Offset: 56
           Type: 15 GoInterfaceType error
@@ -6630,7 +6630,7 @@ Types:
       RawFields:
         - Name: Mutex
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: err
           Offset: 8
           Type: 15 GoInterfaceType error
@@ -6639,7 +6639,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: cipher
           Offset: 32
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: mac
           Offset: 48
           Type: 651 GoInterfaceType hash.Hash
@@ -6651,7 +6651,7 @@ Types:
           Type: 653 ArrayType [13]uint8
         - Name: nextCipher
           Offset: 88
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: nextMac
           Offset: 104
           Type: 651 GoInterfaceType hash.Hash
@@ -6738,7 +6738,7 @@ Types:
           Type: 659 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 149 GoTimeType time.Time
+          Type: 153 GoTimeType time.Time
     - __kind: StructureType
       ID: 688
       Name: crypto/x509.CertPool
@@ -6791,7 +6791,7 @@ Types:
           Type: 541 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
@@ -6806,10 +6806,10 @@ Types:
           Type: 544 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 149 GoTimeType time.Time
+          Type: 153 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 149 GoTimeType time.Time
+          Type: 153 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 549 BaseType crypto/x509.KeyUsage
@@ -7084,7 +7084,7 @@ Types:
           Type: 555 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 552
       Name: crypto/x509/pkix.Extension
@@ -7326,7 +7326,7 @@ Types:
           Type: 1318 GoSliceHeaderType fmt.buffer
         - Name: arg
           Offset: 24
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: value
           Offset: 40
           Type: 1319 StructureType reflect.Value
@@ -7402,7 +7402,7 @@ Types:
       GoRuntimeType: 160224
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 146
+      ID: 123
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 140896
@@ -7624,19 +7624,19 @@ Types:
       GroupType: 1040 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
       GroupSliceType: 1044 GoSliceDataType []noalg.map.group[*net/http.http2serverConn]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 167
+      ID: 173
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 168 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 174 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 169 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 175 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 175 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 181 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
       ID: 1261
       Name: groupReference<crypto/x509.sum224,bool>
@@ -7877,7 +7877,7 @@ Types:
       GoRuntimeType: 137312
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 135
+      ID: 128
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 188352
@@ -8256,7 +8256,7 @@ Types:
       GoRuntimeType: 183328
       GoKind: 2
     - __kind: StructureType
-      ID: 133
+      ID: 142
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 332288
@@ -8384,7 +8384,7 @@ Types:
       RawFields:
         - Name: outMu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: out
           Offset: 8
           Type: 698 GoInterfaceType io.Writer
@@ -8396,7 +8396,7 @@ Types:
           Type: 658 StructureType sync/atomic.Int32
         - Name: isDiscard
           Offset: 36
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
     - __kind: StructureType
       ID: 115
       Name: main.Node
@@ -8529,7 +8529,7 @@ Types:
       TablePtrSliceType: 1043 GoSliceDataType []*table<*net/http.http2serverConn,struct {}>.array
       GroupType: 1040 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 146
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -8542,7 +8542,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<context.canceler,struct {}>
+          Type: 147 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -8561,8 +8561,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 174 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 169 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 180 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 175 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 1244
       Name: map<crypto/x509.sum224,bool>
@@ -9075,12 +9075,12 @@ Types:
       GoKind: 21
       HeaderType: 1032 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: GoMapType
-      ID: 136
+      ID: 144
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 248416
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 146 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 1242
       Name: map[crypto/x509.sum224]bool
@@ -9275,7 +9275,7 @@ Types:
       RawFields:
         - Name: lk
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: s
           Offset: 8
           Type: 1208 PointerType *math/rand.rngSource
@@ -9304,7 +9304,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
     - __kind: StructureType
       ID: 977
       Name: mime/multipart.FileHeader
@@ -9700,7 +9700,7 @@ Types:
           Type: 6 BaseType bool
         - Name: unlinkOnce
           Offset: 28
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
     - __kind: GoStringHeaderType
       ID: 347
       Name: net.UnknownNetworkError
@@ -9811,8 +9811,8 @@ Types:
         - Name: s
           Offset: 0
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 193
+    - __kind: GoContextImplementationType
+      ID: 125
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 394272
@@ -9824,6 +9824,8 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 118 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
       ID: 238
       Name: net.result·2
@@ -10198,19 +10200,19 @@ Types:
           Type: 804 PointerType *net/http.Protocols
         - Name: inShutdown
           Offset: 144
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: disableKeepAlives
           Offset: 148
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: nextProtoOnce
           Offset: 152
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
         - Name: nextProtoErr
           Offset: 168
           Type: 15 GoInterfaceType error
         - Name: mu
           Offset: 184
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: listeners
           Offset: 192
           Type: 806 GoMapType map[*net.Listener]struct {}
@@ -10235,7 +10237,7 @@ Types:
           Type: 672 GoInterfaceType io.Reader
         - Name: hdr
           Offset: 16
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: r
           Offset: 32
           Type: 749 PointerType *bufio.Reader
@@ -10247,7 +10249,7 @@ Types:
           Type: 6 BaseType bool
         - Name: mu
           Offset: 44
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: sawEOF
           Offset: 52
           Type: 6 BaseType bool
@@ -10344,7 +10346,7 @@ Types:
           Type: 788 StructureType sync/atomic.Uint64
         - Name: mu
           Offset: 128
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: hijackedv
           Offset: 136
           Type: 6 BaseType bool
@@ -10360,7 +10362,7 @@ Types:
           Type: 393 GoInterfaceType net.Conn
         - Name: mu
           Offset: 16
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: conn
           Offset: 24
           Type: 766 PointerType *net/http.conn
@@ -10410,10 +10412,10 @@ Types:
           Type: 765 GoInterfaceType io.ReadCloser
         - Name: closed
           Offset: 24
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: sawEOF
           Offset: 28
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
     - __kind: StructureType
       ID: 824
       Name: net/http.globalOptionsHandler
@@ -11095,7 +11097,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: c
           Offset: 8
           Type: 1194 StructureType sync.Cond
@@ -11167,7 +11169,7 @@ Types:
           Type: 996 PointerType *net/http.http2serverConn
         - Name: closeOnce
           Offset: 16
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
         - Name: sawEOF
           Offset: 28
           Type: 6 BaseType bool
@@ -11235,7 +11237,7 @@ Types:
           Type: 14 BaseType int64
         - Name: closeNotifierMu
           Offset: 104
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: closeNotifierCh
           Offset: 112
           Type: 781 GoChannelType chan bool
@@ -11417,10 +11419,10 @@ Types:
           Type: 385 BaseType net/http.http2ErrCode
         - Name: shutdownTimer
           Offset: 352
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: idleTimer
           Offset: 360
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: readIdleTimeout
           Offset: 368
           Type: 791 BaseType time.Duration
@@ -11429,7 +11431,7 @@ Types:
           Type: 791 BaseType time.Duration
         - Name: readIdleTimer
           Offset: 384
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: headerWriteBuf
           Offset: 392
           Type: 655 StructureType bytes.Buffer
@@ -11438,7 +11440,7 @@ Types:
           Type: 1025 PointerType *vendor/golang.org/x/net/http2/hpack.Encoder
         - Name: shutdownOnce
           Offset: 440
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
     - __kind: StructureType
       ID: 1029
       Name: net/http.http2serverInternalState
@@ -11448,7 +11450,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: activeConns
           Offset: 8
           Type: 1030 GoMapType map[*net/http.http2serverConn]struct {}
@@ -11506,10 +11508,10 @@ Types:
           Type: 6 BaseType bool
         - Name: readDeadline
           Offset: 112
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: writeDeadline
           Offset: 120
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: closeErr
           Offset: 128
           Type: 15 GoInterfaceType error
@@ -11841,7 +11843,7 @@ Types:
           Type: 918 GoInterfaceType net.Listener
         - Name: once
           Offset: 16
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
         - Name: closeErr
           Offset: 32
           Type: 15 GoInterfaceType error
@@ -11910,10 +11912,10 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
           Type: 770 PointerType *bufio.Writer
@@ -11949,7 +11951,7 @@ Types:
           Type: 545 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
           Type: 778 ArrayType [29]uint8
@@ -11961,7 +11963,7 @@ Types:
           Type: 780 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
           Type: 781 GoChannelType chan bool
@@ -12364,14 +12366,14 @@ Types:
       HasCount: true
       Element: 1042 StructureType noalg.struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: ArrayType
-      ID: 170
+      ID: 176
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 151712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 171 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 177 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
       ID: 1264
       Name: noalg.[8]struct { key crypto/x509.sum224; elem bool }
@@ -12538,7 +12540,7 @@ Types:
           Offset: 8
           Type: 1041 ArrayType noalg.[8]struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: StructureType
-      ID: 169
+      ID: 175
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 280864
@@ -12549,7 +12551,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 170 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 176 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
       ID: 1263
       Name: noalg.map.group[crypto/x509.sum224]bool
@@ -12744,7 +12746,7 @@ Types:
           Type: 917 PointerType *net.Listener
         - Name: elem
           Offset: 8
-          Type: 173 StructureType struct {}
+          Type: 179 StructureType struct {}
     - __kind: StructureType
       ID: 926
       Name: noalg.struct { key *net/http.conn; elem struct {} }
@@ -12757,7 +12759,7 @@ Types:
           Type: 766 PointerType *net/http.conn
         - Name: elem
           Offset: 8
-          Type: 173 StructureType struct {}
+          Type: 179 StructureType struct {}
     - __kind: StructureType
       ID: 1042
       Name: noalg.struct { key *net/http.http2serverConn; elem struct {} }
@@ -12770,9 +12772,9 @@ Types:
           Type: 996 PointerType *net/http.http2serverConn
         - Name: elem
           Offset: 8
-          Type: 173 StructureType struct {}
+          Type: 179 StructureType struct {}
     - __kind: StructureType
-      ID: 171
+      ID: 177
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 280736
@@ -12780,10 +12782,10 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 172 GoInterfaceType context.canceler
+          Type: 178 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 173 StructureType struct {}
+          Type: 179 StructureType struct {}
     - __kind: StructureType
       ID: 1265
       Name: noalg.struct { key crypto/x509.sum224; elem bool }
@@ -12996,7 +12998,7 @@ Types:
           Offset: 48
           Type: 15 GoInterfaceType error
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 136
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 245600
@@ -13030,7 +13032,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: buf
           Offset: 8
           Type: 642 PointerType *[]uint8
@@ -13104,7 +13106,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 132
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 453184
@@ -13115,13 +13117,13 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 152 GoSubroutineType context.CancelCauseFunc
+          Type: 133 GoSubroutineType context.CancelCauseFunc
         - Name: signals
           Offset: 24
-          Type: 153 GoSliceHeaderType []os.Signal
+          Type: 134 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 156 GoChannelType chan os.Signal
+          Type: 137 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
@@ -13272,7 +13274,7 @@ Types:
       RawFields:
         - Name: arg
           Offset: 0
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: link
           Offset: 16
           Type: 27 PointerType *runtime._panic
@@ -14470,7 +14472,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: StructureType
-      ID: 163
+      ID: 167
       Name: runtime.p
       ByteSize: 15920
       GoRuntimeType: 539424
@@ -15042,7 +15044,7 @@ Types:
           Type: 506 GoSubroutineType func(interface {}, uintptr, int64)
         - Name: arg
           Offset: 48
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: seq
           Offset: 64
           Type: 3 BaseType uintptr
@@ -15401,13 +15403,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 158 PointerType *string.str
+          Type: 162 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 157 GoStringDataType string.str
+      Data: 161 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 157
+      ID: 161
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15490,7 +15492,7 @@ Types:
           Offset: 8
           Type: 427 ArrayType [128]*runtime.mspan
     - __kind: StructureType
-      ID: 173
+      ID: 179
       Name: struct {}
       GoRuntimeType: 185344
       GoKind: 25
@@ -15504,7 +15506,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: L
           Offset: 0
           Type: 1195 GoInterfaceType sync.Locker
@@ -15528,7 +15530,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 131
+      ID: 140
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 318848
@@ -15536,12 +15538,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 133 StructureType internal/sync.Mutex
+          Type: 142 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 141
+      ID: 158
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 361632
@@ -15549,13 +15551,13 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
     - __kind: StructureType
       ID: 1035
       Name: sync.Pool
@@ -15565,7 +15567,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: local
           Offset: 0
           Type: 16 VoidPointerType unsafe.Pointer
@@ -15590,7 +15592,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -15612,7 +15614,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: state
           Offset: 0
           Type: 788 StructureType sync/atomic.Uint64
@@ -15626,7 +15628,7 @@ Types:
       GoRuntimeType: 137120
       GoKind: 12
     - __kind: StructureType
-      ID: 132
+      ID: 141
       Name: sync.noCopy
       GoRuntimeType: 214912
       GoKind: 25
@@ -15654,7 +15656,7 @@ Types:
           Offset: 24
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 142
+      ID: 159
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 320128
@@ -15662,7 +15664,7 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
@@ -15675,7 +15677,7 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
@@ -15691,7 +15693,7 @@ Types:
           Type: 787 ArrayType [0]*net/http.response
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 16 VoidPointerType unsafe.Pointer
@@ -15707,7 +15709,7 @@ Types:
           Type: 1218 ArrayType [0]*os.dirInfo
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 16 VoidPointerType unsafe.Pointer
@@ -15723,7 +15725,7 @@ Types:
           Type: 909 ArrayType [0]*string
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 16 VoidPointerType unsafe.Pointer
@@ -15736,7 +15738,7 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
           Type: 789 StructureType sync/atomic.align64
@@ -15744,7 +15746,7 @@ Types:
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 134
+      ID: 143
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 262304
@@ -15752,7 +15754,7 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 789
       Name: sync/atomic.align64
@@ -15760,7 +15762,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 143
+      ID: 160
       Name: sync/atomic.noCopy
       GoRuntimeType: 215008
       GoKind: 25
@@ -15785,7 +15787,7 @@ Types:
           Offset: 8
           Type: 10 BaseType uint64
     - __kind: BaseType
-      ID: 189
+      ID: 193
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 216352
@@ -15863,7 +15865,7 @@ Types:
           Offset: 16
           Type: 1038 GoSwissMapGroupsType groupReference<*net/http.http2serverConn,struct {}>
     - __kind: StructureType
-      ID: 166
+      ID: 172
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -15885,7 +15887,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 167 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 173 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
       ID: 1260
       Name: table<crypto/x509.sum224,bool>
@@ -16229,7 +16231,7 @@ Types:
       GoRuntimeType: 441152
       GoKind: 6
     - __kind: StructureType
-      ID: 151
+      ID: 155
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 454880
@@ -16240,10 +16242,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 176 GoSliceHeaderType []time.zone
+          Type: 182 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 179 GoSliceHeaderType []time.zoneTrans
+          Type: 185 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -16255,7 +16257,7 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 177 PointerType *time.zone
+          Type: 183 PointerType *time.zone
     - __kind: StructureType
       ID: 257
       Name: time.ParseError
@@ -16279,7 +16281,7 @@ Types:
           Offset: 64
           Type: 11 GoStringHeaderType string
     - __kind: GoTimeType
-      ID: 149
+      ID: 153
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 529472
@@ -16293,7 +16295,7 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 150 PointerType *time.Location
+          Type: 154 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -16303,7 +16305,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 148
+      ID: 152
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 319968
@@ -16311,7 +16313,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 188 GoChannelType <-chan time.Time
+          Type: 192 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -16335,7 +16337,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 178
+      ID: 184
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 361824
@@ -16351,7 +16353,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 181
+      ID: 187
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 399264

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -689,10 +689,10 @@ Types:
       ByteSize: 8
       Pointee: 726 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 159
+      ID: 151
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 158 GoSliceDataType []os.Signal.array
+      Pointee: 150 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -718,15 +718,15 @@ Types:
       ByteSize: 8
       Pointee: 476 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 161
+      ID: 165
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 160 GoSliceDataType []time.zone.array
+      Pointee: 164 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 163
+      ID: 167
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []time.zoneTrans.array
+      Pointee: 166 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1036
       Name: '*[]uint16.array'
@@ -740,15 +740,15 @@ Types:
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 143
+      ID: 147
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 142 GoSliceDataType []uint8.array
+      Pointee: 146 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 145
+      ID: 149
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 144 GoSliceDataType []uintptr.array
+      Pointee: 148 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 890
       Name: '*[]vendor/golang.org/x/net/http2/hpack.HeaderField.array'
@@ -777,10 +777,10 @@ Types:
       ByteSize: 8
       Pointee: 846 GoHMapBucketType bucket<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 125
+      ID: 133
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 126 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 134 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1020
       Name: '*bucket<crypto/x509.sum224,bool>'
@@ -880,19 +880,19 @@ Types:
       GoKind: 22
       Pointee: 504 StructureType bytes.Reader
     - __kind: PointerType
-      ID: 170
+      ID: 117
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 280160
       GoKind: 22
-      Pointee: 117 StructureType context.backgroundCtx
+      Pointee: 118 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 107
+      ID: 126
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 330656
       GoKind: 22
-      Pointee: 108 StructureType context.cancelCtx
+      Pointee: 127 StructureType context.cancelCtx
     - __kind: PointerType
       ID: 308
       Name: '*context.deadlineExceededError'
@@ -901,12 +901,12 @@ Types:
       GoKind: 22
       Pointee: 309 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 167
+      ID: 107
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 244832
       GoKind: 22
-      Pointee: 118 StructureType context.emptyCtx
+      Pointee: 108 StructureType context.emptyCtx
     - __kind: PointerType
       ID: 109
       Name: '*context.stopCtx'
@@ -915,19 +915,19 @@ Types:
       GoKind: 22
       Pointee: 110 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 111
+      ID: 137
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 330848
       GoKind: 22
-      Pointee: 112 StructureType context.timerCtx
+      Pointee: 138 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 113
+      ID: 114
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 279840
       GoKind: 22
-      Pointee: 114 StructureType context.valueCtx
+      Pointee: 115 StructureType context.valueCtx
     - __kind: PointerType
       ID: 260
       Name: '*crypto/aes.KeySizeError'
@@ -1359,10 +1359,10 @@ Types:
       ByteSize: 8
       Pointee: 844 GoHMapHeaderType hash<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 123
+      ID: 131
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 124 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 132 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1018
       Name: '*hash<crypto/x509.sum224,bool>'
@@ -1818,12 +1818,12 @@ Types:
       GoKind: 22
       Pointee: 204 StructureType net.notFoundError
     - __kind: PointerType
-      ID: 168
+      ID: 112
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 245472
       GoKind: 22
-      Pointee: 169 StructureType net.onlyValuesCtx
+      Pointee: 113 StructureType net.onlyValuesCtx
     - __kind: PointerType
       ID: 205
       Name: '*net.result·2'
@@ -2563,12 +2563,12 @@ Types:
       GoKind: 22
       Pointee: 286 StructureType os.LinkError
     - __kind: PointerType
-      ID: 137
+      ID: 123
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 82368
       GoKind: 22
-      Pointee: 138 GoInterfaceType os.Signal
+      Pointee: 124 GoInterfaceType os.Signal
     - __kind: PointerType
       ID: 317
       Name: '*os.SyscallError'
@@ -2612,12 +2612,12 @@ Types:
       GoKind: 22
       Pointee: 601 StructureType os.noWriteTo
     - __kind: PointerType
-      ID: 115
+      ID: 119
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 295712
       GoKind: 22
-      Pointee: 116 StructureType os/signal.signalCtx
+      Pointee: 120 StructureType os/signal.signalCtx
     - __kind: PointerType
       ID: 229
       Name: '*reflect.ValueError'
@@ -2715,12 +2715,12 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 127
+      ID: 135
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 88192
       GoKind: 22
-      Pointee: 128 UnresolvedPointeeType runtime.mapextra
+      Pointee: 136 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 294
       Name: '*runtime.plainError'
@@ -2769,10 +2769,10 @@ Types:
       GoKind: 22
       Pointee: 12 GoStringHeaderType string
     - __kind: PointerType
-      ID: 141
+      ID: 145
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 140 GoStringDataType string.str
+      Pointee: 144 GoStringDataType string.str
     - __kind: PointerType
       ID: 587
       Name: '*strings.Reader'
@@ -2812,7 +2812,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 282240
       GoKind: 22
-      Pointee: 119 StructureType sync.Mutex
+      Pointee: 128 StructureType sync.Mutex
     - __kind: PointerType
       ID: 981
       Name: '*sync.RWMutex'
@@ -2849,19 +2849,19 @@ Types:
       GoKind: 22
       Pointee: 475 StructureType syscall.Iovec
     - __kind: PointerType
-      ID: 166
+      ID: 170
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 202080
       GoKind: 22
-      Pointee: 165 BaseType syscall.Signal
+      Pointee: 169 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 133
+      ID: 142
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 296672
       GoKind: 22
-      Pointee: 134 StructureType time.Location
+      Pointee: 143 StructureType time.Location
     - __kind: PointerType
       ID: 223
       Name: '*time.ParseError'
@@ -2870,12 +2870,12 @@ Types:
       GoKind: 22
       Pointee: 224 StructureType time.ParseError
     - __kind: PointerType
-      ID: 130
+      ID: 139
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 198240
       GoKind: 22
-      Pointee: 131 StructureType time.Timer
+      Pointee: 140 StructureType time.Timer
     - __kind: PointerType
       ID: 222
       Name: '*time.fileSizeError'
@@ -2889,19 +2889,19 @@ Types:
       ByteSize: 8
       Pointee: 185 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 153
+      ID: 159
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 83008
       GoKind: 22
-      Pointee: 154 StructureType time.zone
+      Pointee: 160 StructureType time.zone
     - __kind: PointerType
-      ID: 156
+      ID: 162
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 83072
       GoKind: 22
-      Pointee: 157 StructureType time.zoneTrans
+      Pointee: 163 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 101
       Name: '*uint'
@@ -3020,7 +3020,7 @@ Types:
       GoRuntimeType: 118592
       GoKind: 18
     - __kind: GoChannelType
-      ID: 164
+      ID: 168
       Name: <-chan time.Time
       GoRuntimeType: 120704
       GoKind: 18
@@ -3569,7 +3569,7 @@ Types:
       HasCount: true
       Element: 13 BaseType uint64
     - __kind: ArrayType
-      ID: 146
+      ID: 152
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 125696
@@ -3789,11 +3789,11 @@ Types:
       ByteSize: 80
       Element: 846 GoHMapBucketType bucket<*net/http.http2serverConn,struct {}>
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 157
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 126 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 134 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
       ID: 1032
       Name: '[]bucket<crypto/x509.sum224,bool>.array'
@@ -4222,12 +4222,12 @@ Types:
       HasCount: true
       Element: 803 PointerType *net/http.http2serverConn
     - __kind: ArrayType
-      ID: 147
+      ID: 153
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 148 GoInterfaceType context.canceler
+      Element: 154 GoInterfaceType context.canceler
     - __kind: ArrayType
       ID: 1029
       Name: '[]key<crypto/x509.sum224>'
@@ -4402,7 +4402,7 @@ Types:
       ByteSize: 24
       Element: 725 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 136
+      ID: 122
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 99200
@@ -4410,20 +4410,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 137 PointerType *os.Signal
+          Type: 123 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 158 GoSliceDataType []os.Signal.array
+      Data: 150 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 158
+      ID: 150
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 138 GoInterfaceType os.Signal
+      Element: 124 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -4475,7 +4475,7 @@ Types:
       ByteSize: 16
       Element: 475 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 152
+      ID: 158
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 103680
@@ -4483,22 +4483,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 153 PointerType *time.zone
+          Type: 159 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 160 GoSliceDataType []time.zone.array
+      Data: 164 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 164
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 154 StructureType time.zone
+      Element: 160 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 155
+      ID: 161
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 103744
@@ -4506,20 +4506,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 156 PointerType *time.zoneTrans
+          Type: 162 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 162 GoSliceDataType []time.zoneTrans.array
+      Data: 166 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 166
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 157 StructureType time.zoneTrans
+      Element: 163 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 536
       Name: '[]uint16'
@@ -4559,9 +4559,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 142 GoSliceDataType []uint8.array
+      Data: 146 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 142
+      ID: 146
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4582,9 +4582,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 144 GoSliceDataType []uintptr.array
+      Data: 148 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 144
+      ID: 148
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4674,11 +4674,11 @@ Types:
       HasCount: true
       Element: 12 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 149
+      ID: 155
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
-      Element: 150 StructureType struct {}
+      Element: 156 StructureType struct {}
     - __kind: ArrayType
       ID: 904
       Name: '[]val<uint64>'
@@ -4722,18 +4722,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 748 ArrayType []key<*net.Listener>
         - Name: values
           Offset: 72
-          Type: 149 ArrayType []val<struct {}>
+          Type: 155 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 670 PointerType *bucket<*net.Listener,struct {}>
       KeyType: 749 PointerType *net.Listener
-      ValueType: 150 StructureType struct {}
+      ValueType: 156 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 676
       Name: bucket<*net/http.conn,struct {}>
@@ -4741,18 +4741,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 752 ArrayType []key<*net/http.conn>
         - Name: values
           Offset: 72
-          Type: 149 ArrayType []val<struct {}>
+          Type: 155 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 675 PointerType *bucket<*net/http.conn,struct {}>
       KeyType: 630 PointerType *net/http.conn
-      ValueType: 150 StructureType struct {}
+      ValueType: 156 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 846
       Name: bucket<*net/http.http2serverConn,struct {}>
@@ -4760,37 +4760,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 847 ArrayType []key<*net/http.http2serverConn>
         - Name: values
           Offset: 72
-          Type: 149 ArrayType []val<struct {}>
+          Type: 155 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 845 PointerType *bucket<*net/http.http2serverConn,struct {}>
       KeyType: 803 PointerType *net/http.http2serverConn
-      ValueType: 150 StructureType struct {}
+      ValueType: 156 StructureType struct {}
     - __kind: GoHMapBucketType
-      ID: 126
+      ID: 134
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 147 ArrayType []key<context.canceler>
+          Type: 153 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 149 ArrayType []val<struct {}>
+          Type: 155 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 125 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 148 GoInterfaceType context.canceler
-      ValueType: 150 StructureType struct {}
+          Type: 133 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 154 GoInterfaceType context.canceler
+      ValueType: 156 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 1021
       Name: bucket<crypto/x509.sum224,bool>
@@ -4798,7 +4798,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 1029 ArrayType []key<crypto/x509.sum224>
@@ -4817,7 +4817,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 733 ArrayType []key<net/http.routingIndexKey>
@@ -4836,7 +4836,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4855,7 +4855,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4874,7 +4874,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4893,7 +4893,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4912,7 +4912,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4931,7 +4931,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4950,7 +4950,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4969,7 +4969,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -4988,7 +4988,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 730 ArrayType []key<string>
@@ -5007,7 +5007,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 927 ArrayType []key<uint32>
@@ -5026,7 +5026,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 927 ArrayType []key<uint32>
@@ -5045,7 +5045,7 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: keys
           Offset: 8
           Type: 906 ArrayType []key<vendor/golang.org/x/net/http2/hpack.pairNameValue>
@@ -5178,7 +5178,7 @@ Types:
       GoRuntimeType: 121088
       GoKind: 18
     - __kind: GoChannelType
-      ID: 139
+      ID: 125
       Name: chan os.Signal
       GoRuntimeType: 121856
       GoKind: 18
@@ -5200,7 +5200,7 @@ Types:
       GoRuntimeType: 116032
       GoKind: 15
     - __kind: GoSubroutineType
-      ID: 135
+      ID: 121
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 124928
@@ -5219,19 +5219,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 117
+      ID: 118
       Name: context.backgroundCtx
       GoRuntimeType: 351808
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 118 StructureType context.emptyCtx
+          Type: 108 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 108
+      ID: 127
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 385760
@@ -5242,13 +5242,13 @@ Types:
           Type: 106 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 120 StructureType sync/atomic.Value
+          Type: 129 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 122 GoMapType map[context.canceler]struct {}
+          Type: 130 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -5258,7 +5258,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 148
+      ID: 154
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 214464
@@ -5277,7 +5277,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 118
+      ID: 108
       Name: context.emptyCtx
       GoRuntimeType: 289280
       GoKind: 25
@@ -5297,11 +5297,11 @@ Types:
           Type: 106 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 129 GoSubroutineType func() bool
+          Type: 111 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 112
+      ID: 138
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 290912
@@ -5309,17 +5309,17 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 108 StructureType context.cancelCtx
+          Type: 127 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 130 PointerType *time.Timer
+          Type: 139 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 132 GoTimeType time.Time
+          Type: 141 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 114
+      ID: 115
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 358080
@@ -5330,10 +5330,10 @@ Types:
           Type: 106 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: BaseType
@@ -5430,7 +5430,7 @@ Types:
           Type: 518 GoInterfaceType io.Reader
         - Name: mu
           Offset: 16
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: used
           Offset: 24
           Type: 606 StructureType sync/atomic.Uint32
@@ -5696,7 +5696,7 @@ Types:
           Type: 481 StructureType sync/atomic.Bool
         - Name: handshakeMutex
           Offset: 44
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: handshakeErr
           Offset: 56
           Type: 20 GoInterfaceType error
@@ -6094,7 +6094,7 @@ Types:
       RawFields:
         - Name: Mutex
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: err
           Offset: 8
           Type: 20 GoInterfaceType error
@@ -6103,19 +6103,19 @@ Types:
           Type: 9 BaseType uint16
         - Name: cipher
           Offset: 32
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: mac
           Offset: 48
           Type: 499 GoInterfaceType hash.Hash
         - Name: seq
           Offset: 64
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
         - Name: scratchBuf
           Offset: 72
           Type: 500 ArrayType [13]uint8
         - Name: nextCipher
           Offset: 88
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: nextMac
           Offset: 104
           Type: 499 GoInterfaceType hash.Hash
@@ -6165,7 +6165,7 @@ Types:
           Type: 515 GoChannelType <-chan struct {}
         - Name: cancel
           Offset: 512
-          Type: 135 GoSubroutineType context.CancelFunc
+          Type: 121 GoSubroutineType context.CancelFunc
         - Name: waitingForDrain
           Offset: 520
           Type: 6 BaseType bool
@@ -6193,7 +6193,7 @@ Types:
           Type: 506 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 132 GoTimeType time.Time
+          Type: 141 GoTimeType time.Time
     - __kind: StructureType
       ID: 534
       Name: crypto/x509.CertPool
@@ -6246,7 +6246,7 @@ Types:
           Type: 392 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 11 BaseType int
@@ -6261,10 +6261,10 @@ Types:
           Type: 395 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 132 GoTimeType time.Time
+          Type: 141 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 132 GoTimeType time.Time
+          Type: 141 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 400 BaseType crypto/x509.KeyUsage
@@ -6505,7 +6505,7 @@ Types:
           Type: 406 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 403
       Name: crypto/x509/pkix.Extension
@@ -6747,7 +6747,7 @@ Types:
           Type: 1059 GoSliceHeaderType fmt.buffer
         - Name: arg
           Offset: 24
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: value
           Offset: 40
           Type: 1060 StructureType reflect.Value
@@ -6823,7 +6823,7 @@ Types:
       GoRuntimeType: 134720
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 129
+      ID: 111
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 118848
@@ -7022,7 +7022,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 671 GoHMapBucketType bucket<*net.Listener,struct {}>
       BucketsType: 751 GoSliceDataType []bucket<*net.Listener,struct {}>.array
     - __kind: GoHMapHeaderType
@@ -7056,7 +7056,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 676 GoHMapBucketType bucket<*net/http.conn,struct {}>
       BucketsType: 753 GoSliceDataType []bucket<*net/http.conn,struct {}>.array
     - __kind: GoHMapHeaderType
@@ -7090,11 +7090,11 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 846 GoHMapBucketType bucket<*net/http.http2serverConn,struct {}>
       BucketsType: 848 GoSliceDataType []bucket<*net/http.http2serverConn,struct {}>.array
     - __kind: GoHMapHeaderType
-      ID: 124
+      ID: 132
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -7115,18 +7115,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 125 PointerType *bucket<context.canceler,struct {}>
+          Type: 133 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 125 PointerType *bucket<context.canceler,struct {}>
+          Type: 133 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
-      BucketType: 126 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 151 GoSliceDataType []bucket<context.canceler,struct {}>.array
+          Type: 135 PointerType *runtime.mapextra
+      BucketType: 134 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 157 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 1019
       Name: hash<crypto/x509.sum224,bool>
@@ -7158,7 +7158,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 1021 GoHMapBucketType bucket<crypto/x509.sum224,bool>
       BucketsType: 1032 GoSliceDataType []bucket<crypto/x509.sum224,bool>.array
     - __kind: GoHMapHeaderType
@@ -7192,7 +7192,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 711 GoHMapBucketType bucket<net/http.routingIndexKey,[]*net/http.pattern>
       BucketsType: 736 GoSliceDataType []bucket<net/http.routingIndexKey,[]*net/http.pattern>.array
     - __kind: GoHMapHeaderType
@@ -7226,7 +7226,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 527 GoHMapBucketType bucket<string,*crypto/tls.Certificate>
       BucketsType: 1006 GoSliceDataType []bucket<string,*crypto/tls.Certificate>.array
     - __kind: GoHMapHeaderType
@@ -7260,7 +7260,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 704 GoHMapBucketType bucket<string,*net/http.routingNode>
       BucketsType: 732 GoSliceDataType []bucket<string,*net/http.routingNode>.array
     - __kind: GoHMapHeaderType
@@ -7294,7 +7294,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 784 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
       BucketsType: 789 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
@@ -7328,7 +7328,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 1013 GoHMapBucketType bucket<string,[]int>
       BucketsType: 1024 GoSliceDataType []bucket<string,[]int>.array
     - __kind: GoHMapHeaderType
@@ -7362,7 +7362,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 641 GoHMapBucketType bucket<string,[]string>
       BucketsType: 778 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
@@ -7396,7 +7396,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 660 GoHMapBucketType bucket<string,func(*net/http.Server, *crypto/tls.Conn, net/http.Handler)>
       BucketsType: 745 GoSliceDataType []bucket<string,func(*net/http.Server, *crypto/tls.Conn, net/http.Handler)>.array
     - __kind: GoHMapHeaderType
@@ -7430,7 +7430,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 719 GoHMapBucketType bucket<string,net/http.muxEntry>
       BucketsType: 740 GoSliceDataType []bucket<string,net/http.muxEntry>.array
     - __kind: GoHMapHeaderType
@@ -7464,7 +7464,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 776 GoHMapBucketType bucket<string,string>
       BucketsType: 795 GoSliceDataType []bucket<string,string>.array
     - __kind: GoHMapHeaderType
@@ -7498,7 +7498,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 897 GoHMapBucketType bucket<string,uint64>
       BucketsType: 905 GoSliceDataType []bucket<string,uint64>.array
     - __kind: GoHMapHeaderType
@@ -7532,7 +7532,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 831 GoHMapBucketType bucket<uint32,*net/http.http2stream>
       BucketsType: 961 GoSliceDataType []bucket<uint32,*net/http.http2stream>.array
     - __kind: GoHMapHeaderType
@@ -7566,7 +7566,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 920 GoHMapBucketType bucket<uint32,*net/http.http2writeQueue>
       BucketsType: 929 GoSliceDataType []bucket<uint32,*net/http.http2writeQueue>.array
     - __kind: GoHMapHeaderType
@@ -7600,7 +7600,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 127 PointerType *runtime.mapextra
+          Type: 135 PointerType *runtime.mapextra
       BucketType: 902 GoHMapBucketType bucket<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>
       BucketsType: 908 GoSliceDataType []bucket<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>.array
     - __kind: BaseType
@@ -7647,7 +7647,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoEmptyInterfaceType
-      ID: 121
+      ID: 116
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 159680
@@ -8049,7 +8049,7 @@ Types:
       RawFields:
         - Name: outMu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: out
           Offset: 8
           Type: 544 GoInterfaceType io.Writer
@@ -8110,12 +8110,12 @@ Types:
       GoKind: 21
       HeaderType: 844 GoHMapHeaderType hash<*net/http.http2serverConn,struct {}>
     - __kind: GoMapType
-      ID: 122
+      ID: 130
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 178400
       GoKind: 21
-      HeaderType: 124 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 132 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 1017
       Name: map[crypto/x509.sum224]bool
@@ -8310,7 +8310,7 @@ Types:
       RawFields:
         - Name: lk
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: s
           Offset: 8
           Type: 986 PointerType *math/rand.rngSource
@@ -8339,7 +8339,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
     - __kind: StructureType
       ID: 790
       Name: mime/multipart.FileHeader
@@ -8846,8 +8846,8 @@ Types:
         - Name: s
           Offset: 0
           Type: 12 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 169
+    - __kind: GoContextImplementationType
+      ID: 113
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 336800
@@ -8859,6 +8859,8 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 106 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
       ID: 206
       Name: net.result·2
@@ -9192,7 +9194,7 @@ Types:
           Type: 20 GoInterfaceType error
         - Name: mu
           Offset: 168
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: listeners
           Offset: 176
           Type: 667 GoMapType map[*net.Listener]struct {}
@@ -9217,7 +9219,7 @@ Types:
           Type: 518 GoInterfaceType io.Reader
         - Name: hdr
           Offset: 16
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
         - Name: r
           Offset: 32
           Type: 592 PointerType *bufio.Reader
@@ -9229,7 +9231,7 @@ Types:
           Type: 6 BaseType bool
         - Name: mu
           Offset: 44
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: sawEOF
           Offset: 52
           Type: 6 BaseType bool
@@ -9293,7 +9295,7 @@ Types:
           Type: 646 PointerType *net/http.Server
         - Name: cancelCtx
           Offset: 8
-          Type: 135 GoSubroutineType context.CancelFunc
+          Type: 121 GoSubroutineType context.CancelFunc
         - Name: rwc
           Offset: 16
           Type: 349 GoInterfaceType net.Conn
@@ -9326,7 +9328,7 @@ Types:
           Type: 652 StructureType sync/atomic.Uint64
         - Name: mu
           Offset: 128
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: hijackedv
           Offset: 136
           Type: 6 BaseType bool
@@ -9342,7 +9344,7 @@ Types:
           Type: 630 PointerType *net/http.conn
         - Name: mu
           Offset: 8
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: hasByte
           Offset: 16
           Type: 6 BaseType bool
@@ -9639,7 +9641,7 @@ Types:
           Type: 858 StructureType net/http.http2FrameHeader
         - Name: Data
           Offset: 12
-          Type: 146 ArrayType [8]uint8
+          Type: 152 ArrayType [8]uint8
     - __kind: StructureType
       ID: 868
       Name: net/http.http2PriorityFrame
@@ -10037,7 +10039,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: c
           Offset: 8
           Type: 973 StructureType sync.Cond
@@ -10177,7 +10179,7 @@ Types:
           Type: 16 BaseType int64
         - Name: closeNotifierMu
           Offset: 104
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: closeNotifierCh
           Offset: 112
           Type: 645 GoChannelType chan bool
@@ -10369,7 +10371,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: activeConns
           Offset: 8
           Type: 842 GoMapType map[*net/http.http2serverConn]struct {}
@@ -10465,7 +10467,7 @@ Types:
       RawFields:
         - Name: Timer
           Offset: 0
-          Type: 130 PointerType *time.Timer
+          Type: 139 PointerType *time.Timer
     - __kind: StructureType
       ID: 834
       Name: net/http.http2unstartedHandler
@@ -10823,7 +10825,7 @@ Types:
           Type: 629 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 135 GoSubroutineType context.CancelFunc
+          Type: 121 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -10835,7 +10837,7 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
           Type: 481 StructureType sync/atomic.Bool
@@ -11259,7 +11261,7 @@ Types:
           Offset: 48
           Type: 20 GoInterfaceType error
     - __kind: GoInterfaceType
-      ID: 138
+      ID: 124
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 216384
@@ -11293,7 +11295,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: buf
           Offset: 8
           Type: 487 PointerType *[]uint8
@@ -11367,7 +11369,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 116
+      ID: 120
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 386016
@@ -11378,13 +11380,13 @@ Types:
           Type: 106 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 135 GoSubroutineType context.CancelFunc
+          Type: 121 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 136 GoSliceHeaderType []os.Signal
+          Type: 122 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 139 GoChannelType chan os.Signal
+          Type: 125 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
@@ -12131,7 +12133,7 @@ Types:
           Offset: 24
           Type: 30 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 128
+      ID: 136
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -12300,13 +12302,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 141 PointerType *string.str
+          Type: 145 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 140 GoStringDataType string.str
+      Data: 144 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 140
+      ID: 144
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -12363,7 +12365,7 @@ Types:
           Offset: 16
           Type: 580 GoInterfaceType io.WriterTo
     - __kind: StructureType
-      ID: 150
+      ID: 156
       Name: struct {}
       GoRuntimeType: 157632
       GoKind: 25
@@ -12401,7 +12403,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 119
+      ID: 128
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 262880
@@ -12425,7 +12427,7 @@ Types:
           Type: 606 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
     - __kind: StructureType
       ID: 545
       Name: sync.RWMutex
@@ -12435,7 +12437,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 119 StructureType sync.Mutex
+          Type: 128 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -12602,7 +12604,7 @@ Types:
           Offset: 0
           Type: 13 BaseType uint64
     - __kind: StructureType
-      ID: 120
+      ID: 129
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 226368
@@ -12610,7 +12612,7 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 121 GoEmptyInterfaceType interface {}
+          Type: 116 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 653
       Name: sync/atomic.align64
@@ -12643,7 +12645,7 @@ Types:
           Offset: 8
           Type: 13 BaseType uint64
     - __kind: BaseType
-      ID: 165
+      ID: 169
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 188416
@@ -12655,7 +12657,7 @@ Types:
       GoRuntimeType: 378336
       GoKind: 6
     - __kind: StructureType
-      ID: 134
+      ID: 143
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 388000
@@ -12666,10 +12668,10 @@ Types:
           Type: 12 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 152 GoSliceHeaderType []time.zone
+          Type: 158 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 155 GoSliceHeaderType []time.zoneTrans
+          Type: 161 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 12 GoStringHeaderType string
@@ -12681,7 +12683,7 @@ Types:
           Type: 16 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 153 PointerType *time.zone
+          Type: 159 PointerType *time.zone
     - __kind: StructureType
       ID: 224
       Name: time.ParseError
@@ -12705,7 +12707,7 @@ Types:
           Offset: 64
           Type: 12 GoStringHeaderType string
     - __kind: GoTimeType
-      ID: 132
+      ID: 141
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 456576
@@ -12719,7 +12721,7 @@ Types:
           Type: 16 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 133 PointerType *time.Location
+          Type: 142 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -12729,7 +12731,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 131
+      ID: 140
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 264160
@@ -12737,7 +12739,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 164 GoChannelType <-chan time.Time
+          Type: 168 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -12761,7 +12763,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 154
+      ID: 160
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 296480
@@ -12777,7 +12779,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 157
+      ID: 163
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 341408

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -559,10 +559,10 @@ Types:
       ByteSize: 8
       Pointee: 901 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 132
+      ID: 140
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 133 PointerType *table<context.canceler,struct {}>
+      Pointee: 141 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1112
       Name: '**table<crypto/x509.sum224,bool>'
@@ -790,10 +790,10 @@ Types:
       ByteSize: 8
       Pointee: 729 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 168
+      ID: 156
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []os.Signal.array
+      Pointee: 155 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -819,15 +819,15 @@ Types:
       ByteSize: 8
       Pointee: 494 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 170
+      ID: 174
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType []time.zone.array
+      Pointee: 173 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 172
+      ID: 176
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []time.zoneTrans.array
+      Pointee: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1139
       Name: '*[]uint16.array'
@@ -841,15 +841,15 @@ Types:
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 148
+      ID: 152
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 147 GoSliceDataType []uint8.array
+      Pointee: 151 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 150
+      ID: 154
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 149 GoSliceDataType []uintptr.array
+      Pointee: 153 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 951
       Name: '*[]vendor/golang.org/x/net/http2/hpack.HeaderField.array'
@@ -891,19 +891,19 @@ Types:
       GoKind: 22
       Pointee: 523 StructureType bytes.Reader
     - __kind: PointerType
-      ID: 179
+      ID: 122
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 324768
       GoKind: 22
-      Pointee: 122 StructureType context.backgroundCtx
+      Pointee: 123 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 112
+      ID: 131
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 364608
       GoKind: 22
-      Pointee: 113 StructureType context.cancelCtx
+      Pointee: 132 StructureType context.cancelCtx
     - __kind: PointerType
       ID: 319
       Name: '*context.deadlineExceededError'
@@ -912,12 +912,12 @@ Types:
       GoKind: 22
       Pointee: 320 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 176
+      ID: 112
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 286432
       GoKind: 22
-      Pointee: 123 StructureType context.emptyCtx
+      Pointee: 113 StructureType context.emptyCtx
     - __kind: PointerType
       ID: 114
       Name: '*context.stopCtx'
@@ -926,19 +926,19 @@ Types:
       GoKind: 22
       Pointee: 115 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 116
+      ID: 142
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 364800
       GoKind: 22
-      Pointee: 117 StructureType context.timerCtx
+      Pointee: 143 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 324448
       GoKind: 22
-      Pointee: 119 StructureType context.valueCtx
+      Pointee: 120 StructureType context.valueCtx
     - __kind: PointerType
       ID: 270
       Name: '*crypto/aes.KeySizeError'
@@ -1480,7 +1480,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 329408
       GoKind: 22
-      Pointee: 126 StructureType internal/sync.Mutex
+      Pointee: 135 StructureType internal/sync.Mutex
     - __kind: PointerType
       ID: 570
       Name: '*io.LimitedReader'
@@ -1553,10 +1553,10 @@ Types:
       ByteSize: 8
       Pointee: 899 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 130
+      ID: 138
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 131 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 139 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1110
       Name: '*map<crypto/x509.sum224,bool>'
@@ -1872,12 +1872,12 @@ Types:
       GoKind: 22
       Pointee: 214 StructureType net.notFoundError
     - __kind: PointerType
-      ID: 177
+      ID: 117
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 287072
       GoKind: 22
-      Pointee: 178 StructureType net.onlyValuesCtx
+      Pointee: 118 StructureType net.onlyValuesCtx
     - __kind: PointerType
       ID: 215
       Name: '*net.result·2'
@@ -2660,10 +2660,10 @@ Types:
       ByteSize: 8
       Pointee: 905 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: PointerType
-      ID: 153
+      ID: 159
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 154 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 160 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
       ID: 1129
       Name: '*noalg.map.group[crypto/x509.sum224]bool'
@@ -2749,12 +2749,12 @@ Types:
       GoKind: 22
       Pointee: 297 StructureType os.LinkError
     - __kind: PointerType
-      ID: 142
+      ID: 128
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 91456
       GoKind: 22
-      Pointee: 143 GoInterfaceType os.Signal
+      Pointee: 129 GoInterfaceType os.Signal
     - __kind: PointerType
       ID: 328
       Name: '*os.SyscallError'
@@ -2798,12 +2798,12 @@ Types:
       GoKind: 22
       Pointee: 619 StructureType os.noWriteTo
     - __kind: PointerType
-      ID: 120
+      ID: 124
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 341760
       GoKind: 22
-      Pointee: 121 StructureType os/signal.signalCtx
+      Pointee: 125 StructureType os/signal.signalCtx
     - __kind: PointerType
       ID: 239
       Name: '*reflect.ValueError'
@@ -2955,10 +2955,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 146
+      ID: 150
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 145 GoStringDataType string.str
+      Pointee: 149 GoStringDataType string.str
     - __kind: PointerType
       ID: 605
       Name: '*strings.Reader'
@@ -2998,7 +2998,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 249408
       GoKind: 22
-      Pointee: 124 StructureType sync.Mutex
+      Pointee: 133 StructureType sync.Mutex
     - __kind: PointerType
       ID: 1069
       Name: '*sync.RWMutex'
@@ -3012,7 +3012,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 213024
       GoKind: 22
-      Pointee: 125 StructureType sync.noCopy
+      Pointee: 134 StructureType sync.noCopy
     - __kind: PointerType
       ID: 1065
       Name: '*sync/atomic.noCopy'
@@ -3035,12 +3035,12 @@ Types:
       GoKind: 22
       Pointee: 493 StructureType syscall.Iovec
     - __kind: PointerType
-      ID: 175
+      ID: 179
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 217120
       GoKind: 22
-      Pointee: 174 BaseType syscall.Signal
+      Pointee: 178 BaseType syscall.Signal
     - __kind: PointerType
       ID: 673
       Name: '*table<*net.Listener,struct {}>'
@@ -3057,10 +3057,10 @@ Types:
       ByteSize: 8
       Pointee: 902 StructureType table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 133
+      ID: 141
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 151 StructureType table<context.canceler,struct {}>
+      Pointee: 157 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1113
       Name: '*table<crypto/x509.sum224,bool>'
@@ -3132,12 +3132,12 @@ Types:
       ByteSize: 8
       Pointee: 973 StructureType table<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>
     - __kind: PointerType
-      ID: 138
+      ID: 147
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 342912
       GoKind: 22
-      Pointee: 139 StructureType time.Location
+      Pointee: 148 StructureType time.Location
     - __kind: PointerType
       ID: 233
       Name: '*time.ParseError'
@@ -3146,12 +3146,12 @@ Types:
       GoKind: 22
       Pointee: 234 StructureType time.ParseError
     - __kind: PointerType
-      ID: 135
+      ID: 144
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 213280
       GoKind: 22
-      Pointee: 136 StructureType time.Timer
+      Pointee: 145 StructureType time.Timer
     - __kind: PointerType
       ID: 232
       Name: '*time.fileSizeError'
@@ -3165,19 +3165,19 @@ Types:
       ByteSize: 8
       Pointee: 194 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 162
+      ID: 168
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 92032
       GoKind: 22
-      Pointee: 163 StructureType time.zone
+      Pointee: 169 StructureType time.zone
     - __kind: PointerType
-      ID: 165
+      ID: 171
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 92096
       GoKind: 22
-      Pointee: 166 StructureType time.zoneTrans
+      Pointee: 172 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 106
       Name: '*uint'
@@ -3282,7 +3282,7 @@ Types:
       GoRuntimeType: 132160
       GoKind: 18
     - __kind: GoChannelType
-      ID: 173
+      ID: 177
       Name: <-chan time.Time
       GoRuntimeType: 134208
       GoKind: 18
@@ -4012,11 +4012,11 @@ Types:
       ByteSize: 8
       Element: 901 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 165
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 133 PointerType *table<context.canceler,struct {}>
+      Element: 141 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
       ID: 1134
       Name: '[]*table<crypto/x509.sum224,bool>.array'
@@ -4672,11 +4672,11 @@ Types:
       ByteSize: 136
       Element: 905 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 166
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 154 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 160 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
       ID: 1135
       Name: '[]noalg.map.group[crypto/x509.sum224]bool.array'
@@ -4762,7 +4762,7 @@ Types:
       ByteSize: 328
       Element: 976 StructureType noalg.map.group[vendor/golang.org/x/net/http2/hpack.pairNameValue]uint64
     - __kind: GoSliceHeaderType
-      ID: 141
+      ID: 127
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 108992
@@ -4770,20 +4770,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 142 PointerType *os.Signal
+          Type: 128 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 167 GoSliceDataType []os.Signal.array
+      Data: 155 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 155
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 143 GoInterfaceType os.Signal
+      Element: 129 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -4835,7 +4835,7 @@ Types:
       ByteSize: 16
       Element: 493 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 167
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 114816
@@ -4843,22 +4843,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *time.zone
+          Type: 168 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 169 GoSliceDataType []time.zone.array
+      Data: 173 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 173
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 163 StructureType time.zone
+      Element: 169 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 170
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 114880
@@ -4866,20 +4866,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *time.zoneTrans
+          Type: 171 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 171 GoSliceDataType []time.zoneTrans.array
+      Data: 175 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 175
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 166 StructureType time.zoneTrans
+      Element: 172 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 555
       Name: '[]uint16'
@@ -4919,9 +4919,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 147 GoSliceDataType []uint8.array
+      Data: 151 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 147
+      ID: 151
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4942,9 +4942,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 149 GoSliceDataType []uintptr.array
+      Data: 153 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 153
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -5099,7 +5099,7 @@ Types:
       GoRuntimeType: 134592
       GoKind: 18
     - __kind: GoChannelType
-      ID: 144
+      ID: 130
       Name: chan os.Signal
       GoRuntimeType: 135424
       GoKind: 18
@@ -5121,7 +5121,7 @@ Types:
       GoRuntimeType: 129472
       GoKind: 15
     - __kind: GoSubroutineType
-      ID: 140
+      ID: 126
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 140992
@@ -5140,19 +5140,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 123
       Name: context.backgroundCtx
       GoRuntimeType: 385984
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 123 StructureType context.emptyCtx
+          Type: 113 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 113
+      ID: 132
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 426432
@@ -5163,13 +5163,13 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 127 StructureType sync/atomic.Value
+          Type: 136 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 129 GoMapType map[context.canceler]struct {}
+          Type: 137 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 16 GoInterfaceType error
@@ -5179,7 +5179,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 163
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 229760
@@ -5198,7 +5198,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 113
       Name: context.emptyCtx
       GoRuntimeType: 335168
       GoKind: 25
@@ -5218,11 +5218,11 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 134 GoSubroutineType func() bool
+          Type: 116 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 117
+      ID: 143
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 336960
@@ -5230,17 +5230,17 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 113 StructureType context.cancelCtx
+          Type: 132 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 135 PointerType *time.Timer
+          Type: 144 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 137 GoTimeType time.Time
+          Type: 146 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 120
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 393728
@@ -5251,10 +5251,10 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoEmptyInterfaceType
@@ -5690,7 +5690,7 @@ Types:
           Type: 499 StructureType sync/atomic.Bool
         - Name: handshakeMutex
           Offset: 44
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: handshakeErr
           Offset: 56
           Type: 16 GoInterfaceType error
@@ -6104,7 +6104,7 @@ Types:
       RawFields:
         - Name: Mutex
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: err
           Offset: 8
           Type: 16 GoInterfaceType error
@@ -6113,7 +6113,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: cipher
           Offset: 32
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: mac
           Offset: 48
           Type: 517 GoInterfaceType hash.Hash
@@ -6125,7 +6125,7 @@ Types:
           Type: 519 ArrayType [13]uint8
         - Name: nextCipher
           Offset: 88
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: nextMac
           Offset: 104
           Type: 517 GoInterfaceType hash.Hash
@@ -6181,7 +6181,7 @@ Types:
           Type: 534 GoChannelType <-chan struct {}
         - Name: cancel
           Offset: 512
-          Type: 140 GoSubroutineType context.CancelFunc
+          Type: 126 GoSubroutineType context.CancelFunc
         - Name: waitingForDrain
           Offset: 520
           Type: 6 BaseType bool
@@ -6209,7 +6209,7 @@ Types:
           Type: 525 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 137 GoTimeType time.Time
+          Type: 146 GoTimeType time.Time
     - __kind: StructureType
       ID: 553
       Name: crypto/x509.CertPool
@@ -6262,7 +6262,7 @@ Types:
           Type: 403 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
@@ -6277,10 +6277,10 @@ Types:
           Type: 406 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 137 GoTimeType time.Time
+          Type: 146 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 137 GoTimeType time.Time
+          Type: 146 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 411 BaseType crypto/x509.KeyUsage
@@ -6555,7 +6555,7 @@ Types:
           Type: 417 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 414
       Name: crypto/x509/pkix.Extension
@@ -6797,7 +6797,7 @@ Types:
           Type: 1187 GoSliceHeaderType fmt.buffer
         - Name: arg
           Offset: 24
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: value
           Offset: 40
           Type: 1188 StructureType reflect.Value
@@ -6873,7 +6873,7 @@ Types:
       GoRuntimeType: 150848
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 134
+      ID: 116
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 132416
@@ -7065,19 +7065,19 @@ Types:
       GroupType: 905 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
       GroupSliceType: 909 GoSliceDataType []noalg.map.group[*net/http.http2serverConn]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 152
+      ID: 158
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 153 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 159 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 154 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 160 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 160 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 166 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
       ID: 1128
       Name: groupReference<crypto/x509.sum224,bool>
@@ -7331,7 +7331,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoEmptyInterfaceType
-      ID: 128
+      ID: 121
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 178208
@@ -7618,7 +7618,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 126
+      ID: 135
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 316288
@@ -7746,7 +7746,7 @@ Types:
       RawFields:
         - Name: outMu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: out
           Offset: 8
           Type: 563 GoInterfaceType io.Writer
@@ -7882,7 +7882,7 @@ Types:
       TablePtrSliceType: 908 GoSliceDataType []*table<*net/http.http2serverConn,struct {}>.array
       GroupType: 905 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 131
+      ID: 139
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -7895,7 +7895,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 132 PointerType **table<context.canceler,struct {}>
+          Type: 140 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -7911,8 +7911,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 159 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 154 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 165 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 160 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 1111
       Name: map<crypto/x509.sum224,bool>
@@ -8383,12 +8383,12 @@ Types:
       GoKind: 21
       HeaderType: 899 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: GoMapType
-      ID: 129
+      ID: 137
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 234368
       GoKind: 21
-      HeaderType: 131 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 139 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 1109
       Name: map[crypto/x509.sum224]bool
@@ -8583,7 +8583,7 @@ Types:
       RawFields:
         - Name: lk
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: s
           Offset: 8
           Type: 1074 PointerType *math/rand.rngSource
@@ -8612,7 +8612,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
     - __kind: StructureType
       ID: 840
       Name: mime/multipart.FileHeader
@@ -9119,8 +9119,8 @@ Types:
         - Name: s
           Offset: 0
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 178
+    - __kind: GoContextImplementationType
+      ID: 118
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 370176
@@ -9132,6 +9132,8 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 111 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
       ID: 216
       Name: net.result·2
@@ -9515,7 +9517,7 @@ Types:
           Type: 16 GoInterfaceType error
         - Name: mu
           Offset: 184
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: listeners
           Offset: 192
           Type: 669 GoMapType map[*net.Listener]struct {}
@@ -9540,7 +9542,7 @@ Types:
           Type: 537 GoInterfaceType io.Reader
         - Name: hdr
           Offset: 16
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
         - Name: r
           Offset: 32
           Type: 610 PointerType *bufio.Reader
@@ -9552,7 +9554,7 @@ Types:
           Type: 6 BaseType bool
         - Name: mu
           Offset: 44
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: sawEOF
           Offset: 52
           Type: 6 BaseType bool
@@ -9616,7 +9618,7 @@ Types:
           Type: 643 PointerType *net/http.Server
         - Name: cancelCtx
           Offset: 8
-          Type: 140 GoSubroutineType context.CancelFunc
+          Type: 126 GoSubroutineType context.CancelFunc
         - Name: rwc
           Offset: 16
           Type: 360 GoInterfaceType net.Conn
@@ -9649,7 +9651,7 @@ Types:
           Type: 649 StructureType sync/atomic.Uint64
         - Name: mu
           Offset: 128
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: hijackedv
           Offset: 136
           Type: 6 BaseType bool
@@ -9665,7 +9667,7 @@ Types:
           Type: 627 PointerType *net/http.conn
         - Name: mu
           Offset: 8
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: hasByte
           Offset: 16
           Type: 6 BaseType bool
@@ -10397,7 +10399,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: c
           Offset: 8
           Type: 1060 StructureType sync.Cond
@@ -10537,7 +10539,7 @@ Types:
           Type: 15 BaseType int64
         - Name: closeNotifierMu
           Offset: 104
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: closeNotifierCh
           Offset: 112
           Type: 642 GoChannelType chan bool
@@ -10750,7 +10752,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: activeConns
           Offset: 8
           Type: 897 GoMapType map[*net/http.http2serverConn]struct {}
@@ -10846,7 +10848,7 @@ Types:
       RawFields:
         - Name: Timer
           Offset: 0
-          Type: 135 PointerType *time.Timer
+          Type: 144 PointerType *time.Timer
     - __kind: StructureType
       ID: 890
       Name: net/http.http2unstartedHandler
@@ -11214,7 +11216,7 @@ Types:
           Type: 626 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 140 GoSubroutineType context.CancelFunc
+          Type: 126 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -11226,7 +11228,7 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
           Type: 499 StructureType sync/atomic.Bool
@@ -11677,14 +11679,14 @@ Types:
       HasCount: true
       Element: 907 StructureType noalg.struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: ArrayType
-      ID: 155
+      ID: 161
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 143104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 156 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 162 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
       ID: 1131
       Name: noalg.[8]struct { key crypto/x509.sum224; elem bool }
@@ -11851,7 +11853,7 @@ Types:
           Offset: 8
           Type: 906 ArrayType noalg.[8]struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: StructureType
-      ID: 154
+      ID: 160
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 265920
@@ -11862,7 +11864,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 155 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 161 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
       ID: 1130
       Name: noalg.map.group[crypto/x509.sum224]bool
@@ -12057,7 +12059,7 @@ Types:
           Type: 780 PointerType *net.Listener
         - Name: elem
           Offset: 8
-          Type: 158 StructureType struct {}
+          Type: 164 StructureType struct {}
     - __kind: StructureType
       ID: 789
       Name: noalg.struct { key *net/http.conn; elem struct {} }
@@ -12070,7 +12072,7 @@ Types:
           Type: 627 PointerType *net/http.conn
         - Name: elem
           Offset: 8
-          Type: 158 StructureType struct {}
+          Type: 164 StructureType struct {}
     - __kind: StructureType
       ID: 907
       Name: noalg.struct { key *net/http.http2serverConn; elem struct {} }
@@ -12083,9 +12085,9 @@ Types:
           Type: 859 PointerType *net/http.http2serverConn
         - Name: elem
           Offset: 8
-          Type: 158 StructureType struct {}
+          Type: 164 StructureType struct {}
     - __kind: StructureType
-      ID: 156
+      ID: 162
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 265792
@@ -12093,10 +12095,10 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 157 GoInterfaceType context.canceler
+          Type: 163 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 158 StructureType struct {}
+          Type: 164 StructureType struct {}
     - __kind: StructureType
       ID: 1132
       Name: noalg.struct { key crypto/x509.sum224; elem bool }
@@ -12309,7 +12311,7 @@ Types:
           Offset: 48
           Type: 16 GoInterfaceType error
     - __kind: GoInterfaceType
-      ID: 143
+      ID: 129
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 231680
@@ -12343,7 +12345,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: buf
           Offset: 8
           Type: 505 PointerType *[]uint8
@@ -12417,7 +12419,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 125
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 426688
@@ -12428,13 +12430,13 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 140 GoSubroutineType context.CancelFunc
+          Type: 126 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 141 GoSliceHeaderType []os.Signal
+          Type: 127 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 144 GoChannelType chan os.Signal
+          Type: 130 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
@@ -13384,13 +13386,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 146 PointerType *string.str
+          Type: 150 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 145 GoStringDataType string.str
+      Data: 149 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 145
+      ID: 149
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -13447,7 +13449,7 @@ Types:
           Offset: 16
           Type: 598 GoInterfaceType io.WriterTo
     - __kind: StructureType
-      ID: 158
+      ID: 164
       Name: struct {}
       GoRuntimeType: 175872
       GoKind: 25
@@ -13461,7 +13463,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 125 StructureType sync.noCopy
+          Type: 134 StructureType sync.noCopy
         - Name: L
           Offset: 0
           Type: 1061 GoInterfaceType sync.Locker
@@ -13485,7 +13487,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 124
+      ID: 133
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 304608
@@ -13493,10 +13495,10 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 125 StructureType sync.noCopy
+          Type: 134 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 126 StructureType internal/sync.Mutex
+          Type: 135 StructureType internal/sync.Mutex
     - __kind: StructureType
       ID: 667
       Name: sync.Once
@@ -13506,13 +13508,13 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 125 StructureType sync.noCopy
+          Type: 134 StructureType sync.noCopy
         - Name: done
           Offset: 0
           Type: 668 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
     - __kind: StructureType
       ID: 567
       Name: sync.RWMutex
@@ -13522,7 +13524,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 124 StructureType sync.Mutex
+          Type: 133 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -13544,7 +13546,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 125 StructureType sync.noCopy
+          Type: 134 StructureType sync.noCopy
         - Name: state
           Offset: 0
           Type: 649 StructureType sync/atomic.Uint64
@@ -13558,7 +13560,7 @@ Types:
       GoRuntimeType: 128576
       GoKind: 12
     - __kind: StructureType
-      ID: 125
+      ID: 134
       Name: sync.noCopy
       GoRuntimeType: 201632
       GoKind: 25
@@ -13689,7 +13691,7 @@ Types:
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 127
+      ID: 136
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 250048
@@ -13697,7 +13699,7 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 121 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 650
       Name: sync/atomic.align64
@@ -13730,7 +13732,7 @@ Types:
           Offset: 8
           Type: 10 BaseType uint64
     - __kind: BaseType
-      ID: 174
+      ID: 178
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 202976
@@ -13808,7 +13810,7 @@ Types:
           Offset: 16
           Type: 903 GoSwissMapGroupsType groupReference<*net/http.http2serverConn,struct {}>
     - __kind: StructureType
-      ID: 151
+      ID: 157
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -13830,7 +13832,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 152 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 158 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
       ID: 1127
       Name: table<crypto/x509.sum224,bool>
@@ -14174,7 +14176,7 @@ Types:
       GoRuntimeType: 416448
       GoKind: 6
     - __kind: StructureType
-      ID: 139
+      ID: 148
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 428384
@@ -14185,10 +14187,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 161 GoSliceHeaderType []time.zone
+          Type: 167 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 164 GoSliceHeaderType []time.zoneTrans
+          Type: 170 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -14200,7 +14202,7 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 162 PointerType *time.zone
+          Type: 168 PointerType *time.zone
     - __kind: StructureType
       ID: 234
       Name: time.ParseError
@@ -14224,7 +14226,7 @@ Types:
           Offset: 64
           Type: 11 GoStringHeaderType string
     - __kind: GoTimeType
-      ID: 137
+      ID: 146
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 501184
@@ -14238,7 +14240,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 138 PointerType *time.Location
+          Type: 147 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -14248,7 +14250,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 136
+      ID: 145
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 305728
@@ -14256,7 +14258,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 173 GoChannelType <-chan time.Time
+          Type: 177 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -14280,7 +14282,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 163
+      ID: 169
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 342720
@@ -14296,7 +14298,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 166
+      ID: 172
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 374784

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -565,10 +565,10 @@ Types:
       ByteSize: 8
       Pointee: 1008 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 134
+      ID: 142
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 135 PointerType *table<context.canceler,struct {}>
+      Pointee: 143 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1218
       Name: '**table<crypto/x509.sum224,bool>'
@@ -683,10 +683,10 @@ Types:
       ByteSize: 8
       Pointee: 454 GoSliceDataType []*runtime._defer.array
     - __kind: PointerType
-      ID: 155
+      ID: 159
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 154 GoSliceDataType []*runtime.p.array
+      Pointee: 158 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 457
       Name: '*[]*runtime.sudog.array'
@@ -813,10 +813,10 @@ Types:
       ByteSize: 8
       Pointee: 836 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 173
+      ID: 161
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType []os.Signal.array
+      Pointee: 160 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -852,15 +852,15 @@ Types:
       ByteSize: 8
       Pointee: 603 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 175
+      ID: 179
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []time.zone.array
+      Pointee: 178 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 177
+      ID: 181
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []time.zoneTrans.array
+      Pointee: 180 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1245
       Name: '*[]uint16.array'
@@ -874,15 +874,15 @@ Types:
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 150
+      ID: 154
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 149 GoSliceDataType []uint8.array
+      Pointee: 153 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 152
+      ID: 156
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 151 GoSliceDataType []uintptr.array
+      Pointee: 155 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 462
       Name: '*[]unsafe.Pointer.array'
@@ -929,19 +929,19 @@ Types:
       GoKind: 22
       Pointee: 630 StructureType bytes.Reader
     - __kind: PointerType
-      ID: 184
+      ID: 124
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 328256
       GoKind: 22
-      Pointee: 124 StructureType context.backgroundCtx
+      Pointee: 125 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 114
+      ID: 133
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 370496
       GoKind: 22
-      Pointee: 115 StructureType context.cancelCtx
+      Pointee: 134 StructureType context.cancelCtx
     - __kind: PointerType
       ID: 334
       Name: '*context.deadlineExceededError'
@@ -950,12 +950,12 @@ Types:
       GoKind: 22
       Pointee: 335 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 181
+      ID: 114
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 288800
       GoKind: 22
-      Pointee: 125 StructureType context.emptyCtx
+      Pointee: 115 StructureType context.emptyCtx
     - __kind: PointerType
       ID: 116
       Name: '*context.stopCtx'
@@ -964,19 +964,19 @@ Types:
       GoKind: 22
       Pointee: 117 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 118
+      ID: 144
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 370688
       GoKind: 22
-      Pointee: 119 StructureType context.timerCtx
+      Pointee: 145 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 120
+      ID: 121
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 327936
       GoKind: 22
-      Pointee: 121 StructureType context.valueCtx
+      Pointee: 122 StructureType context.valueCtx
     - __kind: PointerType
       ID: 283
       Name: '*crypto/aes.KeySizeError'
@@ -1543,7 +1543,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 332896
       GoKind: 22
-      Pointee: 128 StructureType internal/sync.Mutex
+      Pointee: 137 StructureType internal/sync.Mutex
     - __kind: PointerType
       ID: 678
       Name: '*io.LimitedReader'
@@ -1616,10 +1616,10 @@ Types:
       ByteSize: 8
       Pointee: 1006 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 132
+      ID: 140
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 133 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 141 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1216
       Name: '*map<crypto/x509.sum224,bool>'
@@ -1935,12 +1935,12 @@ Types:
       GoKind: 22
       Pointee: 222 StructureType net.notFoundError
     - __kind: PointerType
-      ID: 182
+      ID: 119
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 289440
       GoKind: 22
-      Pointee: 183 StructureType net.onlyValuesCtx
+      Pointee: 120 StructureType net.onlyValuesCtx
     - __kind: PointerType
       ID: 223
       Name: '*net.result·2'
@@ -2723,10 +2723,10 @@ Types:
       ByteSize: 8
       Pointee: 1012 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: PointerType
-      ID: 158
+      ID: 164
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 159 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 165 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
       ID: 1235
       Name: '*noalg.map.group[crypto/x509.sum224]bool'
@@ -2812,12 +2812,12 @@ Types:
       GoKind: 22
       Pointee: 310 StructureType os.LinkError
     - __kind: PointerType
-      ID: 144
+      ID: 130
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 93056
       GoKind: 22
-      Pointee: 145 GoInterfaceType os.Signal
+      Pointee: 131 GoInterfaceType os.Signal
     - __kind: PointerType
       ID: 343
       Name: '*os.SyscallError'
@@ -2861,12 +2861,12 @@ Types:
       GoKind: 22
       Pointee: 727 StructureType os.noWriteTo
     - __kind: PointerType
-      ID: 122
+      ID: 126
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 345728
       GoKind: 22
-      Pointee: 123 StructureType os/signal.signalCtx
+      Pointee: 127 StructureType os/signal.signalCtx
     - __kind: PointerType
       ID: 247
       Name: '*reflect.ValueError'
@@ -3032,7 +3032,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 219712
       GoKind: 22
-      Pointee: 153 StructureType runtime.p
+      Pointee: 157 StructureType runtime.p
     - __kind: PointerType
       ID: 415
       Name: '*runtime.pinner'
@@ -3130,10 +3130,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 148
+      ID: 152
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 147 GoStringDataType string.str
+      Pointee: 151 GoStringDataType string.str
     - __kind: PointerType
       ID: 713
       Name: '*strings.Reader'
@@ -3173,7 +3173,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 252416
       GoKind: 22
-      Pointee: 126 StructureType sync.Mutex
+      Pointee: 135 StructureType sync.Mutex
     - __kind: PointerType
       ID: 1176
       Name: '*sync.RWMutex'
@@ -3187,7 +3187,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 216640
       GoKind: 22
-      Pointee: 127 StructureType sync.noCopy
+      Pointee: 136 StructureType sync.noCopy
     - __kind: PointerType
       ID: 1172
       Name: '*sync/atomic.noCopy'
@@ -3210,12 +3210,12 @@ Types:
       GoKind: 22
       Pointee: 602 StructureType syscall.Iovec
     - __kind: PointerType
-      ID: 180
+      ID: 184
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 220736
       GoKind: 22
-      Pointee: 179 BaseType syscall.Signal
+      Pointee: 183 BaseType syscall.Signal
     - __kind: PointerType
       ID: 780
       Name: '*table<*net.Listener,struct {}>'
@@ -3232,10 +3232,10 @@ Types:
       ByteSize: 8
       Pointee: 1009 StructureType table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 135
+      ID: 143
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 156 StructureType table<context.canceler,struct {}>
+      Pointee: 162 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1219
       Name: '*table<crypto/x509.sum224,bool>'
@@ -3307,12 +3307,12 @@ Types:
       ByteSize: 8
       Pointee: 1080 StructureType table<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>
     - __kind: PointerType
-      ID: 140
+      ID: 149
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 346880
       GoKind: 22
-      Pointee: 141 StructureType time.Location
+      Pointee: 150 StructureType time.Location
     - __kind: PointerType
       ID: 241
       Name: '*time.ParseError'
@@ -3321,12 +3321,12 @@ Types:
       GoKind: 22
       Pointee: 242 StructureType time.ParseError
     - __kind: PointerType
-      ID: 137
+      ID: 146
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 216896
       GoKind: 22
-      Pointee: 138 StructureType time.Timer
+      Pointee: 147 StructureType time.Timer
     - __kind: PointerType
       ID: 240
       Name: '*time.fileSizeError'
@@ -3340,19 +3340,19 @@ Types:
       ByteSize: 8
       Pointee: 199 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 167
+      ID: 173
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 93632
       GoKind: 22
-      Pointee: 168 StructureType time.zone
+      Pointee: 174 StructureType time.zone
     - __kind: PointerType
-      ID: 170
+      ID: 176
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 93696
       GoKind: 22
-      Pointee: 171 StructureType time.zoneTrans
+      Pointee: 177 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 108
       Name: '*uint'
@@ -3464,7 +3464,7 @@ Types:
       GoRuntimeType: 134720
       GoKind: 18
     - __kind: GoChannelType
-      ID: 178
+      ID: 182
       Name: <-chan time.Time
       GoRuntimeType: 136704
       GoKind: 18
@@ -4301,9 +4301,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 154 GoSliceDataType []*runtime.p.array
+      Data: 158 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 154
+      ID: 158
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4350,11 +4350,11 @@ Types:
       ByteSize: 8
       Element: 1008 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 170
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 135 PointerType *table<context.canceler,struct {}>
+      Element: 143 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
       ID: 1240
       Name: '[]*table<crypto/x509.sum224,bool>.array'
@@ -5010,11 +5010,11 @@ Types:
       ByteSize: 136
       Element: 1012 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 171
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 159 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 165 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
       ID: 1241
       Name: '[]noalg.map.group[crypto/x509.sum224]bool.array'
@@ -5100,7 +5100,7 @@ Types:
       ByteSize: 328
       Element: 1083 StructureType noalg.map.group[vendor/golang.org/x/net/http2/hpack.pairNameValue]uint64
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 129
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 110528
@@ -5108,20 +5108,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *os.Signal
+          Type: 130 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 172 GoSliceDataType []os.Signal.array
+      Data: 160 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 160
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 145 GoInterfaceType os.Signal
+      Element: 131 GoInterfaceType os.Signal
     - __kind: GoSliceHeaderType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -5215,7 +5215,7 @@ Types:
       ByteSize: 16
       Element: 602 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 172
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 116416
@@ -5223,22 +5223,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *time.zone
+          Type: 173 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 174 GoSliceDataType []time.zone.array
+      Data: 178 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 178
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 168 StructureType time.zone
+      Element: 174 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 175
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 116480
@@ -5246,20 +5246,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *time.zoneTrans
+          Type: 176 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 176 GoSliceDataType []time.zoneTrans.array
+      Data: 180 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 180
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 171 StructureType time.zoneTrans
+      Element: 177 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 662
       Name: '[]uint16'
@@ -5299,9 +5299,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 149 GoSliceDataType []uint8.array
+      Data: 153 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 153
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -5322,9 +5322,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 151 GoSliceDataType []uintptr.array
+      Data: 155 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 155
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -5502,7 +5502,7 @@ Types:
       GoRuntimeType: 137088
       GoKind: 18
     - __kind: GoChannelType
-      ID: 146
+      ID: 132
       Name: chan os.Signal
       GoRuntimeType: 137984
       GoKind: 18
@@ -5524,7 +5524,7 @@ Types:
       GoRuntimeType: 132032
       GoKind: 15
     - __kind: GoSubroutineType
-      ID: 142
+      ID: 128
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 143200
@@ -5543,19 +5543,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 125
       Name: context.backgroundCtx
       GoRuntimeType: 392256
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 125 StructureType context.emptyCtx
+          Type: 115 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 115
+      ID: 134
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 433408
@@ -5566,23 +5566,23 @@ Types:
           Type: 113 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 129 StructureType sync/atomic.Value
+          Type: 138 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 131 GoMapType map[context.canceler]struct {}
+          Type: 139 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 129 StructureType sync/atomic.Value
+          Type: 138 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 16 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 162
+      ID: 168
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 233600
@@ -5601,7 +5601,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 115
       Name: context.emptyCtx
       GoRuntimeType: 338656
       GoKind: 25
@@ -5621,11 +5621,11 @@ Types:
           Type: 113 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 136 GoSubroutineType func() bool
+          Type: 118 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 145
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 340928
@@ -5633,17 +5633,17 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 115 StructureType context.cancelCtx
+          Type: 134 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 137 PointerType *time.Timer
+          Type: 146 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 139 GoTimeType time.Time
+          Type: 148 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 122
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 400768
@@ -5654,10 +5654,10 @@ Types:
           Type: 113 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoEmptyInterfaceType
@@ -6083,7 +6083,7 @@ Types:
           Type: 608 StructureType sync/atomic.Bool
         - Name: handshakeMutex
           Offset: 44
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: handshakeErr
           Offset: 56
           Type: 16 GoInterfaceType error
@@ -6500,7 +6500,7 @@ Types:
       RawFields:
         - Name: Mutex
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: err
           Offset: 8
           Type: 16 GoInterfaceType error
@@ -6509,7 +6509,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: cipher
           Offset: 32
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: mac
           Offset: 48
           Type: 624 GoInterfaceType hash.Hash
@@ -6521,7 +6521,7 @@ Types:
           Type: 626 ArrayType [13]uint8
         - Name: nextCipher
           Offset: 88
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: nextMac
           Offset: 104
           Type: 624 GoInterfaceType hash.Hash
@@ -6577,7 +6577,7 @@ Types:
           Type: 641 GoChannelType <-chan struct {}
         - Name: cancel
           Offset: 512
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 128 GoSubroutineType context.CancelFunc
         - Name: waitingForDrain
           Offset: 520
           Type: 6 BaseType bool
@@ -6605,7 +6605,7 @@ Types:
           Type: 632 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 139 GoTimeType time.Time
+          Type: 148 GoTimeType time.Time
     - __kind: StructureType
       ID: 660
       Name: crypto/x509.CertPool
@@ -6658,7 +6658,7 @@ Types:
           Type: 512 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
@@ -6673,10 +6673,10 @@ Types:
           Type: 515 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 139 GoTimeType time.Time
+          Type: 148 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 139 GoTimeType time.Time
+          Type: 148 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 520 BaseType crypto/x509.KeyUsage
@@ -6951,7 +6951,7 @@ Types:
           Type: 526 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 523
       Name: crypto/x509/pkix.Extension
@@ -7193,7 +7193,7 @@ Types:
           Type: 1292 GoSliceHeaderType fmt.buffer
         - Name: arg
           Offset: 24
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: value
           Offset: 40
           Type: 1293 StructureType reflect.Value
@@ -7269,7 +7269,7 @@ Types:
       GoRuntimeType: 153056
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 136
+      ID: 118
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 134976
@@ -7479,19 +7479,19 @@ Types:
       GroupType: 1012 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
       GroupSliceType: 1016 GoSliceDataType []noalg.map.group[*net/http.http2serverConn]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 157
+      ID: 163
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 158 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 164 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 159 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 165 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 165 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 171 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
       ID: 1234
       Name: groupReference<crypto/x509.sum224,bool>
@@ -7745,7 +7745,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoEmptyInterfaceType
-      ID: 130
+      ID: 123
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 180064
@@ -8128,7 +8128,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 128
+      ID: 137
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 319488
@@ -8256,7 +8256,7 @@ Types:
       RawFields:
         - Name: outMu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: out
           Offset: 8
           Type: 670 GoInterfaceType io.Writer
@@ -8401,7 +8401,7 @@ Types:
       TablePtrSliceType: 1015 GoSliceDataType []*table<*net/http.http2serverConn,struct {}>.array
       GroupType: 1012 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 133
+      ID: 141
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -8414,7 +8414,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 134 PointerType **table<context.canceler,struct {}>
+          Type: 142 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -8433,8 +8433,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 164 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 159 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 170 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 165 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 1217
       Name: map<crypto/x509.sum224,bool>
@@ -8947,12 +8947,12 @@ Types:
       GoKind: 21
       HeaderType: 1006 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: GoMapType
-      ID: 131
+      ID: 139
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 238208
       GoKind: 21
-      HeaderType: 133 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 141 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 1215
       Name: map[crypto/x509.sum224]bool
@@ -9147,7 +9147,7 @@ Types:
       RawFields:
         - Name: lk
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: s
           Offset: 8
           Type: 1181 PointerType *math/rand.rngSource
@@ -9176,7 +9176,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
     - __kind: StructureType
       ID: 947
       Name: mime/multipart.FileHeader
@@ -9683,8 +9683,8 @@ Types:
         - Name: s
           Offset: 0
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 183
+    - __kind: GoContextImplementationType
+      ID: 120
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 376640
@@ -9696,6 +9696,8 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 113 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
       ID: 224
       Name: net.result·2
@@ -10079,7 +10081,7 @@ Types:
           Type: 16 GoInterfaceType error
         - Name: mu
           Offset: 184
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: listeners
           Offset: 192
           Type: 776 GoMapType map[*net.Listener]struct {}
@@ -10104,7 +10106,7 @@ Types:
           Type: 644 GoInterfaceType io.Reader
         - Name: hdr
           Offset: 16
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: r
           Offset: 32
           Type: 718 PointerType *bufio.Reader
@@ -10116,7 +10118,7 @@ Types:
           Type: 6 BaseType bool
         - Name: mu
           Offset: 44
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: sawEOF
           Offset: 52
           Type: 6 BaseType bool
@@ -10180,7 +10182,7 @@ Types:
           Type: 751 PointerType *net/http.Server
         - Name: cancelCtx
           Offset: 8
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 128 GoSubroutineType context.CancelFunc
         - Name: rwc
           Offset: 16
           Type: 377 GoInterfaceType net.Conn
@@ -10213,7 +10215,7 @@ Types:
           Type: 757 StructureType sync/atomic.Uint64
         - Name: mu
           Offset: 128
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: hijackedv
           Offset: 136
           Type: 6 BaseType bool
@@ -10229,7 +10231,7 @@ Types:
           Type: 377 GoInterfaceType net.Conn
         - Name: mu
           Offset: 16
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: conn
           Offset: 24
           Type: 735 PointerType *net/http.conn
@@ -10964,7 +10966,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: c
           Offset: 8
           Type: 1167 StructureType sync.Cond
@@ -11104,7 +11106,7 @@ Types:
           Type: 15 BaseType int64
         - Name: closeNotifierMu
           Offset: 104
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: closeNotifierCh
           Offset: 112
           Type: 750 GoChannelType chan bool
@@ -11317,7 +11319,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: activeConns
           Offset: 8
           Type: 1004 GoMapType map[*net/http.http2serverConn]struct {}
@@ -11413,7 +11415,7 @@ Types:
       RawFields:
         - Name: Timer
           Offset: 0
-          Type: 137 PointerType *time.Timer
+          Type: 146 PointerType *time.Timer
     - __kind: StructureType
       ID: 997
       Name: net/http.http2unstartedHandler
@@ -11781,7 +11783,7 @@ Types:
           Type: 734 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 128 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -11793,7 +11795,7 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
           Type: 608 StructureType sync/atomic.Bool
@@ -11844,7 +11846,7 @@ Types:
           Type: 749 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
           Type: 750 GoChannelType chan bool
@@ -12247,14 +12249,14 @@ Types:
       HasCount: true
       Element: 1014 StructureType noalg.struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: ArrayType
-      ID: 160
+      ID: 166
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 145408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 161 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 167 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
       ID: 1237
       Name: noalg.[8]struct { key crypto/x509.sum224; elem bool }
@@ -12421,7 +12423,7 @@ Types:
           Offset: 8
           Type: 1013 ArrayType noalg.[8]struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: StructureType
-      ID: 159
+      ID: 165
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 268800
@@ -12432,7 +12434,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 160 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 166 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
       ID: 1236
       Name: noalg.map.group[crypto/x509.sum224]bool
@@ -12627,7 +12629,7 @@ Types:
           Type: 887 PointerType *net.Listener
         - Name: elem
           Offset: 8
-          Type: 163 StructureType struct {}
+          Type: 169 StructureType struct {}
     - __kind: StructureType
       ID: 896
       Name: noalg.struct { key *net/http.conn; elem struct {} }
@@ -12640,7 +12642,7 @@ Types:
           Type: 735 PointerType *net/http.conn
         - Name: elem
           Offset: 8
-          Type: 163 StructureType struct {}
+          Type: 169 StructureType struct {}
     - __kind: StructureType
       ID: 1014
       Name: noalg.struct { key *net/http.http2serverConn; elem struct {} }
@@ -12653,9 +12655,9 @@ Types:
           Type: 966 PointerType *net/http.http2serverConn
         - Name: elem
           Offset: 8
-          Type: 163 StructureType struct {}
+          Type: 169 StructureType struct {}
     - __kind: StructureType
-      ID: 161
+      ID: 167
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 268672
@@ -12663,10 +12665,10 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 162 GoInterfaceType context.canceler
+          Type: 168 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 163 StructureType struct {}
+          Type: 169 StructureType struct {}
     - __kind: StructureType
       ID: 1238
       Name: noalg.struct { key crypto/x509.sum224; elem bool }
@@ -12879,7 +12881,7 @@ Types:
           Offset: 48
           Type: 16 GoInterfaceType error
     - __kind: GoInterfaceType
-      ID: 145
+      ID: 131
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 235520
@@ -12913,7 +12915,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: buf
           Offset: 8
           Type: 615 PointerType *[]uint8
@@ -12987,7 +12989,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 127
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 433664
@@ -12998,13 +13000,13 @@ Types:
           Type: 113 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 128 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 143 GoSliceHeaderType []os.Signal
+          Type: 129 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 146 GoChannelType chan os.Signal
+          Type: 132 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
@@ -13139,7 +13141,7 @@ Types:
           Type: 17 VoidPointerType unsafe.Pointer
         - Name: arg
           Offset: 8
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: link
           Offset: 24
           Type: 26 PointerType *runtime._panic
@@ -14303,7 +14305,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: StructureType
-      ID: 153
+      ID: 157
       Name: runtime.p
       ByteSize: 9512
       GoRuntimeType: 512000
@@ -14798,7 +14800,7 @@ Types:
           Type: 477 GoSubroutineType func(interface {}, uintptr, int64)
         - Name: arg
           Offset: 48
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
         - Name: seq
           Offset: 64
           Type: 3 BaseType uintptr
@@ -15007,13 +15009,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 148 PointerType *string.str
+          Type: 152 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 147 GoStringDataType string.str
+      Data: 151 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 147
+      ID: 151
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15083,7 +15085,7 @@ Types:
           Offset: 8
           Type: 412 ArrayType [128]*runtime.mspan
     - __kind: StructureType
-      ID: 163
+      ID: 169
       Name: struct {}
       GoRuntimeType: 177632
       GoKind: 25
@@ -15097,7 +15099,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 127 StructureType sync.noCopy
+          Type: 136 StructureType sync.noCopy
         - Name: L
           Offset: 0
           Type: 1168 GoInterfaceType sync.Locker
@@ -15121,7 +15123,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 126
+      ID: 135
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 307328
@@ -15129,10 +15131,10 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 127 StructureType sync.noCopy
+          Type: 136 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 128 StructureType internal/sync.Mutex
+          Type: 137 StructureType internal/sync.Mutex
     - __kind: StructureType
       ID: 775
       Name: sync.Once
@@ -15142,13 +15144,13 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 127 StructureType sync.noCopy
+          Type: 136 StructureType sync.noCopy
         - Name: done
           Offset: 0
           Type: 608 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
     - __kind: StructureType
       ID: 675
       Name: sync.RWMutex
@@ -15158,7 +15160,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 135 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -15180,7 +15182,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 127 StructureType sync.noCopy
+          Type: 136 StructureType sync.noCopy
         - Name: state
           Offset: 0
           Type: 757 StructureType sync/atomic.Uint64
@@ -15194,7 +15196,7 @@ Types:
       GoRuntimeType: 131136
       GoKind: 12
     - __kind: StructureType
-      ID: 127
+      ID: 136
       Name: sync.noCopy
       GoRuntimeType: 204736
       GoKind: 25
@@ -15312,7 +15314,7 @@ Types:
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 129
+      ID: 138
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 252928
@@ -15320,7 +15322,7 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 130 GoEmptyInterfaceType interface {}
+          Type: 123 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 758
       Name: sync/atomic.align64
@@ -15353,7 +15355,7 @@ Types:
           Offset: 8
           Type: 10 BaseType uint64
     - __kind: BaseType
-      ID: 179
+      ID: 183
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 206176
@@ -15431,7 +15433,7 @@ Types:
           Offset: 16
           Type: 1010 GoSwissMapGroupsType groupReference<*net/http.http2serverConn,struct {}>
     - __kind: StructureType
-      ID: 156
+      ID: 162
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -15453,7 +15455,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 157 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 163 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
       ID: 1233
       Name: table<crypto/x509.sum224,bool>
@@ -15797,7 +15799,7 @@ Types:
       GoRuntimeType: 422656
       GoKind: 6
     - __kind: StructureType
-      ID: 141
+      ID: 150
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 435360
@@ -15808,10 +15810,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 166 GoSliceHeaderType []time.zone
+          Type: 172 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 169 GoSliceHeaderType []time.zoneTrans
+          Type: 175 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -15823,7 +15825,7 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 167 PointerType *time.zone
+          Type: 173 PointerType *time.zone
     - __kind: StructureType
       ID: 242
       Name: time.ParseError
@@ -15847,7 +15849,7 @@ Types:
           Offset: 64
           Type: 11 GoStringHeaderType string
     - __kind: GoTimeType
-      ID: 139
+      ID: 148
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 507904
@@ -15861,7 +15863,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 140 PointerType *time.Location
+          Type: 149 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -15871,7 +15873,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 138
+      ID: 147
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 308448
@@ -15879,7 +15881,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 178 GoChannelType <-chan time.Time
+          Type: 182 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -15903,7 +15905,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 168
+      ID: 174
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 346688
@@ -15919,7 +15921,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 171
+      ID: 177
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 381248

--- a/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/drop_tester.arch=arm64,toolchain=go1.26rc1.yaml
@@ -565,10 +565,10 @@ Types:
       ByteSize: 8
       Pointee: 1033 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 139
+      ID: 147
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<context.canceler,struct {}>
+      Pointee: 148 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1244
       Name: '**table<crypto/x509.sum224,bool>'
@@ -683,10 +683,10 @@ Types:
       ByteSize: 8
       Pointee: 481 GoSliceDataType []*runtime._defer.array
     - __kind: PointerType
-      ID: 165
+      ID: 169
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 164 GoSliceDataType []*runtime.p.array
+      Pointee: 168 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 484
       Name: '*[]*runtime.sudog.array'
@@ -813,10 +813,10 @@ Types:
       ByteSize: 8
       Pointee: 865 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 183
+      ID: 171
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []os.Signal.array
+      Pointee: 170 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -852,15 +852,15 @@ Types:
       ByteSize: 8
       Pointee: 632 GoSliceDataType []syscall.Iovec.array
     - __kind: PointerType
-      ID: 185
+      ID: 189
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []time.zone.array
+      Pointee: 188 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 187
+      ID: 191
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []time.zoneTrans.array
+      Pointee: 190 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 1271
       Name: '*[]uint16.array'
@@ -874,15 +874,15 @@ Types:
       GoKind: 22
       Pointee: 41 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 160
+      ID: 164
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 159 GoSliceDataType []uint8.array
+      Pointee: 163 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 162
+      ID: 166
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []uintptr.array
+      Pointee: 165 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 489
       Name: '*[]unsafe.Pointer.array'
@@ -929,26 +929,26 @@ Types:
       GoKind: 22
       Pointee: 657 StructureType bytes.Reader
     - __kind: PointerType
-      ID: 119
+      ID: 156
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 387392
       GoKind: 22
-      Pointee: 120 StructureType context.afterFuncCtx
+      Pointee: 157 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 194
+      ID: 129
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 341120
       GoKind: 22
-      Pointee: 144 StructureType context.backgroundCtx
+      Pointee: 130 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 121
+      ID: 138
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 386816
       GoKind: 22
-      Pointee: 122 StructureType context.cancelCtx
+      Pointee: 139 StructureType context.cancelCtx
     - __kind: PointerType
       ID: 350
       Name: '*context.deadlineExceededError'
@@ -957,33 +957,33 @@ Types:
       GoKind: 22
       Pointee: 351 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 191
+      ID: 119
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 299744
       GoKind: 22
-      Pointee: 145 StructureType context.emptyCtx
+      Pointee: 120 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 123
+      ID: 121
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 299904
       GoKind: 22
-      Pointee: 124 StructureType context.stopCtx
+      Pointee: 122 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 125
+      ID: 149
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 387008
       GoKind: 22
-      Pointee: 126 StructureType context.timerCtx
+      Pointee: 150 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 127
+      ID: 126
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 340800
       GoKind: 22
-      Pointee: 128 StructureType context.valueCtx
+      Pointee: 127 StructureType context.valueCtx
     - __kind: PointerType
       ID: 297
       Name: '*crypto/aes.KeySizeError'
@@ -1571,7 +1571,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 346400
       GoKind: 22
-      Pointee: 133 StructureType internal/sync.Mutex
+      Pointee: 142 StructureType internal/sync.Mutex
     - __kind: PointerType
       ID: 705
       Name: '*io.LimitedReader'
@@ -1644,10 +1644,10 @@ Types:
       ByteSize: 8
       Pointee: 1031 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 137
+      ID: 145
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 146 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1242
       Name: '*map<crypto/x509.sum224,bool>'
@@ -1963,12 +1963,12 @@ Types:
       GoKind: 22
       Pointee: 236 StructureType net.notFoundError
     - __kind: PointerType
-      ID: 192
+      ID: 124
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 300384
       GoKind: 22
-      Pointee: 193 StructureType net.onlyValuesCtx
+      Pointee: 125 StructureType net.onlyValuesCtx
     - __kind: PointerType
       ID: 237
       Name: '*net.result·2'
@@ -2744,10 +2744,10 @@ Types:
       ByteSize: 8
       Pointee: 1039 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: PointerType
-      ID: 168
+      ID: 174
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 169 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 175 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
       ID: 1261
       Name: '*noalg.map.group[crypto/x509.sum224]bool'
@@ -2833,12 +2833,12 @@ Types:
       GoKind: 22
       Pointee: 324 StructureType os.LinkError
     - __kind: PointerType
-      ID: 154
+      ID: 135
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 97440
       GoKind: 22
-      Pointee: 155 GoInterfaceType os.Signal
+      Pointee: 136 GoInterfaceType os.Signal
     - __kind: PointerType
       ID: 359
       Name: '*os.SyscallError'
@@ -2882,12 +2882,12 @@ Types:
       GoKind: 22
       Pointee: 757 StructureType os.noWriteTo
     - __kind: PointerType
-      ID: 129
+      ID: 131
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 360128
       GoKind: 22
-      Pointee: 130 StructureType os/signal.signalCtx
+      Pointee: 132 StructureType os/signal.signalCtx
     - __kind: PointerType
       ID: 254
       Name: '*os/signal.signalError'
@@ -3072,7 +3072,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 228864
       GoKind: 22
-      Pointee: 163 StructureType runtime.p
+      Pointee: 167 StructureType runtime.p
     - __kind: PointerType
       ID: 430
       Name: '*runtime.pinner'
@@ -3184,10 +3184,10 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 158
+      ID: 162
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 157 GoStringDataType string.str
+      Pointee: 161 GoStringDataType string.str
     - __kind: PointerType
       ID: 743
       Name: '*strings.Reader'
@@ -3227,7 +3227,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 261056
       GoKind: 22
-      Pointee: 131 StructureType sync.Mutex
+      Pointee: 140 StructureType sync.Mutex
     - __kind: PointerType
       ID: 1202
       Name: '*sync.RWMutex'
@@ -3241,14 +3241,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 225920
       GoKind: 22
-      Pointee: 132 StructureType sync.noCopy
+      Pointee: 141 StructureType sync.noCopy
     - __kind: PointerType
       ID: 1198
       Name: '*sync/atomic.noCopy'
       ByteSize: 8
       GoRuntimeType: 226304
       GoKind: 22
-      Pointee: 143 StructureType sync/atomic.noCopy
+      Pointee: 160 StructureType sync/atomic.noCopy
     - __kind: PointerType
       ID: 378
       Name: '*syscall.Errno'
@@ -3264,12 +3264,12 @@ Types:
       GoKind: 22
       Pointee: 631 StructureType syscall.Iovec
     - __kind: PointerType
-      ID: 190
+      ID: 194
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 230144
       GoKind: 22
-      Pointee: 189 BaseType syscall.Signal
+      Pointee: 193 BaseType syscall.Signal
     - __kind: PointerType
       ID: 809
       Name: '*table<*net.Listener,struct {}>'
@@ -3286,10 +3286,10 @@ Types:
       ByteSize: 8
       Pointee: 1036 StructureType table<*net/http.http2serverConn,struct {}>
     - __kind: PointerType
-      ID: 140
+      ID: 148
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 166 StructureType table<context.canceler,struct {}>
+      Pointee: 172 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 1245
       Name: '*table<crypto/x509.sum224,bool>'
@@ -3361,12 +3361,12 @@ Types:
       ByteSize: 8
       Pointee: 1107 StructureType table<vendor/golang.org/x/net/http2/hpack.pairNameValue,uint64>
     - __kind: PointerType
-      ID: 150
+      ID: 154
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 361280
       GoKind: 22
-      Pointee: 151 StructureType time.Location
+      Pointee: 155 StructureType time.Location
     - __kind: PointerType
       ID: 256
       Name: '*time.ParseError'
@@ -3375,12 +3375,12 @@ Types:
       GoKind: 22
       Pointee: 257 StructureType time.ParseError
     - __kind: PointerType
-      ID: 147
+      ID: 151
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 226176
       GoKind: 22
-      Pointee: 148 StructureType time.Timer
+      Pointee: 152 StructureType time.Timer
     - __kind: PointerType
       ID: 255
       Name: '*time.fileSizeError'
@@ -3394,19 +3394,19 @@ Types:
       ByteSize: 8
       Pointee: 212 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 177
+      ID: 183
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 98016
       GoKind: 22
-      Pointee: 178 StructureType time.zone
+      Pointee: 184 StructureType time.zone
     - __kind: PointerType
-      ID: 180
+      ID: 186
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 98080
       GoKind: 22
-      Pointee: 181 StructureType time.zoneTrans
+      Pointee: 187 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 113
       Name: '*uint'
@@ -3518,7 +3518,7 @@ Types:
       GoRuntimeType: 140288
       GoKind: 18
     - __kind: GoChannelType
-      ID: 188
+      ID: 192
       Name: <-chan time.Time
       GoRuntimeType: 143744
       GoKind: 18
@@ -4373,9 +4373,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 164 GoSliceDataType []*runtime.p.array
+      Data: 168 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 168
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4422,11 +4422,11 @@ Types:
       ByteSize: 8
       Element: 1033 PointerType *table<*net/http.http2serverConn,struct {}>
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 180
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 140 PointerType *table<context.canceler,struct {}>
+      Element: 148 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
       ID: 1266
       Name: '[]*table<crypto/x509.sum224,bool>.array'
@@ -5082,11 +5082,11 @@ Types:
       ByteSize: 136
       Element: 1039 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 181
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 169 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 175 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
       ID: 1267
       Name: '[]noalg.map.group[crypto/x509.sum224]bool.array'
@@ -5172,7 +5172,7 @@ Types:
       ByteSize: 328
       Element: 1110 StructureType noalg.map.group[vendor/golang.org/x/net/http2/hpack.pairNameValue]uint64
     - __kind: GoSliceHeaderType
-      ID: 153
+      ID: 134
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 115744
@@ -5180,20 +5180,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 154 PointerType *os.Signal
+          Type: 135 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 182 GoSliceDataType []os.Signal.array
+      Data: 170 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 170
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 155 GoInterfaceType os.Signal
+      Element: 136 GoInterfaceType os.Signal
     - __kind: GoSliceHeaderType
       ID: 43
       Name: '[]runtime.ancestorInfo'
@@ -5287,7 +5287,7 @@ Types:
       ByteSize: 16
       Element: 631 StructureType syscall.Iovec
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 182
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 121888
@@ -5295,22 +5295,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *time.zone
+          Type: 183 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []time.zone.array
+      Data: 188 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 188
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 178 StructureType time.zone
+      Element: 184 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 179
+      ID: 185
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 121952
@@ -5318,20 +5318,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 180 PointerType *time.zoneTrans
+          Type: 186 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType []time.zoneTrans.array
+      Data: 190 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 190
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 181 StructureType time.zoneTrans
+      Element: 187 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 689
       Name: '[]uint16'
@@ -5371,9 +5371,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 159 GoSliceDataType []uint8.array
+      Data: 163 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 163
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -5394,9 +5394,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 161 GoSliceDataType []uintptr.array
+      Data: 165 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 165
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -5574,7 +5574,7 @@ Types:
       GoRuntimeType: 143104
       GoKind: 18
     - __kind: GoChannelType
-      ID: 156
+      ID: 137
       Name: chan os.Signal
       GoRuntimeType: 144064
       GoKind: 18
@@ -5596,7 +5596,7 @@ Types:
       GoRuntimeType: 137664
       GoKind: 15
     - __kind: GoSubroutineType
-      ID: 152
+      ID: 133
       Name: context.CancelCauseFunc
       ByteSize: 8
       GoRuntimeType: 180576
@@ -5621,7 +5621,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 120
+      ID: 157
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 387200
@@ -5629,29 +5629,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 122 StructureType context.cancelCtx
+          Type: 139 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 144
+      ID: 130
       Name: context.backgroundCtx
       GoRuntimeType: 409920
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 145 StructureType context.emptyCtx
+          Type: 120 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 139
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 451968
@@ -5662,23 +5662,23 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 134 StructureType sync/atomic.Value
+          Type: 143 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 136 GoMapType map[context.canceler]struct {}
+          Type: 144 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 134 StructureType sync/atomic.Value
+          Type: 143 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 16 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 172
+      ID: 178
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 242944
@@ -5697,7 +5697,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 145
+      ID: 120
       Name: context.emptyCtx
       GoRuntimeType: 352800
       GoKind: 25
@@ -5706,7 +5706,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 122
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 417088
@@ -5717,11 +5717,11 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 146 GoSubroutineType func() bool
+          Type: 123 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 126
+      ID: 150
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 355712
@@ -5729,17 +5729,17 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 122 StructureType context.cancelCtx
+          Type: 139 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 149 GoTimeType time.Time
+          Type: 153 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 127
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 418208
@@ -5750,10 +5750,10 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoEmptyInterfaceType
@@ -6192,10 +6192,10 @@ Types:
           Type: 635 PointerType *crypto/tls.quicState
         - Name: isHandshakeComplete
           Offset: 40
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: handshakeMutex
           Offset: 44
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: handshakeErr
           Offset: 56
           Type: 16 GoInterfaceType error
@@ -6615,7 +6615,7 @@ Types:
       RawFields:
         - Name: Mutex
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: err
           Offset: 8
           Type: 16 GoInterfaceType error
@@ -6624,7 +6624,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: cipher
           Offset: 32
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: mac
           Offset: 48
           Type: 651 GoInterfaceType hash.Hash
@@ -6636,7 +6636,7 @@ Types:
           Type: 653 ArrayType [13]uint8
         - Name: nextCipher
           Offset: 88
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: nextMac
           Offset: 104
           Type: 651 GoInterfaceType hash.Hash
@@ -6723,7 +6723,7 @@ Types:
           Type: 460 ArrayType [16]uint8
         - Name: created
           Offset: 32
-          Type: 149 GoTimeType time.Time
+          Type: 153 GoTimeType time.Time
     - __kind: StructureType
       ID: 687
       Name: crypto/x509.CertPool
@@ -6776,7 +6776,7 @@ Types:
           Type: 541 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
           Type: 9 BaseType int
@@ -6791,10 +6791,10 @@ Types:
           Type: 544 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 149 GoTimeType time.Time
+          Type: 153 GoTimeType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 149 GoTimeType time.Time
+          Type: 153 GoTimeType time.Time
         - Name: KeyUsage
           Offset: 736
           Type: 549 BaseType crypto/x509.KeyUsage
@@ -7069,7 +7069,7 @@ Types:
           Type: 555 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 552
       Name: crypto/x509/pkix.Extension
@@ -7311,7 +7311,7 @@ Types:
           Type: 1318 GoSliceHeaderType fmt.buffer
         - Name: arg
           Offset: 24
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: value
           Offset: 40
           Type: 1319 StructureType reflect.Value
@@ -7387,7 +7387,7 @@ Types:
       GoRuntimeType: 159872
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 146
+      ID: 123
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 140544
@@ -7609,19 +7609,19 @@ Types:
       GroupType: 1039 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
       GroupSliceType: 1043 GoSliceDataType []noalg.map.group[*net/http.http2serverConn]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 167
+      ID: 173
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 168 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 174 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 169 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 175 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 175 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 181 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
       ID: 1260
       Name: groupReference<crypto/x509.sum224,bool>
@@ -7862,7 +7862,7 @@ Types:
       GoRuntimeType: 136960
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 135
+      ID: 128
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 187712
@@ -8241,7 +8241,7 @@ Types:
       GoRuntimeType: 182688
       GoKind: 2
     - __kind: StructureType
-      ID: 133
+      ID: 142
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 331552
@@ -8369,7 +8369,7 @@ Types:
       RawFields:
         - Name: outMu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: out
           Offset: 8
           Type: 697 GoInterfaceType io.Writer
@@ -8381,7 +8381,7 @@ Types:
           Type: 658 StructureType sync/atomic.Int32
         - Name: isDiscard
           Offset: 36
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
     - __kind: StructureType
       ID: 115
       Name: main.Node
@@ -8514,7 +8514,7 @@ Types:
       TablePtrSliceType: 1042 GoSliceDataType []*table<*net/http.http2serverConn,struct {}>.array
       GroupType: 1039 StructureType noalg.map.group[*net/http.http2serverConn]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 146
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -8527,7 +8527,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<context.canceler,struct {}>
+          Type: 147 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -8546,8 +8546,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 174 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 169 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 180 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 175 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 1243
       Name: map<crypto/x509.sum224,bool>
@@ -9060,12 +9060,12 @@ Types:
       GoKind: 21
       HeaderType: 1031 GoSwissMapHeaderType map<*net/http.http2serverConn,struct {}>
     - __kind: GoMapType
-      ID: 136
+      ID: 144
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 247680
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 146 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 1241
       Name: map[crypto/x509.sum224]bool
@@ -9260,7 +9260,7 @@ Types:
       RawFields:
         - Name: lk
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: s
           Offset: 8
           Type: 1207 PointerType *math/rand.rngSource
@@ -9289,7 +9289,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
     - __kind: StructureType
       ID: 976
       Name: mime/multipart.FileHeader
@@ -9685,7 +9685,7 @@ Types:
           Type: 6 BaseType bool
         - Name: unlinkOnce
           Offset: 28
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
     - __kind: GoStringHeaderType
       ID: 347
       Name: net.UnknownNetworkError
@@ -9796,8 +9796,8 @@ Types:
         - Name: s
           Offset: 0
           Type: 11 GoStringHeaderType string
-    - __kind: StructureType
-      ID: 193
+    - __kind: GoContextImplementationType
+      ID: 125
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 393536
@@ -9809,6 +9809,8 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 118 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
       ID: 238
       Name: net.result·2
@@ -10183,19 +10185,19 @@ Types:
           Type: 803 PointerType *net/http.Protocols
         - Name: inShutdown
           Offset: 144
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: disableKeepAlives
           Offset: 148
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: nextProtoOnce
           Offset: 152
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
         - Name: nextProtoErr
           Offset: 168
           Type: 16 GoInterfaceType error
         - Name: mu
           Offset: 184
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: listeners
           Offset: 192
           Type: 805 GoMapType map[*net.Listener]struct {}
@@ -10220,7 +10222,7 @@ Types:
           Type: 671 GoInterfaceType io.Reader
         - Name: hdr
           Offset: 16
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: r
           Offset: 32
           Type: 748 PointerType *bufio.Reader
@@ -10232,7 +10234,7 @@ Types:
           Type: 6 BaseType bool
         - Name: mu
           Offset: 44
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: sawEOF
           Offset: 52
           Type: 6 BaseType bool
@@ -10329,7 +10331,7 @@ Types:
           Type: 787 StructureType sync/atomic.Uint64
         - Name: mu
           Offset: 128
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: hijackedv
           Offset: 136
           Type: 6 BaseType bool
@@ -10345,7 +10347,7 @@ Types:
           Type: 393 GoInterfaceType net.Conn
         - Name: mu
           Offset: 16
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: conn
           Offset: 24
           Type: 765 PointerType *net/http.conn
@@ -10395,10 +10397,10 @@ Types:
           Type: 764 GoInterfaceType io.ReadCloser
         - Name: closed
           Offset: 24
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: sawEOF
           Offset: 28
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
     - __kind: StructureType
       ID: 823
       Name: net/http.globalOptionsHandler
@@ -11080,7 +11082,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: c
           Offset: 8
           Type: 1193 StructureType sync.Cond
@@ -11152,7 +11154,7 @@ Types:
           Type: 995 PointerType *net/http.http2serverConn
         - Name: closeOnce
           Offset: 16
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
         - Name: sawEOF
           Offset: 28
           Type: 6 BaseType bool
@@ -11220,7 +11222,7 @@ Types:
           Type: 15 BaseType int64
         - Name: closeNotifierMu
           Offset: 104
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: closeNotifierCh
           Offset: 112
           Type: 780 GoChannelType chan bool
@@ -11402,10 +11404,10 @@ Types:
           Type: 385 BaseType net/http.http2ErrCode
         - Name: shutdownTimer
           Offset: 352
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: idleTimer
           Offset: 360
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: readIdleTimeout
           Offset: 368
           Type: 790 BaseType time.Duration
@@ -11414,7 +11416,7 @@ Types:
           Type: 790 BaseType time.Duration
         - Name: readIdleTimer
           Offset: 384
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: headerWriteBuf
           Offset: 392
           Type: 655 StructureType bytes.Buffer
@@ -11423,7 +11425,7 @@ Types:
           Type: 1024 PointerType *vendor/golang.org/x/net/http2/hpack.Encoder
         - Name: shutdownOnce
           Offset: 440
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
     - __kind: StructureType
       ID: 1028
       Name: net/http.http2serverInternalState
@@ -11433,7 +11435,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: activeConns
           Offset: 8
           Type: 1029 GoMapType map[*net/http.http2serverConn]struct {}
@@ -11491,10 +11493,10 @@ Types:
           Type: 6 BaseType bool
         - Name: readDeadline
           Offset: 112
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: writeDeadline
           Offset: 120
-          Type: 147 PointerType *time.Timer
+          Type: 151 PointerType *time.Timer
         - Name: closeErr
           Offset: 128
           Type: 16 GoInterfaceType error
@@ -11826,7 +11828,7 @@ Types:
           Type: 917 GoInterfaceType net.Listener
         - Name: once
           Offset: 16
-          Type: 141 StructureType sync.Once
+          Type: 158 StructureType sync.Once
         - Name: closeErr
           Offset: 32
           Type: 16 GoInterfaceType error
@@ -11895,10 +11897,10 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
           Type: 769 PointerType *bufio.Writer
@@ -11934,7 +11936,7 @@ Types:
           Type: 545 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
           Type: 777 ArrayType [29]uint8
@@ -11946,7 +11948,7 @@ Types:
           Type: 779 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
           Type: 780 GoChannelType chan bool
@@ -12349,14 +12351,14 @@ Types:
       HasCount: true
       Element: 1041 StructureType noalg.struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: ArrayType
-      ID: 170
+      ID: 176
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 151360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 171 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 177 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
       ID: 1263
       Name: noalg.[8]struct { key crypto/x509.sum224; elem bool }
@@ -12523,7 +12525,7 @@ Types:
           Offset: 8
           Type: 1040 ArrayType noalg.[8]struct { key *net/http.http2serverConn; elem struct {} }
     - __kind: StructureType
-      ID: 169
+      ID: 175
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 280128
@@ -12534,7 +12536,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 170 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 176 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
       ID: 1262
       Name: noalg.map.group[crypto/x509.sum224]bool
@@ -12729,7 +12731,7 @@ Types:
           Type: 916 PointerType *net.Listener
         - Name: elem
           Offset: 8
-          Type: 173 StructureType struct {}
+          Type: 179 StructureType struct {}
     - __kind: StructureType
       ID: 925
       Name: noalg.struct { key *net/http.conn; elem struct {} }
@@ -12742,7 +12744,7 @@ Types:
           Type: 765 PointerType *net/http.conn
         - Name: elem
           Offset: 8
-          Type: 173 StructureType struct {}
+          Type: 179 StructureType struct {}
     - __kind: StructureType
       ID: 1041
       Name: noalg.struct { key *net/http.http2serverConn; elem struct {} }
@@ -12755,9 +12757,9 @@ Types:
           Type: 995 PointerType *net/http.http2serverConn
         - Name: elem
           Offset: 8
-          Type: 173 StructureType struct {}
+          Type: 179 StructureType struct {}
     - __kind: StructureType
-      ID: 171
+      ID: 177
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 280000
@@ -12765,10 +12767,10 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 172 GoInterfaceType context.canceler
+          Type: 178 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 173 StructureType struct {}
+          Type: 179 StructureType struct {}
     - __kind: StructureType
       ID: 1264
       Name: noalg.struct { key crypto/x509.sum224; elem bool }
@@ -12981,7 +12983,7 @@ Types:
           Offset: 48
           Type: 16 GoInterfaceType error
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 136
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 244864
@@ -13015,7 +13017,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: buf
           Offset: 8
           Type: 642 PointerType *[]uint8
@@ -13089,7 +13091,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 132
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 452224
@@ -13100,13 +13102,13 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 152 GoSubroutineType context.CancelCauseFunc
+          Type: 133 GoSubroutineType context.CancelCauseFunc
         - Name: signals
           Offset: 24
-          Type: 153 GoSliceHeaderType []os.Signal
+          Type: 134 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 156 GoChannelType chan os.Signal
+          Type: 137 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
@@ -13257,7 +13259,7 @@ Types:
       RawFields:
         - Name: arg
           Offset: 0
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: link
           Offset: 16
           Type: 27 PointerType *runtime._panic
@@ -14455,7 +14457,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: StructureType
-      ID: 163
+      ID: 167
       Name: runtime.p
       ByteSize: 14320
       GoRuntimeType: 538272
@@ -15027,7 +15029,7 @@ Types:
           Type: 506 GoSubroutineType func(interface {}, uintptr, int64)
         - Name: arg
           Offset: 48
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
         - Name: seq
           Offset: 64
           Type: 3 BaseType uintptr
@@ -15362,13 +15364,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 158 PointerType *string.str
+          Type: 162 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 157 GoStringDataType string.str
+      Data: 161 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 157
+      ID: 161
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -15451,7 +15453,7 @@ Types:
           Offset: 8
           Type: 427 ArrayType [128]*runtime.mspan
     - __kind: StructureType
-      ID: 173
+      ID: 179
       Name: struct {}
       GoRuntimeType: 184704
       GoKind: 25
@@ -15465,7 +15467,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: L
           Offset: 0
           Type: 1194 GoInterfaceType sync.Locker
@@ -15489,7 +15491,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 131
+      ID: 140
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 318112
@@ -15497,12 +15499,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 133 StructureType internal/sync.Mutex
+          Type: 142 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 141
+      ID: 158
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 360896
@@ -15510,13 +15512,13 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 142 StructureType sync/atomic.Bool
+          Type: 159 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
     - __kind: StructureType
       ID: 1034
       Name: sync.Pool
@@ -15526,7 +15528,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: local
           Offset: 0
           Type: 17 VoidPointerType unsafe.Pointer
@@ -15551,7 +15553,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 140 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -15573,7 +15575,7 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 141 StructureType sync.noCopy
         - Name: state
           Offset: 0
           Type: 787 StructureType sync/atomic.Uint64
@@ -15587,7 +15589,7 @@ Types:
       GoRuntimeType: 136768
       GoKind: 12
     - __kind: StructureType
-      ID: 132
+      ID: 141
       Name: sync.noCopy
       GoRuntimeType: 214176
       GoKind: 25
@@ -15615,7 +15617,7 @@ Types:
           Offset: 24
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 142
+      ID: 159
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 319392
@@ -15623,7 +15625,7 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
@@ -15636,7 +15638,7 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
@@ -15652,7 +15654,7 @@ Types:
           Type: 786 ArrayType [0]*net/http.response
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 17 VoidPointerType unsafe.Pointer
@@ -15668,7 +15670,7 @@ Types:
           Type: 1217 ArrayType [0]*os.dirInfo
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 17 VoidPointerType unsafe.Pointer
@@ -15684,7 +15686,7 @@ Types:
           Type: 908 ArrayType [0]*string
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 17 VoidPointerType unsafe.Pointer
@@ -15697,7 +15699,7 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 143 StructureType sync/atomic.noCopy
+          Type: 160 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
           Type: 788 StructureType sync/atomic.align64
@@ -15705,7 +15707,7 @@ Types:
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 134
+      ID: 143
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 261568
@@ -15713,7 +15715,7 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 128 GoEmptyInterfaceType interface {}
     - __kind: StructureType
       ID: 788
       Name: sync/atomic.align64
@@ -15721,7 +15723,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 143
+      ID: 160
       Name: sync/atomic.noCopy
       GoRuntimeType: 214272
       GoKind: 25
@@ -15746,7 +15748,7 @@ Types:
           Offset: 8
           Type: 10 BaseType uint64
     - __kind: BaseType
-      ID: 189
+      ID: 193
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 215616
@@ -15824,7 +15826,7 @@ Types:
           Offset: 16
           Type: 1037 GoSwissMapGroupsType groupReference<*net/http.http2serverConn,struct {}>
     - __kind: StructureType
-      ID: 166
+      ID: 172
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -15846,7 +15848,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 167 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 173 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
       ID: 1259
       Name: table<crypto/x509.sum224,bool>
@@ -16190,7 +16192,7 @@ Types:
       GoRuntimeType: 440192
       GoKind: 6
     - __kind: StructureType
-      ID: 151
+      ID: 155
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 453920
@@ -16201,10 +16203,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 176 GoSliceHeaderType []time.zone
+          Type: 182 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 179 GoSliceHeaderType []time.zoneTrans
+          Type: 185 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -16216,7 +16218,7 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 177 PointerType *time.zone
+          Type: 183 PointerType *time.zone
     - __kind: StructureType
       ID: 257
       Name: time.ParseError
@@ -16240,7 +16242,7 @@ Types:
           Offset: 64
           Type: 11 GoStringHeaderType string
     - __kind: GoTimeType
-      ID: 149
+      ID: 153
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 529376
@@ -16254,7 +16256,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 150 PointerType *time.Location
+          Type: 154 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -16264,7 +16266,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 148
+      ID: 152
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 319232
@@ -16272,7 +16274,7 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 188 GoChannelType <-chan time.Time
+          Type: 192 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
@@ -16296,7 +16298,7 @@ Types:
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 178
+      ID: 184
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 361088
@@ -16312,7 +16314,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 181
+      ID: 187
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 398528

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -121,78 +121,78 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 639 PointerType *crypto/x509.Certificate
+      Pointee: 651 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 681
+      ID: 230
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 107 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 920 PointerType *mime/multipart.FileHeader
+      Pointee: 927 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 925 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 932 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 933 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 940 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 684
+      ID: 233
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 683 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 232 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 923 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 936
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 935 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 938
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 937 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 676
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 675 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 213
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 212 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 930 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 943
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 942 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 945
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 944 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 688
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 687 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 199
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 198 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 207
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 206 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 950
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 942 GoSliceDataType []net/http.segment.array
+      Pointee: 949 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 196
+      ID: 209
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType []os.Signal.array
+      Pointee: 208 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -201,77 +201,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 674
+      ID: 686
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 673 GoSliceDataType []string.array
+      Pointee: 685 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 215
+      ID: 226
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []time.zone.array
+      Pointee: 225 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 217
+      ID: 228
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 216 GoSliceDataType []time.zoneTrans.array
+      Pointee: 227 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456768
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 180
+      ID: 187
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []uint8.array
+      Pointee: 186 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 182
+      ID: 189
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []uintptr.array
+      Pointee: 188 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 877728
       GoKind: 22
-      Pointee: 460 GoSliceHeaderType archive/tar.headerError
+      Pointee: 472 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 461 GoSliceDataType archive/tar.headerError.array
+      Pointee: 473 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 845
+      ID: 852
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1164160
       GoKind: 22
-      Pointee: 846 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 853 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1041088
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 837 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 847
+      ID: 854
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1279776
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 855 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1040832
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 835 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -280,57 +280,57 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 132
+      ID: 175
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 133 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 176 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*bucket<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 754 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 209
+      ID: 203
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 916 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 923 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 782
+      ID: 789
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 783 GoHMapBucketType bucket<string,[]string>
+      Pointee: 790 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 164
+      ID: 131
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 165 GoHMapBucketType bucket<string,float64>
+      Pointee: 132 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 644
+      ID: 656
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 657 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 159
+      ID: 126
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 160 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 127 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
-      ID: 154
+      ID: 119
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 155 GoHMapBucketType bucket<string,string>
+      Pointee: 120 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1860672
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType bufio.Writer
+      Pointee: 784 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 109
       Name: '*bytes.Buffer'
@@ -339,351 +339,351 @@ Types:
       GoKind: 22
       Pointee: 110 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 864096
       GoKind: 22
-      Pointee: 264 BaseType compress/flate.CorruptInputError
+      Pointee: 276 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 864192
       GoKind: 22
-      Pointee: 265 GoStringHeaderType compress/flate.InternalError
+      Pointee: 277 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 267
+      ID: 279
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 266 GoStringDataType compress/flate.InternalError.str
+      Pointee: 278 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 1886880
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 885 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1470976
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 866 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 949
+      ID: 158
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1389568
       GoKind: 22
-      Pointee: 124 StructureType context.backgroundCtx
+      Pointee: 159 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 112
+      ID: 169
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1630624
       GoKind: 22
-      Pointee: 113 StructureType context.cancelCtx
+      Pointee: 170 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1121792
       GoKind: 22
-      Pointee: 566 StructureType context.deadlineExceededError
+      Pointee: 578 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 944
+      ID: 144
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1255776
       GoKind: 22
-      Pointee: 125 StructureType context.emptyCtx
+      Pointee: 145 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 114
+      ID: 146
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1255936
       GoKind: 22
-      Pointee: 115 StructureType context.stopCtx
+      Pointee: 147 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 116
+      ID: 177
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1630816
       GoKind: 22
-      Pointee: 117 StructureType context.timerCtx
+      Pointee: 178 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 950
+      ID: 160
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1389728
       GoKind: 22
-      Pointee: 142 StructureType context.todoCtx
+      Pointee: 161 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 118
+      ID: 153
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1389248
       GoKind: 22
-      Pointee: 119 StructureType context.valueCtx
+      Pointee: 154 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 120
+      ID: 156
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1389408
       GoKind: 22
-      Pointee: 121 StructureType context.withoutCancelCtx
+      Pointee: 157 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863136
       GoKind: 22
-      Pointee: 261 BaseType crypto/aes.KeySizeError
+      Pointee: 273 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 395
+      ID: 407
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863328
       GoKind: 22
-      Pointee: 262 BaseType crypto/des.KeySizeError
+      Pointee: 274 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863616
       GoKind: 22
-      Pointee: 263 BaseType crypto/rc4.KeySizeError
+      Pointee: 275 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 335
+      ID: 347
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 852768
       GoKind: 22
-      Pointee: 238 BaseType crypto/tls.AlertError
+      Pointee: 250 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1017024
       GoKind: 22
-      Pointee: 525 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 537 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2287968
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 915 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 797 StructureType crypto/tls.ConnectionState
+      Pointee: 804 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 333
+      ID: 345
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 852576
       GoKind: 22
-      Pointee: 334 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 346 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 331
+      ID: 343
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 852480
       GoKind: 22
-      Pointee: 332 StructureType crypto/tls.RecordHeaderError
+      Pointee: 344 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1015360
       GoKind: 22
-      Pointee: 492 BaseType crypto/tls.alert
+      Pointee: 504 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1263456
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 643 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 639
+      ID: 651
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1952864
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 652 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 862944
       GoKind: 22
-      Pointee: 391 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 403 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 862464
       GoKind: 22
-      Pointee: 385 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 397 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 386
+      ID: 398
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 862560
       GoKind: 22
-      Pointee: 387 StructureType crypto/x509.HostnameError
+      Pointee: 399 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 862368
       GoKind: 22
-      Pointee: 260 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 272 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 538
+      ID: 550
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1027520
       GoKind: 22
-      Pointee: 539 StructureType crypto/x509.SystemRootsError
+      Pointee: 551 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 863040
       GoKind: 22
-      Pointee: 393 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 405 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 862848
       GoKind: 22
-      Pointee: 389 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 401 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 451
+      ID: 463
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 873504
       GoKind: 22
-      Pointee: 452 StructureType encoding/asn1.StructuralError
+      Pointee: 464 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 873696
       GoKind: 22
-      Pointee: 456 StructureType encoding/asn1.SyntaxError
+      Pointee: 468 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 873600
       GoKind: 22
-      Pointee: 454 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 466 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 336
+      ID: 348
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 852864
       GoKind: 22
-      Pointee: 239 BaseType encoding/base64.CorruptInputError
+      Pointee: 251 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 861312
       GoKind: 22
-      Pointee: 259 BaseType encoding/hex.InvalidByteError
+      Pointee: 271 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 353
+      ID: 365
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 856416
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 366 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 536
+      ID: 548
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1022272
       GoKind: 22
-      Pointee: 537 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 549 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 856032
       GoKind: 22
-      Pointee: 346 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 358 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 351
+      ID: 363
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 856320
       GoKind: 22
-      Pointee: 352 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 364 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 856224
       GoKind: 22
-      Pointee: 350 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 362 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 856128
       GoKind: 22
-      Pointee: 348 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 360 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 856800
       GoKind: 22
-      Pointee: 356 StructureType encoding/json.jsonError
+      Pointee: 368 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 871296
       GoKind: 22
-      Pointee: 447 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 459 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 871200
       GoKind: 22
-      Pointee: 445 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 457 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 871392
       GoKind: 22
-      Pointee: 269 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 281 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 271
+      ID: 283
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 270 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 282 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 449
+      ID: 461
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 871488
       GoKind: 22
-      Pointee: 450 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 462 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -692,19 +692,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 319
+      ID: 331
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 847968
       GoKind: 22
-      Pointee: 320 UnresolvedPointeeType errors.errorString
+      Pointee: 332 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1008320
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType errors.joinError
+      Pointee: 524 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -720,118 +720,118 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 495
+      ID: 507
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 998336
       GoKind: 22
-      Pointee: 496 UnresolvedPointeeType fmt.wrapError
+      Pointee: 508 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 497
+      ID: 509
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 998464
       GoKind: 22
-      Pointee: 498 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 510 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 860832
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 389 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 1921024
       GoKind: 22
-      Pointee: 749 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 756 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 858048
       GoKind: 22
-      Pointee: 359 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 371 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 858144
       GoKind: 22
-      Pointee: 361 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 373 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 857856
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 672 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 364
+      ID: 376
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 858432
       GoKind: 22
-      Pointee: 365 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 377 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 857952
       GoKind: 22
-      Pointee: 662 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 362
+      ID: 374
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 858240
       GoKind: 22
-      Pointee: 253 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 265 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 255
+      ID: 267
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 254 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 266 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 357
+      ID: 369
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 857760
       GoKind: 22
-      Pointee: 250 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 262 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 252
+      ID: 264
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 251 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 263 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 858336
       GoKind: 22
-      Pointee: 256 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 268 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 258
+      ID: 270
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 257 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 269 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 401
+      ID: 413
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 865152
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 414 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
       ByteSize: 8
       GoRuntimeType: 1634464
       GoKind: 22
-      Pointee: 740 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
+      Pointee: 747 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
     - __kind: PointerType
       ID: 107
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -840,773 +840,773 @@ Types:
       GoKind: 22
       Pointee: 108 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 172
+      ID: 139
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1916704
       GoKind: 22
-      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 140 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 167
+      ID: 134
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1129216
       GoKind: 22
-      Pointee: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1806944
       GoKind: 22
-      Pointee: 873 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 880 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1710272
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+      Pointee: 874 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 170
+      ID: 137
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1129344
       GoKind: 22
-      Pointee: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 138 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1129984
       GoKind: 22
-      Pointee: 689 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 696 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 219
+      ID: 222
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1130112
       GoKind: 22
-      Pointee: 220 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 223 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 174
+      ID: 141
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2131968
       GoKind: 22
-      Pointee: 175 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 142 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer'
       ByteSize: 8
       GoRuntimeType: 2117632
       GoKind: 22
-      Pointee: 755 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
+      Pointee: 762 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 606
+      ID: 618
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1151360
       GoKind: 22
-      Pointee: 607 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 619 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 690
+      ID: 697
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1396768
       GoKind: 22
-      Pointee: 691 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 698 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2082240
       GoKind: 22
-      Pointee: 751 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
+      Pointee: 758 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 947
+      ID: 151
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1266336
       GoKind: 22
-      Pointee: 948 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 152 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2082656
       GoKind: 22
-      Pointee: 753 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
+      Pointee: 760 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1031232
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
+      Pointee: 833 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 867360
       GoKind: 22
-      Pointee: 404 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 416 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 410
+      ID: 422
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 868416
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 423 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 868128
       GoKind: 22
-      Pointee: 268 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 280 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 868320
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 421 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 406
+      ID: 418
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 868224
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 419 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 869760
       GoKind: 22
-      Pointee: 419 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 431 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 869952
       GoKind: 22
-      Pointee: 423 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 435 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 869856
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 433 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 869664
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 429 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 678
+      ID: 690
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 677 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 689 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 870336
       GoKind: 22
-      Pointee: 431 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 443 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 870048
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 437 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 870240
       GoKind: 22
-      Pointee: 429 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 441 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 870144
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 439 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 870432
       GoKind: 22
-      Pointee: 433 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 445 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 870720
       GoKind: 22
-      Pointee: 439 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 451 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 870816
       GoKind: 22
-      Pointee: 441 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 453 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 870624
       GoKind: 22
-      Pointee: 437 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 449 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 870528
       GoKind: 22
-      Pointee: 435 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 447 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 871008
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 455 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2233152
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 772 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2216352
       GoKind: 22
-      Pointee: 759 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 766 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2225472
       GoKind: 22
-      Pointee: 761 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 768 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2226112
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 770 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 859584
       GoKind: 22
-      Pointee: 367 StructureType github.com/cihub/seelog.baseError
+      Pointee: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1712736
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 749 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 368
+      ID: 380
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 859680
       GoKind: 22
-      Pointee: 369 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 381 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1269536
       GoKind: 22
-      Pointee: 732 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 739 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 733
+      ID: 740
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1480000
       GoKind: 22
-      Pointee: 734 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 741 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1480768
       GoKind: 22
-      Pointee: 738 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 745 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 859872
       GoKind: 22
-      Pointee: 373 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 385 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1480192
       GoKind: 22
-      Pointee: 736 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 743 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2194688
       GoKind: 22
-      Pointee: 757 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 764 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 859776
       GoKind: 22
-      Pointee: 371 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 383 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 22
-      Pointee: 375 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 387 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1159424
       GoKind: 22
-      Pointee: 844 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 851 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1641760
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 870 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 634
+      ID: 646
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1281056
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 647 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 550
+      ID: 562
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1046080
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 563 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 548
+      ID: 560
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1045952
       GoKind: 22
-      Pointee: 549 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 561 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 552
+      ID: 564
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1050432
       GoKind: 22
-      Pointee: 553 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 565 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 554
+      ID: 566
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1050560
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 567 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 544
+      ID: 556
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1035072
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 557 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 861504
       GoKind: 22
-      Pointee: 380 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 392 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 608
+      ID: 620
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1158528
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 621 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 594
+      ID: 606
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1143424
       GoKind: 22
-      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 607 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1143040
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 601 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 530
+      ID: 542
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1019968
       GoKind: 22
-      Pointee: 531 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 543 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 600
+      ID: 612
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1143808
       GoKind: 22
-      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 613 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 529
+      ID: 541
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1019840
       GoKind: 22
-      Pointee: 494 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 506 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 592
+      ID: 604
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1143296
       GoKind: 22
-      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 590
+      ID: 602
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1143168
       GoKind: 22
-      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 603 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 598
+      ID: 610
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1143680
       GoKind: 22
-      Pointee: 599 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 611 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1143552
       GoKind: 22
-      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 609 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 604
+      ID: 616
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1144192
       GoKind: 22
-      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 617 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 534
+      ID: 546
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1020224
       GoKind: 22
-      Pointee: 535 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 547 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1020096
       GoKind: 22
-      Pointee: 533 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 545 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 602
+      ID: 614
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1144064
       GoKind: 22
-      Pointee: 603 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 615 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 888960
       GoKind: 22
-      Pointee: 276 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 288 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 278
+      ID: 290
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 289 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 647
+      ID: 659
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1508416
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 660 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 558
+      ID: 570
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1065408
       GoKind: 22
-      Pointee: 559 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 571 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 890208
       GoKind: 22
-      Pointee: 279 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 291 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 616
+      ID: 628
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1196672
       GoKind: 22
-      Pointee: 617 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 629 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 890496
       GoKind: 22
-      Pointee: 478 StructureType golang.org/x/net/http2.connError
+      Pointee: 490 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 890400
       GoKind: 22
-      Pointee: 283 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 295 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 285
+      ID: 297
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 296 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 890688
       GoKind: 22
-      Pointee: 289 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 301 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 291
+      ID: 303
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 290 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 302 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 479
+      ID: 491
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 890592
       GoKind: 22
-      Pointee: 286 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 298 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 288
+      ID: 300
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 287 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 299 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 475
+      ID: 487
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 890304
       GoKind: 22
-      Pointee: 280 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 292 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 282
+      ID: 294
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 293 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 890784
       GoKind: 22
-      Pointee: 482 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 494 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 483
+      ID: 495
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 890880
       GoKind: 22
-      Pointee: 292 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 304 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 884640
       GoKind: 22
-      Pointee: 470 StructureType google.golang.org/grpc.dropError
+      Pointee: 482 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1193600
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 627 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1288576
       GoKind: 22
-      Pointee: 637 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 649 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 887232
       GoKind: 22
-      Pointee: 472 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 484 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1721024
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 876 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 556
+      ID: 568
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1059648
       GoKind: 22
-      Pointee: 557 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 569 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1407648
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 860 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 876384
       GoKind: 22
-      Pointee: 458 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 470 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 546
+      ID: 558
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1039296
       GoKind: 22
-      Pointee: 547 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 559 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 612
+      ID: 624
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1162752
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 625 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1162496
       GoKind: 22
-      Pointee: 611 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 623 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 463
+      ID: 475
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 878688
       GoKind: 22
-      Pointee: 464 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 476 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 465
+      ID: 477
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 878784
       GoKind: 22
-      Pointee: 466 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 478 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 868512
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 425 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 130
+      ID: 173
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 131 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 174 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*hash<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 745 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 752 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 207
+      ID: 201
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 208 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 202 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 914 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 921 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 781 GoHMapHeaderType hash<string,[]string>
+      Pointee: 788 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 162
+      ID: 129
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 163 GoHMapHeaderType hash<string,float64>
+      Pointee: 130 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 642
+      ID: 654
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 643 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 655 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 157
+      ID: 124
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 158 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 152
+      ID: 117
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 153 GoHMapHeaderType hash<string,string>
+      Pointee: 118 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 891648
       GoKind: 22
-      Pointee: 485 UnresolvedPointeeType html/template.Error
+      Pointee: 497 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 95
       Name: '*int'
@@ -1643,269 +1643,269 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 861888
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 394 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 586
+      ID: 598
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1138816
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 599 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2282784
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType internal/poll.FD
+      Pointee: 913 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 584
+      ID: 596
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1138688
       GoKind: 22
-      Pointee: 585 StructureType internal/poll.errNetClosing
+      Pointee: 597 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 321
+      ID: 333
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 848352
       GoKind: 22
-      Pointee: 322 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 334 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1750144
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType io.PipeReader
+      Pointee: 878 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1393728
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType io.SectionReader
+      Pointee: 882 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1008832
       GoKind: 22
-      Pointee: 824 StructureType io.nopCloser
+      Pointee: 831 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1132800
       GoKind: 22
-      Pointee: 842 StructureType io.nopCloserWriterTo
+      Pointee: 849 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1137920
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType io/fs.PathError
+      Pointee: 595 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 864768
       GoKind: 22
-      Pointee: 400 StructureType math/big.ErrNaN
+      Pointee: 412 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 920
+      ID: 927
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853632
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 929 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 795 StructureType mime/multipart.Form
+      Pointee: 802 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1470208
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 862 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1470400
       GoKind: 22
-      Pointee: 857 StructureType mime/multipart.sectionReadCloser
+      Pointee: 864 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 568
+      ID: 580
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1122944
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType net.AddrError
+      Pointee: 581 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1256576
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType net.DNSError
+      Pointee: 634 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2136896
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType net.IPConn
+      Pointee: 889 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 619
+      ID: 631
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1256256
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType net.OpError
+      Pointee: 632 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 570
+      ID: 582
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1123072
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType net.ParseError
+      Pointee: 583 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2168128
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType net.TCPConn
+      Pointee: 897 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2215136
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType net.UDPConn
+      Pointee: 901 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2167616
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType net.UnixConn
+      Pointee: 895 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1122176
       GoKind: 22
-      Pointee: 562 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 574 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 563 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 575 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 499
+      ID: 511
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 999360
       GoKind: 22
-      Pointee: 500 StructureType net.canceledError
+      Pointee: 512 StructureType net.canceledError
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1915264
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType net.conn
+      Pointee: 887 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1744096
       GoKind: 22
-      Pointee: 666 StructureType net.dialResult·1
+      Pointee: 678 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2218784
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType net.netFD
+      Pointee: 903 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 293
+      ID: 305
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 294 UnresolvedPointeeType net.notFoundError
+      Pointee: 306 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 945
+      ID: 149
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1256416
       GoKind: 22
-      Pointee: 946 StructureType net.onlyValuesCtx
+      Pointee: 150 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 295
+      ID: 307
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 841824
       GoKind: 22
-      Pointee: 296 StructureType net.result·2
+      Pointee: 308 StructureType net.result·2
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2151744
       GoKind: 22
-      Pointee: 886 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 893 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2151264
       GoKind: 22
-      Pointee: 884 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 891 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1123712
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType net.temporaryError
+      Pointee: 585 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1256896
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType net.timeoutError
+      Pointee: 636 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 301
+      ID: 313
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 844416
       GoKind: 22
-      Pointee: 302 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 314 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 501
+      ID: 513
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1002688
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 514 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 105
       Name: '*net/http.Request'
@@ -1914,507 +1914,507 @@ Types:
       GoKind: 22
       Pointee: 106 StructureType net/http.Request
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1632160
       GoKind: 22
-      Pointee: 800 StructureType net/http.Response
+      Pointee: 807 StructureType net/http.Response
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1709600
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType net/http.body
+      Pointee: 872 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1126400
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 843 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1002560
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 823 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1745216
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType net/http.conn
+      Pointee: 780 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1001408
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 813 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1004608
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 827 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 303
+      ID: 315
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 844608
       GoKind: 22
-      Pointee: 222 BaseType net/http.http2ConnectionError
+      Pointee: 234 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 304
+      ID: 316
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 844704
       GoKind: 22
-      Pointee: 305 StructureType net/http.http2GoAwayError
+      Pointee: 317 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1257856
       GoKind: 22
-      Pointee: 626 StructureType net/http.http2StreamError
+      Pointee: 638 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 1916416
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 857 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 310
+      ID: 322
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 845568
       GoKind: 22
-      Pointee: 311 StructureType net/http.http2connError
+      Pointee: 323 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 307
+      ID: 319
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 845088
       GoKind: 22
-      Pointee: 226 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 238 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 228
+      ID: 240
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 227 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 239 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 845184
       GoKind: 22
-      Pointee: 309 StructureType net/http.http2goAwayFlowError
+      Pointee: 321 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1002304
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 821 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 313
+      ID: 325
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 845760
       GoKind: 22
-      Pointee: 232 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 244 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 234
+      ID: 246
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 233 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 245 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 312
+      ID: 324
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 22
-      Pointee: 229 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 241 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 231
+      ID: 243
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 230 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 242 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 576
+      ID: 588
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1127936
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 589 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1002048
       GoKind: 22
-      Pointee: 810 StructureType net/http.http2missingBody
+      Pointee: 817 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1004864
       GoKind: 22
-      Pointee: 822 StructureType net/http.http2noBodyReader
+      Pointee: 829 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 507
+      ID: 519
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1004736
       GoKind: 22
-      Pointee: 508 StructureType net/http.http2noCachedConnError
+      Pointee: 520 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 306
+      ID: 318
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 844992
       GoKind: 22
-      Pointee: 223 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 235 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 225
+      ID: 237
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 224 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 236 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1003200
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 825 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 727
+      ID: 734
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1876224
       GoKind: 22
-      Pointee: 728 StructureType net/http.http2responseWriter
+      Pointee: 735 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1455040
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 778 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1002176
       GoKind: 22
-      Pointee: 812 StructureType net/http.http2transportResponseBody
+      Pointee: 819 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1001536
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 815 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1126656
       GoKind: 22
-      Pointee: 840 StructureType net/http.noBody
+      Pointee: 847 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 503
+      ID: 515
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1004352
       GoKind: 22
-      Pointee: 504 StructureType net/http.nothingWrittenError
+      Pointee: 516 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1453120
       GoKind: 22
-      Pointee: 802 StructureType net/http.pattern
+      Pointee: 809 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 803
+      ID: 810
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1000896
       GoKind: 22
-      Pointee: 804 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 811 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1126528
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 845 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 314
+      ID: 326
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 845952
       GoKind: 22
-      Pointee: 315 StructureType net/http.requestBodyReadError
+      Pointee: 327 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 729
+      ID: 736
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2117184
       GoKind: 22
-      Pointee: 730 StructureType net/http.response
+      Pointee: 737 StructureType net/http.response
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367808
       GoKind: 22
-      Pointee: 941 StructureType net/http.segment
+      Pointee: 948 StructureType net/http.segment
     - __kind: PointerType
-      ID: 299
+      ID: 311
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 844320
       GoKind: 22
-      Pointee: 300 StructureType net/http.statusError
+      Pointee: 312 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1259296
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 640 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1127808
       GoKind: 22
-      Pointee: 575 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 587 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 505
+      ID: 517
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1004480
       GoKind: 22
-      Pointee: 506 StructureType net/http.transportReadFromServerError
+      Pointee: 518 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 297
+      ID: 309
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 843552
       GoKind: 22
-      Pointee: 298 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 310 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1066048
       GoKind: 22
-      Pointee: 832 StructureType net/http/httputil.failureToReadBody
+      Pointee: 839 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 327
+      ID: 339
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 328 StructureType net/netip.parseAddrError
+      Pointee: 340 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 325
+      ID: 337
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 326 StructureType net/netip.parsePrefixError
+      Pointee: 338 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 854112
       GoKind: 22
-      Pointee: 341 UnresolvedPointeeType net/textproto.Error
+      Pointee: 353 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 339
+      ID: 351
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 854016
       GoKind: 22
-      Pointee: 246 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 258 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 248
+      ID: 260
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 247 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 259 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 632
+      ID: 644
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1263936
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType net/url.Error
+      Pointee: 645 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 852960
       GoKind: 22
-      Pointee: 240 GoStringHeaderType net/url.EscapeError
+      Pointee: 252 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 242
+      ID: 254
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 241 GoStringDataType net/url.EscapeError.str
+      Pointee: 253 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 853056
       GoKind: 22
-      Pointee: 243 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 255 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 245
+      ID: 257
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 244 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 256 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2001920
       GoKind: 22
-      Pointee: 791 StructureType net/url.URL
+      Pointee: 798 StructureType net/url.URL
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1141376
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 917 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2258656
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType os.File
+      Pointee: 909 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 509
+      ID: 521
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1006656
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType os.LinkError
+      Pointee: 522 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 145
+      ID: 166
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 370560
       GoKind: 22
-      Pointee: 146 GoInterfaceType os.Signal
+      Pointee: 167 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1128448
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType os.SyscallError
+      Pointee: 591 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2254976
       GoKind: 22
-      Pointee: 900 StructureType os.fileWithoutReadFrom
+      Pointee: 907 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2254240
       GoKind: 22
-      Pointee: 898 StructureType os.fileWithoutWriteTo
+      Pointee: 905 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 540
+      ID: 552
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1029824
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType os/exec.Error
+      Pointee: 553 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2004032
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 682 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 542
+      ID: 554
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1029952
       GoKind: 22
-      Pointee: 543 StructureType os/exec.wrappedError
+      Pointee: 555 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 122
+      ID: 162
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1457728
       GoKind: 22
-      Pointee: 123 StructureType os/signal.signalCtx
+      Pointee: 163 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 468
+      ID: 480
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 882720
       GoKind: 22
-      Pointee: 273 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 285 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 275
+      ID: 287
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 286 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 882624
       GoKind: 22
-      Pointee: 272 BaseType os/user.UnknownUserIdError
+      Pointee: 284 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 323
+      ID: 335
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 849216
       GoKind: 22
-      Pointee: 324 UnresolvedPointeeType reflect.ValueError
+      Pointee: 336 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 868992
       GoKind: 22
-      Pointee: 415 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 427 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1011264
       GoKind: 22
-      Pointee: 517 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 529 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1013184
       GoKind: 22
-      Pointee: 522 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 534 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2430,12 +2430,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1011392
       GoKind: 22
-      Pointee: 519 StructureType runtime.boundsError
+      Pointee: 531 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -2451,24 +2451,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 580
+      ID: 592
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1136768
       GoKind: 22
-      Pointee: 581 StructureType runtime.errorAddressString
+      Pointee: 593 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1011008
       GoKind: 22
-      Pointee: 486 GoStringHeaderType runtime.errorString
+      Pointee: 498 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 487 GoStringDataType runtime.errorString.str
+      Pointee: 499 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -2484,24 +2484,24 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 134
+      ID: 121
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 379904
       GoKind: 22
-      Pointee: 135 UnresolvedPointeeType runtime.mapextra
+      Pointee: 122 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 520
+      ID: 532
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1012928
       GoKind: 22
-      Pointee: 489 GoStringHeaderType runtime.plainError
+      Pointee: 501 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 491
+      ID: 503
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 490 GoStringDataType runtime.plainError.str
+      Pointee: 502 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2524,12 +2524,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1010624
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType strconv.NumError
+      Pointee: 526 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -2538,190 +2538,190 @@ Types:
       GoKind: 22
       Pointee: 13 GoStringHeaderType string
     - __kind: PointerType
-      ID: 178
+      ID: 185
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 177 GoStringDataType string.str
+      Pointee: 184 GoStringDataType string.str
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1532416
       GoKind: 22
-      Pointee: 697 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 704 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 710
+      ID: 717
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1656736
       GoKind: 22
-      Pointee: 711 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 718 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1532032
       GoKind: 22
-      Pointee: 693 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 700 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1655968
       GoKind: 22
-      Pointee: 703 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 710 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1726624
       GoKind: 22
-      Pointee: 717 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 724 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1656160
       GoKind: 22
-      Pointee: 705 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 712 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1655776
       GoKind: 22
-      Pointee: 701 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 708 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1726176
       GoKind: 22
-      Pointee: 713 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 720 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1794496
       GoKind: 22
-      Pointee: 721 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 728 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 714
+      ID: 721
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1726400
       GoKind: 22
-      Pointee: 715 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 722 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1532608
       GoKind: 22
-      Pointee: 699 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 706 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1532224
       GoKind: 22
-      Pointee: 695 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 702 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 706
+      ID: 713
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1656352
       GoKind: 22
-      Pointee: 707 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 714 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1726848
       GoKind: 22
-      Pointee: 719 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 726 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 708
+      ID: 715
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1656544
       GoKind: 22
-      Pointee: 709 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 716 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1073312
       GoKind: 22
-      Pointee: 834 StructureType struct { io.Reader; io.Closer }
+      Pointee: 841 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 629
+      ID: 641
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1262816
       GoKind: 22
-      Pointee: 618 BaseType syscall.Errno
+      Pointee: 630 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 686
+      ID: 693
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1013696
       GoKind: 22
-      Pointee: 685 BaseType syscall.Signal
+      Pointee: 692 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1069248
       GoKind: 22
-      Pointee: 561 StructureType text/template.ExecError
+      Pointee: 573 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 140
+      ID: 182
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1458112
       GoKind: 22
-      Pointee: 141 StructureType time.Location
+      Pointee: 183 StructureType time.Location
     - __kind: PointerType
-      ID: 317
+      ID: 329
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 846816
       GoKind: 22
-      Pointee: 318 UnresolvedPointeeType time.ParseError
+      Pointee: 330 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 137
+      ID: 179
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1007168
       GoKind: 22
-      Pointee: 138 StructureType time.Timer
+      Pointee: 180 StructureType time.Timer
     - __kind: PointerType
-      ID: 316
+      ID: 328
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 846720
       GoKind: 22
-      Pointee: 235 GoStringHeaderType time.fileSizeError
+      Pointee: 247 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 237
+      ID: 249
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 236 GoStringDataType time.fileSizeError.str
+      Pointee: 248 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 190
+      ID: 216
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370880
       GoKind: 22
-      Pointee: 191 StructureType time.zone
+      Pointee: 217 StructureType time.zone
     - __kind: PointerType
-      ID: 193
+      ID: 219
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 370944
       GoKind: 22
-      Pointee: 194 StructureType time.zoneTrans
+      Pointee: 220 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -2765,47 +2765,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 329
+      ID: 341
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 851616
       GoKind: 22
-      Pointee: 330 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 342 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 342
+      ID: 354
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 854496
       GoKind: 22
-      Pointee: 343 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 355 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 344
+      ID: 356
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 854592
       GoKind: 22
-      Pointee: 249 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 261 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 526
+      ID: 538
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1018432
       GoKind: 22
-      Pointee: 527 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 539 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1018560
       GoKind: 22
-      Pointee: 493 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 505 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 798
+      ID: 805
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
     - __kind: GoChannelType
-      ID: 679
+      ID: 691
       Name: <-chan time.Time
       GoRuntimeType: 558496
       GoKind: 18
@@ -2884,7 +2884,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 785
+      ID: 792
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 635488
@@ -2893,7 +2893,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 784
+      ID: 791
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 635392
@@ -2956,7 +2956,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 786
+      ID: 793
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 635584
@@ -2974,7 +2974,7 @@ Types:
       HasCount: true
       Element: 12 BaseType uint64
     - __kind: ArrayType
-      ID: 653
+      ID: 665
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 652960
@@ -3001,7 +3001,7 @@ Types:
       HasCount: true
       Element: 81 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 183
+      ID: 190
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
@@ -3010,7 +3010,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 925
+      ID: 932
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473760
@@ -3018,22 +3018,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 926 PointerType **crypto/x509.Certificate
+          Type: 933 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 933 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 940 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 933
+      ID: 940
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 639 PointerType *crypto/x509.Certificate
+      Element: 651 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 680
+      ID: 229
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 463872
@@ -3041,22 +3041,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 681 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 230 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 683 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 232 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 232
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 107 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 918
+      ID: 925
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461504
@@ -3064,22 +3064,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 919 PointerType **mime/multipart.FileHeader
+          Type: 926 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 923 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 930 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 923
+      ID: 930
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 920 PointerType *mime/multipart.FileHeader
+      Element: 927 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 927
+      ID: 934
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473888
@@ -3087,22 +3087,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 928 PointerType *[]*crypto/x509.Certificate
+          Type: 935 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 935 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 942 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 935
+      ID: 942
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 925 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 932 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 929
+      ID: 936
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457024
@@ -3110,76 +3110,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 930 PointerType *[]uint8
+          Type: 937 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 937 GoSliceDataType [][]uint8.array
+      Data: 944 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 937
+      ID: 944
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 214
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 133 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 176 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 769
+      ID: 776
       Name: '[]bucket<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
-      Element: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      Element: 754 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 224
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 921
+      ID: 928
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 916 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 923 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 789
+      ID: 796
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 783 GoHMapBucketType bucket<string,[]string>
+      Element: 790 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 197
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 165 GoHMapBucketType bucket<string,float64>
+      Element: 132 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 672
+      ID: 684
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 657 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 195
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 160 GoHMapBucketType bucket<string,interface {}>
+      Element: 127 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 193
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 155 GoHMapBucketType bucket<string,string>
+      Element: 120 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 658
+      ID: 670
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 468736
@@ -3194,15 +3194,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 675 GoSliceDataType []float64.array
+      Data: 687 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 675
+      ID: 687
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 19 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 133
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 463424
@@ -3210,22 +3210,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 204 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 198 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 198
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 136
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 463616
@@ -3233,43 +3233,43 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 137 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 212 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 206 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 206
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 138 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 184
+      ID: 210
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 185 GoInterfaceType context.canceler
+      Element: 211 GoInterfaceType context.canceler
     - __kind: ArrayType
-      ID: 766
+      ID: 773
       Name: '[]key<github.com/cihub/seelog.LogLevel>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 767 BaseType github.com/cihub/seelog.LogLevel
+      Element: 774 BaseType github.com/cihub/seelog.LogLevel
     - __kind: ArrayType
-      ID: 197
+      ID: 191
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 939
+      ID: 946
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459008
@@ -3277,22 +3277,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 940 PointerType *net/http.segment
+          Type: 947 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 942 GoSliceDataType []net/http.segment.array
+      Data: 949 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 942
+      ID: 949
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 941 StructureType net/http.segment
+      Element: 948 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 165
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 456832
@@ -3300,26 +3300,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 145 PointerType *os.Signal
+          Type: 166 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 195 GoSliceDataType []os.Signal.array
+      Data: 208 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 208
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 146 GoInterfaceType os.Signal
+      Element: 167 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 657
+      ID: 669
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -3334,15 +3334,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 673 GoSliceDataType []string.array
+      Data: 685 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 673
+      ID: 685
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 189
+      ID: 215
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463104
@@ -3350,22 +3350,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 190 PointerType *time.zone
+          Type: 216 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 214 GoSliceDataType []time.zone.array
+      Data: 225 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 225
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 191 StructureType time.zone
+      Element: 217 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 192
+      ID: 218
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463168
@@ -3373,20 +3373,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 193 PointerType *time.zoneTrans
+          Type: 219 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 216 GoSliceDataType []time.zoneTrans.array
+      Data: 227 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 227
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 194 StructureType time.zoneTrans
+      Element: 220 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3403,9 +3403,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 179 GoSliceDataType []uint8.array
+      Data: 186 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 186
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3426,77 +3426,77 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 181 GoSliceDataType []uintptr.array
+      Data: 188 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 188
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 218
+      ID: 221
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 219 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 917
+      ID: 924
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 918 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 925 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 788
+      ID: 795
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 657 GoSliceHeaderType []string
+      Element: 669 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 768
+      ID: 775
       Name: '[]val<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 202
+      ID: 196
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 671
+      ID: 683
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 676 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 200
+      ID: 194
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 128 GoEmptyInterfaceType interface {}
+      Element: 155 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 198
+      ID: 192
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 186
+      ID: 212
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
-      Element: 187 StructureType struct {}
+      Element: 213 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 460
+      ID: 472
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 877824
@@ -3511,27 +3511,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 461 GoSliceDataType archive/tar.headerError.array
+      Data: 473 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 473
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 846
+      ID: 853
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 855
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3541,178 +3541,178 @@ Types:
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 133
+      ID: 176
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 184 ArrayType []key<context.canceler>
+          Type: 210 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 186 ArrayType []val<struct {}>
+          Type: 212 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 132 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 185 GoInterfaceType context.canceler
-      ValueType: 187 StructureType struct {}
+          Type: 175 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 211 GoInterfaceType context.canceler
+      ValueType: 213 StructureType struct {}
     - __kind: GoHMapBucketType
-      ID: 747
+      ID: 754
       Name: bucket<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 766 ArrayType []key<github.com/cihub/seelog.LogLevel>
+          Type: 773 ArrayType []key<github.com/cihub/seelog.LogLevel>
         - Name: values
           Offset: 16
-          Type: 768 ArrayType []val<bool>
+          Type: 775 ArrayType []val<bool>
         - Name: overflow
           Offset: 24
-          Type: 746 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
-      KeyType: 767 BaseType github.com/cihub/seelog.LogLevel
+          Type: 753 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+      KeyType: 774 BaseType github.com/cihub/seelog.LogLevel
       ValueType: 6 BaseType bool
     - __kind: GoHMapBucketType
-      ID: 210
+      ID: 204
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 218 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 221 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 219 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 916
+      ID: 923
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 917 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 924 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 915 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 922 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 918 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 925 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 783
+      ID: 790
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 788 ArrayType []val<[]string>
+          Type: 795 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 782 PointerType *bucket<string,[]string>
+          Type: 789 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 657 GoSliceHeaderType []string
+      ValueType: 669 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 165
+      ID: 132
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 202 ArrayType []val<float64>
+          Type: 196 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 164 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 645
+      ID: 657
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 671 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 683 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 656 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 676 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
-      ID: 160
+      ID: 127
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 200 ArrayType []val<interface {}>
+          Type: 194 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 159 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 128 GoEmptyInterfaceType interface {}
+      ValueType: 155 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 155
+      ID: 120
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 198 ArrayType []val<string>
+          Type: 192 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 154 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 784
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3720,12 +3720,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 787
+      ID: 794
       Name: chan bool
       GoRuntimeType: 554720
       GoKind: 18
     - __kind: GoChannelType
-      ID: 147
+      ID: 168
       Name: chan os.Signal
       GoRuntimeType: 561248
       GoKind: 18
@@ -3742,13 +3742,13 @@ Types:
       GoRuntimeType: 543072
       GoKind: 15
     - __kind: BaseType
-      ID: 264
+      ID: 276
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 781152
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 265
+      ID: 277
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 781248
@@ -3756,26 +3756,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 267 PointerType *compress/flate.InternalError.str
+          Type: 279 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 266 GoStringDataType compress/flate.InternalError.str
+      Data: 278 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 266
+      ID: 278
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 885
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 866
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 143
+      ID: 164
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 629536
@@ -3794,19 +3794,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 159
       Name: context.backgroundCtx
       GoRuntimeType: 1708256
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 125 StructureType context.emptyCtx
+          Type: 145 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 113
+      ID: 170
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1872192
@@ -3817,13 +3817,13 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 126 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 127 StructureType sync/atomic.Value
+          Type: 171 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 129 GoMapType map[context.canceler]struct {}
+          Type: 172 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -3833,7 +3833,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 185
+      ID: 211
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1090432
@@ -3846,13 +3846,13 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 566
+      ID: 578
       Name: context.deadlineExceededError
       GoRuntimeType: 1305824
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 145
       Name: context.emptyCtx
       GoRuntimeType: 1434720
       GoKind: 25
@@ -3861,7 +3861,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 115
+      ID: 147
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1732384
@@ -3872,11 +3872,11 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 136 GoSubroutineType func() bool
+          Type: 148 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 117
+      ID: 178
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1451200
@@ -3884,29 +3884,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 113 StructureType context.cancelCtx
+          Type: 170 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 137 PointerType *time.Timer
+          Type: 179 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 139 GoTimeType time.Time
+          Type: 181 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 142
+      ID: 161
       Name: context.todoCtx
       GoRuntimeType: 1708480
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 125 StructureType context.emptyCtx
+          Type: 145 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 154
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1742528
@@ -3917,14 +3917,14 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 157
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1708032
@@ -3936,39 +3936,39 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 261
+      ID: 273
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 780864
       GoKind: 2
     - __kind: BaseType
-      ID: 262
+      ID: 274
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 780960
       GoKind: 2
     - __kind: BaseType
-      ID: 263
+      ID: 275
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 781056
       GoKind: 2
     - __kind: BaseType
-      ID: 238
+      ID: 250
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 778656
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 525
+      ID: 537
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 797
+      ID: 804
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2160384
@@ -3997,13 +3997,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 925 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 932 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 927 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 934 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 929 GoSliceHeaderType [][]uint8
+          Type: 936 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -4015,25 +4015,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 931 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 938 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 932 BaseType crypto/tls.CurveID
+          Type: 939 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 932
+      ID: 939
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778464
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 334
+      ID: 346
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 332
+      ID: 344
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1636960
@@ -4044,26 +4044,26 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 653 ArrayType [5]uint8
+          Type: 665 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 654 GoInterfaceType net.Conn
+          Type: 666 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 492
+      ID: 504
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 967520
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 643
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 652
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 391
+      ID: 403
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1639840
@@ -4071,21 +4071,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 639 PointerType *crypto/x509.Certificate
+          Type: 651 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 663 BaseType crypto/x509.InvalidReason
+          Type: 675 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 385
+      ID: 397
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1097088
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 387
+      ID: 399
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1436640
@@ -4093,24 +4093,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 639 PointerType *crypto/x509.Certificate
+          Type: 651 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 260
+      ID: 272
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 780672
       GoKind: 2
     - __kind: BaseType
-      ID: 663
+      ID: 675
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 546464
       GoKind: 2
     - __kind: StructureType
-      ID: 539
+      ID: 551
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1399808
@@ -4120,13 +4120,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 393
+      ID: 405
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1097344
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 389
+      ID: 401
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1639648
@@ -4134,15 +4134,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 639 PointerType *crypto/x509.Certificate
+          Type: 651 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 639 PointerType *crypto/x509.Certificate
+          Type: 651 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 452
+      ID: 464
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1276896
@@ -4152,7 +4152,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 456
+      ID: 468
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1277056
@@ -4162,47 +4162,47 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 454
+      ID: 466
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 239
+      ID: 251
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 778752
       GoKind: 6
     - __kind: BaseType
-      ID: 259
+      ID: 271
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 780480
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 366
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 537
+      ID: 549
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 346
+      ID: 358
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 352
+      ID: 364
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 350
+      ID: 362
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 348
+      ID: 360
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 356
+      ID: 368
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1266976
@@ -4212,15 +4212,15 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 447
+      ID: 459
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 445
+      ID: 457
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 269
+      ID: 281
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 782688
@@ -4228,18 +4228,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 271 PointerType *encoding/xml.UnmarshalError.str
+          Type: 283 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 270 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 282 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 270
+      ID: 282
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 450
+      ID: 462
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4256,11 +4256,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 320
+      ID: 332
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 524
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4276,11 +4276,11 @@ Types:
       GoRuntimeType: 543264
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 496
+      ID: 508
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 498
+      ID: 510
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4290,13 +4290,13 @@ Types:
       GoRuntimeType: 455360
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 792
+      ID: 799
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645280
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 136
+      ID: 148
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 553376
@@ -4308,23 +4308,23 @@ Types:
       GoRuntimeType: 798176
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 931
+      ID: 938
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 982976
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 389
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 749
+      ID: 756
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 1961472
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 359
+      ID: 371
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1638112
@@ -4332,7 +4332,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 655 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 667 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -4340,25 +4340,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 361
+      ID: 373
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 672
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 365
+      ID: 377
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1095680
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 662
+      ID: 674
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 253
+      ID: 265
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 779808
@@ -4366,18 +4366,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 255 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 267 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 254 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 266 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 254
+      ID: 266
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 655
+      ID: 667
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2126592
@@ -4385,13 +4385,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 656 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 668 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 13 GoStringHeaderType string
@@ -4400,7 +4400,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 658 GoSliceHeaderType []float64
+          Type: 670 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4409,13 +4409,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 659 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 671 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 661 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 673 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 13 GoStringHeaderType string
@@ -4426,13 +4426,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 656
+      ID: 668
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 544992
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 250
+      ID: 262
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 779712
@@ -4440,18 +4440,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 252 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 264 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 251 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 263 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 251
+      ID: 263
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 256
+      ID: 268
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 779904
@@ -4459,22 +4459,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 258 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 270 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 257 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 269 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 257
+      ID: 269
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 414
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
-      ID: 740
+      ID: 747
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
       GoRuntimeType: 1733056
       GoKind: 25
@@ -4488,7 +4488,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 148 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -4509,13 +4509,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 156 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 123 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 161 GoMapType map[string]float64
+          Type: 128 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 12 BaseType uint64
@@ -4530,10 +4530,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 133 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 169 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 136 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -4545,7 +4545,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 139 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 13 GoStringHeaderType string
@@ -4568,7 +4568,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 173
+      ID: 140
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2124800
@@ -4579,13 +4579,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 174 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 141 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 107 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -4594,16 +4594,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 176 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 143 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 12 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 148 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -4612,12 +4612,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 133 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 168
+      ID: 135
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1822016
@@ -4634,7 +4634,7 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -4642,7 +4642,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 873
+      ID: 880
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1872704
@@ -4650,29 +4650,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 866 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+          Type: 873 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 876 BaseType time.Duration
+          Type: 883 BaseType time.Duration
     - __kind: GoMapType
-      ID: 156
+      ID: 123
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1007296
       GoKind: 21
-      HeaderType: 158 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 682
+      ID: 231
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542112
       GoKind: 10
     - __kind: StructureType
-      ID: 171
+      ID: 138
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1663808
@@ -4686,16 +4686,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 206 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 200 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 211 GoMapType map[string]interface {}
+          Type: 205 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 689
+      ID: 696
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 220
+      ID: 223
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1822272
@@ -4703,7 +4703,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 687 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 694 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -4718,15 +4718,15 @@ Types:
           Type: 19 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 688 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 695 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 687
+      ID: 694
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965024
       GoKind: 5
     - __kind: StructureType
-      ID: 175
+      ID: 142
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2016960
@@ -4734,16 +4734,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 148 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 680 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 229 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 11 BaseType int
@@ -4758,12 +4758,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 682 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 231 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 107 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 176
+      ID: 143
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847584
@@ -4772,15 +4772,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 755
+      ID: 762
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 607
+      ID: 619
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 722
+      ID: 729
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1265696
@@ -4793,7 +4793,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 691
+      ID: 698
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1436160
@@ -4806,11 +4806,11 @@ Types:
           Offset: 16
           Type: 11 BaseType int
     - __kind: UnresolvedPointeeType
-      ID: 751
+      ID: 758
       Name: github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 948
+    - __kind: GoContextImplementationType
+      ID: 152
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1474240
@@ -4819,38 +4819,40 @@ Types:
         - Name: Context
           Offset: 0
           Type: 111 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 753
+      ID: 760
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 404
+      ID: 416
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 411
+      ID: 423
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1099136
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 268
+      ID: 280
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 782016
       GoKind: 2
     - __kind: StructureType
-      ID: 409
+      ID: 421
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1099008
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 407
+      ID: 419
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1437600
@@ -4863,7 +4865,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 419
+      ID: 431
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1438240
@@ -4876,7 +4878,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 423
+      ID: 435
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1641376
@@ -4892,7 +4894,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1275456
@@ -4902,7 +4904,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 417
+      ID: 429
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1275136
@@ -4912,14 +4914,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 641
+      ID: 653
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1158784
       GoKind: 21
-      HeaderType: 643 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 655 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 664
+      ID: 676
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1033152
@@ -4934,15 +4936,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 677 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 689 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 677
+      ID: 689
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 431
+      ID: 443
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1438560
@@ -4950,12 +4952,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 641 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 653 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 641 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 653 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 425
+      ID: 437
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1275616
@@ -4965,7 +4967,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 429
+      ID: 441
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1641568
@@ -4976,12 +4978,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 676 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 676 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 427
+      ID: 439
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1438400
@@ -4994,7 +4996,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 433
+      ID: 445
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1275776
@@ -5002,9 +5004,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 139 GoTimeType time.Time
+          Type: 181 GoTimeType time.Time
     - __kind: StructureType
-      ID: 439
+      ID: 451
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1438880
@@ -5017,7 +5019,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 441
+      ID: 453
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1276096
@@ -5027,7 +5029,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 437
+      ID: 449
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1438720
@@ -5040,7 +5042,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1275936
@@ -5050,7 +5052,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 443
+      ID: 455
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1439040
@@ -5063,29 +5065,29 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 767
+      ID: 774
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 780192
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 772
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 759
+      ID: 766
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 761
+      ID: 768
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 770
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 367
+      ID: 379
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1268256
@@ -5095,11 +5097,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 749
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 369
+      ID: 381
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1268416
@@ -5107,17 +5109,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 367 StructureType github.com/cihub/seelog.baseError
+          Type: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 732
+      ID: 739
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 734
+      ID: 741
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 738
+      ID: 745
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1734176
@@ -5125,12 +5127,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 733 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 740 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 743 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 750 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 373
+      ID: 385
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1268736
@@ -5138,9 +5140,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 367 StructureType github.com/cihub/seelog.baseError
+          Type: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 736
+      ID: 743
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1712960
@@ -5148,13 +5150,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 733 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 740 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 757
+      ID: 764
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 371
+      ID: 383
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1268576
@@ -5162,9 +5164,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 367 StructureType github.com/cihub/seelog.baseError
+          Type: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 375
+      ID: 387
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1268896
@@ -5172,9 +5174,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 367 StructureType github.com/cihub/seelog.baseError
+          Type: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 860
+      ID: 867
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1099392
@@ -5187,7 +5189,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 844
+      ID: 851
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1490560
@@ -5195,48 +5197,48 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 860 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 867 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 870
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 647
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 563
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 549
+      ID: 561
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 553
+      ID: 565
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 567
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 557
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 380
+      ID: 392
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1269856
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 621
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 595
+      ID: 607
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1755968
@@ -5252,11 +5254,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 601
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 531
+      ID: 543
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1544224
@@ -5269,7 +5271,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 601
+      ID: 613
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1756416
@@ -5285,13 +5287,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 494
+      ID: 506
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 968192
       GoKind: 8
     - __kind: StructureType
-      ID: 593
+      ID: 605
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1755744
@@ -5307,13 +5309,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 667
+      ID: 679
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 779328
       GoKind: 8
     - __kind: StructureType
-      ID: 591
+      ID: 603
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1755520
@@ -5321,15 +5323,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 667 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 679 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 667 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 679 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 599
+      ID: 611
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1672448
@@ -5342,7 +5344,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1756192
@@ -5358,7 +5360,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 605
+      ID: 617
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1473280
@@ -5368,19 +5370,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 535
+      ID: 547
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1217984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 533
+      ID: 545
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1217856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 603
+      ID: 615
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1672640
@@ -5393,7 +5395,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 288
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 784608
@@ -5401,22 +5403,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 290 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 277 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 289 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 289
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 660
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 559
+      ID: 571
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1291296
@@ -5426,19 +5428,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 279
+      ID: 291
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 785184
       GoKind: 10
     - __kind: BaseType
-      ID: 646
+      ID: 658
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 980288
       GoKind: 10
     - __kind: StructureType
-      ID: 617
+      ID: 629
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1789792
@@ -5449,12 +5451,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 646 BaseType golang.org/x/net/http2.ErrCode
+          Type: 658 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 478
+      ID: 490
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1445760
@@ -5462,12 +5464,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 646 BaseType golang.org/x/net/http2.ErrCode
+          Type: 658 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 295
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 785376
@@ -5475,18 +5477,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 297 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 284 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 296 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 296
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 289
+      ID: 301
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 785568
@@ -5494,18 +5496,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 291 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 303 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 290 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 302 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 290
+      ID: 302
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 286
+      ID: 298
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 785472
@@ -5513,18 +5515,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 288 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 300 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 287 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 299 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 287
+      ID: 299
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 292
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 785280
@@ -5532,18 +5534,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 294 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 281 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 293 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 293
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 482
+      ID: 494
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1291936
@@ -5553,13 +5555,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 292
+      ID: 304
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 785664
       GoKind: 2
     - __kind: StructureType
-      ID: 470
+      ID: 482
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1286976
@@ -5569,11 +5571,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 627
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 637
+      ID: 649
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1816672
@@ -5589,7 +5591,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 472
+      ID: 484
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1445280
@@ -5602,11 +5604,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 876
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 569
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1406848
@@ -5616,29 +5618,29 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 860
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 458
+      ID: 470
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 547
+      ID: 559
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 625
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 611
+      ID: 623
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1354144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 464
+      ID: 476
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1280256
@@ -5648,7 +5650,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 466
+      ID: 478
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1280416
@@ -5658,11 +5660,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 425
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 131
+      ID: 174
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -5683,20 +5685,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 132 PointerType *bucket<context.canceler,struct {}>
+          Type: 175 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 132 PointerType *bucket<context.canceler,struct {}>
+          Type: 175 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 133 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 188 GoSliceDataType []bucket<context.canceler,struct {}>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 176 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 214 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
-      ID: 745
+      ID: 752
       Name: hash<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       RawFields:
@@ -5717,20 +5719,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 746 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+          Type: 753 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
         - Name: oldbuckets
           Offset: 24
-          Type: 746 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+          Type: 753 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
-      BucketsType: 769 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 754 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      BucketsType: 776 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
     - __kind: GoHMapHeaderType
-      ID: 208
+      ID: 202
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -5751,20 +5753,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 221 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 224 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 914
+      ID: 921
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -5785,20 +5787,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 915 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 922 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 915 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 922 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 916 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 921 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 923 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 928 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 781
+      ID: 788
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -5819,20 +5821,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 782 PointerType *bucket<string,[]string>
+          Type: 789 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 782 PointerType *bucket<string,[]string>
+          Type: 789 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 783 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 789 GoSliceDataType []bucket<string,[]string>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 790 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 796 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 163
+      ID: 130
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -5853,20 +5855,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 164 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 164 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 165 GoHMapBucketType bucket<string,float64>
-      BucketsType: 203 GoSliceDataType []bucket<string,float64>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 132 GoHMapBucketType bucket<string,float64>
+      BucketsType: 197 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 643
+      ID: 655
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -5887,20 +5889,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 656 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 656 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 672 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 657 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 684 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
-      ID: 158
+      ID: 125
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -5921,20 +5923,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 159 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 159 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 160 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 201 GoSliceDataType []bucket<string,interface {}>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 127 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 195 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 153
+      ID: 118
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -5955,20 +5957,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 154 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 154 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 155 GoHMapBucketType bucket<string,string>
-      BucketsType: 199 GoSliceDataType []bucket<string,string>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 120 GoHMapBucketType bucket<string,string>
+      BucketsType: 193 GoSliceDataType []bucket<string,string>.array
     - __kind: UnresolvedPointeeType
-      ID: 485
+      ID: 497
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -6002,7 +6004,7 @@ Types:
       GoRuntimeType: 542368
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 128
+      ID: 155
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 797888
@@ -6015,7 +6017,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 394
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -6041,21 +6043,21 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 599
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 913
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 585
+      ID: 597
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1323104
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 322
+      ID: 334
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6136,7 +6138,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 861
+      ID: 868
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1009344
@@ -6149,11 +6151,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 878
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 774
+      ID: 781
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1092864
@@ -6166,7 +6168,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 851
+      ID: 858
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1008704
@@ -6179,11 +6181,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 824
+      ID: 831
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1393568
@@ -6191,9 +6193,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 851 GoInterfaceType io.Reader
+          Type: 858 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 842
+      ID: 849
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1459264
@@ -6201,69 +6203,69 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 851 GoInterfaceType io.Reader
+          Type: 858 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 595
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoMapType
-      ID: 129
+      ID: 172
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 897312
       GoKind: 21
-      HeaderType: 131 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 174 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 743
+      ID: 750
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 919808
       GoKind: 21
-      HeaderType: 745 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 752 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 206
+      ID: 200
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 21
-      HeaderType: 208 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 202 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 912
+      ID: 919
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 21
-      HeaderType: 914 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 921 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 911
+      ID: 918
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899232
       GoKind: 21
-      HeaderType: 781 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 788 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 161
+      ID: 128
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 21
-      HeaderType: 163 GoHMapHeaderType hash<string,float64>
+      HeaderType: 130 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 211
+      ID: 205
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896352
       GoKind: 21
-      HeaderType: 158 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
-      ID: 151
+      ID: 116
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
-      HeaderType: 153 GoHMapHeaderType hash<string,string>
+      HeaderType: 118 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 400
+      ID: 412
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1272256
@@ -6273,11 +6275,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 795
+      ID: 802
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1325824
@@ -6285,16 +6287,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 911 GoMapType map[string][]string
+          Type: 918 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 912 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 919 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 862
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1825856
@@ -6302,16 +6304,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 874 PointerType *io.SectionReader
+          Type: 881 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 861 GoInterfaceType io.Closer
+          Type: 868 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 581
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 654
+      ID: 666
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1434880
@@ -6324,35 +6326,35 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 634
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 889
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 632
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 583
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 901
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 562
+      ID: 574
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1090688
@@ -6360,28 +6362,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 564 PointerType *net.UnknownNetworkError.str
+          Type: 576 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 563 GoStringDataType net.UnknownNetworkError.str
+      Data: 575 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 563
+      ID: 575
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 500
+      ID: 512
       Name: net.canceledError
       GoRuntimeType: 1215808
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 887
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 666
+      ID: 678
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2016256
@@ -6389,7 +6391,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 654 GoInterfaceType net.Conn
+          Type: 666 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -6400,27 +6402,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 903
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: net.noReadFrom
       GoRuntimeType: 1090944
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: net.noWriteTo
       GoRuntimeType: 1090816
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 294
+      ID: 306
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 946
+    - __kind: GoContextImplementationType
+      ID: 150
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1658240
@@ -6432,8 +6434,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 111 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 296
+      ID: 308
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1631584
@@ -6441,7 +6445,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 649 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 661 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -6449,7 +6453,7 @@ Types:
           Offset: 96
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 886
+      ID: 893
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2197952
@@ -6457,12 +6461,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 892 StructureType net.noReadFrom
+          Type: 899 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 889 PointerType *net.TCPConn
+          Type: 896 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2197408
@@ -6470,20 +6474,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 891 StructureType net.noWriteTo
+          Type: 898 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 889 PointerType *net.TCPConn
+          Type: 896 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 585
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 636
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 725
+      ID: 732
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1006528
@@ -6496,7 +6500,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 723
+      ID: 730
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1005120
@@ -6509,14 +6513,14 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 779
+      ID: 786
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1963712
       GoKind: 21
-      HeaderType: 781 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 788 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 726
+      ID: 733
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1005248
@@ -6529,15 +6533,15 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 302
+      ID: 314
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 514
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 724
+      ID: 731
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1005504
@@ -6561,7 +6565,7 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 790 PointerType *net/url.URL
+          Type: 797 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -6573,19 +6577,19 @@ Types:
           Type: 11 BaseType int
         - Name: Header
           Offset: 56
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 774 GoInterfaceType io.ReadCloser
+          Type: 781 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 792 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 799 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6594,16 +6598,16 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 793 GoMapType net/url.Values
+          Type: 800 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 793 GoMapType net/url.Values
+          Type: 800 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 794 PointerType *mime/multipart.Form
+          Type: 801 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 13 GoStringHeaderType string
@@ -6612,13 +6616,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 796 PointerType *crypto/tls.ConnectionState
+          Type: 803 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 798 GoChannelType <-chan struct {}
+          Type: 805 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 799 PointerType *net/http.Response
+          Type: 806 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 13 GoStringHeaderType string
@@ -6627,15 +6631,15 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 801 PointerType *net/http.pattern
+          Type: 808 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
     - __kind: StructureType
-      ID: 800
+      ID: 807
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2123456
@@ -6658,16 +6662,16 @@ Types:
           Type: 11 BaseType int
         - Name: Header
           Offset: 56
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 774 GoInterfaceType io.ReadCloser
+          Type: 781 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6676,13 +6680,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 105 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 796 PointerType *crypto/tls.ConnectionState
+          Type: 803 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 104
       Name: net/http.ResponseWriter
@@ -6697,19 +6701,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 872
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 843
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1659776
@@ -6717,10 +6721,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 729 PointerType *net/http.response
+          Type: 736 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6728,31 +6732,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 780
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 813
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 222
+      ID: 234
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 776256
       GoKind: 10
     - __kind: BaseType
-      ID: 638
+      ID: 650
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 964832
       GoKind: 10
     - __kind: StructureType
-      ID: 305
+      ID: 317
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1633120
@@ -6763,12 +6767,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 638 BaseType net/http.http2ErrCode
+          Type: 650 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 626
+      ID: 638
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1806176
@@ -6779,16 +6783,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 638 BaseType net/http.http2ErrCode
+          Type: 650 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 857
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 311
+      ID: 323
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1435360
@@ -6796,12 +6800,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 638 BaseType net/http.http2ErrCode
+          Type: 650 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 226
+      ID: 238
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 776448
@@ -6809,28 +6813,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 228 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 240 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 227 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 239 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 227
+      ID: 239
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 309
+      ID: 321
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1091968
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 821
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 232
+      ID: 244
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 776640
@@ -6838,18 +6842,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 234 PointerType *net/http.http2headerFieldNameError.str
+          Type: 246 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 233 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 245 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 233
+      ID: 245
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 229
+      ID: 241
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 776544
@@ -6857,40 +6861,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 231 PointerType *net/http.http2headerFieldValueError.str
+          Type: 243 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 230 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 242 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 230
+      ID: 242
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 589
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: net/http.http2missingBody
       GoRuntimeType: 1216064
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 822
+      ID: 829
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1216576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 508
+      ID: 520
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1216448
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 223
+      ID: 235
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 776352
@@ -6898,22 +6902,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 225 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 237 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 224 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 236 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 224
+      ID: 236
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 728
+      ID: 735
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1125760
@@ -6921,13 +6925,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 770 PointerType *net/http.http2responseWriterState
+          Type: 777 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 778
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 812
+      ID: 819
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1391008
@@ -6935,19 +6939,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 849 PointerType *net/http.http2clientStream
+          Type: 856 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 815
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: net/http.noBody
       GoRuntimeType: 1308864
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 504
+      ID: 516
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1392128
@@ -6957,7 +6961,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 802
+      ID: 809
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1744992
@@ -6974,20 +6978,20 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 939 GoSliceHeaderType []net/http.segment
+          Type: 946 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 804
+      ID: 811
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 845
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 315
+      ID: 327
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1260096
@@ -6997,7 +7001,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 730
+      ID: 737
       Name: net/http.response
       ByteSize: 224
       GoRuntimeType: 2256448
@@ -7005,16 +7009,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 772 PointerType *net/http.conn
+          Type: 779 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 105 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 774 GoInterfaceType io.ReadCloser
+          Type: 781 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 143 GoSubroutineType context.CancelFunc
+          Type: 164 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7026,19 +7030,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 126 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 775 StructureType sync/atomic.Bool
+          Type: 782 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 776 PointerType *bufio.Writer
+          Type: 783 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 778 StructureType net/http.chunkWriter
+          Type: 785 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7062,27 +7066,27 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 775 StructureType sync/atomic.Bool
+          Type: 782 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 784 ArrayType [29]uint8
+          Type: 791 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 785 ArrayType [10]uint8
+          Type: 792 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 786 ArrayType [3]uint8
+          Type: 793 ArrayType [3]uint8
         - Name: closeNotifyCh
           Offset: 208
-          Type: 787 GoChannelType chan bool
+          Type: 794 GoChannelType chan bool
         - Name: didCloseNotify
           Offset: 216
-          Type: 775 StructureType sync/atomic.Bool
+          Type: 782 StructureType sync/atomic.Bool
     - __kind: StructureType
-      ID: 941
+      ID: 948
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1452928
@@ -7098,7 +7102,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 300
+      ID: 312
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1435200
@@ -7111,17 +7115,17 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 640
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 575
+      ID: 587
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1310304
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 506
+      ID: 518
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1392288
@@ -7131,17 +7135,17 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 298
+      ID: 310
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 832
+      ID: 839
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1222848
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 328
+      ID: 340
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1636384
@@ -7157,7 +7161,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 326
+      ID: 338
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1435680
@@ -7170,11 +7174,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 353
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 246
+      ID: 258
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 779040
@@ -7182,22 +7186,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 248 PointerType *net/textproto.ProtocolError.str
+          Type: 260 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 247 GoStringDataType net/textproto.ProtocolError.str
+      Data: 259 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 247
+      ID: 259
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 645
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 240
+      ID: 252
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 778848
@@ -7205,18 +7209,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 242 PointerType *net/url.EscapeError.str
+          Type: 254 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 241 GoStringDataType net/url.EscapeError.str
+      Data: 253 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 241
+      ID: 253
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 243
+      ID: 255
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 778944
@@ -7224,18 +7228,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 245 PointerType *net/url.InvalidHostError.str
+          Type: 257 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 244 GoStringDataType net/url.InvalidHostError.str
+      Data: 256 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 244
+      ID: 256
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 791
+      ID: 798
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2040992
@@ -7249,7 +7253,7 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 909 PointerType *net/url.Userinfo
+          Type: 916 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 13 GoStringHeaderType string
@@ -7275,26 +7279,26 @@ Types:
           Offset: 128
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 917
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 793
+      ID: 800
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1711840
       GoKind: 21
-      HeaderType: 781 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 788 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 909
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 522
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 146
+      ID: 167
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1092608
@@ -7307,11 +7311,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 591
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 900
+      ID: 907
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2268672
@@ -7319,12 +7323,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 904 StructureType os.noReadFrom
+          Type: 911 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 901 PointerType *os.File
+          Type: 908 PointerType *os.File
     - __kind: StructureType
-      ID: 898
+      ID: 905
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2267872
@@ -7332,32 +7336,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 903 StructureType os.noWriteTo
+          Type: 910 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 901 PointerType *os.File
+          Type: 908 PointerType *os.File
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: os.noReadFrom
       GoRuntimeType: 1092480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 903
+      ID: 910
       Name: os.noWriteTo
       GoRuntimeType: 1092352
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 553
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 682
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 543
+      ID: 555
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1544608
@@ -7370,7 +7374,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 163
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1872448
@@ -7381,17 +7385,17 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 143 GoSubroutineType context.CancelFunc
+          Type: 164 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 144 GoSliceHeaderType []os.Signal
+          Type: 165 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 147 GoChannelType chan os.Signal
+          Type: 168 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 285
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 783840
@@ -7399,36 +7403,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *os/user.UnknownGroupIdError.str
+          Type: 287 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 274 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 286 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 286
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 272
+      ID: 284
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 783744
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 324
+      ID: 336
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 415
+      ID: 427
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 517
+      ID: 529
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 522
+      ID: 534
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7440,7 +7444,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 519
+      ID: 531
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1795616
@@ -7457,9 +7461,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 668 BaseType runtime.boundsErrorCode
+          Type: 680 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 668
+      ID: 680
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 543456
@@ -7479,7 +7483,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 581
+      ID: 593
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1667072
@@ -7492,7 +7496,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 486
+      ID: 498
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 966080
@@ -7500,13 +7504,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 488 PointerType *runtime.errorString.str
+          Type: 500 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 487 GoStringDataType runtime.errorString.str
+      Data: 499 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 487
+      ID: 499
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8083,7 +8087,7 @@ Types:
           Offset: 24
           Type: 30 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 135
+      ID: 122
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -8132,7 +8136,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 489
+      ID: 501
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 966656
@@ -8140,13 +8144,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 491 PointerType *runtime.plainError.str
+          Type: 503 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 490 GoStringDataType runtime.plainError.str
+      Data: 502 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 490
+      ID: 502
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8228,7 +8232,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 526
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8240,18 +8244,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 178 PointerType *string.str
+          Type: 185 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 177 GoStringDataType string.str
+      Data: 184 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 177
+      ID: 184
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 697
+      ID: 704
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1855808
@@ -8259,12 +8263,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 711
+      ID: 718
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1931104
@@ -8272,15 +8276,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 693
+      ID: 700
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1855296
@@ -8288,12 +8292,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 703
+      ID: 710
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1929952
@@ -8301,15 +8305,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 717
+      ID: 724
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1999552
@@ -8317,18 +8321,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 705
+      ID: 712
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1930240
@@ -8336,15 +8340,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 701
+      ID: 708
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1929664
@@ -8352,15 +8356,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 713
+      ID: 720
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1998912
@@ -8368,18 +8372,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 721
+      ID: 728
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2058656
@@ -8387,21 +8391,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 715
+      ID: 722
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1999232
@@ -8409,18 +8413,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 699
+      ID: 706
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1856064
@@ -8428,12 +8432,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 695
+      ID: 702
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1855552
@@ -8441,12 +8445,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 707
+      ID: 714
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1930528
@@ -8454,15 +8458,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1999872
@@ -8470,18 +8474,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 709
+      ID: 716
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1930816
@@ -8489,15 +8493,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 834
+      ID: 841
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1556320
@@ -8505,18 +8509,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 851 GoInterfaceType io.Reader
+          Type: 858 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 861 GoInterfaceType io.Closer
+          Type: 868 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 187
+      ID: 213
       Name: struct {}
       GoRuntimeType: 789600
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 126
+      ID: 113
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1313984
@@ -8529,7 +8533,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 148
+      ID: 112
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1750592
@@ -8537,7 +8541,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -8546,12 +8550,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 775
+      ID: 782
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1315264
@@ -8559,12 +8563,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 115 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 149
+      ID: 114
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1315424
@@ -8572,12 +8576,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 115 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 127
+      ID: 171
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1134080
@@ -8585,27 +8589,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 150
+      ID: 115
       Name: sync/atomic.noCopy
       GoRuntimeType: 965792
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 618
+      ID: 630
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1217088
       GoKind: 12
     - __kind: BaseType
-      ID: 685
+      ID: 692
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 966848
       GoKind: 2
     - __kind: StructureType
-      ID: 561
+      ID: 573
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1548832
@@ -8618,13 +8622,13 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 876
+      ID: 883
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1821760
       GoKind: 6
     - __kind: StructureType
-      ID: 141
+      ID: 183
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1877376
@@ -8635,10 +8639,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 189 GoSliceHeaderType []time.zone
+          Type: 215 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 192 GoSliceHeaderType []time.zoneTrans
+          Type: 218 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -8650,13 +8654,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 190 PointerType *time.zone
+          Type: 216 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 318
+      ID: 330
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 139
+      ID: 181
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2280896
@@ -8670,7 +8674,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 140 PointerType *time.Location
+          Type: 182 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -8680,7 +8684,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 138
+      ID: 180
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1311104
@@ -8688,12 +8692,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 679 GoChannelType <-chan time.Time
+          Type: 691 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 235
+      ID: 247
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 776736
@@ -8701,18 +8705,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 237 PointerType *time.fileSizeError.str
+          Type: 249 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 236 GoStringDataType time.fileSizeError.str
+      Data: 248 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 236
+      ID: 248
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 191
+      ID: 217
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1457920
@@ -8728,7 +8732,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 194
+      ID: 220
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1663616
@@ -8789,7 +8793,7 @@ Types:
       GoRuntimeType: 543392
       GoKind: 26
     - __kind: StructureType
-      ID: 649
+      ID: 661
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1967232
@@ -8800,10 +8804,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 650 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 662 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 651 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 663 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -8818,18 +8822,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 652 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 664 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 652
+      ID: 664
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 967136
       GoKind: 9
     - __kind: StructureType
-      ID: 650
+      ID: 662
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1825088
@@ -8854,17 +8858,17 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 330
+      ID: 342
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 651
+      ID: 663
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 544288
       GoKind: 8
     - __kind: StructureType
-      ID: 343
+      ID: 355
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1265056
@@ -8874,13 +8878,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 249
+      ID: 261
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 779136
       GoKind: 2
     - __kind: StructureType
-      ID: 527
+      ID: 539
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1544032
@@ -8893,7 +8897,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 493
+      ID: 505
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 968000

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -121,124 +121,124 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 675 PointerType *crypto/x509.Certificate
+      Pointee: 687 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 723
+      ID: 262
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 980 PointerType *mime/multipart.FileHeader
+      Pointee: 987 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 139
+      ID: 180
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<context.canceler,struct {}>
+      Pointee: 181 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 789 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 796 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 235
+      ID: 224
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 236 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 225 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 971 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 978 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 830 PointerType *table<string,[]string>
+      Pointee: 837 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 169
+      ID: 136
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 170 PointerType *table<string,float64>
+      Pointee: 137 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 680
+      ID: 692
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 693 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 164
+      ID: 131
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 165 PointerType *table<string,interface {}>
+      Pointee: 132 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 159
+      ID: 126
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 160 PointerType *table<string,string>
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 986 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 993 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 995
+      ID: 1002
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 994 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1001 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 726
+      ID: 265
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 725 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 264 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 984 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 997
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 996 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 999
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 998 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 718
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 717 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 231
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 230 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 239
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 991 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 1004
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1003 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1006
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1005 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 730
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 729 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 220
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 228
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 227 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1011
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1003 GoSliceDataType []net/http.segment.array
+      Pointee: 1010 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 205
+      ID: 230
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []os.Signal.array
+      Pointee: 229 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -247,77 +247,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 716
+      ID: 728
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 715 GoSliceDataType []string.array
+      Pointee: 727 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 241
+      ID: 258
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []time.zone.array
+      Pointee: 257 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 243
+      ID: 260
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []time.zoneTrans.array
+      Pointee: 259 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483552
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 185
+      ID: 192
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []uint8.array
+      Pointee: 191 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 187
+      ID: 194
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []uintptr.array
+      Pointee: 193 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 495
+      ID: 507
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 945920
       GoKind: 22
-      Pointee: 496 GoSliceHeaderType archive/tar.headerError
+      Pointee: 508 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 497 GoSliceDataType archive/tar.headerError.array
+      Pointee: 509 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1246272
       GoKind: 22
-      Pointee: 899 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 906 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1078656
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 890 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1455392
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 908 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1078400
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 888 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -326,12 +326,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1988352
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType bufio.Writer
+      Pointee: 831 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 114
       Name: '*bytes.Buffer'
@@ -340,358 +340,358 @@ Types:
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 433
+      ID: 445
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 931520
       GoKind: 22
-      Pointee: 297 BaseType compress/flate.CorruptInputError
+      Pointee: 309 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 931616
       GoKind: 22
-      Pointee: 298 GoStringHeaderType compress/flate.InternalError
+      Pointee: 310 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 300
+      ID: 312
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 299 GoStringDataType compress/flate.InternalError.str
+      Pointee: 311 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 2015808
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 940 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1655456
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 919 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 1010
+      ID: 163
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1570112
       GoKind: 22
-      Pointee: 129 StructureType context.backgroundCtx
+      Pointee: 164 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 117
+      ID: 174
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1749856
       GoKind: 22
-      Pointee: 118 StructureType context.cancelCtx
+      Pointee: 175 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1203520
       GoKind: 22
-      Pointee: 602 StructureType context.deadlineExceededError
+      Pointee: 614 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1005
+      ID: 149
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1430592
       GoKind: 22
-      Pointee: 130 StructureType context.emptyCtx
+      Pointee: 150 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 119
+      ID: 151
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1430752
       GoKind: 22
-      Pointee: 120 StructureType context.stopCtx
+      Pointee: 152 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 121
+      ID: 182
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1750048
       GoKind: 22
-      Pointee: 122 StructureType context.timerCtx
+      Pointee: 183 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1011
+      ID: 165
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1570272
       GoKind: 22
-      Pointee: 147 StructureType context.todoCtx
+      Pointee: 166 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 123
+      ID: 158
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1569792
       GoKind: 22
-      Pointee: 124 StructureType context.valueCtx
+      Pointee: 159 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 125
+      ID: 161
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1569952
       GoKind: 22
-      Pointee: 126 StructureType context.withoutCancelCtx
+      Pointee: 162 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 429
+      ID: 441
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930272
       GoKind: 22
-      Pointee: 293 BaseType crypto/aes.KeySizeError
+      Pointee: 305 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930464
       GoKind: 22
-      Pointee: 294 BaseType crypto/des.KeySizeError
+      Pointee: 306 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 431
+      ID: 443
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930752
       GoKind: 22
-      Pointee: 295 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 307 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 931040
       GoKind: 22
-      Pointee: 296 BaseType crypto/rc4.KeySizeError
+      Pointee: 308 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 368
+      ID: 380
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 270 BaseType crypto/tls.AlertError
+      Pointee: 282 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1056128
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 573 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2431712
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 970 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 850 StructureType crypto/tls.ConnectionState
+      Pointee: 857 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 919808
       GoKind: 22
-      Pointee: 367 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 379 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 364
+      ID: 376
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 365 StructureType crypto/tls.RecordHeaderError
+      Pointee: 377 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1054464
       GoKind: 22
-      Pointee: 528 BaseType crypto/tls.alert
+      Pointee: 540 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 666
+      ID: 678
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1438272
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 679 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 675
+      ID: 687
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2082688
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 688 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 930080
       GoKind: 22
-      Pointee: 426 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 438 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 419
+      ID: 431
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 929600
       GoKind: 22
-      Pointee: 420 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 432 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 421
+      ID: 433
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 929696
       GoKind: 22
-      Pointee: 422 StructureType crypto/x509.HostnameError
+      Pointee: 434 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 929504
       GoKind: 22
-      Pointee: 292 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 304 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1065728
       GoKind: 22
-      Pointee: 575 StructureType crypto/x509.SystemRootsError
+      Pointee: 587 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 930176
       GoKind: 22
-      Pointee: 428 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 440 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 423
+      ID: 435
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 929984
       GoKind: 22
-      Pointee: 424 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 436 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 487
+      ID: 499
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 941600
       GoKind: 22
-      Pointee: 488 StructureType encoding/asn1.StructuralError
+      Pointee: 500 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 491
+      ID: 503
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 941792
       GoKind: 22
-      Pointee: 492 StructureType encoding/asn1.SyntaxError
+      Pointee: 504 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 489
+      ID: 501
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 941696
       GoKind: 22
-      Pointee: 490 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 502 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 920096
       GoKind: 22
-      Pointee: 271 BaseType encoding/base64.CorruptInputError
+      Pointee: 283 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 928352
       GoKind: 22
-      Pointee: 291 BaseType encoding/hex.InvalidByteError
+      Pointee: 303 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 386
+      ID: 398
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 399 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1061248
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 585 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923072
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 391 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 923360
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 397 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 382
+      ID: 394
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923264
       GoKind: 22
-      Pointee: 383 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 395 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 380
+      ID: 392
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 923168
       GoKind: 22
-      Pointee: 381 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 393 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 923840
       GoKind: 22
-      Pointee: 389 StructureType encoding/json.jsonError
+      Pointee: 401 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 482
+      ID: 494
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 938816
       GoKind: 22
-      Pointee: 483 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 495 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 938720
       GoKind: 22
-      Pointee: 481 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 493 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 938912
       GoKind: 22
-      Pointee: 302 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 314 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 304
+      ID: 316
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 303 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 315 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 485
+      ID: 497
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 939008
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 498 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -700,19 +700,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 352
+      ID: 364
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 915296
       GoKind: 22
-      Pointee: 353 UnresolvedPointeeType errors.errorString
+      Pointee: 365 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 547
+      ID: 559
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1047424
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType errors.joinError
+      Pointee: 560 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -728,118 +728,118 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 531
+      ID: 543
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1037184
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType fmt.wrapError
+      Pointee: 544 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1037312
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 546 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 409
+      ID: 421
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927872
       GoKind: 22
-      Pointee: 410 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2050528
       GoKind: 22
-      Pointee: 791 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 798 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 925088
       GoKind: 22
-      Pointee: 392 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 404 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 393
+      ID: 405
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 925184
       GoKind: 22
-      Pointee: 394 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 406 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 695
+      ID: 707
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 924896
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 708 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 925472
       GoKind: 22
-      Pointee: 398 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 410 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 697
+      ID: 709
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 924992
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 710 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 395
+      ID: 407
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 925280
       GoKind: 22
-      Pointee: 285 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 297 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 287
+      ID: 299
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 286 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 298 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 924800
       GoKind: 22
-      Pointee: 282 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 294 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 284
+      ID: 296
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 283 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 925376
       GoKind: 22
-      Pointee: 288 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 300 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 290
+      ID: 302
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 301 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 437
+      ID: 449
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 932672
       GoKind: 22
-      Pointee: 438 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 450 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
       ByteSize: 8
       GoRuntimeType: 1753696
       GoKind: 22
-      Pointee: 782 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
+      Pointee: 789 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
     - __kind: PointerType
       ID: 112
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -848,728 +848,728 @@ Types:
       GoKind: 22
       Pointee: 113 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 177
+      ID: 144
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2046208
       GoKind: 22
-      Pointee: 178 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 172
+      ID: 139
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1210688
       GoKind: 22
-      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 140 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1932832
       GoKind: 22
-      Pointee: 928 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 935 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1829760
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+      Pointee: 927 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 175
+      ID: 142
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1210816
       GoKind: 22
-      Pointee: 176 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 143 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 730
+      ID: 737
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1211456
       GoKind: 22
-      Pointee: 731 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 738 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 250
+      ID: 253
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1211584
       GoKind: 22
-      Pointee: 251 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 254 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 179
+      ID: 146
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2270240
       GoKind: 22
-      Pointee: 180 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 147 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer'
       ByteSize: 8
       GoRuntimeType: 2254592
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
+      Pointee: 804 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 642
+      ID: 654
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1232576
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 655 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1577632
       GoKind: 22
-      Pointee: 733 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 740 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2218816
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
+      Pointee: 800 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1008
+      ID: 156
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1441152
       GoKind: 22
-      Pointee: 1009 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 157 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2219232
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
+      Pointee: 802 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1069056
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
+      Pointee: 886 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 439
+      ID: 451
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 934880
       GoKind: 22
-      Pointee: 440 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 452 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 935936
       GoKind: 22
-      Pointee: 447 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 459 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 935648
       GoKind: 22
-      Pointee: 301 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 313 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 935840
       GoKind: 22
-      Pointee: 445 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 457 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 455 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 454
+      ID: 466
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 937280
       GoKind: 22
-      Pointee: 455 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 467 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 458
+      ID: 470
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 937472
       GoKind: 22
-      Pointee: 459 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 471 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 456
+      ID: 468
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 457 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 469 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 452
+      ID: 464
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 937184
       GoKind: 22
-      Pointee: 453 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 465 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 720
+      ID: 732
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 731 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 466
+      ID: 478
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 937856
       GoKind: 22
-      Pointee: 467 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 479 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 937568
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 473 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 464
+      ID: 476
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 937760
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 477 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 937664
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 475 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 468
+      ID: 480
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 937952
       GoKind: 22
-      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 481 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 938240
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 487 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 938336
       GoKind: 22
-      Pointee: 477 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 489 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 472
+      ID: 484
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 938144
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 485 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 470
+      ID: 482
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 938048
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 483 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 938528
       GoKind: 22
-      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 491 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2374816
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 814 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2357344
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 808 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2365856
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 810 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2366496
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 812 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 926624
       GoKind: 22
-      Pointee: 400 StructureType github.com/cihub/seelog.baseError
+      Pointee: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1832000
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 791 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 401
+      ID: 413
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 926720
       GoKind: 22
-      Pointee: 402 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 414 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1444352
       GoKind: 22
-      Pointee: 774 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 781 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1664672
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 783 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1665440
       GoKind: 22
-      Pointee: 780 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 787 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 406 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 418 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1664864
       GoKind: 22
-      Pointee: 778 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 785 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2335104
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 806 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 926816
       GoKind: 22
-      Pointee: 404 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 416 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 927008
       GoKind: 22
-      Pointee: 408 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 420 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1241536
       GoKind: 22
-      Pointee: 897 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 904 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1759648
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 923 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 670
+      ID: 682
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1456672
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 683 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 586
+      ID: 598
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1083648
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 599 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 584
+      ID: 596
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1083520
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 597 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1088000
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 601 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 590
+      ID: 602
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1088128
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 603 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 580
+      ID: 592
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1072640
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 593 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 928544
       GoKind: 22
-      Pointee: 413 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 425 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 644
+      ID: 656
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1240768
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 657 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1224512
       GoKind: 22
-      Pointee: 631 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 624
+      ID: 636
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1224128
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 637 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 566
+      ID: 578
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1059072
       GoKind: 22
-      Pointee: 567 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 579 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1224896
       GoKind: 22
-      Pointee: 637 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 649 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1058944
       GoKind: 22
-      Pointee: 530 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 542 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1224384
       GoKind: 22
-      Pointee: 629 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 626
+      ID: 638
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1224256
       GoKind: 22
-      Pointee: 627 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 639 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 634
+      ID: 646
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1224768
       GoKind: 22
-      Pointee: 635 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 647 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 632
+      ID: 644
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1224640
       GoKind: 22
-      Pointee: 633 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 640
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1225280
       GoKind: 22
-      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 570
+      ID: 582
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1059328
       GoKind: 22
-      Pointee: 571 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 568
+      ID: 580
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1059200
       GoKind: 22
-      Pointee: 569 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 638
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1225152
       GoKind: 22
-      Pointee: 639 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 509
+      ID: 521
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 957344
       GoKind: 22
-      Pointee: 309 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 321 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 311
+      ID: 323
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 310 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 322 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 683
+      ID: 695
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1692704
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 696 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 594
+      ID: 606
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1102848
       GoKind: 22
-      Pointee: 595 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 607 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 958592
       GoKind: 22
-      Pointee: 312 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 324 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 652
+      ID: 664
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1278912
       GoKind: 22
-      Pointee: 653 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 665 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 958880
       GoKind: 22
-      Pointee: 514 StructureType golang.org/x/net/http2.connError
+      Pointee: 526 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 958784
       GoKind: 22
-      Pointee: 316 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 328 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 318
+      ID: 330
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 329 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 959072
       GoKind: 22
-      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 334 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 324
+      ID: 336
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 335 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 958976
       GoKind: 22
-      Pointee: 319 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 331 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 321
+      ID: 333
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 332 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 958688
       GoKind: 22
-      Pointee: 313 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 325 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 315
+      ID: 327
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 326 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 959168
       GoKind: 22
-      Pointee: 518 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 530 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 519
+      ID: 531
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 959264
       GoKind: 22
-      Pointee: 325 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 337 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 505
+      ID: 517
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 953024
       GoKind: 22
-      Pointee: 506 StructureType google.golang.org/grpc.dropError
+      Pointee: 518 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1275968
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 663 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 672
+      ID: 684
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1464192
       GoKind: 22
-      Pointee: 673 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 685 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 507
+      ID: 519
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 955616
       GoKind: 22
-      Pointee: 508 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 520 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1839840
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 929 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 592
+      ID: 604
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1097088
       GoKind: 22
-      Pointee: 593 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 605 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1589472
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 913 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 493
+      ID: 505
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 944576
       GoKind: 22
-      Pointee: 494 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 506 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1077248
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 595 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1244864
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 661 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 646
+      ID: 658
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1244608
       GoKind: 22
-      Pointee: 647 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 659 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 499
+      ID: 511
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 946880
       GoKind: 22
-      Pointee: 500 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 512 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 501
+      ID: 513
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 946976
       GoKind: 22
-      Pointee: 502 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 514 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 936032
       GoKind: 22
-      Pointee: 449 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 461 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 520
+      ID: 532
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 960032
       GoKind: 22
-      Pointee: 521 UnresolvedPointeeType html/template.Error
+      Pointee: 533 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -1606,321 +1606,321 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 929120
       GoKind: 22
-      Pointee: 417 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 429 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 929024
       GoKind: 22
-      Pointee: 415 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 427 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 622
+      ID: 634
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1219648
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 635 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2425376
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType internal/poll.FD
+      Pointee: 968 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1219520
       GoKind: 22
-      Pointee: 621 StructureType internal/poll.errNetClosing
+      Pointee: 633 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 915680
       GoKind: 22
-      Pointee: 355 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 367 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1871744
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType io.PipeReader
+      Pointee: 933 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1574432
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType io.SectionReader
+      Pointee: 937 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1047936
       GoKind: 22
-      Pointee: 877 StructureType io.nopCloser
+      Pointee: 884 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1214272
       GoKind: 22
-      Pointee: 895 StructureType io.nopCloserWriterTo
+      Pointee: 902 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1218752
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType io/fs.PathError
+      Pointee: 631 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 137
+      ID: 178
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 179 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 787 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 794 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 233
+      ID: 222
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 234 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 223 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 969 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 976 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 828 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 835 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 167
+      ID: 134
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 168 GoSwissMapHeaderType map<string,float64>
+      Pointee: 135 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 678
+      ID: 690
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 691 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 162
+      ID: 129
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 163 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 157
+      ID: 124
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 158 GoSwissMapHeaderType map<string,string>
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 435
+      ID: 447
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 932288
       GoKind: 22
-      Pointee: 436 StructureType math/big.ErrNaN
+      Pointee: 448 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 990 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 847
+      ID: 854
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 848 StructureType mime/multipart.Form
+      Pointee: 855 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1654496
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 915 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1654688
       GoKind: 22
-      Pointee: 910 StructureType mime/multipart.sectionReadCloser
+      Pointee: 917 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 604
+      ID: 616
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1204672
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType net.AddrError
+      Pointee: 617 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 657
+      ID: 669
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1431392
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType net.DNSError
+      Pointee: 670 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2276544
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net.IPConn
+      Pointee: 944 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 655
+      ID: 667
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1431072
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType net.OpError
+      Pointee: 668 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 606
+      ID: 618
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1204800
       GoKind: 22
-      Pointee: 607 UnresolvedPointeeType net.ParseError
+      Pointee: 619 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2310112
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType net.TCPConn
+      Pointee: 952 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2356128
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType net.UDPConn
+      Pointee: 956 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2309600
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType net.UnixConn
+      Pointee: 950 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1203904
       GoKind: 22
-      Pointee: 598 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 610 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 600
+      ID: 612
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 599 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 611 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 535
+      ID: 547
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1038208
       GoKind: 22
-      Pointee: 536 StructureType net.canceledError
+      Pointee: 548 StructureType net.canceledError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2044480
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType net.conn
+      Pointee: 942 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 701
+      ID: 713
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1865472
       GoKind: 22
-      Pointee: 702 StructureType net.dialResult·1
+      Pointee: 714 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2359776
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType net.netFD
+      Pointee: 958 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 326
+      ID: 338
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 908288
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType net.notFoundError
+      Pointee: 339 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1006
+      ID: 154
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1431232
       GoKind: 22
-      Pointee: 1007 StructureType net.onlyValuesCtx
+      Pointee: 155 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 328
+      ID: 340
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908960
       GoKind: 22
-      Pointee: 329 StructureType net.result·2
+      Pointee: 341 StructureType net.result·2
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2293728
       GoKind: 22
-      Pointee: 941 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 948 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2293248
       GoKind: 22
-      Pointee: 939 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 946 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 608
+      ID: 620
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1205440
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType net.temporaryError
+      Pointee: 621 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1431712
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType net.timeoutError
+      Pointee: 672 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 334
+      ID: 346
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 911552
       GoKind: 22
-      Pointee: 335 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 347 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 537
+      ID: 549
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1041664
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 550 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -1929,559 +1929,559 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1751392
       GoKind: 22
-      Pointee: 853 StructureType net/http.Response
+      Pointee: 860 StructureType net/http.Response
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1828864
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType net/http.body
+      Pointee: 925 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1208000
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 896 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1041536
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 876 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1931808
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType net/http.conn
+      Pointee: 827 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1040256
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 866 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1043840
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 880 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 336
+      ID: 348
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 254 BaseType net/http.http2ConnectionError
+      Pointee: 266 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 911840
       GoKind: 22
-      Pointee: 338 StructureType net/http.http2GoAwayError
+      Pointee: 350 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1432672
       GoKind: 22
-      Pointee: 662 StructureType net/http.http2StreamError
+      Pointee: 674 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2045920
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 910 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 343
+      ID: 355
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 912896
       GoKind: 22
-      Pointee: 344 StructureType net/http.http2connError
+      Pointee: 356 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 912320
       GoKind: 22
-      Pointee: 258 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 270 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 260
+      ID: 272
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 259 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 271 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 912416
       GoKind: 22
-      Pointee: 342 StructureType net/http.http2goAwayFlowError
+      Pointee: 354 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1041280
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 874 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 913088
       GoKind: 22
-      Pointee: 264 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 276 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 266
+      ID: 278
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 265 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 277 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 912992
       GoKind: 22
-      Pointee: 261 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 273 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 263
+      ID: 275
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 274 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 612
+      ID: 624
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1209408
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 625 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1041024
       GoKind: 22
-      Pointee: 863 StructureType net/http.http2missingBody
+      Pointee: 870 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1044096
       GoKind: 22
-      Pointee: 875 StructureType net/http.http2noBodyReader
+      Pointee: 882 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 543
+      ID: 555
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1043968
       GoKind: 22
-      Pointee: 544 StructureType net/http.http2noCachedConnError
+      Pointee: 556 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 339
+      ID: 351
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 912224
       GoKind: 22
-      Pointee: 255 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 267 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 257
+      ID: 269
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 256 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 268 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1042176
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 878 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2045344
       GoKind: 22
-      Pointee: 770 StructureType net/http.http2responseWriter
+      Pointee: 777 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1639712
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 825 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1041152
       GoKind: 22
-      Pointee: 865 StructureType net/http.http2transportResponseBody
+      Pointee: 872 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1040512
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 868 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1208256
       GoKind: 22
-      Pointee: 893 StructureType net/http.noBody
+      Pointee: 900 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1043584
       GoKind: 22
-      Pointee: 540 StructureType net/http.nothingWrittenError
+      Pointee: 552 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1637792
       GoKind: 22
-      Pointee: 855 StructureType net/http.pattern
+      Pointee: 862 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1039872
       GoKind: 22
-      Pointee: 857 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 864 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1208128
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 898 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 913280
       GoKind: 22
-      Pointee: 348 StructureType net/http.requestBodyReadError
+      Pointee: 360 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2254144
       GoKind: 22
-      Pointee: 772 StructureType net/http.response
+      Pointee: 779 StructureType net/http.response
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393504
       GoKind: 22
-      Pointee: 1002 StructureType net/http.segment
+      Pointee: 1009 StructureType net/http.segment
     - __kind: PointerType
-      ID: 332
+      ID: 344
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 911456
       GoKind: 22
-      Pointee: 333 StructureType net/http.statusError
+      Pointee: 345 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 663
+      ID: 675
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1434112
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 676 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1209280
       GoKind: 22
-      Pointee: 611 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 623 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 541
+      ID: 553
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1043712
       GoKind: 22
-      Pointee: 542 StructureType net/http.transportReadFromServerError
+      Pointee: 554 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1867040
       GoKind: 22
-      Pointee: 924 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 931 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 330
+      ID: 342
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 331 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 343 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1103488
       GoKind: 22
-      Pointee: 885 StructureType net/http/httputil.failureToReadBody
+      Pointee: 892 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 361 StructureType net/netip.parseAddrError
+      Pointee: 373 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 917984
       GoKind: 22
-      Pointee: 359 StructureType net/netip.parsePrefixError
+      Pointee: 371 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 373
+      ID: 385
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 921344
       GoKind: 22
-      Pointee: 374 UnresolvedPointeeType net/textproto.Error
+      Pointee: 386 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 921248
       GoKind: 22
-      Pointee: 278 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 290 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 280
+      ID: 292
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 279 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 291 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 668
+      ID: 680
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1438752
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType net/url.Error
+      Pointee: 681 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 920192
       GoKind: 22
-      Pointee: 272 GoStringHeaderType net/url.EscapeError
+      Pointee: 284 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 274
+      ID: 286
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 273 GoStringDataType net/url.EscapeError.str
+      Pointee: 285 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 275 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 287 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 277
+      ID: 289
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 276 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 288 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2160480
       GoKind: 22
-      Pointee: 844 StructureType net/url.URL
+      Pointee: 851 StructureType net/url.URL
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1222208
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 972 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 190
+      ID: 233
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 234 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 818 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 246
+      ID: 249
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 250 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 975 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 982 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 838 StructureType noalg.map.group[string][]string
+      Pointee: 845 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 224
+      ID: 213
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[string]float64
+      Pointee: 214 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 709
+      ID: 721
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 722 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 216
+      ID: 205
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[string]interface {}
+      Pointee: 206 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 208
+      ID: 197
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[string]string
+      Pointee: 198 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2401088
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType os.File
+      Pointee: 964 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 545
+      ID: 557
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1045888
       GoKind: 22
-      Pointee: 546 UnresolvedPointeeType os.LinkError
+      Pointee: 558 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 150
+      ID: 171
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 396320
       GoKind: 22
-      Pointee: 151 GoInterfaceType os.Signal
+      Pointee: 172 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1209920
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType os.SyscallError
+      Pointee: 627 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2396672
       GoKind: 22
-      Pointee: 955 StructureType os.fileWithoutReadFrom
+      Pointee: 962 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2395936
       GoKind: 22
-      Pointee: 953 StructureType os.fileWithoutWriteTo
+      Pointee: 960 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 576
+      ID: 588
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1067776
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType os/exec.Error
+      Pointee: 589 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 705
+      ID: 717
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2133152
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 718 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1067904
       GoKind: 22
-      Pointee: 579 StructureType os/exec.wrappedError
+      Pointee: 591 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 127
+      ID: 167
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1642400
       GoKind: 22
-      Pointee: 128 StructureType os/signal.signalCtx
+      Pointee: 168 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 951104
       GoKind: 22
-      Pointee: 306 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 318 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 319 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 503
+      ID: 515
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 951008
       GoKind: 22
-      Pointee: 305 BaseType os/user.UnknownUserIdError
+      Pointee: 317 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 916448
       GoKind: 22
-      Pointee: 357 UnresolvedPointeeType reflect.ValueError
+      Pointee: 369 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 450
+      ID: 462
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 936512
       GoKind: 22
-      Pointee: 451 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 463 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 553
+      ID: 565
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1050496
       GoKind: 22
-      Pointee: 554 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 566 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 557
+      ID: 569
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1052288
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 570 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2497,12 +2497,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 555
+      ID: 567
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1050624
       GoKind: 22
-      Pointee: 556 StructureType runtime.boundsError
+      Pointee: 568 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -2518,24 +2518,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 616
+      ID: 628
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1218112
       GoKind: 22
-      Pointee: 617 StructureType runtime.errorAddressString
+      Pointee: 629 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 551
+      ID: 563
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1050112
       GoKind: 22
-      Pointee: 522 GoStringHeaderType runtime.errorString
+      Pointee: 534 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 523 GoStringDataType runtime.errorString.str
+      Pointee: 535 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2551,17 +2551,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 552
+      ID: 564
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1050240
       GoKind: 22
-      Pointee: 525 GoStringHeaderType runtime.plainError
+      Pointee: 537 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 526 GoStringDataType runtime.plainError.str
+      Pointee: 538 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2591,12 +2591,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1049728
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType strconv.NumError
+      Pointee: 562 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -2605,235 +2605,235 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 183
+      ID: 190
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 182 GoStringDataType string.str
+      Pointee: 189 GoStringDataType string.str
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1716704
       GoKind: 22
-      Pointee: 739 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 746 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1774624
       GoKind: 22
-      Pointee: 753 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 760 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1716320
       GoKind: 22
-      Pointee: 735 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 742 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1773856
       GoKind: 22
-      Pointee: 745 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 752 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1845888
       GoKind: 22
-      Pointee: 759 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 766 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1774048
       GoKind: 22
-      Pointee: 747 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 754 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 742
+      ID: 749
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1773664
       GoKind: 22
-      Pointee: 743 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 750 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1845440
       GoKind: 22
-      Pointee: 755 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 762 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1918112
       GoKind: 22
-      Pointee: 763 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 770 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1845664
       GoKind: 22
-      Pointee: 757 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 764 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 740
+      ID: 747
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1716896
       GoKind: 22
-      Pointee: 741 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 748 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 736
+      ID: 743
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1716512
       GoKind: 22
-      Pointee: 737 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 744 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1774240
       GoKind: 22
-      Pointee: 749 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 756 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1846112
       GoKind: 22
-      Pointee: 761 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 768 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1774432
       GoKind: 22
-      Pointee: 751 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 758 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1110624
       GoKind: 22
-      Pointee: 887 StructureType struct { io.Reader; io.Closer }
+      Pointee: 894 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1437632
       GoKind: 22
-      Pointee: 654 BaseType syscall.Errno
+      Pointee: 666 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1052800
       GoKind: 22
-      Pointee: 727 BaseType syscall.Signal
+      Pointee: 734 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 140
+      ID: 181
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 188 StructureType table<context.canceler,struct {}>
+      Pointee: 231 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 808 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 815 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 236
+      ID: 225
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 244 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 247 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 972 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 979 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 830
+      ID: 837
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 835 StructureType table<string,[]string>
+      Pointee: 842 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 170
+      ID: 137
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 222 StructureType table<string,float64>
+      Pointee: 211 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 681
+      ID: 693
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 707 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 719 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 165
+      ID: 132
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 214 StructureType table<string,interface {}>
+      Pointee: 203 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 160
+      ID: 127
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 206 StructureType table<string,string>
+      Pointee: 195 StructureType table<string,string>
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1106688
       GoKind: 22
-      Pointee: 597 StructureType text/template.ExecError
+      Pointee: 609 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 145
+      ID: 187
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1642784
       GoKind: 22
-      Pointee: 146 StructureType time.Location
+      Pointee: 188 StructureType time.Location
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 914144
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType time.ParseError
+      Pointee: 363 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 142
+      ID: 184
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1046400
       GoKind: 22
-      Pointee: 143 StructureType time.Timer
+      Pointee: 185 StructureType time.Timer
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 914048
       GoKind: 22
-      Pointee: 267 GoStringHeaderType time.fileSizeError
+      Pointee: 279 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 269
+      ID: 281
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType time.fileSizeError.str
+      Pointee: 280 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 199
+      ID: 242
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 200 StructureType time.zone
+      Pointee: 243 StructureType time.zone
     - __kind: PointerType
-      ID: 202
+      ID: 245
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396704
       GoKind: 22
-      Pointee: 203 StructureType time.zoneTrans
+      Pointee: 246 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -2877,47 +2877,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 362
+      ID: 374
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 363 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 375 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 375
+      ID: 387
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 921536
       GoKind: 22
-      Pointee: 376 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 388 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 377
+      ID: 389
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 921632
       GoKind: 22
-      Pointee: 281 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 293 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1057664
       GoKind: 22
-      Pointee: 563 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 575 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1057792
       GoKind: 22
-      Pointee: 529 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 541 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 851
+      ID: 858
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
     - __kind: GoChannelType
-      ID: 721
+      ID: 733
       Name: <-chan time.Time
       GoRuntimeType: 606688
       GoKind: 18
@@ -3003,7 +3003,7 @@ Types:
       HasCount: true
       Element: 92 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 832
+      ID: 839
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 690880
@@ -3012,7 +3012,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 831
+      ID: 838
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 690784
@@ -3084,7 +3084,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 833
+      ID: 840
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 690976
@@ -3102,7 +3102,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 689
+      ID: 701
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 709056
@@ -3129,7 +3129,7 @@ Types:
       HasCount: true
       Element: 85 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 986
+      ID: 993
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -3137,22 +3137,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 987 PointerType **crypto/x509.Certificate
+          Type: 994 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 994 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1001 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 994
+      ID: 1001
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 675 PointerType *crypto/x509.Certificate
+      Element: 687 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 722
+      ID: 261
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491968
@@ -3160,22 +3160,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 723 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 262 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 725 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 264 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 725
+      ID: 264
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 978
+      ID: 985
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 489088
@@ -3183,76 +3183,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 979 PointerType **mime/multipart.FileHeader
+          Type: 986 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 984 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 991 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 984
+      ID: 991
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 980 PointerType *mime/multipart.FileHeader
+      Element: 987 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 239
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 140 PointerType *table<context.canceler,struct {}>
+      Element: 181 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 815
+      ID: 822
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 789 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 796 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 255
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 236 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 225 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 981
+      ID: 988
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 971 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 978 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 841
+      ID: 848
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 830 PointerType *table<string,[]string>
+      Element: 837 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 217
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 170 PointerType *table<string,float64>
+      Element: 137 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 713
+      ID: 725
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 693 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 209
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 165 PointerType *table<string,interface {}>
+      Element: 132 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 201
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 160 PointerType *table<string,string>
+      Element: 127 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 988
+      ID: 995
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503936
@@ -3260,22 +3260,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 989 PointerType *[]*crypto/x509.Certificate
+          Type: 996 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 996 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1003 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 996
+      ID: 1003
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 986 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 993 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 990
+      ID: 997
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483936
@@ -3283,22 +3283,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 991 PointerType *[]uint8
+          Type: 998 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 998 GoSliceDataType [][]uint8.array
+      Data: 1005 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 998
+      ID: 1005
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 694
+      ID: 706
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 497920
@@ -3313,15 +3313,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 717 GoSliceDataType []float64.array
+      Data: 729 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 717
+      ID: 729
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 20 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 138
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 491520
@@ -3329,22 +3329,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 139 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 230 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 219 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 219
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 140 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 141
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 491712
@@ -3352,22 +3352,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 175 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 142 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 227 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 227
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 176 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 143 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1000
+      ID: 1007
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486528
@@ -3375,76 +3375,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1001 PointerType *net/http.segment
+          Type: 1008 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1003 GoSliceDataType []net/http.segment.array
+      Data: 1010 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1003
+      ID: 1010
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1002 StructureType net/http.segment
+      Element: 1009 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 240
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 191 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 234 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 816
+      ID: 823
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 818 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 256
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 250 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 982
+      ID: 989
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 975 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 982 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 842
+      ID: 849
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 838 StructureType noalg.map.group[string][]string
+      Element: 845 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 218
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 225 StructureType noalg.map.group[string]float64
+      Element: 214 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 726
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 722 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 210
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 217 StructureType noalg.map.group[string]interface {}
+      Element: 206 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 202
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 209 StructureType noalg.map.group[string]string
+      Element: 198 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 170
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 483680
@@ -3452,26 +3452,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *os.Signal
+          Type: 171 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 204 GoSliceDataType []os.Signal.array
+      Data: 229 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 229
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 151 GoInterfaceType os.Signal
+      Element: 172 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 693
+      ID: 705
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498176
@@ -3486,15 +3486,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 715 GoSliceDataType []string.array
+      Data: 727 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 715
+      ID: 727
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 198
+      ID: 241
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 491072
@@ -3502,22 +3502,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 199 PointerType *time.zone
+          Type: 242 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 240 GoSliceDataType []time.zone.array
+      Data: 257 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 257
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 200 StructureType time.zone
+      Element: 243 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 201
+      ID: 244
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491136
@@ -3525,20 +3525,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 202 PointerType *time.zoneTrans
+          Type: 245 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 242 GoSliceDataType []time.zoneTrans.array
+      Data: 259 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 259
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 203 StructureType time.zoneTrans
+      Element: 246 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3555,9 +3555,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []uint8.array
+      Data: 191 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 191
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3578,15 +3578,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType []uintptr.array
+      Data: 193 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 193
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 496
+      ID: 508
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 946016
@@ -3601,27 +3601,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 497 GoSliceDataType archive/tar.headerError.array
+      Data: 509 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 509
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 899
+      ID: 906
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 890
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 908
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 888
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3631,7 +3631,7 @@ Types:
       GoRuntimeType: 591392
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3639,12 +3639,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 834
+      ID: 841
       Name: chan bool
       GoRuntimeType: 602848
       GoKind: 18
     - __kind: GoChannelType
-      ID: 152
+      ID: 173
       Name: chan os.Signal
       GoRuntimeType: 609504
       GoKind: 18
@@ -3661,13 +3661,13 @@ Types:
       GoRuntimeType: 591136
       GoKind: 15
     - __kind: BaseType
-      ID: 297
+      ID: 309
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 846720
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 298
+      ID: 310
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 846816
@@ -3675,26 +3675,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 300 PointerType *compress/flate.InternalError.str
+          Type: 312 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 299 GoStringDataType compress/flate.InternalError.str
+      Data: 311 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 299
+      ID: 311
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 940
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 919
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 148
+      ID: 169
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 685216
@@ -3713,19 +3713,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 129
+      ID: 164
       Name: context.backgroundCtx
       GoRuntimeType: 1827296
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 130 StructureType context.emptyCtx
+          Type: 150 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 118
+      ID: 175
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 2001408
@@ -3736,13 +3736,13 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 131 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 134 StructureType sync/atomic.Value
+          Type: 176 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 136 GoMapType map[context.canceler]struct {}
+          Type: 177 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 15 GoInterfaceType error
@@ -3752,7 +3752,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 194
+      ID: 237
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1127872
@@ -3765,13 +3765,13 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 602
+      ID: 614
       Name: context.deadlineExceededError
       GoRuntimeType: 1481312
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 150
       Name: context.emptyCtx
       GoRuntimeType: 1618752
       GoKind: 25
@@ -3780,7 +3780,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 120
+      ID: 152
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1853312
@@ -3791,11 +3791,11 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 141 GoSubroutineType func() bool
+          Type: 153 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 183
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1635872
@@ -3803,29 +3803,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 118 StructureType context.cancelCtx
+          Type: 175 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 142 PointerType *time.Timer
+          Type: 184 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 144 GoTimeType time.Time
+          Type: 186 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 147
+      ID: 166
       Name: context.todoCtx
       GoRuntimeType: 1827520
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 130 StructureType context.emptyCtx
+          Type: 150 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 159
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1863904
@@ -3836,14 +3836,14 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 160 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 160 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 126
+      ID: 162
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1827072
@@ -3855,45 +3855,45 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 293
+      ID: 305
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846336
       GoKind: 2
     - __kind: BaseType
-      ID: 294
+      ID: 306
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846432
       GoKind: 2
     - __kind: BaseType
-      ID: 295
+      ID: 307
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846528
       GoKind: 2
     - __kind: BaseType
-      ID: 296
+      ID: 308
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846624
       GoKind: 2
     - __kind: BaseType
-      ID: 270
+      ID: 282
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 844128
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 573
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 970
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 857
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2302368
@@ -3922,13 +3922,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 986 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 993 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 988 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 995 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 990 GoSliceHeaderType [][]uint8
+          Type: 997 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -3940,25 +3940,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 992 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 999 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 993 BaseType crypto/tls.CurveID
+          Type: 1000 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 993
+      ID: 1000
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843936
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 367
+      ID: 379
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 365
+      ID: 377
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1755616
@@ -3969,26 +3969,26 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 689 ArrayType [5]uint8
+          Type: 701 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 690 GoInterfaceType net.Conn
+          Type: 702 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 528
+      ID: 540
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1004896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 679
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 688
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 426
+      ID: 438
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1757728
@@ -3996,21 +3996,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 687 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 699 BaseType crypto/x509.InvalidReason
+          Type: 711 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 420
+      ID: 432
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1134656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 422
+      ID: 434
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1620832
@@ -4018,24 +4018,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 687 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 292
+      ID: 304
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 846144
       GoKind: 2
     - __kind: BaseType
-      ID: 699
+      ID: 711
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 594528
       GoKind: 2
     - __kind: StructureType
-      ID: 575
+      ID: 587
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1580992
@@ -4045,13 +4045,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 428
+      ID: 440
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1134912
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 424
+      ID: 436
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1757536
@@ -4059,15 +4059,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 687 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 687 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 488
+      ID: 500
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1452512
@@ -4077,7 +4077,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 492
+      ID: 504
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1452672
@@ -4087,47 +4087,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 490
+      ID: 502
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 271
+      ID: 283
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 844224
       GoKind: 6
     - __kind: BaseType
-      ID: 291
+      ID: 303
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 845952
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 399
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 585
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 391
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 397
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 383
+      ID: 395
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 381
+      ID: 393
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 389
+      ID: 401
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1441792
@@ -4137,15 +4137,15 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 483
+      ID: 495
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 481
+      ID: 493
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 302
+      ID: 314
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 848256
@@ -4153,18 +4153,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 304 PointerType *encoding/xml.UnmarshalError.str
+          Type: 316 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 303 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 315 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 303
+      ID: 315
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 498
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4181,11 +4181,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 353
+      ID: 365
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 560
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4201,11 +4201,11 @@ Types:
       GoRuntimeType: 591328
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 544
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 546
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4215,13 +4215,13 @@ Types:
       GoRuntimeType: 482080
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 845
+      ID: 852
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701280
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 141
+      ID: 153
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 601504
@@ -4233,23 +4233,23 @@ Types:
       GoRuntimeType: 863936
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 992
+      ID: 999
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1020736
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 410
+      ID: 422
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 791
+      ID: 798
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2091936
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 392
+      ID: 404
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1756576
@@ -4257,7 +4257,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 691 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 703 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4265,25 +4265,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 394
+      ID: 406
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 708
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 398
+      ID: 410
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1133376
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 710
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 285
+      ID: 297
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 845280
@@ -4291,18 +4291,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 287 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 299 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 286 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 298 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 286
+      ID: 298
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 691
+      ID: 703
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2264000
@@ -4310,13 +4310,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 692 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 704 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4325,7 +4325,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 694 GoSliceHeaderType []float64
+          Type: 706 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4334,13 +4334,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 695 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 707 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 697 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 709 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4351,13 +4351,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 692
+      ID: 704
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 593056
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 282
+      ID: 294
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 845184
@@ -4365,18 +4365,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 284 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 296 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 283 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 283
+      ID: 295
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 300
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 845376
@@ -4384,22 +4384,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 302 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 301 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 301
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 438
+      ID: 450
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
       GoRuntimeType: 1854208
       GoKind: 25
@@ -4413,7 +4413,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 153 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -4434,13 +4434,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 161 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 128 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 166 GoMapType map[string]float64
+          Type: 133 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -4455,10 +4455,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 171 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 138 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 174 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 141 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -4470,7 +4470,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 177 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -4493,7 +4493,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 178
+      ID: 145
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2261760
@@ -4504,13 +4504,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 179 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 146 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 154 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4519,16 +4519,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 181 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 148 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 153 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -4537,12 +4537,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 171 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 138 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 173
+      ID: 140
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1947136
@@ -4559,7 +4559,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4567,7 +4567,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 928
+      ID: 935
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 2001920
@@ -4575,29 +4575,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 919 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+          Type: 926 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 931 BaseType time.Duration
+          Type: 938 BaseType time.Duration
     - __kind: GoMapType
-      ID: 161
+      ID: 128
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1299968
       GoKind: 21
-      HeaderType: 163 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 724
+      ID: 263
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 590176
       GoKind: 10
     - __kind: StructureType
-      ID: 176
+      ID: 143
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1781696
@@ -4611,16 +4611,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 232 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 221 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 237 GoMapType map[string]interface {}
+          Type: 226 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 731
+      ID: 738
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 251
+      ID: 254
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1947392
@@ -4628,7 +4628,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 729 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 736 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4643,15 +4643,15 @@ Types:
           Type: 20 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 730 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 737 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 729
+      ID: 736
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1002400
       GoKind: 5
     - __kind: StructureType
-      ID: 180
+      ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2148896
@@ -4659,16 +4659,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 153 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 722 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 261 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -4683,12 +4683,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 724 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 263 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 181
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914912
@@ -4697,15 +4697,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 804
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 655
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 764
+      ID: 771
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1440512
@@ -4718,7 +4718,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 733
+      ID: 740
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1620352
@@ -4731,11 +4731,11 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1009
+    - __kind: GoContextImplementationType
+      ID: 157
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1658528
@@ -4744,38 +4744,40 @@ Types:
         - Name: Context
           Offset: 0
           Type: 116 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 802
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 440
+      ID: 452
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 447
+      ID: 459
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1136576
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 301
+      ID: 313
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 2
     - __kind: StructureType
-      ID: 445
+      ID: 457
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1136448
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 443
+      ID: 455
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1621632
@@ -4788,7 +4790,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 455
+      ID: 467
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1622272
@@ -4801,7 +4803,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 459
+      ID: 471
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1759264
@@ -4817,7 +4819,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 457
+      ID: 469
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1451072
@@ -4827,7 +4829,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 453
+      ID: 465
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1450752
@@ -4837,14 +4839,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 677
+      ID: 689
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1523392
       GoKind: 21
-      HeaderType: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 691 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 700
+      ID: 712
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1070976
@@ -4859,15 +4861,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 731 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 719
+      ID: 731
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 467
+      ID: 479
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1622592
@@ -4875,12 +4877,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 689 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 689 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 461
+      ID: 473
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1451232
@@ -4890,7 +4892,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 465
+      ID: 477
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1759456
@@ -4901,12 +4903,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 712 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 712 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 463
+      ID: 475
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1622432
@@ -4919,7 +4921,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 469
+      ID: 481
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1451392
@@ -4927,9 +4929,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 144 GoTimeType time.Time
+          Type: 186 GoTimeType time.Time
     - __kind: StructureType
-      ID: 475
+      ID: 487
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1622912
@@ -4942,7 +4944,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 477
+      ID: 489
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1451712
@@ -4952,7 +4954,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 473
+      ID: 485
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1622752
@@ -4965,7 +4967,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 471
+      ID: 483
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1451552
@@ -4975,7 +4977,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 479
+      ID: 491
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1623072
@@ -4988,29 +4990,29 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 814
+      ID: 821
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 845664
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 814
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 400
+      ID: 412
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1443072
@@ -5020,11 +5022,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 791
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 402
+      ID: 414
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1443232
@@ -5032,17 +5034,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 400 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 774
+      ID: 781
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 783
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1855552
@@ -5050,12 +5052,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 775 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 782 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 785 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 792 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 406
+      ID: 418
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1443552
@@ -5063,9 +5065,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 400 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1832224
@@ -5073,13 +5075,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 775 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 782 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 806
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 404
+      ID: 416
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1443392
@@ -5087,9 +5089,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 400 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 408
+      ID: 420
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1443712
@@ -5097,9 +5099,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 400 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 913
+      ID: 920
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1136832
@@ -5112,7 +5114,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1674656
@@ -5120,48 +5122,48 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 913 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 920 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 923
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 683
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 599
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 597
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 601
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 603
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 593
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 413
+      ID: 425
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1444672
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 657
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 631
+      ID: 643
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1878240
@@ -5177,11 +5179,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 637
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 567
+      ID: 579
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1729280
@@ -5194,7 +5196,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 637
+      ID: 649
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1878688
@@ -5210,13 +5212,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 530
+      ID: 542
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1005568
       GoKind: 8
     - __kind: StructureType
-      ID: 629
+      ID: 641
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1878016
@@ -5232,13 +5234,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 703
+      ID: 715
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 844800
       GoKind: 8
     - __kind: StructureType
-      ID: 627
+      ID: 639
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1877792
@@ -5246,15 +5248,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 715 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 715 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 635
+      ID: 647
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1789952
@@ -5267,7 +5269,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 633
+      ID: 645
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1878464
@@ -5283,7 +5285,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 641
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1657568
@@ -5293,19 +5295,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 571
+      ID: 583
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1301376
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 569
+      ID: 581
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1301248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 639
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1790144
@@ -5318,7 +5320,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 309
+      ID: 321
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 850176
@@ -5326,22 +5328,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 311 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 323 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 310 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 322 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 310
+      ID: 322
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 696
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 595
+      ID: 607
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1466912
@@ -5351,19 +5353,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 312
+      ID: 324
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 850752
       GoKind: 10
     - __kind: BaseType
-      ID: 682
+      ID: 694
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1017760
       GoKind: 10
     - __kind: StructureType
-      ID: 653
+      ID: 665
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1912512
@@ -5374,12 +5376,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 682 BaseType golang.org/x/net/http2.ErrCode
+          Type: 694 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 514
+      ID: 526
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1629792
@@ -5387,12 +5389,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 682 BaseType golang.org/x/net/http2.ErrCode
+          Type: 694 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 328
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850944
@@ -5400,18 +5402,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 330 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 329 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 329
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 334
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 851136
@@ -5419,18 +5421,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 336 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 323 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 335 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 335
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 331
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 851040
@@ -5438,18 +5440,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 333 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 320 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 332 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 332
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 325
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850848
@@ -5457,18 +5459,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 327 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 314 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 326 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 326
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 518
+      ID: 530
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1467552
@@ -5478,13 +5480,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 325
+      ID: 337
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 851232
       GoKind: 2
     - __kind: StructureType
-      ID: 506
+      ID: 518
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1462592
@@ -5494,11 +5496,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 663
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 673
+      ID: 685
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1941792
@@ -5514,7 +5516,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 508
+      ID: 520
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1629312
@@ -5527,11 +5529,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 593
+      ID: 605
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1588672
@@ -5541,29 +5543,29 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 913
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 494
+      ID: 506
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 595
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 661
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 647
+      ID: 659
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1532992
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 500
+      ID: 512
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1455872
@@ -5573,7 +5575,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 502
+      ID: 514
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1456032
@@ -5583,137 +5585,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 449
+      ID: 461
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 232
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 233 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 197 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 234 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 240 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 809
+      ID: 816
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 810 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 817 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 816 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 818 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 823 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 245
+      ID: 248
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 246 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 249 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 250 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 256 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 973
+      ID: 980
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 974 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 981 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 975 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 982 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 982 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 989 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 836
+      ID: 843
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 837 PointerType *noalg.map.group[string][]string
+          Type: 844 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 838 StructureType noalg.map.group[string][]string
-      GroupSliceType: 842 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 845 StructureType noalg.map.group[string][]string
+      GroupSliceType: 849 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 212
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[string]float64
+          Type: 213 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[string]float64
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 214 StructureType noalg.map.group[string]float64
+      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 708
+      ID: 720
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 709 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 721 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 714 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 722 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 726 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 204
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[string]interface {}
+          Type: 205 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 206 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 210 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 196
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[string]string
+          Type: 197 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 198 StructureType noalg.map.group[string]string
+      GroupSliceType: 202 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 521
+      ID: 533
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5747,7 +5749,7 @@ Types:
       GoRuntimeType: 590432
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 135
+      ID: 160
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863648
@@ -5760,7 +5762,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 417
+      ID: 429
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5786,25 +5788,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 415
+      ID: 427
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 635
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 968
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 621
+      ID: 633
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1498592
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 355
+      ID: 367
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5885,7 +5887,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 133
+      ID: 120
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1512992
@@ -5898,7 +5900,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 914
+      ID: 921
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1048448
@@ -5911,11 +5913,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 933
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 821
+      ID: 828
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1130304
@@ -5928,7 +5930,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 904
+      ID: 911
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1047808
@@ -5941,11 +5943,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 937
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 884
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1574272
@@ -5953,9 +5955,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 904 GoInterfaceType io.Reader
+          Type: 911 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1643936
@@ -5963,13 +5965,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 904 GoInterfaceType io.Reader
+          Type: 911 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 631
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 179
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -5982,7 +5984,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<context.canceler,struct {}>
+          Type: 180 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5998,10 +6000,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 196 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 191 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 239 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 234 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 787
+      ID: 794
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6014,7 +6016,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 788 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 795 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6030,10 +6032,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 815 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 822 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 818 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 234
+      ID: 223
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6046,7 +6048,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 235 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 224 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6062,10 +6064,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 255 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 250 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 969
+      ID: 976
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6078,7 +6080,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 970 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 977 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6094,10 +6096,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 981 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 975 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 988 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 982 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 828
+      ID: 835
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6110,7 +6112,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 829 PointerType **table<string,[]string>
+          Type: 836 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6126,10 +6128,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 841 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 838 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 848 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 845 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 168
+      ID: 135
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6142,7 +6144,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 169 PointerType **table<string,float64>
+          Type: 136 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6158,10 +6160,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<string,float64>.array
-      GroupType: 225 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 217 GoSliceDataType []*table<string,float64>.array
+      GroupType: 214 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 679
+      ID: 691
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6174,7 +6176,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 680 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 692 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6190,10 +6192,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 713 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 725 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 722 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 163
+      ID: 130
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6206,7 +6208,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 164 PointerType **table<string,interface {}>
+          Type: 131 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6222,10 +6224,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 217 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 209 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 206 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 158
+      ID: 125
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6238,7 +6240,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 159 PointerType **table<string,string>
+          Type: 126 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6254,66 +6256,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 209 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 201 GoSliceDataType []*table<string,string>.array
+      GroupType: 198 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 136
+      ID: 177
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1147328
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 179 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 785
+      ID: 792
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1165248
       GoKind: 21
-      HeaderType: 787 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 794 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 232
+      ID: 221
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1153728
       GoKind: 21
-      HeaderType: 234 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 223 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 967
+      ID: 974
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1152960
       GoKind: 21
-      HeaderType: 969 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 976 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 966
+      ID: 973
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1148352
       GoKind: 21
-      HeaderType: 828 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 835 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 166
+      ID: 133
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1153600
       GoKind: 21
-      HeaderType: 168 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 135 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 237
+      ID: 226
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1146944
       GoKind: 21
-      HeaderType: 163 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 156
+      ID: 123
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1149376
       GoKind: 21
-      HeaderType: 158 GoSwissMapHeaderType map<string,string>
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 436
+      ID: 448
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1447872
@@ -6323,11 +6325,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 990
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 848
+      ID: 855
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1501472
@@ -6335,16 +6337,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 966 GoMapType map[string][]string
+          Type: 973 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 967 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 974 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1950720
@@ -6352,16 +6354,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 929 PointerType *io.SectionReader
+          Type: 936 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 914 GoInterfaceType io.Closer
+          Type: 921 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 617
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 690
+      ID: 702
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1618912
@@ -6374,35 +6376,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 670
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 668
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 607
+      ID: 619
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 950
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 598
+      ID: 610
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1128128
@@ -6410,28 +6412,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 600 PointerType *net.UnknownNetworkError.str
+          Type: 612 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 599 GoStringDataType net.UnknownNetworkError.str
+      Data: 611 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 599
+      ID: 611
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 536
+      ID: 548
       Name: net.canceledError
       GoRuntimeType: 1298944
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 942
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 714
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2147840
@@ -6439,7 +6441,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 690 GoInterfaceType net.Conn
+          Type: 702 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -6450,27 +6452,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 947
+      ID: 954
       Name: net.noReadFrom
       GoRuntimeType: 1128384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 946
+      ID: 953
       Name: net.noWriteTo
       GoRuntimeType: 1128256
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 339
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1007
+    - __kind: GoContextImplementationType
+      ID: 155
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1775936
@@ -6482,8 +6484,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 116 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 329
+      ID: 341
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1750816
@@ -6491,7 +6495,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 685 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 697 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6499,7 +6503,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 941
+      ID: 948
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2338368
@@ -6507,12 +6511,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 947 StructureType net.noReadFrom
+          Type: 954 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 944 PointerType *net.TCPConn
+          Type: 951 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 939
+      ID: 946
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2337824
@@ -6520,20 +6524,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 946 StructureType net.noWriteTo
+          Type: 953 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 944 PointerType *net.TCPConn
+          Type: 951 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 621
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 672
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 767
+      ID: 774
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1045760
@@ -6546,7 +6550,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 765
+      ID: 772
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1044352
@@ -6559,14 +6563,14 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 826
+      ID: 833
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2148192
       GoKind: 21
-      HeaderType: 828 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 835 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 768
+      ID: 775
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1044480
@@ -6579,15 +6583,15 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 335
+      ID: 347
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 550
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 766
+      ID: 773
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1044736
@@ -6611,7 +6615,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 843 PointerType *net/url.URL
+          Type: 850 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6623,19 +6627,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 821 GoInterfaceType io.ReadCloser
+          Type: 828 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 845 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 852 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6644,16 +6648,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 846 GoMapType net/url.Values
+          Type: 853 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 846 GoMapType net/url.Values
+          Type: 853 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 847 PointerType *mime/multipart.Form
+          Type: 854 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6662,13 +6666,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 849 PointerType *crypto/tls.ConnectionState
+          Type: 856 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 851 GoChannelType <-chan struct {}
+          Type: 858 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 852 PointerType *net/http.Response
+          Type: 859 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6677,15 +6681,15 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 854 PointerType *net/http.pattern
+          Type: 861 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2260416
@@ -6708,16 +6712,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 821 GoInterfaceType io.ReadCloser
+          Type: 828 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6726,13 +6730,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 110 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 849 PointerType *crypto/tls.ConnectionState
+          Type: 856 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 109
       Name: net/http.ResponseWriter
@@ -6747,19 +6751,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 896
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 876
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 832
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1777472
@@ -6767,10 +6771,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 771 PointerType *net/http.response
+          Type: 778 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6778,31 +6782,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 866
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 254
+      ID: 266
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 841728
       GoKind: 10
     - __kind: BaseType
-      ID: 674
+      ID: 686
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1002208
       GoKind: 10
     - __kind: StructureType
-      ID: 338
+      ID: 350
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1752544
@@ -6813,12 +6817,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 686 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 674
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1932064
@@ -6829,16 +6833,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 686 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 344
+      ID: 356
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1619392
@@ -6846,12 +6850,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 686 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 258
+      ID: 270
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841920
@@ -6859,28 +6863,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 260 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 272 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 259 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 271 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 259
+      ID: 271
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 342
+      ID: 354
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1129408
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 264
+      ID: 276
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 842112
@@ -6888,18 +6892,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 266 PointerType *net/http.http2headerFieldNameError.str
+          Type: 278 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 265 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 277 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 265
+      ID: 277
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 273
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 842016
@@ -6907,40 +6911,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *net/http.http2headerFieldValueError.str
+          Type: 275 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 262 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 274 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 274
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 625
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 863
+      ID: 870
       Name: net/http.http2missingBody
       GoRuntimeType: 1299200
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1299712
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 544
+      ID: 556
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1299584
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 255
+      ID: 267
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841824
@@ -6948,22 +6952,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 257 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 269 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 256 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 268 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 256
+      ID: 268
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 878
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 770
+      ID: 777
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1207360
@@ -6971,13 +6975,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 817 PointerType *net/http.http2responseWriterState
+          Type: 824 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 865
+      ID: 872
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1571552
@@ -6985,19 +6989,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 902 PointerType *net/http.http2clientStream
+          Type: 909 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 868
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: net/http.noBody
       GoRuntimeType: 1484352
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 540
+      ID: 552
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1572832
@@ -7007,7 +7011,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 855
+      ID: 862
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1866368
@@ -7024,20 +7028,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1000 GoSliceHeaderType []net/http.segment
+          Type: 1007 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 857
+      ID: 864
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 898
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 348
+      ID: 360
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1434912
@@ -7047,7 +7051,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 772
+      ID: 779
       Name: net/http.response
       ByteSize: 224
       GoRuntimeType: 2398880
@@ -7055,16 +7059,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 819 PointerType *net/http.conn
+          Type: 826 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 110 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 821 GoInterfaceType io.ReadCloser
+          Type: 828 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 148 GoSubroutineType context.CancelFunc
+          Type: 169 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7076,19 +7080,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 131 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 822 StructureType sync/atomic.Bool
+          Type: 829 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 823 PointerType *bufio.Writer
+          Type: 830 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 825 StructureType net/http.chunkWriter
+          Type: 832 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7112,27 +7116,27 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 822 StructureType sync/atomic.Bool
+          Type: 829 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 831 ArrayType [29]uint8
+          Type: 838 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 832 ArrayType [10]uint8
+          Type: 839 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 833 ArrayType [3]uint8
+          Type: 840 ArrayType [3]uint8
         - Name: closeNotifyCh
           Offset: 208
-          Type: 834 GoChannelType chan bool
+          Type: 841 GoChannelType chan bool
         - Name: didCloseNotify
           Offset: 216
-          Type: 822 StructureType sync/atomic.Bool
+          Type: 829 StructureType sync/atomic.Bool
     - __kind: StructureType
-      ID: 1002
+      ID: 1009
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1637600
@@ -7148,7 +7152,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 333
+      ID: 345
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1619232
@@ -7161,17 +7165,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 676
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 611
+      ID: 623
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1485952
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 542
+      ID: 554
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1572992
@@ -7181,7 +7185,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 924
+      ID: 931
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2064608
@@ -7189,22 +7193,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 690 GoInterfaceType net.Conn
+          Type: 702 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 690 GoInterfaceType net.Conn
+          Type: 702 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 331
+      ID: 343
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1308416
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 361
+      ID: 373
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1755232
@@ -7220,7 +7224,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 359
+      ID: 371
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1619872
@@ -7233,11 +7237,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 374
+      ID: 386
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 278
+      ID: 290
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 844512
@@ -7245,22 +7249,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 280 PointerType *net/textproto.ProtocolError.str
+          Type: 292 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 279 GoStringDataType net/textproto.ProtocolError.str
+      Data: 291 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 279
+      ID: 291
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 681
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 272
+      ID: 284
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 844320
@@ -7268,18 +7272,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 274 PointerType *net/url.EscapeError.str
+          Type: 286 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 273 GoStringDataType net/url.EscapeError.str
+      Data: 285 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 273
+      ID: 285
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 275
+      ID: 287
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 844416
@@ -7287,18 +7291,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 277 PointerType *net/url.InvalidHostError.str
+          Type: 289 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 276 GoStringDataType net/url.InvalidHostError.str
+      Data: 288 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 276
+      ID: 288
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 844
+      ID: 851
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2173728
@@ -7312,7 +7316,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 964 PointerType *net/url.Userinfo
+          Type: 971 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7338,99 +7342,99 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 972
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 846
+      ID: 853
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1920800
       GoKind: 21
-      HeaderType: 828 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 835 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 192
+      ID: 235
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 692704
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 236 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 812
+      ID: 819
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 748000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 813 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 820 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 248
+      ID: 251
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 249 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 252 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 976
+      ID: 983
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 977 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 984 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 839
+      ID: 846
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 840 StructureType noalg.struct { key string; elem []string }
+      Element: 847 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 226
+      ID: 215
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key string; elem float64 }
+      Element: 216 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 711
+      ID: 723
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 771936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 712 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 724 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 218
+      ID: 207
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key string; elem interface {} }
+      Element: 208 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 210
+      ID: 199
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key string; elem string }
+      Element: 200 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 191
+      ID: 234
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1310720
@@ -7441,9 +7445,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 235 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 811
+      ID: 818
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1357696
@@ -7454,9 +7458,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 812 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 819 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 247
+      ID: 250
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1327872
@@ -7467,9 +7471,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 248 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 251 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 975
+      ID: 982
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1321600
@@ -7480,9 +7484,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 976 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 983 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 838
+      ID: 845
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1312128
@@ -7493,9 +7497,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 839 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 846 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 225
+      ID: 214
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1327616
@@ -7506,9 +7510,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 215 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 710
+      ID: 722
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1376640
@@ -7519,9 +7523,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 711 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 723 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 217
+      ID: 206
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1309568
@@ -7532,9 +7536,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 207 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 209
+      ID: 198
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1314432
@@ -7545,9 +7549,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 199 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 193
+      ID: 236
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1310592
@@ -7555,12 +7559,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 194 GoInterfaceType context.canceler
+          Type: 237 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 195 StructureType struct {}
+          Type: 238 StructureType struct {}
     - __kind: StructureType
-      ID: 813
+      ID: 820
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1357568
@@ -7568,12 +7572,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 814 BaseType github.com/cihub/seelog.LogLevel
+          Type: 821 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 249
+      ID: 252
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1327744
@@ -7584,9 +7588,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 250 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 253 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 977
+      ID: 984
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1321472
@@ -7597,9 +7601,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 978 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 985 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1312000
@@ -7610,9 +7614,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 227
+      ID: 216
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1327488
@@ -7625,7 +7629,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 712
+      ID: 724
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1376512
@@ -7636,9 +7640,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 712 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 219
+      ID: 208
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1309440
@@ -7649,9 +7653,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 160 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 211
+      ID: 200
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1314304
@@ -7664,15 +7668,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 964
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 546
+      ID: 558
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 172
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1130048
@@ -7685,11 +7689,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 627
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 955
+      ID: 962
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2409536
@@ -7697,12 +7701,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 959 StructureType os.noReadFrom
+          Type: 966 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 956 PointerType *os.File
+          Type: 963 PointerType *os.File
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2408736
@@ -7710,32 +7714,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 958 StructureType os.noWriteTo
+          Type: 965 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 956 PointerType *os.File
+          Type: 963 PointerType *os.File
     - __kind: StructureType
-      ID: 959
+      ID: 966
       Name: os.noReadFrom
       GoRuntimeType: 1129920
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 958
+      ID: 965
       Name: os.noWriteTo
       GoRuntimeType: 1129792
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 589
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 718
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 579
+      ID: 591
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1729664
@@ -7748,7 +7752,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 168
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 2001664
@@ -7759,17 +7763,17 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 148 GoSubroutineType context.CancelFunc
+          Type: 169 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 149 GoSliceHeaderType []os.Signal
+          Type: 170 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 152 GoChannelType chan os.Signal
+          Type: 173 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 318
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 849408
@@ -7777,36 +7781,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *os/user.UnknownGroupIdError.str
+          Type: 320 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 319 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 319
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 305
+      ID: 317
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 849312
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 357
+      ID: 369
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 451
+      ID: 463
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 554
+      ID: 566
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 570
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7818,7 +7822,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 556
+      ID: 568
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1920352
@@ -7835,9 +7839,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 704 BaseType runtime.boundsErrorCode
+          Type: 716 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 704
+      ID: 716
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 591520
@@ -7857,7 +7861,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 617
+      ID: 629
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1784768
@@ -7870,7 +7874,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 522
+      ID: 534
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1003456
@@ -7878,13 +7882,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 524 PointerType *runtime.errorString.str
+          Type: 536 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 523 GoStringDataType runtime.errorString.str
+      Data: 535 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 523
+      ID: 535
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8540,7 +8544,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 525
+      ID: 537
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1003552
@@ -8548,13 +8552,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 527 PointerType *runtime.plainError.str
+          Type: 539 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 526 GoStringDataType runtime.plainError.str
+      Data: 538 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 526
+      ID: 538
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8640,7 +8644,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 562
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8652,18 +8656,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 183 PointerType *string.str
+          Type: 190 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 182 GoStringDataType string.str
+      Data: 189 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 182
+      ID: 189
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 739
+      ID: 746
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1982976
@@ -8671,12 +8675,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 753
+      ID: 760
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2060320
@@ -8684,15 +8688,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 735
+      ID: 742
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1982464
@@ -8700,12 +8704,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 745
+      ID: 752
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2059168
@@ -8713,15 +8717,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2129376
@@ -8729,18 +8733,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 747
+      ID: 754
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2059456
@@ -8748,15 +8752,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 743
+      ID: 750
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2058880
@@ -8764,15 +8768,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 755
+      ID: 762
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2128736
@@ -8780,18 +8784,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 763
+      ID: 770
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2191008
@@ -8799,21 +8803,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 757
+      ID: 764
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2129056
@@ -8821,18 +8825,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 741
+      ID: 748
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1983232
@@ -8840,12 +8844,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 737
+      ID: 744
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1982720
@@ -8853,12 +8857,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 749
+      ID: 756
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2059744
@@ -8866,15 +8870,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2129696
@@ -8882,18 +8886,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 751
+      ID: 758
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2060032
@@ -8901,15 +8905,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 887
+      ID: 894
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1734656
@@ -8917,18 +8921,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 904 GoInterfaceType io.Reader
+          Type: 911 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 914 GoInterfaceType io.Closer
+          Type: 921 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 195
+      ID: 238
       Name: struct {}
       GoRuntimeType: 855072
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 131
+      ID: 118
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1489632
@@ -8936,12 +8940,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 119 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 133 StructureType internal/sync.Mutex
+          Type: 120 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 153
+      ID: 117
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1872192
@@ -8949,7 +8953,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -8958,18 +8962,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 154 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 154 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 132
+      ID: 119
       Name: sync.noCopy
       GoRuntimeType: 1003072
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 822
+      ID: 829
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1490752
@@ -8977,12 +8981,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 155 StructureType sync/atomic.noCopy
+          Type: 122 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 154
+      ID: 121
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1490912
@@ -8990,12 +8994,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 155 StructureType sync/atomic.noCopy
+          Type: 122 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 134
+      ID: 176
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1215552
@@ -9003,27 +9007,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 160 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 155
+      ID: 122
       Name: sync/atomic.noCopy
       GoRuntimeType: 1003168
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 654
+      ID: 666
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1300480
       GoKind: 12
     - __kind: BaseType
-      ID: 727
+      ID: 734
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 1004416
       GoKind: 2
     - __kind: StructureType
-      ID: 188
+      ID: 231
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9045,9 +9049,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 232 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 808
+      ID: 815
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9069,9 +9073,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 809 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 816 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 244
+      ID: 247
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9093,9 +9097,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 245 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 248 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 972
+      ID: 979
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9117,9 +9121,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 973 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 980 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9141,9 +9145,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 836 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 843 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 222
+      ID: 211
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9165,9 +9169,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 212 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 707
+      ID: 719
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9189,9 +9193,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 708 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 720 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 214
+      ID: 203
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9213,9 +9217,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 204 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 206
+      ID: 195
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9237,9 +9241,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<string,string>
+          Type: 196 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1733888
@@ -9252,13 +9256,13 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 931
+      ID: 938
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1946880
       GoKind: 6
     - __kind: StructureType
-      ID: 146
+      ID: 188
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2006016
@@ -9269,10 +9273,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 198 GoSliceHeaderType []time.zone
+          Type: 241 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 201 GoSliceHeaderType []time.zoneTrans
+          Type: 244 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9284,13 +9288,13 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 199 PointerType *time.zone
+          Type: 242 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 363
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 144
+      ID: 186
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2424416
@@ -9304,7 +9308,7 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 145 PointerType *time.Location
+          Type: 187 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9314,7 +9318,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 143
+      ID: 185
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1486752
@@ -9322,12 +9326,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 721 GoChannelType <-chan time.Time
+          Type: 733 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 279
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 842208
@@ -9335,18 +9339,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *time.fileSizeError.str
+          Type: 281 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType time.fileSizeError.str
+      Data: 280 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 280
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 200
+      ID: 243
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1642592
@@ -9362,7 +9366,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 203
+      ID: 246
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1781504
@@ -9423,7 +9427,7 @@ Types:
       GoRuntimeType: 591456
       GoKind: 26
     - __kind: StructureType
-      ID: 685
+      ID: 697
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2096736
@@ -9434,10 +9438,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 686 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 698 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 687 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 699 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9452,18 +9456,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 688 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 700 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 688
+      ID: 700
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1004512
       GoKind: 9
     - __kind: StructureType
-      ID: 686
+      ID: 698
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1949952
@@ -9488,17 +9492,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 363
+      ID: 375
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 687
+      ID: 699
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 592352
       GoKind: 8
     - __kind: StructureType
-      ID: 376
+      ID: 388
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1439872
@@ -9508,13 +9512,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 281
+      ID: 293
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 844608
       GoKind: 2
     - __kind: StructureType
-      ID: 563
+      ID: 575
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1729088
@@ -9527,7 +9531,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 529
+      ID: 541
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1005376

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -121,23 +121,23 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 694 PointerType *crypto/x509.Certificate
+      Pointee: 706 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 742
+      ID: 267
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 114 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 999 PointerType *mime/multipart.FileHeader
+      Pointee: 1006 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
       ID: 65
       Name: '**runtime.p'
@@ -145,111 +145,111 @@ Types:
       GoKind: 22
       Pointee: 66 PointerType *runtime.p
     - __kind: PointerType
-      ID: 141
+      ID: 182
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 142 PointerType *table<context.canceler,struct {}>
+      Pointee: 183 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 808 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 815 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 240
+      ID: 229
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 241 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 230 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 990 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 997 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 849 PointerType *table<string,[]string>
+      Pointee: 856 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 171
+      ID: 138
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<string,float64>
+      Pointee: 139 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 699
+      ID: 711
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 712 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 166
+      ID: 133
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 167 PointerType *table<string,interface {}>
+      Pointee: 134 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 161
+      ID: 128
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 162 PointerType *table<string,string>
+      Pointee: 129 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1006 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 1013 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 1014 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1021 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 745
+      ID: 270
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 744 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 269 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 1004
+      ID: 1011
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 1003 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 1010 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 192
+      ID: 199
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []*runtime.p.array
-    - __kind: PointerType
-      ID: 1017
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 1016 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 1019
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 1018 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 737
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 736 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 236
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 235 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 244
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 198 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 1024
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1023 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1026
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1025 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 749
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 748 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 225
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 224 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 233
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 232 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1031
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1023 GoSliceDataType []net/http.segment.array
+      Pointee: 1030 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 210
+      ID: 235
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []os.Signal.array
+      Pointee: 234 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -258,77 +258,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 735
+      ID: 747
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 734 GoSliceDataType []string.array
+      Pointee: 746 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 246
+      ID: 263
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType []time.zone.array
+      Pointee: 262 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 248
+      ID: 265
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []time.zoneTrans.array
+      Pointee: 264 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486560
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 187
+      ID: 194
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []uint8.array
+      Pointee: 193 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 189
+      ID: 196
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []uintptr.array
+      Pointee: 195 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 950624
       GoKind: 22
-      Pointee: 509 GoSliceHeaderType archive/tar.headerError
+      Pointee: 521 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 510 GoSliceDataType archive/tar.headerError.array
+      Pointee: 522 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1250528
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 923 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1083360
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 909 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1459744
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 927 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1083104
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 907 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -337,12 +337,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1996576
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType bufio.Writer
+      Pointee: 850 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 116
       Name: '*bytes.Buffer'
@@ -351,372 +351,372 @@ Types:
       GoKind: 22
       Pointee: 117 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 936224
       GoKind: 22
-      Pointee: 305 BaseType compress/flate.CorruptInputError
+      Pointee: 317 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 447
+      ID: 459
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 936320
       GoKind: 22
-      Pointee: 306 GoStringHeaderType compress/flate.InternalError
+      Pointee: 318 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType compress/flate.InternalError.str
+      Pointee: 319 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 951
+      ID: 958
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 2024832
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 959 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1660544
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 938 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 1030
+      ID: 165
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1575296
       GoKind: 22
-      Pointee: 131 StructureType context.backgroundCtx
+      Pointee: 166 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 119
+      ID: 176
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1756864
       GoKind: 22
-      Pointee: 120 StructureType context.cancelCtx
+      Pointee: 177 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1207520
       GoKind: 22
-      Pointee: 619 StructureType context.deadlineExceededError
+      Pointee: 631 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1025
+      ID: 151
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1434464
       GoKind: 22
-      Pointee: 132 StructureType context.emptyCtx
+      Pointee: 152 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 121
+      ID: 153
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1434624
       GoKind: 22
-      Pointee: 122 StructureType context.stopCtx
+      Pointee: 154 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 123
+      ID: 184
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1757056
       GoKind: 22
-      Pointee: 124 StructureType context.timerCtx
+      Pointee: 185 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1031
+      ID: 167
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1575456
       GoKind: 22
-      Pointee: 149 StructureType context.todoCtx
+      Pointee: 168 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 125
+      ID: 160
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1574976
       GoKind: 22
-      Pointee: 126 StructureType context.valueCtx
+      Pointee: 161 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 127
+      ID: 163
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1575136
       GoKind: 22
-      Pointee: 128 StructureType context.withoutCancelCtx
+      Pointee: 164 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 934976
       GoKind: 22
-      Pointee: 301 BaseType crypto/aes.KeySizeError
+      Pointee: 313 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 443
+      ID: 455
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935168
       GoKind: 22
-      Pointee: 302 BaseType crypto/des.KeySizeError
+      Pointee: 314 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935456
       GoKind: 22
-      Pointee: 303 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 315 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 597
+      ID: 609
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1080032
       GoKind: 22
-      Pointee: 598 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 610 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 445
+      ID: 457
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 304 BaseType crypto/rc4.KeySizeError
+      Pointee: 316 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 380
+      ID: 392
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 275 BaseType crypto/tls.AlertError
+      Pointee: 287 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 573
+      ID: 585
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1060448
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 586 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 981
+      ID: 988
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2436000
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 989 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 869 StructureType crypto/tls.ConnectionState
+      Pointee: 876 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 389 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 924320
       GoKind: 22
-      Pointee: 375 StructureType crypto/tls.RecordHeaderError
+      Pointee: 387 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1058784
       GoKind: 22
-      Pointee: 541 BaseType crypto/tls.alert
+      Pointee: 553 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 924512
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 391 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 683
+      ID: 695
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1442944
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 696 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 694
+      ID: 706
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2089664
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 707 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 934784
       GoKind: 22
-      Pointee: 439 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 451 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 934304
       GoKind: 22
-      Pointee: 433 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 445 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 934400
       GoKind: 22
-      Pointee: 435 StructureType crypto/x509.HostnameError
+      Pointee: 447 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 431
+      ID: 443
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 934208
       GoKind: 22
-      Pointee: 300 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 312 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 589
+      ID: 601
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1070304
       GoKind: 22
-      Pointee: 590 StructureType crypto/x509.SystemRootsError
+      Pointee: 602 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 934880
       GoKind: 22
-      Pointee: 441 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 453 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 934688
       GoKind: 22
-      Pointee: 437 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 449 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 946304
       GoKind: 22
-      Pointee: 501 StructureType encoding/asn1.StructuralError
+      Pointee: 513 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 946496
       GoKind: 22
-      Pointee: 505 StructureType encoding/asn1.SyntaxError
+      Pointee: 517 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 946400
       GoKind: 22
-      Pointee: 503 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 515 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 924800
       GoKind: 22
-      Pointee: 276 BaseType encoding/base64.CorruptInputError
+      Pointee: 288 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 423
+      ID: 435
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 932960
       GoKind: 22
-      Pointee: 296 BaseType encoding/hex.InvalidByteError
+      Pointee: 308 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 928160
       GoKind: 22
-      Pointee: 399 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 411 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 585
+      ID: 597
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1065568
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 598 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 391 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 403 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 928064
       GoKind: 22
-      Pointee: 397 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 409 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 927968
       GoKind: 22
-      Pointee: 395 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 407 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 927872
       GoKind: 22
-      Pointee: 393 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 405 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 928544
       GoKind: 22
-      Pointee: 401 StructureType encoding/json.jsonError
+      Pointee: 413 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 495
+      ID: 507
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 943520
       GoKind: 22
-      Pointee: 496 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 508 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 493
+      ID: 505
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 943424
       GoKind: 22
-      Pointee: 494 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 506 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 497
+      ID: 509
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 943616
       GoKind: 22
-      Pointee: 310 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 322 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 312
+      ID: 324
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 323 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 943712
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 511 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -725,19 +725,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 919616
       GoKind: 22
-      Pointee: 361 UnresolvedPointeeType errors.errorString
+      Pointee: 373 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1051744
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType errors.joinError
+      Pointee: 573 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -753,118 +753,118 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 544
+      ID: 556
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1041376
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType fmt.wrapError
+      Pointee: 557 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 546
+      ID: 558
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1041504
       GoKind: 22
-      Pointee: 547 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 559 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 421
+      ID: 433
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932480
       GoKind: 22
-      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 434 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2058080
       GoKind: 22
-      Pointee: 810 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 817 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 929792
       GoKind: 22
-      Pointee: 404 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 416 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 929888
       GoKind: 22
-      Pointee: 406 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 418 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 714
+      ID: 726
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 929600
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 727 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 409
+      ID: 421
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 930176
       GoKind: 22
-      Pointee: 410 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 422 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 716
+      ID: 728
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 929696
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 729 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 929984
       GoKind: 22
-      Pointee: 290 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 302 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 292
+      ID: 304
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 291 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 303 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 402
+      ID: 414
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 929504
       GoKind: 22
-      Pointee: 287 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 299 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 289
+      ID: 301
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 300 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 930080
       GoKind: 22
-      Pointee: 293 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 305 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 295
+      ID: 307
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 294 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 450
+      ID: 462
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 451 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 463 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
       ByteSize: 8
       GoRuntimeType: 1760704
       GoKind: 22
-      Pointee: 801 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
+      Pointee: 808 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
     - __kind: PointerType
       ID: 114
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -873,728 +873,728 @@ Types:
       GoKind: 22
       Pointee: 115 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 179
+      ID: 146
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2054336
       GoKind: 22
-      Pointee: 180 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 147 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 174
+      ID: 141
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1214560
       GoKind: 22
-      Pointee: 175 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 142 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1940064
       GoKind: 22
-      Pointee: 947 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 954 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1837536
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+      Pointee: 946 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 177
+      ID: 144
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1214688
       GoKind: 22
-      Pointee: 178 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1215328
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 757 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 255
+      ID: 258
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1215456
       GoKind: 22
-      Pointee: 256 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 259 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 181
+      ID: 148
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2277568
       GoKind: 22
-      Pointee: 182 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 149 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer'
       ByteSize: 8
       GoRuntimeType: 2262336
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
+      Pointee: 823 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1236448
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 672 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1582816
       GoKind: 22
-      Pointee: 752 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 759 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2227424
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
+      Pointee: 819 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1028
+      ID: 158
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1445664
       GoKind: 22
-      Pointee: 1029 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2227840
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
+      Pointee: 821 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1073632
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
+      Pointee: 905 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 452
+      ID: 464
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 939584
       GoKind: 22
-      Pointee: 453 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 465 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 940640
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 472 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 454
+      ID: 466
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 940352
       GoKind: 22
-      Pointee: 309 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 321 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 940544
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 470 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 940448
       GoKind: 22
-      Pointee: 456 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 468 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 941984
       GoKind: 22
-      Pointee: 468 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 942176
       GoKind: 22
-      Pointee: 472 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 942080
       GoKind: 22
-      Pointee: 470 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 465
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 941888
       GoKind: 22
-      Pointee: 466 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 739
+      ID: 751
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 750 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 479
+      ID: 491
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 942560
       GoKind: 22
-      Pointee: 480 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 942272
       GoKind: 22
-      Pointee: 474 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 942464
       GoKind: 22
-      Pointee: 478 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 475
+      ID: 487
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 942368
       GoKind: 22
-      Pointee: 476 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 942656
       GoKind: 22
-      Pointee: 482 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 487
+      ID: 499
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 942944
       GoKind: 22
-      Pointee: 488 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 489
+      ID: 501
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 943040
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 485
+      ID: 497
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 942848
       GoKind: 22
-      Pointee: 486 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 483
+      ID: 495
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 942752
       GoKind: 22
-      Pointee: 484 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 491
+      ID: 503
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 943232
       GoKind: 22
-      Pointee: 492 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 504 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2379296
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 833 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2362464
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 827 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2370976
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 829 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2371616
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 831 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 931328
       GoKind: 22
-      Pointee: 412 StructureType github.com/cihub/seelog.baseError
+      Pointee: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1839776
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 810 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 413
+      ID: 425
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 931424
       GoKind: 22
-      Pointee: 414 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 426 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1448864
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 800 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1669760
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 802 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1670528
       GoKind: 22
-      Pointee: 799 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 806 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 417
+      ID: 429
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 931616
       GoKind: 22
-      Pointee: 418 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 430 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1669952
       GoKind: 22
-      Pointee: 797 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 804 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2340224
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 825 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 415
+      ID: 427
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 931520
       GoKind: 22
-      Pointee: 416 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 428 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 419
+      ID: 431
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 931712
       GoKind: 22
-      Pointee: 420 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1245664
       GoKind: 22
-      Pointee: 914 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 921 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1766656
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 942 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 687
+      ID: 699
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1461024
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 700 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1088352
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 616 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1088224
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 614 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 605
+      ID: 617
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1092704
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 618 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 607
+      ID: 619
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1092832
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 620 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 595
+      ID: 607
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1077216
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 608 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 933152
       GoKind: 22
-      Pointee: 425 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 437 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1244896
       GoKind: 22
-      Pointee: 662 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 674 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 647
+      ID: 659
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1228384
       GoKind: 22
-      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 641
+      ID: 653
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1228000
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 654 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 579
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1063392
       GoKind: 22
-      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 653
+      ID: 665
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1228768
       GoKind: 22
-      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1063264
       GoKind: 22
-      Pointee: 543 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 555 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 645
+      ID: 657
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1228256
       GoKind: 22
-      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 643
+      ID: 655
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1228128
       GoKind: 22
-      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 651
+      ID: 663
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1228640
       GoKind: 22
-      Pointee: 652 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 649
+      ID: 661
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1228512
       GoKind: 22
-      Pointee: 650 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 657
+      ID: 669
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1229152
       GoKind: 22
-      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 670 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 583
+      ID: 595
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1063648
       GoKind: 22
-      Pointee: 584 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 596 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 581
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1063520
       GoKind: 22
-      Pointee: 582 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 655
+      ID: 667
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1229024
       GoKind: 22
-      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 522
+      ID: 534
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 962048
       GoKind: 22
-      Pointee: 317 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 329 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 319
+      ID: 331
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 318 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 702
+      ID: 714
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1697984
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 715 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 611
+      ID: 623
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1107552
       GoKind: 22
-      Pointee: 612 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 624 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 963296
       GoKind: 22
-      Pointee: 320 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 332 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1283168
       GoKind: 22
-      Pointee: 670 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 682 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 526
+      ID: 538
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 963584
       GoKind: 22
-      Pointee: 527 StructureType golang.org/x/net/http2.connError
+      Pointee: 539 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 525
+      ID: 537
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 963488
       GoKind: 22
-      Pointee: 324 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 336 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 326
+      ID: 338
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 325 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 529
+      ID: 541
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 963776
       GoKind: 22
-      Pointee: 330 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 342 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 332
+      ID: 344
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 331 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 963680
       GoKind: 22
-      Pointee: 327 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 339 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 329
+      ID: 341
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 328 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 963392
       GoKind: 22
-      Pointee: 321 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 333 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 323
+      ID: 335
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 322 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 530
+      ID: 542
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 963872
       GoKind: 22
-      Pointee: 531 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 543 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 963968
       GoKind: 22
-      Pointee: 333 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 345 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 957728
       GoKind: 22
-      Pointee: 519 StructureType google.golang.org/grpc.dropError
+      Pointee: 531 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1280224
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 680 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 689
+      ID: 701
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1468544
       GoKind: 22
-      Pointee: 690 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 702 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 520
+      ID: 532
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 960320
       GoKind: 22
-      Pointee: 521 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 533 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1847168
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 948 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 609
+      ID: 621
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1101792
       GoKind: 22
-      Pointee: 610 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 622 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1594656
       GoKind: 22
-      Pointee: 925 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 932 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 949280
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 519 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 599
+      ID: 611
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1081952
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 612 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1249120
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 678 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 663
+      ID: 675
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1248864
       GoKind: 22
-      Pointee: 664 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 676 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 951584
       GoKind: 22
-      Pointee: 513 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 525 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 514
+      ID: 526
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 951680
       GoKind: 22
-      Pointee: 515 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 527 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 461
+      ID: 473
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 940736
       GoKind: 22
-      Pointee: 462 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 474 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 964736
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType html/template.Error
+      Pointee: 546 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -1631,347 +1631,347 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType int8
     - __kind: PointerType
-      ID: 691
+      ID: 703
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2263680
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType internal/abi.Type
+      Pointee: 704 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 429
+      ID: 441
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 933824
       GoKind: 22
-      Pointee: 430 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 442 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 933728
       GoKind: 22
-      Pointee: 428 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 440 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 639
+      ID: 651
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1223520
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 652 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2430720
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType internal/poll.FD
+      Pointee: 987 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 637
+      ID: 649
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1223392
       GoKind: 22
-      Pointee: 638 StructureType internal/poll.errNetClosing
+      Pointee: 650 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 362
+      ID: 374
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 363 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 375 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 933632
       GoKind: 22
-      Pointee: 297 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 309 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 299
+      ID: 311
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 310 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1069280
       GoKind: 22
-      Pointee: 588 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 600 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1880992
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType io.PipeReader
+      Pointee: 952 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1579616
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType io.SectionReader
+      Pointee: 956 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1052256
       GoKind: 22
-      Pointee: 896 StructureType io.nopCloser
+      Pointee: 903 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1218144
       GoKind: 22
-      Pointee: 912 StructureType io.nopCloserWriterTo
+      Pointee: 919 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 635
+      ID: 647
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1222368
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType io/fs.PathError
+      Pointee: 648 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 139
+      ID: 180
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 140 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 181 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 806 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 813 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 238
+      ID: 227
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 239 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 228 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 988 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 995 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 847 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 854 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 169
+      ID: 136
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<string,float64>
+      Pointee: 137 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 697
+      ID: 709
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 710 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 164
+      ID: 131
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 165 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 159
+      ID: 126
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 160 GoSwissMapHeaderType map<string,string>
+      Pointee: 127 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 936992
       GoKind: 22
-      Pointee: 449 StructureType math/big.ErrNaN
+      Pointee: 461 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 999
+      ID: 1006
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 1009 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 867 StructureType mime/multipart.Form
+      Pointee: 874 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1659584
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 934 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1659776
       GoKind: 22
-      Pointee: 929 StructureType mime/multipart.sectionReadCloser
+      Pointee: 936 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1208672
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType net.AddrError
+      Pointee: 634 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 674
+      ID: 686
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1435264
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType net.DNSError
+      Pointee: 687 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 955
+      ID: 962
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2282048
       GoKind: 22
-      Pointee: 956 UnresolvedPointeeType net.IPConn
+      Pointee: 963 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 672
+      ID: 684
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1434944
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType net.OpError
+      Pointee: 685 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1208800
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType net.ParseError
+      Pointee: 636 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2314720
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType net.TCPConn
+      Pointee: 971 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2361248
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType net.UDPConn
+      Pointee: 975 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2314208
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType net.UnixConn
+      Pointee: 969 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1207904
       GoKind: 22
-      Pointee: 615 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 627 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 617
+      ID: 629
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 616 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 628 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 548
+      ID: 560
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1042400
       GoKind: 22
-      Pointee: 549 StructureType net.canceledError
+      Pointee: 561 StructureType net.canceledError
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2052608
       GoKind: 22
-      Pointee: 954 UnresolvedPointeeType net.conn
+      Pointee: 961 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 720
+      ID: 732
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1874720
       GoKind: 22
-      Pointee: 721 StructureType net.dialResult·1
+      Pointee: 733 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2364896
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType net.netFD
+      Pointee: 977 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 334
+      ID: 346
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 912608
       GoKind: 22
-      Pointee: 335 UnresolvedPointeeType net.notFoundError
+      Pointee: 347 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1026
+      ID: 156
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1435104
       GoKind: 22
-      Pointee: 1027 StructureType net.onlyValuesCtx
+      Pointee: 157 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 336
+      ID: 348
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 913280
       GoKind: 22
-      Pointee: 337 StructureType net.result·2
+      Pointee: 349 StructureType net.result·2
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2298336
       GoKind: 22
-      Pointee: 960 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 967 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 957
+      ID: 964
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2297856
       GoKind: 22
-      Pointee: 958 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 965 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1209440
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType net.temporaryError
+      Pointee: 638 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 676
+      ID: 688
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1435584
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType net.timeoutError
+      Pointee: 689 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 342
+      ID: 354
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 915872
       GoKind: 22
-      Pointee: 343 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 355 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 550
+      ID: 562
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1045856
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 563 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 112
       Name: '*net/http.Request'
@@ -1980,559 +1980,559 @@ Types:
       GoKind: 22
       Pointee: 113 StructureType net/http.Request
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1758400
       GoKind: 22
-      Pointee: 872 StructureType net/http.Response
+      Pointee: 879 StructureType net/http.Response
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1836640
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net/http.body
+      Pointee: 944 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1212000
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 915 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1045728
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 895 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1939040
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType net/http.conn
+      Pointee: 846 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1044448
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 885 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1048032
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 899 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 344
+      ID: 356
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 916064
       GoKind: 22
-      Pointee: 259 BaseType net/http.http2ConnectionError
+      Pointee: 271 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 916160
       GoKind: 22
-      Pointee: 346 StructureType net/http.http2GoAwayError
+      Pointee: 358 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 678
+      ID: 690
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1436544
       GoKind: 22
-      Pointee: 679 StructureType net/http.http2StreamError
+      Pointee: 691 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2054048
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 929 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 351
+      ID: 363
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 917216
       GoKind: 22
-      Pointee: 352 StructureType net/http.http2connError
+      Pointee: 364 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916640
       GoKind: 22
-      Pointee: 263 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 275 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 265
+      ID: 277
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 276 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 916736
       GoKind: 22
-      Pointee: 350 StructureType net/http.http2goAwayFlowError
+      Pointee: 362 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1045472
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 893 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 917408
       GoKind: 22
-      Pointee: 269 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 281 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 271
+      ID: 283
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 270 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 282 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 353
+      ID: 365
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 917312
       GoKind: 22
-      Pointee: 266 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 278 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 268
+      ID: 280
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 279 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 629
+      ID: 641
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1213280
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 642 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1045216
       GoKind: 22
-      Pointee: 882 StructureType net/http.http2missingBody
+      Pointee: 889 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1048288
       GoKind: 22
-      Pointee: 894 StructureType net/http.http2noBodyReader
+      Pointee: 901 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 556
+      ID: 568
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1048160
       GoKind: 22
-      Pointee: 557 StructureType net/http.http2noCachedConnError
+      Pointee: 569 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 260 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 272 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 262
+      ID: 274
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 261 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 273 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1046368
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 897 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2053472
       GoKind: 22
-      Pointee: 789 StructureType net/http.http2responseWriter
+      Pointee: 796 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1644608
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 844 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1045344
       GoKind: 22
-      Pointee: 884 StructureType net/http.http2transportResponseBody
+      Pointee: 891 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1044704
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 887 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1212128
       GoKind: 22
-      Pointee: 910 StructureType net/http.noBody
+      Pointee: 917 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 552
+      ID: 564
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1047776
       GoKind: 22
-      Pointee: 553 StructureType net/http.nothingWrittenError
+      Pointee: 565 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1642688
       GoKind: 22
-      Pointee: 874 StructureType net/http.pattern
+      Pointee: 881 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 875
+      ID: 882
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1044064
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 883 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1436864
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 925 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 356 StructureType net/http.requestBodyReadError
+      Pointee: 368 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2277120
       GoKind: 22
-      Pointee: 791 StructureType net/http.response
+      Pointee: 798 StructureType net/http.response
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396384
       GoKind: 22
-      Pointee: 1022 StructureType net/http.segment
+      Pointee: 1029 StructureType net/http.segment
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 915776
       GoKind: 22
-      Pointee: 341 StructureType net/http.statusError
+      Pointee: 353 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 680
+      ID: 692
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1438144
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 693 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1213152
       GoKind: 22
-      Pointee: 628 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 640 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 554
+      ID: 566
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1047904
       GoKind: 22
-      Pointee: 555 StructureType net/http.transportReadFromServerError
+      Pointee: 567 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1876288
       GoKind: 22
-      Pointee: 943 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 950 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 915008
       GoKind: 22
-      Pointee: 339 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 351 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1108192
       GoKind: 22
-      Pointee: 904 StructureType net/http/httputil.failureToReadBody
+      Pointee: 911 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 922688
       GoKind: 22
-      Pointee: 371 StructureType net/netip.parseAddrError
+      Pointee: 383 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 368
+      ID: 380
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 922592
       GoKind: 22
-      Pointee: 369 StructureType net/netip.parsePrefixError
+      Pointee: 381 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 926048
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType net/textproto.Error
+      Pointee: 398 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 925952
       GoKind: 22
-      Pointee: 283 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 295 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 285
+      ID: 297
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 296 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 685
+      ID: 697
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1443264
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType net/url.Error
+      Pointee: 698 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 382
+      ID: 394
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 924896
       GoKind: 22
-      Pointee: 277 GoStringHeaderType net/url.EscapeError
+      Pointee: 289 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 279
+      ID: 291
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType net/url.EscapeError.str
+      Pointee: 290 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 924992
       GoKind: 22
-      Pointee: 280 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 292 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 282
+      ID: 294
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 293 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2167328
       GoKind: 22
-      Pointee: 863 StructureType net/url.URL
+      Pointee: 870 StructureType net/url.URL
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1226080
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 991 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 195
+      ID: 238
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 239 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 837 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 251
+      ID: 254
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 255 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 994 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 1001 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 857 StructureType noalg.map.group[string][]string
+      Pointee: 864 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 229
+      ID: 218
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 230 StructureType noalg.map.group[string]float64
+      Pointee: 219 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 728
+      ID: 740
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 741 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 221
+      ID: 210
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 222 StructureType noalg.map.group[string]interface {}
+      Pointee: 211 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 213
+      ID: 202
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 214 StructureType noalg.map.group[string]string
+      Pointee: 203 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2407072
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType os.File
+      Pointee: 983 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 558
+      ID: 570
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1050208
       GoKind: 22
-      Pointee: 559 UnresolvedPointeeType os.LinkError
+      Pointee: 571 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 152
+      ID: 173
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 399200
       GoKind: 22
-      Pointee: 153 GoInterfaceType os.Signal
+      Pointee: 174 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 631
+      ID: 643
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1213664
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType os.SyscallError
+      Pointee: 644 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2404832
       GoKind: 22
-      Pointee: 974 StructureType os.fileWithoutReadFrom
+      Pointee: 981 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2404096
       GoKind: 22
-      Pointee: 972 StructureType os.fileWithoutWriteTo
+      Pointee: 979 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 591
+      ID: 603
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1072352
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType os/exec.Error
+      Pointee: 604 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 724
+      ID: 736
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2141408
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 737 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 593
+      ID: 605
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1072480
       GoKind: 22
-      Pointee: 594 StructureType os/exec.wrappedError
+      Pointee: 606 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 129
+      ID: 169
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1647296
       GoKind: 22
-      Pointee: 130 StructureType os/signal.signalCtx
+      Pointee: 170 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 955808
       GoKind: 22
-      Pointee: 314 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 326 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 316
+      ID: 328
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 315 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 327 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 955712
       GoKind: 22
-      Pointee: 313 BaseType os/user.UnknownUserIdError
+      Pointee: 325 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 364
+      ID: 376
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 920768
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType reflect.ValueError
+      Pointee: 377 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 463
+      ID: 475
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 941216
       GoKind: 22
-      Pointee: 464 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 476 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 566
+      ID: 578
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1054816
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 579 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 570
+      ID: 582
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1056608
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 583 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2548,12 +2548,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 568
+      ID: 580
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1054944
       GoKind: 22
-      Pointee: 569 StructureType runtime.boundsError
+      Pointee: 581 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -2569,24 +2569,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 633
+      ID: 645
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1221856
       GoKind: 22
-      Pointee: 634 StructureType runtime.errorAddressString
+      Pointee: 646 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1054432
       GoKind: 22
-      Pointee: 535 GoStringHeaderType runtime.errorString
+      Pointee: 547 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 537
+      ID: 549
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType runtime.errorString.str
+      Pointee: 548 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2607,19 +2607,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1055968
       GoKind: 22
-      Pointee: 190 UnresolvedPointeeType runtime.p
+      Pointee: 197 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1054560
       GoKind: 22
-      Pointee: 538 GoStringHeaderType runtime.plainError
+      Pointee: 550 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 540
+      ID: 552
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 539 GoStringDataType runtime.plainError.str
+      Pointee: 551 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2635,12 +2635,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 922304
       GoKind: 22
-      Pointee: 367 StructureType runtime.synctestDeadlockError
+      Pointee: 379 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -2656,12 +2656,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1054048
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType strconv.NumError
+      Pointee: 575 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -2670,235 +2670,235 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 185
+      ID: 192
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 184 GoStringDataType string.str
+      Pointee: 191 GoStringDataType string.str
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1722368
       GoKind: 22
-      Pointee: 758 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 765 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1781632
       GoKind: 22
-      Pointee: 772 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 779 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 753
+      ID: 760
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1721984
       GoKind: 22
-      Pointee: 754 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 761 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1780864
       GoKind: 22
-      Pointee: 764 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 771 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1853888
       GoKind: 22
-      Pointee: 778 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 785 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1781056
       GoKind: 22
-      Pointee: 766 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 773 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1780672
       GoKind: 22
-      Pointee: 762 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 769 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1853440
       GoKind: 22
-      Pointee: 774 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 781 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1925792
       GoKind: 22
-      Pointee: 782 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 789 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1853664
       GoKind: 22
-      Pointee: 776 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 783 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1722560
       GoKind: 22
-      Pointee: 760 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 767 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1722176
       GoKind: 22
-      Pointee: 756 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 763 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1781248
       GoKind: 22
-      Pointee: 768 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 775 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1854112
       GoKind: 22
-      Pointee: 780 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 787 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1781440
       GoKind: 22
-      Pointee: 770 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 777 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1115328
       GoKind: 22
-      Pointee: 906 StructureType struct { io.Reader; io.Closer }
+      Pointee: 913 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 682
+      ID: 694
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1442144
       GoKind: 22
-      Pointee: 671 BaseType syscall.Errno
+      Pointee: 683 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1057120
       GoKind: 22
-      Pointee: 746 BaseType syscall.Signal
+      Pointee: 753 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 142
+      ID: 183
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 193 StructureType table<context.canceler,struct {}>
+      Pointee: 236 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 827 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 834 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 241
+      ID: 230
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 249 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 252 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 990
+      ID: 997
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 991 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 998 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 854 StructureType table<string,[]string>
+      Pointee: 861 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 172
+      ID: 139
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 227 StructureType table<string,float64>
+      Pointee: 216 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 700
+      ID: 712
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 726 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 738 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 167
+      ID: 134
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 219 StructureType table<string,interface {}>
+      Pointee: 208 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 162
+      ID: 129
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 211 StructureType table<string,string>
+      Pointee: 200 StructureType table<string,string>
     - __kind: PointerType
-      ID: 613
+      ID: 625
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1111392
       GoKind: 22
-      Pointee: 614 StructureType text/template.ExecError
+      Pointee: 626 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 147
+      ID: 189
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1647680
       GoKind: 22
-      Pointee: 148 StructureType time.Location
+      Pointee: 190 StructureType time.Location
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 918464
       GoKind: 22
-      Pointee: 359 UnresolvedPointeeType time.ParseError
+      Pointee: 371 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 144
+      ID: 186
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1050720
       GoKind: 22
-      Pointee: 145 StructureType time.Timer
+      Pointee: 187 StructureType time.Timer
     - __kind: PointerType
-      ID: 357
+      ID: 369
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 918368
       GoKind: 22
-      Pointee: 272 GoStringHeaderType time.fileSizeError
+      Pointee: 284 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 274
+      ID: 286
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 273 GoStringDataType time.fileSizeError.str
+      Pointee: 285 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 204
+      ID: 247
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399456
       GoKind: 22
-      Pointee: 205 StructureType time.zone
+      Pointee: 248 StructureType time.zone
     - __kind: PointerType
-      ID: 207
+      ID: 250
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399520
       GoKind: 22
-      Pointee: 208 StructureType time.zoneTrans
+      Pointee: 251 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -2942,47 +2942,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 373 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 385 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 926240
       GoKind: 22
-      Pointee: 388 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 400 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 389
+      ID: 401
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 926336
       GoKind: 22
-      Pointee: 286 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 298 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1061984
       GoKind: 22
-      Pointee: 576 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 588 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1062112
       GoKind: 22
-      Pointee: 542 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 554 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 870
+      ID: 877
       Name: <-chan struct {}
       GoRuntimeType: 607264
       GoKind: 18
     - __kind: GoChannelType
-      ID: 740
+      ID: 752
       Name: <-chan time.Time
       GoRuntimeType: 610528
       GoKind: 18
@@ -3061,7 +3061,7 @@ Types:
       HasCount: true
       Element: 95 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 851
+      ID: 858
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 694784
@@ -3070,7 +3070,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 850
+      ID: 857
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 694688
@@ -3142,7 +3142,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 852
+      ID: 859
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 694880
@@ -3160,7 +3160,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 708
+      ID: 720
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 712672
@@ -3187,7 +3187,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1006
+      ID: 1013
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507488
@@ -3195,22 +3195,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1007 PointerType **crypto/x509.Certificate
+          Type: 1014 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1014 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1021 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1014
+      ID: 1021
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 694 PointerType *crypto/x509.Certificate
+      Element: 706 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 741
+      ID: 266
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 495232
@@ -3218,22 +3218,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 742 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 267 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 744 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 269 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 744
+      ID: 269
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 114 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 997
+      ID: 1004
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492224
@@ -3241,20 +3241,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 998 PointerType **mime/multipart.FileHeader
+          Type: 1005 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1003 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 1010 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 1003
+      ID: 1010
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 999 PointerType *mime/multipart.FileHeader
+      Element: 1006 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 64
       Name: '[]*runtime.p'
@@ -3271,69 +3271,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 191 GoSliceDataType []*runtime.p.array
+      Data: 198 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 198
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 66 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 244
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 142 PointerType *table<context.canceler,struct {}>
+      Element: 183 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 834
+      ID: 841
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 808 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 815 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 260
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 241 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 230 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 1000
+      ID: 1007
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 990 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 997 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 860
+      ID: 867
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 849 PointerType *table<string,[]string>
+      Element: 856 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 222
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 172 PointerType *table<string,float64>
+      Element: 139 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 732
+      ID: 744
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 712 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 214
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 167 PointerType *table<string,interface {}>
+      Element: 134 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 206
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 162 PointerType *table<string,string>
+      Element: 129 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 1008
+      ID: 1015
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507552
@@ -3341,22 +3341,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1009 PointerType *[]*crypto/x509.Certificate
+          Type: 1016 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1016 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1023 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1016
+      ID: 1023
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1006 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 1013 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 1010
+      ID: 1017
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 486880
@@ -3364,22 +3364,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1011 PointerType *[]uint8
+          Type: 1018 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1018 GoSliceDataType [][]uint8.array
+      Data: 1025 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 1018
+      ID: 1025
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 713
+      ID: 725
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 501184
@@ -3394,15 +3394,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 736 GoSliceDataType []float64.array
+      Data: 748 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 736
+      ID: 748
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 140
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 494784
@@ -3410,22 +3410,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 174 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 141 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 235 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 224 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 224
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 175 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 142 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 143
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 494976
@@ -3433,22 +3433,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 232 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 232
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 178 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1020
+      ID: 1027
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489600
@@ -3456,76 +3456,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1021 PointerType *net/http.segment
+          Type: 1028 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1023 GoSliceDataType []net/http.segment.array
+      Data: 1030 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1023
+      ID: 1030
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1022 StructureType net/http.segment
+      Element: 1029 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 245
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 196 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 239 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 835
+      ID: 842
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 837 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 261
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 255 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 1001
+      ID: 1008
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 994 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 1001 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 861
+      ID: 868
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 857 StructureType noalg.map.group[string][]string
+      Element: 864 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 223
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 230 StructureType noalg.map.group[string]float64
+      Element: 219 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 733
+      ID: 745
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 741 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 215
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 222 StructureType noalg.map.group[string]interface {}
+      Element: 211 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 207
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 214 StructureType noalg.map.group[string]string
+      Element: 203 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 151
+      ID: 172
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 486688
@@ -3533,26 +3533,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 152 PointerType *os.Signal
+          Type: 173 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 209 GoSliceDataType []os.Signal.array
+      Data: 234 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 234
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 153 GoInterfaceType os.Signal
+      Element: 174 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 712
+      ID: 724
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501440
@@ -3567,15 +3567,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 734 GoSliceDataType []string.array
+      Data: 746 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 734
+      ID: 746
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 203
+      ID: 246
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494336
@@ -3583,22 +3583,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 204 PointerType *time.zone
+          Type: 247 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 245 GoSliceDataType []time.zone.array
+      Data: 262 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 262
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 205 StructureType time.zone
+      Element: 248 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 206
+      ID: 249
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494400
@@ -3606,20 +3606,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 207 PointerType *time.zoneTrans
+          Type: 250 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType []time.zoneTrans.array
+      Data: 264 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 264
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 208 StructureType time.zoneTrans
+      Element: 251 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3636,9 +3636,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType []uint8.array
+      Data: 193 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 193
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3659,15 +3659,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []uintptr.array
+      Data: 195 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 195
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 509
+      ID: 521
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 950720
@@ -3682,27 +3682,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 510 GoSliceDataType archive/tar.headerError.array
+      Data: 522 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 510
+      ID: 522
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 923
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 909
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 907
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3712,7 +3712,7 @@ Types:
       GoRuntimeType: 595232
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 850
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3720,12 +3720,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 853
+      ID: 860
       Name: chan bool
       GoRuntimeType: 606688
       GoKind: 18
     - __kind: GoChannelType
-      ID: 154
+      ID: 175
       Name: chan os.Signal
       GoRuntimeType: 613600
       GoKind: 18
@@ -3742,13 +3742,13 @@ Types:
       GoRuntimeType: 594976
       GoKind: 15
     - __kind: BaseType
-      ID: 305
+      ID: 317
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 850176
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 318
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 850272
@@ -3756,26 +3756,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *compress/flate.InternalError.str
+          Type: 320 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType compress/flate.InternalError.str
+      Data: 319 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 319
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 959
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 150
+      ID: 171
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 689024
@@ -3794,19 +3794,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 131
+      ID: 166
       Name: context.backgroundCtx
       GoRuntimeType: 1835072
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 132 StructureType context.emptyCtx
+          Type: 152 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 120
+      ID: 177
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 2009888
@@ -3817,23 +3817,23 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 133 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 136 StructureType sync/atomic.Value
+          Type: 178 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 138 GoMapType map[context.canceler]struct {}
+          Type: 179 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 136 StructureType sync/atomic.Value
+          Type: 178 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 15 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 199
+      ID: 242
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1132736
@@ -3846,13 +3846,13 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 619
+      ID: 631
       Name: context.deadlineExceededError
       GoRuntimeType: 1485856
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 132
+      ID: 152
       Name: context.emptyCtx
       GoRuntimeType: 1623008
       GoKind: 25
@@ -3861,7 +3861,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 154
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1862112
@@ -3872,11 +3872,11 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 143 GoSubroutineType func() bool
+          Type: 155 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 185
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1640768
@@ -3884,29 +3884,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 120 StructureType context.cancelCtx
+          Type: 177 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 144 PointerType *time.Timer
+          Type: 186 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 146 GoTimeType time.Time
+          Type: 188 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 149
+      ID: 168
       Name: context.todoCtx
       GoRuntimeType: 1835296
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 132 StructureType context.emptyCtx
+          Type: 152 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 126
+      ID: 161
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1873152
@@ -3917,14 +3917,14 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 137 GoEmptyInterfaceType interface {}
+          Type: 162 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 137 GoEmptyInterfaceType interface {}
+          Type: 162 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 164
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1834848
@@ -3936,51 +3936,51 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 301
+      ID: 313
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849792
       GoKind: 2
     - __kind: BaseType
-      ID: 302
+      ID: 314
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849888
       GoKind: 2
     - __kind: BaseType
-      ID: 303
+      ID: 315
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849984
       GoKind: 2
     - __kind: StructureType
-      ID: 598
+      ID: 610
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1309728
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 304
+      ID: 316
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 850080
       GoKind: 2
     - __kind: BaseType
-      ID: 275
+      ID: 287
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 847488
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 586
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 989
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2323424
@@ -4000,7 +4000,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 1005 BaseType crypto/tls.CurveID
+          Type: 1012 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4012,13 +4012,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 1006 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 1013 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 1008 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 1015 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 1010 GoSliceHeaderType [][]uint8
+          Type: 1017 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -4030,25 +4030,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 1012 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 1019 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 1013 BaseType crypto/tls.SignatureScheme
+          Type: 1020 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 1005
+      ID: 1012
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 847200
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 389
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 375
+      ID: 387
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1762624
@@ -4059,36 +4059,36 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 708 ArrayType [5]uint8
+          Type: 720 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 709 GoInterfaceType net.Conn
+          Type: 721 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 1013
+      ID: 1020
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 847296
       GoKind: 9
     - __kind: BaseType
-      ID: 541
+      ID: 553
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1009312
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 391
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 696
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 707
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 439
+      ID: 451
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1764736
@@ -4096,21 +4096,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 706 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 718 BaseType crypto/x509.InvalidReason
+          Type: 730 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 433
+      ID: 445
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1139520
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1625568
@@ -4118,24 +4118,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 706 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 300
+      ID: 312
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 849600
       GoKind: 2
     - __kind: BaseType
-      ID: 718
+      ID: 730
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 598368
       GoKind: 2
     - __kind: StructureType
-      ID: 590
+      ID: 602
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1586336
@@ -4145,13 +4145,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 441
+      ID: 453
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1139776
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 437
+      ID: 449
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1764544
@@ -4159,15 +4159,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 706 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 706 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1456864
@@ -4177,7 +4177,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 505
+      ID: 517
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1457024
@@ -4187,47 +4187,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 503
+      ID: 515
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 276
+      ID: 288
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 6
     - __kind: BaseType
-      ID: 296
+      ID: 308
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 849312
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 399
+      ID: 411
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 598
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 391
+      ID: 403
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 397
+      ID: 409
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 395
+      ID: 407
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 393
+      ID: 405
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 401
+      ID: 413
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1446304
@@ -4237,15 +4237,15 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 496
+      ID: 508
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 494
+      ID: 506
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 322
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 851712
@@ -4253,18 +4253,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *encoding/xml.UnmarshalError.str
+          Type: 324 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 311 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 323 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 323
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 511
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4281,11 +4281,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 361
+      ID: 373
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 573
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4301,11 +4301,11 @@ Types:
       GoRuntimeType: 595168
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 557
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 547
+      ID: 559
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4315,13 +4315,13 @@ Types:
       GoRuntimeType: 484960
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 864
+      ID: 871
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 705088
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 143
+      ID: 155
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 605344
@@ -4333,23 +4333,23 @@ Types:
       GoRuntimeType: 867392
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 1012
+      ID: 1019
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1025152
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 422
+      ID: 434
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2098912
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 404
+      ID: 416
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1763584
@@ -4357,7 +4357,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 710 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 722 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4365,25 +4365,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 406
+      ID: 418
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 727
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 410
+      ID: 422
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1138240
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 729
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 290
+      ID: 302
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 848640
@@ -4391,18 +4391,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 292 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 304 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 291 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 303 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 291
+      ID: 303
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 710
+      ID: 722
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2271296
@@ -4410,13 +4410,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 711 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 723 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4425,7 +4425,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 713 GoSliceHeaderType []float64
+          Type: 725 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4434,13 +4434,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 714 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 726 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 716 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 728 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4451,13 +4451,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 711
+      ID: 723
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 596896
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 299
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 848544
@@ -4465,18 +4465,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 301 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 288 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 300 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 300
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 293
+      ID: 305
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 848736
@@ -4484,22 +4484,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 295 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 307 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 294 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 294
+      ID: 306
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 451
+      ID: 463
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
-      ID: 801
+      ID: 808
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
       GoRuntimeType: 1863008
       GoKind: 25
@@ -4513,7 +4513,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 155 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -4534,13 +4534,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 163 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 130 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 168 GoMapType map[string]float64
+          Type: 135 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -4555,10 +4555,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 173 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 140 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 176 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 143 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -4570,7 +4570,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 179 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 146 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -4593,7 +4593,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 180
+      ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2269952
@@ -4604,13 +4604,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 181 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 114 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 156 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4619,16 +4619,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 183 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 150 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 155 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -4637,12 +4637,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 173 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 140 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 175
+      ID: 142
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1955616
@@ -4659,7 +4659,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4667,7 +4667,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 947
+      ID: 954
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 2010400
@@ -4675,29 +4675,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 938 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+          Type: 945 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 950 BaseType time.Duration
+          Type: 957 BaseType time.Duration
     - __kind: GoMapType
-      ID: 163
+      ID: 130
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1304480
       GoKind: 21
-      HeaderType: 165 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 743
+      ID: 268
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 594016
       GoKind: 10
     - __kind: StructureType
-      ID: 178
+      ID: 145
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1789664
@@ -4711,16 +4711,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 237 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 226 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 242 GoMapType map[string]interface {}
+          Type: 231 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 757
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 256
+      ID: 259
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1955872
@@ -4728,7 +4728,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 748 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 755 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4743,15 +4743,15 @@ Types:
           Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 749 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 756 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 748
+      ID: 755
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1006720
       GoKind: 5
     - __kind: StructureType
-      ID: 182
+      ID: 149
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2155744
@@ -4759,16 +4759,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 155 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 741 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 266 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -4783,12 +4783,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 743 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 268 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 114 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 183
+      ID: 150
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 919232
@@ -4797,15 +4797,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 672
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 783
+      ID: 790
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1445024
@@ -4818,7 +4818,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 752
+      ID: 759
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1625088
@@ -4831,11 +4831,11 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 819
       Name: github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1029
+    - __kind: GoContextImplementationType
+      ID: 159
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1663616
@@ -4844,38 +4844,40 @@ Types:
         - Name: Context
           Offset: 0
           Type: 118 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 821
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 905
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 453
+      ID: 465
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 460
+      ID: 472
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1141440
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 309
+      ID: 321
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 851040
       GoKind: 2
     - __kind: StructureType
-      ID: 458
+      ID: 470
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1141312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 456
+      ID: 468
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1626368
@@ -4888,7 +4890,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 468
+      ID: 480
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1627008
@@ -4901,7 +4903,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 472
+      ID: 484
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1766272
@@ -4917,7 +4919,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 470
+      ID: 482
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1455424
@@ -4927,7 +4929,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 466
+      ID: 478
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1455104
@@ -4937,14 +4939,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 696
+      ID: 708
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1528736
       GoKind: 21
-      HeaderType: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 710 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 719
+      ID: 731
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1075552
@@ -4959,15 +4961,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 750 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 738
+      ID: 750
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 480
+      ID: 492
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1627328
@@ -4975,12 +4977,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 708 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 708 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 474
+      ID: 486
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1455584
@@ -4990,7 +4992,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 478
+      ID: 490
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1766464
@@ -5001,12 +5003,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 731 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 731 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 476
+      ID: 488
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1627168
@@ -5019,7 +5021,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 482
+      ID: 494
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1455744
@@ -5027,9 +5029,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 146 GoTimeType time.Time
+          Type: 188 GoTimeType time.Time
     - __kind: StructureType
-      ID: 488
+      ID: 500
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1627648
@@ -5042,7 +5044,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 490
+      ID: 502
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1456064
@@ -5052,7 +5054,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 486
+      ID: 498
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1627488
@@ -5065,7 +5067,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 484
+      ID: 496
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1455904
@@ -5075,7 +5077,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 492
+      ID: 504
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1627808
@@ -5088,29 +5090,29 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 833
+      ID: 840
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 849024
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 412
+      ID: 424
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1447584
@@ -5120,11 +5122,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 414
+      ID: 426
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1447744
@@ -5132,17 +5134,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 412 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 802
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 806
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1864352
@@ -5150,12 +5152,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 794 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 801 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 804 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 811 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 418
+      ID: 430
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1448064
@@ -5163,9 +5165,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 412 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 797
+      ID: 804
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1840000
@@ -5173,13 +5175,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 794 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 801 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 416
+      ID: 428
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1447904
@@ -5187,9 +5189,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 412 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 420
+      ID: 432
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1448224
@@ -5197,9 +5199,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 412 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 932
+      ID: 939
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1141696
@@ -5212,7 +5214,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 914
+      ID: 921
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1679744
@@ -5220,48 +5222,48 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 932 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 939 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 942
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 700
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 616
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 614
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 618
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 620
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 608
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 425
+      ID: 437
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1449184
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 662
+      ID: 674
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 648
+      ID: 660
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1887040
@@ -5277,11 +5279,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 654
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1734944
@@ -5294,7 +5296,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 654
+      ID: 666
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1887488
@@ -5310,13 +5312,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 543
+      ID: 555
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1009984
       GoKind: 8
     - __kind: StructureType
-      ID: 646
+      ID: 658
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1886816
@@ -5332,13 +5334,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 722
+      ID: 734
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 848160
       GoKind: 8
     - __kind: StructureType
-      ID: 644
+      ID: 656
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1886592
@@ -5346,15 +5348,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 734 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 734 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 652
+      ID: 664
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1797920
@@ -5367,7 +5369,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 650
+      ID: 662
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1887264
@@ -5383,7 +5385,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 658
+      ID: 670
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1662656
@@ -5393,19 +5395,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 584
+      ID: 596
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1305888
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 582
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1305760
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 656
+      ID: 668
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1798112
@@ -5418,7 +5420,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 317
+      ID: 329
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 853632
@@ -5426,22 +5428,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 319 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 331 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 318 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 318
+      ID: 330
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 715
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 612
+      ID: 624
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1471264
@@ -5451,19 +5453,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 320
+      ID: 332
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 854208
       GoKind: 10
     - __kind: BaseType
-      ID: 701
+      ID: 713
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1022176
       GoKind: 10
     - __kind: StructureType
-      ID: 670
+      ID: 682
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1920640
@@ -5474,12 +5476,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 701 BaseType golang.org/x/net/http2.ErrCode
+          Type: 713 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 527
+      ID: 539
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1634528
@@ -5487,12 +5489,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 701 BaseType golang.org/x/net/http2.ErrCode
+          Type: 713 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 324
+      ID: 336
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 854400
@@ -5500,18 +5502,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 326 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 338 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 325 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 325
+      ID: 337
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 330
+      ID: 342
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 854592
@@ -5519,18 +5521,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 332 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 344 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 331 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 331
+      ID: 343
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 327
+      ID: 339
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 854496
@@ -5538,18 +5540,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 329 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 341 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 328 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 328
+      ID: 340
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 321
+      ID: 333
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 854304
@@ -5557,18 +5559,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 323 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 335 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 322 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 322
+      ID: 334
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 531
+      ID: 543
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1471904
@@ -5578,13 +5580,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 333
+      ID: 345
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 854688
       GoKind: 2
     - __kind: StructureType
-      ID: 519
+      ID: 531
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1466944
@@ -5594,11 +5596,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 680
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 690
+      ID: 702
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1949792
@@ -5614,7 +5616,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 521
+      ID: 533
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1634048
@@ -5627,11 +5629,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 948
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 610
+      ID: 622
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1593856
@@ -5641,29 +5643,29 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 925
+      ID: 932
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 519
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 612
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 678
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 664
+      ID: 676
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1538336
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 513
+      ID: 525
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1460224
@@ -5673,7 +5675,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 515
+      ID: 527
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1460384
@@ -5683,137 +5685,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 462
+      ID: 474
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 237
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 238 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 202 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 239 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 828
+      ID: 835
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 829 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 836 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 835 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 837 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 842 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 250
+      ID: 253
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 251 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 254 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 255 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 992
+      ID: 999
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 993 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 1000 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 994 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 1001 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 1001 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 1008 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 855
+      ID: 862
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 856 PointerType *noalg.map.group[string][]string
+          Type: 863 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 857 StructureType noalg.map.group[string][]string
-      GroupSliceType: 861 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 864 StructureType noalg.map.group[string][]string
+      GroupSliceType: 868 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 228
+      ID: 217
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 229 PointerType *noalg.map.group[string]float64
+          Type: 218 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 230 StructureType noalg.map.group[string]float64
-      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 219 StructureType noalg.map.group[string]float64
+      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 727
+      ID: 739
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 728 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 740 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 733 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 741 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 745 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 220
+      ID: 209
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 221 PointerType *noalg.map.group[string]interface {}
+          Type: 210 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 222 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 226 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 211 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 215 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 212
+      ID: 201
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 213 PointerType *noalg.map.group[string]string
+          Type: 202 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 214 StructureType noalg.map.group[string]string
-      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 203 StructureType noalg.map.group[string]string
+      GroupSliceType: 207 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 546
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5847,7 +5849,7 @@ Types:
       GoRuntimeType: 594272
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 137
+      ID: 162
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 867104
@@ -5860,11 +5862,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 704
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 430
+      ID: 442
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5890,25 +5892,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 428
+      ID: 440
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 652
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 987
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 650
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1503936
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 363
+      ID: 375
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5989,7 +5991,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 309
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 849504
@@ -5997,18 +5999,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 311 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 310 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 310
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 588
+      ID: 600
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1585376
@@ -6016,9 +6018,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 691 PointerType *internal/abi.Type
+          Type: 703 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 135
+      ID: 122
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1518176
@@ -6031,7 +6033,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 933
+      ID: 940
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1052768
@@ -6044,11 +6046,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 840
+      ID: 847
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1135168
@@ -6061,7 +6063,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 923
+      ID: 930
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1052128
@@ -6074,11 +6076,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 896
+      ID: 903
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1579456
@@ -6086,9 +6088,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 923 GoInterfaceType io.Reader
+          Type: 930 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 912
+      ID: 919
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1648832
@@ -6096,13 +6098,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 923 GoInterfaceType io.Reader
+          Type: 930 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 648
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 140
+      ID: 181
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -6115,7 +6117,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 141 PointerType **table<context.canceler,struct {}>
+          Type: 182 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6134,10 +6136,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 201 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 196 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 244 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 239 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 806
+      ID: 813
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6150,7 +6152,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 807 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 814 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6169,10 +6171,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 834 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 841 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 837 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 239
+      ID: 228
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6185,7 +6187,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 240 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 229 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6204,10 +6206,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 260 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 255 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 988
+      ID: 995
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6220,7 +6222,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 989 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 996 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6239,10 +6241,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1000 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 994 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 1007 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 1001 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 847
+      ID: 854
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6255,7 +6257,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 848 PointerType **table<string,[]string>
+          Type: 855 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6274,10 +6276,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 860 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 857 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 867 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 864 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 137
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6290,7 +6292,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<string,float64>
+          Type: 138 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6309,10 +6311,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 233 GoSliceDataType []*table<string,float64>.array
-      GroupType: 230 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 222 GoSliceDataType []*table<string,float64>.array
+      GroupType: 219 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 698
+      ID: 710
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6325,7 +6327,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 699 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 711 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6344,10 +6346,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 732 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 744 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 741 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 165
+      ID: 132
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6360,7 +6362,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 166 PointerType **table<string,interface {}>
+          Type: 133 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6379,10 +6381,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 225 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 222 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 214 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 211 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 160
+      ID: 127
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6395,7 +6397,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 161 PointerType **table<string,string>
+          Type: 128 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6414,66 +6416,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 217 GoSliceDataType []*table<string,string>.array
-      GroupType: 214 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 206 GoSliceDataType []*table<string,string>.array
+      GroupType: 203 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 138
+      ID: 179
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1152192
       GoKind: 21
-      HeaderType: 140 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 181 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 804
+      ID: 811
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1169632
       GoKind: 21
-      HeaderType: 806 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 813 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 237
+      ID: 226
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1158336
       GoKind: 21
-      HeaderType: 239 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 228 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 986
+      ID: 993
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1157568
       GoKind: 21
-      HeaderType: 988 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 995 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 985
+      ID: 992
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1153216
       GoKind: 21
-      HeaderType: 847 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 854 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 168
+      ID: 135
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1158208
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 137 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 242
+      ID: 231
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1151808
       GoKind: 21
-      HeaderType: 165 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 158
+      ID: 125
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1154240
       GoKind: 21
-      HeaderType: 160 GoSwissMapHeaderType map<string,string>
+      HeaderType: 127 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 449
+      ID: 461
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1452064
@@ -6483,11 +6485,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1009
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 867
+      ID: 874
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1506656
@@ -6495,16 +6497,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 985 GoMapType map[string][]string
+          Type: 992 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 986 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 993 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 934
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 929
+      ID: 936
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1959712
@@ -6512,16 +6514,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 948 PointerType *io.SectionReader
+          Type: 955 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 933 GoInterfaceType io.Closer
+          Type: 940 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 634
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 709
+      ID: 721
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1623168
@@ -6534,35 +6536,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 687
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 956
+      ID: 963
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 685
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 636
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 971
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 975
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 969
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 615
+      ID: 627
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1132992
@@ -6570,28 +6572,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 617 PointerType *net.UnknownNetworkError.str
+          Type: 629 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 616 GoStringDataType net.UnknownNetworkError.str
+      Data: 628 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 616
+      ID: 628
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 549
+      ID: 561
       Name: net.canceledError
       GoRuntimeType: 1303456
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 954
+      ID: 961
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 721
+      ID: 733
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2154688
@@ -6599,7 +6601,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 709 GoInterfaceType net.Conn
+          Type: 721 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -6610,27 +6612,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 977
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 966
+      ID: 973
       Name: net.noReadFrom
       GoRuntimeType: 1133248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 965
+      ID: 972
       Name: net.noWriteTo
       GoRuntimeType: 1133120
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 335
+      ID: 347
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1027
+    - __kind: GoContextImplementationType
+      ID: 157
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1783904
@@ -6642,8 +6644,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 118 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 337
+      ID: 349
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1757824
@@ -6651,7 +6655,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 704 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 716 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6659,7 +6663,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 960
+      ID: 967
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2343488
@@ -6667,12 +6671,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 966 StructureType net.noReadFrom
+          Type: 973 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 963 PointerType *net.TCPConn
+          Type: 970 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 958
+      ID: 965
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2342944
@@ -6680,20 +6684,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 965 StructureType net.noWriteTo
+          Type: 972 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 963 PointerType *net.TCPConn
+          Type: 970 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 638
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 689
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 786
+      ID: 793
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1050080
@@ -6706,7 +6710,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 784
+      ID: 791
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1048544
@@ -6719,14 +6723,14 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 845
+      ID: 852
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2155040
       GoKind: 21
-      HeaderType: 847 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 854 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 787
+      ID: 794
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1048672
@@ -6739,15 +6743,15 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 343
+      ID: 355
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 563
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 785
+      ID: 792
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1048928
@@ -6771,7 +6775,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 862 PointerType *net/url.URL
+          Type: 869 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6783,19 +6787,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 840 GoInterfaceType io.ReadCloser
+          Type: 847 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 864 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 871 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6804,16 +6808,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 865 GoMapType net/url.Values
+          Type: 872 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 865 GoMapType net/url.Values
+          Type: 872 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 866 PointerType *mime/multipart.Form
+          Type: 873 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6822,13 +6826,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 868 PointerType *crypto/tls.ConnectionState
+          Type: 875 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 870 GoChannelType <-chan struct {}
+          Type: 877 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 871 PointerType *net/http.Response
+          Type: 878 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6837,15 +6841,15 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 873 PointerType *net/http.pattern
+          Type: 880 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
     - __kind: StructureType
-      ID: 872
+      ID: 879
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2268608
@@ -6868,16 +6872,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 840 GoInterfaceType io.ReadCloser
+          Type: 847 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6886,13 +6890,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 112 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 868 PointerType *crypto/tls.ConnectionState
+          Type: 875 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 111
       Name: net/http.ResponseWriter
@@ -6907,19 +6911,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 844
+      ID: 851
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1785440
@@ -6927,10 +6931,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 790 PointerType *net/http.response
+          Type: 797 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6938,31 +6942,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 846
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 885
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 899
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 259
+      ID: 271
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 845184
       GoKind: 10
     - __kind: BaseType
-      ID: 693
+      ID: 705
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1006528
       GoKind: 10
     - __kind: StructureType
-      ID: 346
+      ID: 358
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1759552
@@ -6973,12 +6977,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 705 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 679
+      ID: 691
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1939296
@@ -6989,16 +6993,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 705 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 352
+      ID: 364
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1623648
@@ -7006,12 +7010,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 705 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 275
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 845376
@@ -7019,28 +7023,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 277 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 276 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 276
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 350
+      ID: 362
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1134272
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 269
+      ID: 281
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 845568
@@ -7048,18 +7052,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 271 PointerType *net/http.http2headerFieldNameError.str
+          Type: 283 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 270 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 282 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 270
+      ID: 282
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 278
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 845472
@@ -7067,40 +7071,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *net/http.http2headerFieldValueError.str
+          Type: 280 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 267 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 279 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 279
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 642
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 882
+      ID: 889
       Name: net/http.http2missingBody
       GoRuntimeType: 1303712
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 894
+      ID: 901
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1304224
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 557
+      ID: 569
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1304096
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 260
+      ID: 272
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 845280
@@ -7108,22 +7112,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 262 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 274 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 261 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 273 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 261
+      ID: 273
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 789
+      ID: 796
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1211360
@@ -7131,13 +7135,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 836 PointerType *net/http.http2responseWriterState
+          Type: 843 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 844
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1576736
@@ -7145,19 +7149,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 921 PointerType *net/http.http2clientStream
+          Type: 928 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 887
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: net/http.noBody
       GoRuntimeType: 1488896
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 553
+      ID: 565
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1578016
@@ -7167,7 +7171,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 874
+      ID: 881
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1875616
@@ -7184,20 +7188,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1020 GoSliceHeaderType []net/http.segment
+          Type: 1027 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 883
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 356
+      ID: 368
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1438944
@@ -7207,7 +7211,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 791
+      ID: 798
       Name: net/http.response
       ByteSize: 232
       GoRuntimeType: 2406304
@@ -7215,16 +7219,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 838 PointerType *net/http.conn
+          Type: 845 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 112 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 840 GoInterfaceType io.ReadCloser
+          Type: 847 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 150 GoSubroutineType context.CancelFunc
+          Type: 171 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7236,19 +7240,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 133 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 841 StructureType sync/atomic.Bool
+          Type: 848 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 842 PointerType *bufio.Writer
+          Type: 849 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 844 StructureType net/http.chunkWriter
+          Type: 851 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7272,30 +7276,30 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 841 StructureType sync/atomic.Bool
+          Type: 848 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 850 ArrayType [29]uint8
+          Type: 857 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 851 ArrayType [10]uint8
+          Type: 858 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 852 ArrayType [3]uint8
+          Type: 859 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 133 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
-          Type: 853 GoChannelType chan bool
+          Type: 860 GoChannelType chan bool
         - Name: closeNotifyTriggered
           Offset: 224
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1022
+      ID: 1029
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1642496
@@ -7311,7 +7315,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 341
+      ID: 353
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1623488
@@ -7324,17 +7328,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 693
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 640
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1490496
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 555
+      ID: 567
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1578176
@@ -7344,7 +7348,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 943
+      ID: 950
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2072160
@@ -7352,22 +7356,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 709 GoInterfaceType net.Conn
+          Type: 721 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 709 GoInterfaceType net.Conn
+          Type: 721 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 339
+      ID: 351
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1312928
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 371
+      ID: 383
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1762240
@@ -7383,7 +7387,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 369
+      ID: 381
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1624608
@@ -7396,11 +7400,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 398
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 295
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 847872
@@ -7408,22 +7412,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *net/textproto.ProtocolError.str
+          Type: 297 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 284 GoStringDataType net/textproto.ProtocolError.str
+      Data: 296 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 296
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 698
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 289
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 847680
@@ -7431,18 +7435,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *net/url.EscapeError.str
+          Type: 291 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 278 GoStringDataType net/url.EscapeError.str
+      Data: 290 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 290
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 292
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 847776
@@ -7450,18 +7454,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *net/url.InvalidHostError.str
+          Type: 294 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 281 GoStringDataType net/url.InvalidHostError.str
+      Data: 293 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 293
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 863
+      ID: 870
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2181632
@@ -7475,7 +7479,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 983 PointerType *net/url.Userinfo
+          Type: 990 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7501,99 +7505,99 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 991
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 865
+      ID: 872
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1928480
       GoKind: 21
-      HeaderType: 847 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 854 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 197
+      ID: 240
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 696608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 198 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 241 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 831
+      ID: 838
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 752256
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 832 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 839 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 253
+      ID: 256
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 254 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 257 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 995
+      ID: 1002
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 996 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 1003 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 858
+      ID: 865
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 859 StructureType noalg.struct { key string; elem []string }
+      Element: 866 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 231
+      ID: 220
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 232 StructureType noalg.struct { key string; elem float64 }
+      Element: 221 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 730
+      ID: 742
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 776960
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 731 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 743 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 223
+      ID: 212
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 224 StructureType noalg.struct { key string; elem interface {} }
+      Element: 213 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 215
+      ID: 204
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 216 StructureType noalg.struct { key string; elem string }
+      Element: 205 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 196
+      ID: 239
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1315232
@@ -7604,9 +7608,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 240 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 830
+      ID: 837
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1361952
@@ -7617,9 +7621,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 831 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 838 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 252
+      ID: 255
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1332000
@@ -7630,9 +7634,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 253 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 256 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 994
+      ID: 1001
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1325728
@@ -7643,9 +7647,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 995 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 1002 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1316640
@@ -7656,9 +7660,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 858 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 865 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 230
+      ID: 219
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1331744
@@ -7669,9 +7673,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 231 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 220 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 729
+      ID: 741
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1380896
@@ -7682,9 +7686,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 730 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 742 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 222
+      ID: 211
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1314080
@@ -7695,9 +7699,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 223 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 212 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 214
+      ID: 203
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1319072
@@ -7708,9 +7712,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 215 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 204 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 198
+      ID: 241
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1315104
@@ -7718,12 +7722,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 199 GoInterfaceType context.canceler
+          Type: 242 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 200 StructureType struct {}
+          Type: 243 StructureType struct {}
     - __kind: StructureType
-      ID: 832
+      ID: 839
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1361824
@@ -7731,12 +7735,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 833 BaseType github.com/cihub/seelog.LogLevel
+          Type: 840 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 254
+      ID: 257
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1331872
@@ -7747,9 +7751,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 255 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 996
+      ID: 1003
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1325600
@@ -7760,9 +7764,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 997 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 1004 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 859
+      ID: 866
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1316512
@@ -7773,9 +7777,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 232
+      ID: 221
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1331616
@@ -7788,7 +7792,7 @@ Types:
           Offset: 16
           Type: 17 BaseType float64
     - __kind: StructureType
-      ID: 731
+      ID: 743
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1380768
@@ -7799,9 +7803,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 731 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 224
+      ID: 213
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1313952
@@ -7812,9 +7816,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 137 GoEmptyInterfaceType interface {}
+          Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 216
+      ID: 205
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1318944
@@ -7827,15 +7831,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 983
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 559
+      ID: 571
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 174
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1134912
@@ -7848,11 +7852,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 644
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 974
+      ID: 981
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2416448
@@ -7860,12 +7864,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 978 StructureType os.noReadFrom
+          Type: 985 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 975 PointerType *os.File
+          Type: 982 PointerType *os.File
     - __kind: StructureType
-      ID: 972
+      ID: 979
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2415648
@@ -7873,32 +7877,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 977 StructureType os.noWriteTo
+          Type: 984 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 975 PointerType *os.File
+          Type: 982 PointerType *os.File
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: os.noReadFrom
       GoRuntimeType: 1134784
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 977
+      ID: 984
       Name: os.noWriteTo
       GoRuntimeType: 1134656
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 604
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 737
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 594
+      ID: 606
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1735328
@@ -7911,7 +7915,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 170
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 2010144
@@ -7922,17 +7926,17 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 150 GoSubroutineType context.CancelFunc
+          Type: 171 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 151 GoSliceHeaderType []os.Signal
+          Type: 172 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 154 GoChannelType chan os.Signal
+          Type: 175 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 314
+      ID: 326
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 852864
@@ -7940,36 +7944,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 316 PointerType *os/user.UnknownGroupIdError.str
+          Type: 328 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 315 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 327 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 315
+      ID: 327
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 313
+      ID: 325
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 852768
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 377
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 464
+      ID: 476
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 579
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 583
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7981,7 +7985,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 569
+      ID: 581
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1928032
@@ -7998,9 +8002,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 723 BaseType runtime.boundsErrorCode
+          Type: 735 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 723
+      ID: 735
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 595360
@@ -8020,7 +8024,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 634
+      ID: 646
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1792928
@@ -8033,7 +8037,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 547
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1007776
@@ -8041,13 +8045,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *runtime.errorString.str
+          Type: 549 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 536 GoStringDataType runtime.errorString.str
+      Data: 548 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 548
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8674,7 +8678,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 190
+      ID: 197
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -8710,7 +8714,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 538
+      ID: 550
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1007872
@@ -8718,13 +8722,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 540 PointerType *runtime.plainError.str
+          Type: 552 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 539 GoStringDataType runtime.plainError.str
+      Data: 551 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 539
+      ID: 551
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8765,7 +8769,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 367
+      ID: 379
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1624288
@@ -8823,7 +8827,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 575
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8835,18 +8839,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 185 PointerType *string.str
+          Type: 192 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 184 GoStringDataType string.str
+      Data: 191 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 184
+      ID: 191
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 758
+      ID: 765
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1991456
@@ -8854,12 +8858,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 772
+      ID: 779
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2067584
@@ -8867,15 +8871,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 754
+      ID: 761
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1990944
@@ -8883,12 +8887,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 764
+      ID: 771
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2066432
@@ -8896,15 +8900,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2137312
@@ -8912,18 +8916,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 766
+      ID: 773
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2066720
@@ -8931,15 +8935,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 762
+      ID: 769
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2066144
@@ -8947,15 +8951,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 774
+      ID: 781
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2136672
@@ -8963,18 +8967,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2199296
@@ -8982,21 +8986,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 776
+      ID: 783
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2136992
@@ -9004,18 +9008,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 760
+      ID: 767
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1991712
@@ -9023,12 +9027,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 756
+      ID: 763
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1991200
@@ -9036,12 +9040,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 768
+      ID: 775
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2067008
@@ -9049,15 +9053,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2137632
@@ -9065,18 +9069,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 770
+      ID: 777
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2067296
@@ -9084,15 +9088,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1740512
@@ -9100,18 +9104,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 923 GoInterfaceType io.Reader
+          Type: 930 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 933 GoInterfaceType io.Closer
+          Type: 940 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 200
+      ID: 243
       Name: struct {}
       GoRuntimeType: 858528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 133
+      ID: 120
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1494336
@@ -9119,12 +9123,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 134 StructureType sync.noCopy
+          Type: 121 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 135 StructureType internal/sync.Mutex
+          Type: 122 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 155
+      ID: 119
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1881440
@@ -9132,7 +9136,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 133 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -9141,18 +9145,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 156 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 156 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 134
+      ID: 121
       Name: sync.noCopy
       GoRuntimeType: 1007392
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1495456
@@ -9160,12 +9164,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 157 StructureType sync/atomic.noCopy
+          Type: 124 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 156
+      ID: 123
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1495616
@@ -9173,12 +9177,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 157 StructureType sync/atomic.noCopy
+          Type: 124 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 136
+      ID: 178
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1219296
@@ -9186,27 +9190,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 137 GoEmptyInterfaceType interface {}
+          Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 157
+      ID: 124
       Name: sync/atomic.noCopy
       GoRuntimeType: 1007488
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 671
+      ID: 683
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1304992
       GoKind: 12
     - __kind: BaseType
-      ID: 746
+      ID: 753
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 1008832
       GoKind: 2
     - __kind: StructureType
-      ID: 193
+      ID: 236
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9228,9 +9232,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 237 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 827
+      ID: 834
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9252,9 +9256,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 828 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 835 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 249
+      ID: 252
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9276,9 +9280,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 250 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 253 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 991
+      ID: 998
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9300,9 +9304,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 992 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 999 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9324,9 +9328,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 855 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 862 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 227
+      ID: 216
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9348,9 +9352,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 228 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 217 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 726
+      ID: 738
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9372,9 +9376,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 727 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 739 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 219
+      ID: 208
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9396,9 +9400,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 220 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 209 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 211
+      ID: 200
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9420,9 +9424,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 212 GoSwissMapGroupsType groupReference<string,string>
+          Type: 201 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 614
+      ID: 626
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1739552
@@ -9435,13 +9439,13 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 950
+      ID: 957
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1955360
       GoKind: 6
     - __kind: StructureType
-      ID: 148
+      ID: 190
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2014752
@@ -9452,10 +9456,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 203 GoSliceHeaderType []time.zone
+          Type: 246 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 206 GoSliceHeaderType []time.zoneTrans
+          Type: 249 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9467,13 +9471,13 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 204 PointerType *time.zone
+          Type: 247 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 359
+      ID: 371
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 146
+      ID: 188
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2429760
@@ -9487,7 +9491,7 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 147 PointerType *time.Location
+          Type: 189 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9497,7 +9501,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 145
+      ID: 187
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1491456
@@ -9505,12 +9509,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 740 GoChannelType <-chan time.Time
+          Type: 752 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 272
+      ID: 284
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 845664
@@ -9518,18 +9522,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 274 PointerType *time.fileSizeError.str
+          Type: 286 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 273 GoStringDataType time.fileSizeError.str
+      Data: 285 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 273
+      ID: 285
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 205
+      ID: 248
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1647488
@@ -9545,7 +9549,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 208
+      ID: 251
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1789472
@@ -9606,7 +9610,7 @@ Types:
       GoRuntimeType: 595296
       GoKind: 26
     - __kind: StructureType
-      ID: 704
+      ID: 716
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2104032
@@ -9617,10 +9621,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 717 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 706 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 718 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9635,18 +9639,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 719 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 707
+      ID: 719
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1008928
       GoKind: 9
     - __kind: StructureType
-      ID: 705
+      ID: 717
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1958944
@@ -9671,17 +9675,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 373
+      ID: 385
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 706
+      ID: 718
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 596192
       GoKind: 8
     - __kind: StructureType
-      ID: 388
+      ID: 400
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1444384
@@ -9691,13 +9695,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 286
+      ID: 298
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 847968
       GoKind: 2
     - __kind: StructureType
-      ID: 576
+      ID: 588
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1734752
@@ -9710,7 +9714,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 542
+      ID: 554
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1009792

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.26rc1.yaml
@@ -121,23 +121,23 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 704 PointerType *crypto/x509.Certificate
+      Pointee: 716 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 752
+      ID: 277
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 120 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1009 PointerType *mime/multipart.FileHeader
+      Pointee: 1016 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
       ID: 69
       Name: '**runtime.p'
@@ -145,111 +145,111 @@ Types:
       GoKind: 22
       Pointee: 70 PointerType *runtime.p
     - __kind: PointerType
-      ID: 147
+      ID: 188
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 148 PointerType *table<context.canceler,struct {}>
+      Pointee: 189 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 818 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 825 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 250
+      ID: 239
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 251 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 240 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 999
+      ID: 1006
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 1000 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 1007 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 859 PointerType *table<string,[]string>
+      Pointee: 866 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 144
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 182 PointerType *table<string,float64>
+      Pointee: 145 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 709
+      ID: 721
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 710 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 722 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 176
+      ID: 139
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<string,interface {}>
+      Pointee: 140 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 171
+      ID: 134
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<string,string>
+      Pointee: 135 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1016 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 1023 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 1025
+      ID: 1032
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 1024 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1031 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 755
+      ID: 280
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 754 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 279 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 1014
+      ID: 1021
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 1013 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 1020 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 202
+      ID: 209
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []*runtime.p.array
-    - __kind: PointerType
-      ID: 1027
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 1026 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 1029
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 1028 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 747
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 746 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 246
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 245 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 254
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 253 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 208 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 1034
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1033 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1036
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1035 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 759
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 758 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 235
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 234 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 243
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1041
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1033 GoSliceDataType []net/http.segment.array
+      Pointee: 1040 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 220
+      ID: 245
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []os.Signal.array
+      Pointee: 244 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -258,77 +258,77 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 745
+      ID: 757
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 744 GoSliceDataType []string.array
+      Pointee: 756 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 256
+      ID: 273
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []time.zone.array
+      Pointee: 272 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 258
+      ID: 275
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []time.zoneTrans.array
+      Pointee: 274 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 492352
       GoKind: 22
       Pointee: 41 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 197
+      ID: 204
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []uint8.array
+      Pointee: 203 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 199
+      ID: 206
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []uintptr.array
+      Pointee: 205 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 960224
       GoKind: 22
-      Pointee: 519 GoSliceHeaderType archive/tar.headerError
+      Pointee: 531 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 520 GoSliceDataType archive/tar.headerError.array
+      Pointee: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1260544
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 929 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1092352
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 915 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1471136
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 933 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1092096
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 913 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -337,12 +337,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 2017120
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType bufio.Writer
+      Pointee: 860 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 122
       Name: '*bytes.Buffer'
@@ -358,353 +358,353 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 402
+      ID: 414
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 935360
       GoKind: 22
-      Pointee: 300 BaseType compress/flate.CorruptInputError
+      Pointee: 312 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 935456
       GoKind: 22
-      Pointee: 301 GoStringHeaderType compress/flate.InternalError
+      Pointee: 313 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 303
+      ID: 315
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 302 GoStringDataType compress/flate.InternalError.str
+      Pointee: 314 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 2041312
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 969 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1676736
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 948 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 125
+      ID: 197
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 1774400
       GoKind: 22
-      Pointee: 126 StructureType context.afterFuncCtx
+      Pointee: 198 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 1040
+      ID: 171
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1588736
       GoKind: 22
-      Pointee: 152 StructureType context.backgroundCtx
+      Pointee: 172 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 127
+      ID: 182
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1773824
       GoKind: 22
-      Pointee: 128 StructureType context.cancelCtx
+      Pointee: 183 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1215872
       GoKind: 22
-      Pointee: 629 StructureType context.deadlineExceededError
+      Pointee: 641 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1035
+      ID: 157
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1445376
       GoKind: 22
-      Pointee: 153 StructureType context.emptyCtx
+      Pointee: 158 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 129
+      ID: 159
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1445536
       GoKind: 22
-      Pointee: 130 StructureType context.stopCtx
+      Pointee: 160 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 131
+      ID: 190
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1774016
       GoKind: 22
-      Pointee: 132 StructureType context.timerCtx
+      Pointee: 191 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1041
+      ID: 173
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1588896
       GoKind: 22
-      Pointee: 160 StructureType context.todoCtx
+      Pointee: 174 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 133
+      ID: 166
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1588416
       GoKind: 22
-      Pointee: 134 StructureType context.valueCtx
+      Pointee: 167 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 135
+      ID: 169
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1588576
       GoKind: 22
-      Pointee: 136 StructureType context.withoutCancelCtx
+      Pointee: 170 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945152
       GoKind: 22
-      Pointee: 319 BaseType crypto/aes.KeySizeError
+      Pointee: 331 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945344
       GoKind: 22
-      Pointee: 320 BaseType crypto/des.KeySizeError
+      Pointee: 332 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 461
+      ID: 473
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945632
       GoKind: 22
-      Pointee: 321 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 333 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 607
+      ID: 619
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1089024
       GoKind: 22
-      Pointee: 608 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 620 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945920
       GoKind: 22
-      Pointee: 322 BaseType crypto/rc4.KeySizeError
+      Pointee: 334 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 933440
       GoKind: 22
-      Pointee: 289 BaseType crypto/tls.AlertError
+      Pointee: 301 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 583
+      ID: 595
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1070080
       GoKind: 22
-      Pointee: 584 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 596 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2458976
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 999 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 933056
       GoKind: 22
-      Pointee: 879 StructureType crypto/tls.ConnectionState
+      Pointee: 886 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 933536
       GoKind: 22
-      Pointee: 393 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 405 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 389
+      ID: 401
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 933344
       GoKind: 22
-      Pointee: 390 StructureType crypto/tls.RecordHeaderError
+      Pointee: 402 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1068416
       GoKind: 22
-      Pointee: 551 BaseType crypto/tls.alert
+      Pointee: 563 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 933632
       GoKind: 22
-      Pointee: 395 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 407 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 693
+      ID: 705
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1453376
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 706 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 704
+      ID: 716
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2079168
       GoKind: 22
-      Pointee: 705 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 717 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 944768
       GoKind: 22
-      Pointee: 456 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 468 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 449
+      ID: 461
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 943808
       GoKind: 22
-      Pointee: 450 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 462 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 451
+      ID: 463
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 944288
       GoKind: 22
-      Pointee: 452 StructureType crypto/x509.HostnameError
+      Pointee: 464 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 943712
       GoKind: 22
-      Pointee: 318 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 330 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 599
+      ID: 611
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1080064
       GoKind: 22
-      Pointee: 600 StructureType crypto/x509.SystemRootsError
+      Pointee: 612 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 944864
       GoKind: 22
-      Pointee: 458 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 470 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 944672
       GoKind: 22
-      Pointee: 454 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 466 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 955616
       GoKind: 22
-      Pointee: 511 StructureType encoding/asn1.StructuralError
+      Pointee: 523 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 514
+      ID: 526
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 955808
       GoKind: 22
-      Pointee: 515 StructureType encoding/asn1.SyntaxError
+      Pointee: 527 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 955712
       GoKind: 22
-      Pointee: 513 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 525 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 933824
       GoKind: 22
-      Pointee: 290 BaseType encoding/base64.CorruptInputError
+      Pointee: 302 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 942464
       GoKind: 22
-      Pointee: 314 BaseType encoding/hex.InvalidByteError
+      Pointee: 326 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 415
+      ID: 427
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 937664
       GoKind: 22
-      Pointee: 416 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 428 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 595
+      ID: 607
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1075200
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 608 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 937280
       GoKind: 22
-      Pointee: 408 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 420 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 413
+      ID: 425
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 937568
       GoKind: 22
-      Pointee: 414 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 426 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 937472
       GoKind: 22
-      Pointee: 412 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 424 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 409
+      ID: 421
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 422 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 417
+      ID: 429
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 938048
       GoKind: 22
-      Pointee: 418 StructureType encoding/json.jsonError
+      Pointee: 430 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 953024
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 521 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -713,19 +713,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 928352
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType errors.errorString
+      Pointee: 387 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 570
+      ID: 582
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1061248
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType errors.joinError
+      Pointee: 583 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -741,118 +741,118 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 554
+      ID: 566
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1050624
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType fmt.wrapError
+      Pointee: 567 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 556
+      ID: 568
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1050752
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 569 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 941984
       GoKind: 22
-      Pointee: 439 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 451 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2080320
       GoKind: 22
-      Pointee: 820 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 827 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 939296
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 433 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 939392
       GoKind: 22
-      Pointee: 423 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 435 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 724
+      ID: 736
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 939104
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 737 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 939680
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 439 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 726
+      ID: 738
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 939200
       GoKind: 22
-      Pointee: 727 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 739 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 939488
       GoKind: 22
-      Pointee: 308 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 320 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 310
+      ID: 322
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 309 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 321 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 419
+      ID: 431
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 939008
       GoKind: 22
-      Pointee: 305 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 317 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 307
+      ID: 319
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 318 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 939584
       GoKind: 22
-      Pointee: 311 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 323 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 313
+      ID: 325
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 312 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 324 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 465
+      ID: 477
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 947072
       GoKind: 22
-      Pointee: 466 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 478 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
       ByteSize: 8
       GoRuntimeType: 1778432
       GoKind: 22
-      Pointee: 811 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
+      Pointee: 818 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
     - __kind: PointerType
       ID: 120
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -861,728 +861,728 @@ Types:
       GoKind: 22
       Pointee: 121 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 189
+      ID: 152
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2076000
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 153 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 184
+      ID: 147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1222656
       GoKind: 22
-      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1959072
       GoKind: 22
-      Pointee: 957 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 964 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1855968
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+      Pointee: 956 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 187
+      ID: 150
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1222784
       GoKind: 22
-      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1223424
       GoKind: 22
-      Pointee: 760 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 767 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 265
+      ID: 268
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1223552
       GoKind: 22
-      Pointee: 266 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 269 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 191
+      ID: 154
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2300576
       GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 155 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer'
       ByteSize: 8
       GoRuntimeType: 2286240
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
+      Pointee: 833 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1245696
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 682 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1597376
       GoKind: 22
-      Pointee: 762 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 769 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2250080
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
+      Pointee: 829 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1038
+      ID: 164
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1456736
       GoKind: 22
-      Pointee: 1039 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 165 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2250496
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
+      Pointee: 831 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1083136
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
+      Pointee: 911 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 949280
       GoKind: 22
-      Pointee: 468 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 480 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 950336
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 487 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 950048
       GoKind: 22
-      Pointee: 323 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 335 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 472
+      ID: 484
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 950240
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 485 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 470
+      ID: 482
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 950144
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 483 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 482
+      ID: 494
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 951680
       GoKind: 22
-      Pointee: 483 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 495 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 486
+      ID: 498
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 951872
       GoKind: 22
-      Pointee: 487 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 499 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 951776
       GoKind: 22
-      Pointee: 485 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 497 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 951584
       GoKind: 22
-      Pointee: 481 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 493 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 749
+      ID: 761
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 748 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 760 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 494
+      ID: 506
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 952256
       GoKind: 22
-      Pointee: 495 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 507 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 951968
       GoKind: 22
-      Pointee: 489 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 501 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 492
+      ID: 504
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 952160
       GoKind: 22
-      Pointee: 493 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 505 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 490
+      ID: 502
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 952064
       GoKind: 22
-      Pointee: 491 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 503 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 952352
       GoKind: 22
-      Pointee: 497 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 509 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 952640
       GoKind: 22
-      Pointee: 503 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 515 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 952736
       GoKind: 22
-      Pointee: 505 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 517 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 952544
       GoKind: 22
-      Pointee: 501 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 513 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 952448
       GoKind: 22
-      Pointee: 499 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 511 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 952928
       GoKind: 22
-      Pointee: 507 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 519 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2400288
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 843 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2384096
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 837 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2392608
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 839 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2393248
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 841 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 940832
       GoKind: 22
-      Pointee: 429 StructureType github.com/cihub/seelog.baseError
+      Pointee: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1858432
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 820 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 940928
       GoKind: 22
-      Pointee: 431 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 443 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1459936
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 810 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1685760
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 812 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1686528
       GoKind: 22
-      Pointee: 809 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 816 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 941120
       GoKind: 22
-      Pointee: 435 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 447 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1685952
       GoKind: 22
-      Pointee: 807 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 814 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2361792
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 835 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 941024
       GoKind: 22
-      Pointee: 433 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 445 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 941216
       GoKind: 22
-      Pointee: 437 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 449 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1254912
       GoKind: 22
-      Pointee: 920 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 927 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1784768
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 952 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 697
+      ID: 709
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1472416
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 710 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 613
+      ID: 625
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1097344
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 626 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 611
+      ID: 623
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1097216
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 624 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 615
+      ID: 627
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1101696
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 628 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 617
+      ID: 629
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1101824
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 630 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 605
+      ID: 617
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1086208
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 618 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 942656
       GoKind: 22
-      Pointee: 442 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 454 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 671
+      ID: 683
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1254400
       GoKind: 22
-      Pointee: 672 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 684 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 657
+      ID: 669
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1237760
       GoKind: 22
-      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 670 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 651
+      ID: 663
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1237376
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 664 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 589
+      ID: 601
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1073024
       GoKind: 22
-      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 602 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 663
+      ID: 675
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1238144
       GoKind: 22
-      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 676 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1072896
       GoKind: 22
-      Pointee: 553 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 565 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 655
+      ID: 667
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1237632
       GoKind: 22
-      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 653
+      ID: 665
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1237504
       GoKind: 22
-      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1238016
       GoKind: 22
-      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1237888
       GoKind: 22
-      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1238528
       GoKind: 22
-      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 680 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 593
+      ID: 605
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1073280
       GoKind: 22
-      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 606 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 591
+      ID: 603
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1073152
       GoKind: 22
-      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 604 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1238400
       GoKind: 22
-      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 678 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 971648
       GoKind: 22
-      Pointee: 328 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 340 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 330
+      ID: 342
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 341 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 712
+      ID: 724
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1715328
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 725 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1116544
       GoKind: 22
-      Pointee: 622 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 634 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 972896
       GoKind: 22
-      Pointee: 331 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 343 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 679
+      ID: 691
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1293056
       GoKind: 22
-      Pointee: 680 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 692 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 536
+      ID: 548
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 973184
       GoKind: 22
-      Pointee: 537 StructureType golang.org/x/net/http2.connError
+      Pointee: 549 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 535
+      ID: 547
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 973088
       GoKind: 22
-      Pointee: 335 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 347 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 336 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 348 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 973376
       GoKind: 22
-      Pointee: 341 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 353 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 343
+      ID: 355
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 342 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 354 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 538
+      ID: 550
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 973280
       GoKind: 22
-      Pointee: 338 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 350 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 339 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 351 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 534
+      ID: 546
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 972992
       GoKind: 22
-      Pointee: 332 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 344 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 334
+      ID: 346
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 333 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 345 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 540
+      ID: 552
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 973472
       GoKind: 22
-      Pointee: 541 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 553 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 542
+      ID: 554
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 973568
       GoKind: 22
-      Pointee: 344 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 356 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 967328
       GoKind: 22
-      Pointee: 529 StructureType google.golang.org/grpc.dropError
+      Pointee: 541 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 677
+      ID: 689
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1290112
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 690 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 699
+      ID: 711
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1479936
       GoKind: 22
-      Pointee: 700 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 712 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 530
+      ID: 542
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 969920
       GoKind: 22
-      Pointee: 531 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 543 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1866048
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 958 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 619
+      ID: 631
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1110784
       GoKind: 22
-      Pointee: 620 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 632 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1609536
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 942 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 958880
       GoKind: 22
-      Pointee: 517 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 529 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 609
+      ID: 621
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1090944
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 622 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 675
+      ID: 687
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1259136
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 688 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 673
+      ID: 685
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1258880
       GoKind: 22
-      Pointee: 674 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 686 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 522
+      ID: 534
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 961184
       GoKind: 22
-      Pointee: 523 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 535 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 961280
       GoKind: 22
-      Pointee: 525 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 537 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 950432
       GoKind: 22
-      Pointee: 477 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 489 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 543
+      ID: 555
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 974336
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType html/template.Error
+      Pointee: 556 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 106
       Name: '*int'
@@ -1619,54 +1619,54 @@ Types:
       GoKind: 22
       Pointee: 22 BaseType int8
     - __kind: PointerType
-      ID: 701
+      ID: 713
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2273344
       GoKind: 22
-      Pointee: 702 UnresolvedPointeeType internal/abi.Type
+      Pointee: 714 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 943328
       GoKind: 22
-      Pointee: 447 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 459 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 943232
       GoKind: 22
-      Pointee: 445 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 457 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 649
+      ID: 661
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1232000
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 662 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2452608
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType internal/poll.FD
+      Pointee: 997 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 647
+      ID: 659
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1231872
       GoKind: 22
-      Pointee: 648 StructureType internal/poll.errNetClosing
+      Pointee: 660 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 928736
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 389 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -1675,305 +1675,305 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 443
+      ID: 455
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 943136
       GoKind: 22
-      Pointee: 315 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 327 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 317
+      ID: 329
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 316 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 328 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 597
+      ID: 609
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1078912
       GoKind: 22
-      Pointee: 598 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 610 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 386
+      ID: 398
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 932384
       GoKind: 22
-      Pointee: 288 BaseType internal/strconv.Error
+      Pointee: 300 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1899872
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType io.PipeReader
+      Pointee: 962 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1593856
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType io.SectionReader
+      Pointee: 966 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1061760
       GoKind: 22
-      Pointee: 902 StructureType io.nopCloser
+      Pointee: 909 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1226240
       GoKind: 22
-      Pointee: 918 StructureType io.nopCloserWriterTo
+      Pointee: 925 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 645
+      ID: 657
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1230848
       GoKind: 22
-      Pointee: 646 UnresolvedPointeeType io/fs.PathError
+      Pointee: 658 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 145
+      ID: 186
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 146 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 187 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 816 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 823 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 248
+      ID: 237
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 249 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 238 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 998 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 1005 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 857 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 864 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 179
+      ID: 142
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 180 GoSwissMapHeaderType map<string,float64>
+      Pointee: 143 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 707
+      ID: 719
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 708 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 720 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 174
+      ID: 137
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 169
+      ID: 132
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<string,string>
+      Pointee: 133 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 463
+      ID: 475
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 946688
       GoKind: 22
-      Pointee: 464 StructureType math/big.ErrNaN
+      Pointee: 476 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 934592
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 1019 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 934688
       GoKind: 22
-      Pointee: 877 StructureType mime/multipart.Form
+      Pointee: 884 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1675584
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 944 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1675776
       GoKind: 22
-      Pointee: 939 StructureType mime/multipart.sectionReadCloser
+      Pointee: 946 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 631
+      ID: 643
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1217024
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType net.AddrError
+      Pointee: 644 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 684
+      ID: 696
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1446176
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType net.DNSError
+      Pointee: 697 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2305504
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType net.IPConn
+      Pointee: 973 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 682
+      ID: 694
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1445856
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType net.OpError
+      Pointee: 695 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 633
+      ID: 645
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1217152
       GoKind: 22
-      Pointee: 634 UnresolvedPointeeType net.ParseError
+      Pointee: 646 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2336736
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType net.TCPConn
+      Pointee: 981 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2382272
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType net.UDPConn
+      Pointee: 985 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2336224
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType net.UnixConn
+      Pointee: 979 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1216256
       GoKind: 22
-      Pointee: 625 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 637 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 626 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 638 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 558
+      ID: 570
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1051648
       GoKind: 22
-      Pointee: 559 StructureType net.canceledError
+      Pointee: 571 StructureType net.canceledError
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2073984
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType net.conn
+      Pointee: 971 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 730
+      ID: 742
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1893376
       GoKind: 22
-      Pointee: 731 StructureType net.dialResult·1
+      Pointee: 743 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2386528
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType net.netFD
+      Pointee: 987 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 921152
       GoKind: 22
-      Pointee: 346 UnresolvedPointeeType net.notFoundError
+      Pointee: 358 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1036
+      ID: 162
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1446016
       GoKind: 22
-      Pointee: 1037 StructureType net.onlyValuesCtx
+      Pointee: 163 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 921824
       GoKind: 22
-      Pointee: 348 StructureType net.result·2
+      Pointee: 360 StructureType net.result·2
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2321792
       GoKind: 22
-      Pointee: 970 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 977 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2321312
       GoKind: 22
-      Pointee: 968 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 975 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 635
+      ID: 647
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1217792
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType net.temporaryError
+      Pointee: 648 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 686
+      ID: 698
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1446496
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType net.timeoutError
+      Pointee: 699 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 353
+      ID: 365
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 366 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1055360
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 573 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 118
       Name: '*net/http.Request'
@@ -1982,571 +1982,571 @@ Types:
       GoKind: 22
       Pointee: 119 StructureType net/http.Request
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1775552
       GoKind: 22
-      Pointee: 882 StructureType net/http.Response
+      Pointee: 889 StructureType net/http.Response
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1855072
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType net/http.body
+      Pointee: 954 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1220096
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 921 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1055232
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 903 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1957280
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType net/http.conn
+      Pointee: 856 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1053952
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 895 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1592416
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 939 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 924608
       GoKind: 22
-      Pointee: 269 BaseType net/http.http2ConnectionError
+      Pointee: 281 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 357 StructureType net/http.http2GoAwayError
+      Pointee: 369 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 688
+      ID: 700
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1447296
       GoKind: 22
-      Pointee: 689 StructureType net/http.http2StreamError
+      Pointee: 701 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2075712
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 935 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 362
+      ID: 374
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 925760
       GoKind: 22
-      Pointee: 363 StructureType net/http.http2connError
+      Pointee: 375 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 359
+      ID: 371
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 925184
       GoKind: 22
-      Pointee: 273 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 285 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 275
+      ID: 287
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 286 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 925280
       GoKind: 22
-      Pointee: 361 StructureType net/http.http2goAwayFlowError
+      Pointee: 373 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1590816
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 937 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 925952
       GoKind: 22
-      Pointee: 279 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 291 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 281
+      ID: 293
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 280 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 292 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 364
+      ID: 376
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 925856
       GoKind: 22
-      Pointee: 276 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 288 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 278
+      ID: 290
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 289 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 639
+      ID: 651
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1221376
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 652 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1054848
       GoKind: 22
-      Pointee: 892 StructureType net/http.http2missingBody
+      Pointee: 899 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1057664
       GoKind: 22
-      Pointee: 900 StructureType net/http.http2noBodyReader
+      Pointee: 907 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 566
+      ID: 578
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1057536
       GoKind: 22
-      Pointee: 567 StructureType net/http.http2noCachedConnError
+      Pointee: 579 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 925088
       GoKind: 22
-      Pointee: 270 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 282 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 272
+      ID: 284
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 283 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1055872
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 905 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2075136
       GoKind: 22
-      Pointee: 799 StructureType net/http.http2responseWriter
+      Pointee: 806 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1660608
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 854 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1054976
       GoKind: 22
-      Pointee: 894 StructureType net/http.http2transportResponseBody
+      Pointee: 901 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1054208
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 897 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1220224
       GoKind: 22
-      Pointee: 916 StructureType net/http.noBody
+      Pointee: 923 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1057280
       GoKind: 22
-      Pointee: 563 StructureType net/http.nothingWrittenError
+      Pointee: 575 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1658880
       GoKind: 22
-      Pointee: 884 StructureType net/http.pattern
+      Pointee: 891 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1053568
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 893 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1447616
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 931 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 926144
       GoKind: 22
-      Pointee: 367 StructureType net/http.requestBodyReadError
+      Pointee: 379 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2300128
       GoKind: 22
-      Pointee: 801 StructureType net/http.response
+      Pointee: 808 StructureType net/http.response
     - __kind: PointerType
-      ID: 1031
+      ID: 1038
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 401472
       GoKind: 22
-      Pointee: 1032 StructureType net/http.segment
+      Pointee: 1039 StructureType net/http.segment
     - __kind: PointerType
-      ID: 351
+      ID: 363
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 924320
       GoKind: 22
-      Pointee: 352 StructureType net/http.statusError
+      Pointee: 364 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 690
+      ID: 702
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1448736
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 703 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 637
+      ID: 649
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1221248
       GoKind: 22
-      Pointee: 638 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 650 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1057408
       GoKind: 22
-      Pointee: 565 StructureType net/http.transportReadFromServerError
+      Pointee: 577 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1894720
       GoKind: 22
-      Pointee: 953 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 960 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 923552
       GoKind: 22
-      Pointee: 350 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 362 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1117184
       GoKind: 22
-      Pointee: 910 StructureType net/http/httputil.failureToReadBody
+      Pointee: 917 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 931616
       GoKind: 22
-      Pointee: 385 StructureType net/netip.parseAddrError
+      Pointee: 397 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 382
+      ID: 394
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 931520
       GoKind: 22
-      Pointee: 383 StructureType net/netip.parsePrefixError
+      Pointee: 395 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 935072
       GoKind: 22
-      Pointee: 401 UnresolvedPointeeType net/textproto.Error
+      Pointee: 413 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 934976
       GoKind: 22
-      Pointee: 297 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 309 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 299
+      ID: 311
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 310 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 695
+      ID: 707
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1453696
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType net/url.Error
+      Pointee: 708 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 933920
       GoKind: 22
-      Pointee: 291 GoStringHeaderType net/url.EscapeError
+      Pointee: 303 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 293
+      ID: 305
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 292 GoStringDataType net/url.EscapeError.str
+      Pointee: 304 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 934016
       GoKind: 22
-      Pointee: 294 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 306 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 296
+      ID: 308
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 295 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 307 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2203520
       GoKind: 22
-      Pointee: 873 StructureType net/url.URL
+      Pointee: 880 StructureType net/url.URL
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1234944
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 1001 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 205
+      ID: 248
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 206 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 249 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 847 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 261
+      ID: 264
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 265 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 1004 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 1011 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 867 StructureType noalg.map.group[string][]string
+      Pointee: 874 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 239
+      ID: 228
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 240 StructureType noalg.map.group[string]float64
+      Pointee: 229 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 738
+      ID: 750
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 751 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 231
+      ID: 220
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 232 StructureType noalg.map.group[string]interface {}
+      Pointee: 221 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 223
+      ID: 212
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 224 StructureType noalg.map.group[string]string
+      Pointee: 213 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2428096
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType os.File
+      Pointee: 993 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 568
+      ID: 580
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1059712
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType os.LinkError
+      Pointee: 581 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 163
+      ID: 179
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 404416
       GoKind: 22
-      Pointee: 164 GoInterfaceType os.Signal
+      Pointee: 180 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 641
+      ID: 653
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1221760
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType os.SyscallError
+      Pointee: 654 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2425824
       GoKind: 22
-      Pointee: 984 StructureType os.fileWithoutReadFrom
+      Pointee: 991 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 981
+      ID: 988
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2425088
       GoKind: 22
-      Pointee: 982 StructureType os.fileWithoutWriteTo
+      Pointee: 989 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1081856
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType os/exec.Error
+      Pointee: 614 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 734
+      ID: 746
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2163264
       GoKind: 22
-      Pointee: 735 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 747 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1081984
       GoKind: 22
-      Pointee: 604 StructureType os/exec.wrappedError
+      Pointee: 616 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 137
+      ID: 175
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1662912
       GoKind: 22
-      Pointee: 138 StructureType os/signal.signalCtx
+      Pointee: 176 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 368
+      ID: 380
       Name: '*os/signal.signalError'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 282 GoStringHeaderType os/signal.signalError
+      Pointee: 294 GoStringHeaderType os/signal.signalError
     - __kind: PointerType
-      ID: 284
+      ID: 296
       Name: '*os/signal.signalError.str'
       ByteSize: 8
-      Pointee: 283 GoStringDataType os/signal.signalError.str
+      Pointee: 295 GoStringDataType os/signal.signalError.str
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 965408
       GoKind: 22
-      Pointee: 325 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 337 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 327
+      ID: 339
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 338 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 526
+      ID: 538
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 965312
       GoKind: 22
-      Pointee: 324 BaseType os/user.UnknownUserIdError
+      Pointee: 336 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 929504
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType reflect.ValueError
+      Pointee: 391 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 950912
       GoKind: 22
-      Pointee: 479 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 491 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 576
+      ID: 588
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1065600
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 589 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 580
+      ID: 592
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1066240
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 593 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -2562,12 +2562,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1065728
       GoKind: 22
-      Pointee: 579 StructureType runtime.boundsError
+      Pointee: 591 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -2583,24 +2583,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 643
+      ID: 655
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1230336
       GoKind: 22
-      Pointee: 644 StructureType runtime.errorAddressString
+      Pointee: 656 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1063936
       GoKind: 22
-      Pointee: 545 GoStringHeaderType runtime.errorString
+      Pointee: 557 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 547
+      ID: 559
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 546 GoStringDataType runtime.errorString.str
+      Pointee: 558 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -2621,19 +2621,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1065344
       GoKind: 22
-      Pointee: 200 UnresolvedPointeeType runtime.p
+      Pointee: 207 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1064064
       GoKind: 22
-      Pointee: 548 GoStringHeaderType runtime.plainError
+      Pointee: 560 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 550
+      ID: 562
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 549 GoStringDataType runtime.plainError.str
+      Pointee: 561 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -2649,12 +2649,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 380
+      ID: 392
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 931232
       GoKind: 22
-      Pointee: 381 StructureType runtime.synctestDeadlockError
+      Pointee: 393 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -2677,12 +2677,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1063552
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType strconv.NumError
+      Pointee: 585 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -2691,242 +2691,242 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 195
+      ID: 202
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 194 GoStringDataType string.str
+      Pointee: 201 GoStringDataType string.str
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1739520
       GoKind: 22
-      Pointee: 768 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 775 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1799744
       GoKind: 22
-      Pointee: 782 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 789 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1739136
       GoKind: 22
-      Pointee: 764 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 771 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1798976
       GoKind: 22
-      Pointee: 774 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 781 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1872320
       GoKind: 22
-      Pointee: 788 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 795 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1799168
       GoKind: 22
-      Pointee: 776 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 783 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1798784
       GoKind: 22
-      Pointee: 772 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 779 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1871872
       GoKind: 22
-      Pointee: 784 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 791 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1944224
       GoKind: 22
-      Pointee: 792 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 799 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1872096
       GoKind: 22
-      Pointee: 786 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 793 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1739712
       GoKind: 22
-      Pointee: 770 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 777 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1739328
       GoKind: 22
-      Pointee: 766 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 773 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1799360
       GoKind: 22
-      Pointee: 778 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 785 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1872544
       GoKind: 22
-      Pointee: 790 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 797 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1799552
       GoKind: 22
-      Pointee: 780 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 787 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1124096
       GoKind: 22
-      Pointee: 912 StructureType struct { io.Reader; io.Closer }
+      Pointee: 919 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 692
+      ID: 704
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1452576
       GoKind: 22
-      Pointee: 681 BaseType syscall.Errno
+      Pointee: 693 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1066752
       GoKind: 22
-      Pointee: 756 BaseType syscall.Signal
+      Pointee: 763 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 148
+      ID: 189
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 203 StructureType table<context.canceler,struct {}>
+      Pointee: 246 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 837 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 844 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 251
+      ID: 240
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 259 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 262 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 1000
+      ID: 1007
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 1001 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 1008 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 864 StructureType table<string,[]string>
+      Pointee: 871 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 145
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 237 StructureType table<string,float64>
+      Pointee: 226 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 710
+      ID: 722
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 736 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 748 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 177
+      ID: 140
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 229 StructureType table<string,interface {}>
+      Pointee: 218 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 172
+      ID: 135
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 221 StructureType table<string,string>
+      Pointee: 210 StructureType table<string,string>
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1120384
       GoKind: 22
-      Pointee: 624 StructureType text/template.ExecError
+      Pointee: 636 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 158
+      ID: 195
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1663296
       GoKind: 22
-      Pointee: 159 StructureType time.Location
+      Pointee: 196 StructureType time.Location
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 927200
       GoKind: 22
-      Pointee: 373 UnresolvedPointeeType time.ParseError
+      Pointee: 385 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 155
+      ID: 192
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1060224
       GoKind: 22
-      Pointee: 156 StructureType time.Timer
+      Pointee: 193 StructureType time.Timer
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 927008
       GoKind: 22
-      Pointee: 285 GoStringHeaderType time.fileSizeError
+      Pointee: 297 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 287
+      ID: 299
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 286 GoStringDataType time.fileSizeError.str
+      Pointee: 298 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 927104
       GoKind: 22
-      Pointee: 371 UnresolvedPointeeType time.parseDurationError
+      Pointee: 383 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 214
+      ID: 257
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 404672
       GoKind: 22
-      Pointee: 215 StructureType time.zone
+      Pointee: 258 StructureType time.zone
     - __kind: PointerType
-      ID: 217
+      ID: 260
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 404736
       GoKind: 22
-      Pointee: 218 StructureType time.zoneTrans
+      Pointee: 261 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -2970,47 +2970,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 932480
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 400 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 404
+      ID: 416
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 405 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 417 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 406
+      ID: 418
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 935840
       GoKind: 22
-      Pointee: 304 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 316 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 585
+      ID: 597
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1071616
       GoKind: 22
-      Pointee: 586 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 598 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1071744
       GoKind: 22
-      Pointee: 552 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 564 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 880
+      ID: 887
       Name: <-chan struct {}
       GoRuntimeType: 613696
       GoKind: 18
     - __kind: GoChannelType
-      ID: 750
+      ID: 762
       Name: <-chan time.Time
       GoRuntimeType: 619392
       GoKind: 18
@@ -3089,7 +3089,7 @@ Types:
       HasCount: true
       Element: 98 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 861
+      ID: 868
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 702304
@@ -3098,7 +3098,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 860
+      ID: 867
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 702208
@@ -3170,7 +3170,7 @@ Types:
       HasCount: true
       Element: 35 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 862
+      ID: 869
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 702400
@@ -3188,7 +3188,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 718
+      ID: 730
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 719968
@@ -3215,7 +3215,7 @@ Types:
       HasCount: true
       Element: 91 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1016
+      ID: 1023
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 513472
@@ -3223,22 +3223,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1017 PointerType **crypto/x509.Certificate
+          Type: 1024 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1024 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1031 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1024
+      ID: 1031
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 704 PointerType *crypto/x509.Certificate
+      Element: 716 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 751
+      ID: 276
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -3246,22 +3246,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 752 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 277 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 754 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 279 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 754
+      ID: 279
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 120 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 1007
+      ID: 1014
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 498336
@@ -3269,20 +3269,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1008 PointerType **mime/multipart.FileHeader
+          Type: 1015 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1013 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 1020 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 1013
+      ID: 1020
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1009 PointerType *mime/multipart.FileHeader
+      Element: 1016 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 68
       Name: '[]*runtime.p'
@@ -3299,69 +3299,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 201 GoSliceDataType []*runtime.p.array
+      Data: 208 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 208
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 70 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 254
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 148 PointerType *table<context.canceler,struct {}>
+      Element: 189 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 844
+      ID: 851
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 818 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 825 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 270
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 251 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 240 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 1010
+      ID: 1017
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1000 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 1007 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 870
+      ID: 877
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 859 PointerType *table<string,[]string>
+      Element: 866 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 232
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 182 PointerType *table<string,float64>
+      Element: 145 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 742
+      ID: 754
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 710 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 722 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 224
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 177 PointerType *table<string,interface {}>
+      Element: 140 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 216
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 172 PointerType *table<string,string>
+      Element: 135 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 1018
+      ID: 1025
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 513536
@@ -3369,22 +3369,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1019 PointerType *[]*crypto/x509.Certificate
+          Type: 1026 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1026 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1033 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1026
+      ID: 1033
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1016 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 1023 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 1020
+      ID: 1027
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -3392,22 +3392,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1021 PointerType *[]uint8
+          Type: 1028 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1028 GoSliceDataType [][]uint8.array
+      Data: 1035 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 1028
+      ID: 1035
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 41 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 723
+      ID: 735
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 507296
@@ -3422,15 +3422,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 746 GoSliceDataType []float64.array
+      Data: 758 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 746
+      ID: 758
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 15 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 183
+      ID: 146
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 500832
@@ -3438,22 +3438,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 245 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 234 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 234
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 186
+      ID: 149
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 501024
@@ -3461,22 +3461,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 253 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 242
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1030
+      ID: 1037
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 495648
@@ -3484,76 +3484,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1031 PointerType *net/http.segment
+          Type: 1038 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1033 GoSliceDataType []net/http.segment.array
+      Data: 1040 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1033
+      ID: 1040
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1032 StructureType net/http.segment
+      Element: 1039 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 255
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 206 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 249 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 845
+      ID: 852
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 847 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 271
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 265 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 1011
+      ID: 1018
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1004 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 1011 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 871
+      ID: 878
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 867 StructureType noalg.map.group[string][]string
+      Element: 874 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 233
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 240 StructureType noalg.map.group[string]float64
+      Element: 229 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 743
+      ID: 755
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 751 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 225
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 232 StructureType noalg.map.group[string]interface {}
+      Element: 221 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 217
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 224 StructureType noalg.map.group[string]string
+      Element: 213 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 178
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 492480
@@ -3561,26 +3561,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *os.Signal
+          Type: 179 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []os.Signal.array
+      Data: 244 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 244
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 164 GoInterfaceType os.Signal
+      Element: 180 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 43
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 722
+      ID: 734
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 507552
@@ -3595,15 +3595,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 744 GoSliceDataType []string.array
+      Data: 756 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 744
+      ID: 756
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 213
+      ID: 256
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 500384
@@ -3611,22 +3611,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 214 PointerType *time.zone
+          Type: 257 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 255 GoSliceDataType []time.zone.array
+      Data: 272 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 272
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 215 StructureType time.zone
+      Element: 258 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 216
+      ID: 259
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 500448
@@ -3634,20 +3634,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 217 PointerType *time.zoneTrans
+          Type: 260 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 257 GoSliceDataType []time.zoneTrans.array
+      Data: 274 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 274
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 218 StructureType time.zoneTrans
+      Element: 261 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 41
       Name: '[]uint8'
@@ -3664,9 +3664,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 196 GoSliceDataType []uint8.array
+      Data: 203 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 203
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3687,15 +3687,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 198 GoSliceDataType []uintptr.array
+      Data: 205 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 205
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 519
+      ID: 531
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 960320
@@ -3710,27 +3710,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 520 GoSliceDataType archive/tar.headerError.array
+      Data: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 532
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 933
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 913
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3740,7 +3740,7 @@ Types:
       GoRuntimeType: 601216
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 860
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3748,12 +3748,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 863
+      ID: 870
       Name: chan bool
       GoRuntimeType: 613184
       GoKind: 18
     - __kind: GoChannelType
-      ID: 165
+      ID: 181
       Name: chan os.Signal
       GoRuntimeType: 620096
       GoKind: 18
@@ -3770,13 +3770,13 @@ Types:
       GoRuntimeType: 600960
       GoKind: 15
     - __kind: BaseType
-      ID: 300
+      ID: 312
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 855168
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 301
+      ID: 313
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 855264
@@ -3784,32 +3784,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 303 PointerType *compress/flate.InternalError.str
+          Type: 315 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 302 GoStringDataType compress/flate.InternalError.str
+      Data: 314 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 302
+      ID: 314
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 969
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 948
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 161
+      ID: 177
       Name: context.CancelCauseFunc
       ByteSize: 8
       GoRuntimeType: 851424
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 851
+      ID: 858
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 695584
@@ -3828,7 +3828,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 126
+      ID: 198
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 1774208
@@ -3836,29 +3836,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 128 StructureType context.cancelCtx
+          Type: 183 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 149 StructureType sync.Once
+          Type: 199 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 152
+      ID: 172
       Name: context.backgroundCtx
       GoRuntimeType: 1853728
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 153 StructureType context.emptyCtx
+          Type: 158 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 183
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 2030688
@@ -3869,23 +3869,23 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 142 StructureType sync/atomic.Value
+          Type: 184 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 144 GoMapType map[context.canceler]struct {}
+          Type: 185 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 142 StructureType sync/atomic.Value
+          Type: 184 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 17 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 209
+      ID: 252
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1141536
@@ -3898,13 +3898,13 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 629
+      ID: 641
       Name: context.deadlineExceededError
       GoRuntimeType: 1497376
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 153
+      ID: 158
       Name: context.emptyCtx
       GoRuntimeType: 1638368
       GoKind: 25
@@ -3913,7 +3913,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 160
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1880992
@@ -3924,11 +3924,11 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 154 GoSubroutineType func() bool
+          Type: 161 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 132
+      ID: 191
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1656768
@@ -3936,29 +3936,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 128 StructureType context.cancelCtx
+          Type: 183 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 155 PointerType *time.Timer
+          Type: 192 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 157 GoTimeType time.Time
+          Type: 194 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 160
+      ID: 174
       Name: context.todoCtx
       GoRuntimeType: 1853952
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 153 StructureType context.emptyCtx
+          Type: 158 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 134
+      ID: 167
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1891808
@@ -3969,14 +3969,14 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 143 GoEmptyInterfaceType interface {}
+          Type: 168 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 143 GoEmptyInterfaceType interface {}
+          Type: 168 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 136
+      ID: 170
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1853504
@@ -3988,51 +3988,51 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 319
+      ID: 331
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 857280
       GoKind: 2
     - __kind: BaseType
-      ID: 320
+      ID: 332
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 857376
       GoKind: 2
     - __kind: BaseType
-      ID: 321
+      ID: 333
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 857472
       GoKind: 2
     - __kind: StructureType
-      ID: 608
+      ID: 620
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1320512
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 322
+      ID: 334
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 857568
       GoKind: 2
     - __kind: BaseType
-      ID: 289
+      ID: 301
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 854688
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 584
+      ID: 596
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 999
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 879
+      ID: 886
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2344416
@@ -4052,7 +4052,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 1015 BaseType crypto/tls.CurveID
+          Type: 1022 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4064,13 +4064,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 1016 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 1023 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 1018 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 1025 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 1020 GoSliceHeaderType [][]uint8
+          Type: 1027 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 41 GoSliceHeaderType []uint8
@@ -4085,22 +4085,22 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 1022 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 1029 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 184
-          Type: 1023 BaseType crypto/tls.SignatureScheme
+          Type: 1030 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 1015
+      ID: 1022
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 854400
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 393
+      ID: 405
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 390
+      ID: 402
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1780352
@@ -4111,36 +4111,36 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 718 ArrayType [5]uint8
+          Type: 730 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 719 GoInterfaceType net.Conn
+          Type: 731 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 1023
+      ID: 1030
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 854496
       GoKind: 9
     - __kind: BaseType
-      ID: 551
+      ID: 563
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1018752
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 395
+      ID: 407
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 706
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 705
+      ID: 717
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 456
+      ID: 468
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1782464
@@ -4148,21 +4148,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 704 PointerType *crypto/x509.Certificate
+          Type: 716 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 728 BaseType crypto/x509.InvalidReason
+          Type: 740 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 450
+      ID: 462
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1148704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 452
+      ID: 464
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1641248
@@ -4170,24 +4170,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 704 PointerType *crypto/x509.Certificate
+          Type: 716 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 318
+      ID: 330
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 856992
       GoKind: 2
     - __kind: BaseType
-      ID: 728
+      ID: 740
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 604288
       GoKind: 2
     - __kind: StructureType
-      ID: 600
+      ID: 612
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1600896
@@ -4197,13 +4197,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 458
+      ID: 470
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1148960
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 454
+      ID: 466
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1782272
@@ -4211,15 +4211,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 704 PointerType *crypto/x509.Certificate
+          Type: 716 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 704 PointerType *crypto/x509.Certificate
+          Type: 716 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 511
+      ID: 523
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1468256
@@ -4229,7 +4229,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 515
+      ID: 527
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1468416
@@ -4239,47 +4239,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 513
+      ID: 525
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 290
+      ID: 302
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 854784
       GoKind: 6
     - __kind: BaseType
-      ID: 314
+      ID: 326
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 856704
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 416
+      ID: 428
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 608
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 408
+      ID: 420
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 414
+      ID: 426
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 412
+      ID: 424
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 410
+      ID: 422
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 418
+      ID: 430
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1457376
@@ -4289,7 +4289,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 521
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4306,11 +4306,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 387
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 583
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4326,11 +4326,11 @@ Types:
       GoRuntimeType: 601152
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 567
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 569
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4340,13 +4340,13 @@ Types:
       GoRuntimeType: 490688
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 874
+      ID: 881
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 712672
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 154
+      ID: 161
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 611200
@@ -4358,23 +4358,23 @@ Types:
       GoRuntimeType: 871520
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 1022
+      ID: 1029
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1034688
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 439
+      ID: 451
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 820
+      ID: 827
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2120800
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1781312
@@ -4382,7 +4382,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 720 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 732 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4390,25 +4390,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 423
+      ID: 435
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 737
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 427
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1147296
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 727
+      ID: 739
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 308
+      ID: 320
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 856032
@@ -4416,18 +4416,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 310 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 322 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 309 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 321 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 309
+      ID: 321
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 720
+      ID: 732
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2294304
@@ -4435,13 +4435,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 721 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 733 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4450,7 +4450,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 723 GoSliceHeaderType []float64
+          Type: 735 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4459,13 +4459,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 724 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 736 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 726 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 738 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4476,13 +4476,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 721
+      ID: 733
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 602816
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 305
+      ID: 317
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 855936
@@ -4490,18 +4490,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 319 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 318 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 318
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 311
+      ID: 323
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 856128
@@ -4509,22 +4509,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 313 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 325 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 312 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 324 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 312
+      ID: 324
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 466
+      ID: 478
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
-      ID: 811
+      ID: 818
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
       GoRuntimeType: 1881664
       GoKind: 25
@@ -4538,7 +4538,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 166 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -4559,13 +4559,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 173 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 136 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 178 GoMapType map[string]float64
+          Type: 141 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -4580,10 +4580,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 183 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 186 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 149 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -4595,7 +4595,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 152 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -4618,7 +4618,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 190
+      ID: 153
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2292960
@@ -4629,13 +4629,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 154 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 120 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 167 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4644,16 +4644,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 193 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 156 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 166 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -4662,12 +4662,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 183 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 185
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1974880
@@ -4684,7 +4684,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4692,7 +4692,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 957
+      ID: 964
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 2031200
@@ -4700,29 +4700,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 948 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+          Type: 955 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 960 BaseType time.Duration
+          Type: 967 BaseType time.Duration
     - __kind: GoMapType
-      ID: 173
+      ID: 136
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1315136
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 753
+      ID: 278
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 600000
       GoKind: 10
     - __kind: StructureType
-      ID: 188
+      ID: 151
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1807936
@@ -4736,16 +4736,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 247 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 236 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 252 GoMapType map[string]interface {}
+          Type: 241 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 760
+      ID: 767
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 266
+      ID: 269
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1975136
@@ -4753,7 +4753,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 758 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 765 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4768,15 +4768,15 @@ Types:
           Type: 15 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 759 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 766 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 758
+      ID: 765
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1016160
       GoKind: 5
     - __kind: StructureType
-      ID: 192
+      ID: 155
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2177600
@@ -4784,16 +4784,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 166 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 751 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 276 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -4808,12 +4808,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 753 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 278 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 120 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 193
+      ID: 156
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 927968
@@ -4822,15 +4822,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 682
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 793
+      ID: 800
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1456096
@@ -4843,7 +4843,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 762
+      ID: 769
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1640608
@@ -4856,11 +4856,11 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1039
+    - __kind: GoContextImplementationType
+      ID: 165
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1679616
@@ -4869,38 +4869,40 @@ Types:
         - Name: Context
           Offset: 0
           Type: 124 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 911
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 468
+      ID: 480
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 475
+      ID: 487
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1150368
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 323
+      ID: 335
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 858336
       GoKind: 2
     - __kind: StructureType
-      ID: 473
+      ID: 485
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1150240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 471
+      ID: 483
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1642368
@@ -4913,7 +4915,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 483
+      ID: 495
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1643008
@@ -4926,7 +4928,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 487
+      ID: 499
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1784384
@@ -4942,7 +4944,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 485
+      ID: 497
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1466816
@@ -4952,7 +4954,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 481
+      ID: 493
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1466496
@@ -4962,14 +4964,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 706
+      ID: 718
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1542496
       GoKind: 21
-      HeaderType: 708 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 720 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 729
+      ID: 741
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1085056
@@ -4984,15 +4986,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 748 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 760 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 748
+      ID: 760
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 495
+      ID: 507
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1643328
@@ -5000,12 +5002,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 706 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 718 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 706 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 718 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 489
+      ID: 501
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1466976
@@ -5015,7 +5017,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 493
+      ID: 505
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1784576
@@ -5026,12 +5028,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 491
+      ID: 503
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1643168
@@ -5044,7 +5046,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 497
+      ID: 509
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1467136
@@ -5052,9 +5054,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 157 GoTimeType time.Time
+          Type: 194 GoTimeType time.Time
     - __kind: StructureType
-      ID: 503
+      ID: 515
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1643648
@@ -5067,7 +5069,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 505
+      ID: 517
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1467456
@@ -5077,7 +5079,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1643488
@@ -5090,7 +5092,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 499
+      ID: 511
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1467296
@@ -5100,7 +5102,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 507
+      ID: 519
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1643808
@@ -5113,29 +5115,29 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 843
+      ID: 850
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 856416
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 843
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 839
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 841
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 429
+      ID: 441
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1458656
@@ -5145,11 +5147,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 431
+      ID: 443
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1458816
@@ -5157,17 +5159,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 429 StructureType github.com/cihub/seelog.baseError
+          Type: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 816
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1883008
@@ -5175,12 +5177,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 804 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 811 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 814 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 821 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1459136
@@ -5188,9 +5190,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 429 StructureType github.com/cihub/seelog.baseError
+          Type: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 807
+      ID: 814
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1858656
@@ -5198,13 +5200,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 804 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 811 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 433
+      ID: 445
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1458976
@@ -5212,9 +5214,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 429 StructureType github.com/cihub/seelog.baseError
+          Type: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 437
+      ID: 449
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1459296
@@ -5222,9 +5224,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 429 StructureType github.com/cihub/seelog.baseError
+          Type: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 942
+      ID: 949
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1150624
@@ -5237,7 +5239,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 920
+      ID: 927
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1696512
@@ -5245,48 +5247,48 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 942 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 949 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 710
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 626
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 624
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 628
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 630
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 618
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 442
+      ID: 454
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1460256
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 672
+      ID: 684
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 658
+      ID: 670
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1905920
@@ -5302,11 +5304,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 664
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 602
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1752672
@@ -5319,7 +5321,7 @@ Types:
           Offset: 1
           Type: 22 BaseType int8
     - __kind: StructureType
-      ID: 664
+      ID: 676
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1906368
@@ -5335,13 +5337,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 553
+      ID: 565
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1019424
       GoKind: 8
     - __kind: StructureType
-      ID: 656
+      ID: 668
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1905696
@@ -5357,13 +5359,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 732
+      ID: 744
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 855552
       GoKind: 8
     - __kind: StructureType
-      ID: 654
+      ID: 666
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1905472
@@ -5371,15 +5373,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 732 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 744 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 732 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 744 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 674
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1816768
@@ -5392,7 +5394,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 660
+      ID: 672
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1906144
@@ -5408,7 +5410,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 668
+      ID: 680
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1678656
@@ -5418,19 +5420,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 594
+      ID: 606
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1316416
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 592
+      ID: 604
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1316288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 666
+      ID: 678
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1816960
@@ -5443,7 +5445,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 340
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 860832
@@ -5451,22 +5453,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 342 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 329 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 341 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 341
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 725
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 622
+      ID: 634
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1482656
@@ -5476,19 +5478,19 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 331
+      ID: 343
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 861408
       GoKind: 10
     - __kind: BaseType
-      ID: 711
+      ID: 723
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1031712
       GoKind: 10
     - __kind: StructureType
-      ID: 680
+      ID: 692
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1939072
@@ -5499,12 +5501,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 711 BaseType golang.org/x/net/http2.ErrCode
+          Type: 723 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 537
+      ID: 549
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1650528
@@ -5512,12 +5514,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 711 BaseType golang.org/x/net/http2.ErrCode
+          Type: 723 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 335
+      ID: 347
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 861600
@@ -5525,18 +5527,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 337 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 349 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 336 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 348 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 336
+      ID: 348
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 341
+      ID: 353
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 861792
@@ -5544,18 +5546,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 343 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 355 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 342 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 354 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 342
+      ID: 354
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 338
+      ID: 350
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 861696
@@ -5563,18 +5565,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 340 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 352 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 339 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 351 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 339
+      ID: 351
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 332
+      ID: 344
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 861504
@@ -5582,18 +5584,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 334 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 346 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 333 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 345 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 333
+      ID: 345
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 541
+      ID: 553
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1483296
@@ -5603,13 +5605,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 344
+      ID: 356
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 861888
       GoKind: 2
     - __kind: StructureType
-      ID: 529
+      ID: 541
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1478336
@@ -5619,11 +5621,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 690
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 700
+      ID: 712
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1969312
@@ -5639,7 +5641,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 531
+      ID: 543
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1650048
@@ -5652,11 +5654,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 620
+      ID: 632
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1608736
@@ -5666,29 +5668,29 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 942
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 517
+      ID: 529
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 622
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 688
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 674
+      ID: 686
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1552256
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 523
+      ID: 535
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1471616
@@ -5698,7 +5700,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 525
+      ID: 537
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1471776
@@ -5708,137 +5710,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 477
+      ID: 489
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 204
+      ID: 247
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 205 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 248 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 206 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 212 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 249 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 838
+      ID: 845
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 839 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 846 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 845 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 847 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 852 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 260
+      ID: 263
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 261 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 264 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 268 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 265 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 271 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 1002
+      ID: 1009
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1003 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 1010 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1004 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 1011 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 1011 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 1018 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 865
+      ID: 872
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 866 PointerType *noalg.map.group[string][]string
+          Type: 873 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 867 StructureType noalg.map.group[string][]string
-      GroupSliceType: 871 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 874 StructureType noalg.map.group[string][]string
+      GroupSliceType: 878 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 238
+      ID: 227
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 239 PointerType *noalg.map.group[string]float64
+          Type: 228 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 240 StructureType noalg.map.group[string]float64
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 229 StructureType noalg.map.group[string]float64
+      GroupSliceType: 233 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 737
+      ID: 749
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 738 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 750 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 743 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 751 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 755 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 230
+      ID: 219
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 231 PointerType *noalg.map.group[string]interface {}
+          Type: 220 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 232 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 221 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 222
+      ID: 211
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 223 PointerType *noalg.map.group[string]string
+          Type: 212 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 224 StructureType noalg.map.group[string]string
-      GroupSliceType: 228 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 213 StructureType noalg.map.group[string]string
+      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 556
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5872,7 +5874,7 @@ Types:
       GoRuntimeType: 600256
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 143
+      ID: 168
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 875360
@@ -5885,17 +5887,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 733
+      ID: 745
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 603712
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 702
+      ID: 714
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 447
+      ID: 459
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5921,25 +5923,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 445
+      ID: 457
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 662
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 997
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 648
+      ID: 660
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1516256
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 389
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6011,7 +6013,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 315
+      ID: 327
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 856896
@@ -6019,18 +6021,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 317 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 329 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 316 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 328 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 316
+      ID: 328
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 598
+      ID: 610
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1599936
@@ -6038,15 +6040,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 701 PointerType *internal/abi.Type
+          Type: 713 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 288
+      ID: 300
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 854208
       GoKind: 2
     - __kind: StructureType
-      ID: 141
+      ID: 128
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1531456
@@ -6059,7 +6061,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 943
+      ID: 950
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1062272
@@ -6072,11 +6074,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 850
+      ID: 857
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1143968
@@ -6089,7 +6091,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 933
+      ID: 940
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1061632
@@ -6102,11 +6104,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 966
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 902
+      ID: 909
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1593696
@@ -6114,9 +6116,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 933 GoInterfaceType io.Reader
+          Type: 940 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 918
+      ID: 925
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1664448
@@ -6124,13 +6126,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 933 GoInterfaceType io.Reader
+          Type: 940 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 646
+      ID: 658
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 146
+      ID: 187
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -6143,7 +6145,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 147 PointerType **table<context.canceler,struct {}>
+          Type: 188 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6162,10 +6164,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 211 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 206 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 254 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 249 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 816
+      ID: 823
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6178,7 +6180,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 817 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 824 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6197,10 +6199,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 844 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 851 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 847 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 249
+      ID: 238
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6213,7 +6215,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 250 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 239 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6232,10 +6234,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 267 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 270 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 265 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 998
+      ID: 1005
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6248,7 +6250,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 999 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 1006 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6267,10 +6269,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1010 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 1004 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 1017 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 1011 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 857
+      ID: 864
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6283,7 +6285,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 858 PointerType **table<string,[]string>
+          Type: 865 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6302,10 +6304,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 870 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 867 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 877 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 874 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 180
+      ID: 143
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6318,7 +6320,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 181 PointerType **table<string,float64>
+          Type: 144 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6337,10 +6339,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,float64>.array
-      GroupType: 240 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 232 GoSliceDataType []*table<string,float64>.array
+      GroupType: 229 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 708
+      ID: 720
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6353,7 +6355,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 709 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 721 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6372,10 +6374,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 742 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 754 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 751 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 138
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6388,7 +6390,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<string,interface {}>
+          Type: 139 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6407,10 +6409,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 232 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 224 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 221 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 133
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6423,7 +6425,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<string,string>
+          Type: 134 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6442,66 +6444,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 227 GoSliceDataType []*table<string,string>.array
-      GroupType: 224 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 216 GoSliceDataType []*table<string,string>.array
+      GroupType: 213 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 144
+      ID: 185
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1161120
       GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 187 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 814
+      ID: 821
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1178080
       GoKind: 21
-      HeaderType: 816 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 823 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 247
+      ID: 236
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1167264
       GoKind: 21
-      HeaderType: 249 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 238 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 996
+      ID: 1003
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1166496
       GoKind: 21
-      HeaderType: 998 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 1005 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 995
+      ID: 1002
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1162144
       GoKind: 21
-      HeaderType: 857 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 864 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 178
+      ID: 141
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1167136
       GoKind: 21
-      HeaderType: 180 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 143 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 252
+      ID: 241
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1160736
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 168
+      ID: 131
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1163168
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<string,string>
+      HeaderType: 133 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 464
+      ID: 476
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1463456
@@ -6511,11 +6513,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1019
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 884
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1519296
@@ -6523,16 +6525,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 995 GoMapType map[string][]string
+          Type: 1002 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 996 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 1003 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 939
+      ID: 946
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1979232
@@ -6540,16 +6542,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 958 PointerType *io.SectionReader
+          Type: 965 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 943 GoInterfaceType io.Closer
+          Type: 950 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 644
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 719
+      ID: 731
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1638528
@@ -6562,35 +6564,35 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 697
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 973
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 695
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 634
+      ID: 646
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 981
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 985
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 979
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 625
+      ID: 637
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1141792
@@ -6598,28 +6600,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 627 PointerType *net.UnknownNetworkError.str
+          Type: 639 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 626 GoStringDataType net.UnknownNetworkError.str
+      Data: 638 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 626
+      ID: 638
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 559
+      ID: 571
       Name: net.canceledError
       GoRuntimeType: 1313856
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 971
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 731
+      ID: 743
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2176544
@@ -6627,7 +6629,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 719 GoInterfaceType net.Conn
+          Type: 731 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -6638,27 +6640,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 987
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 976
+      ID: 983
       Name: net.noReadFrom
       GoRuntimeType: 1142048
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 975
+      ID: 982
       Name: net.noWriteTo
       GoRuntimeType: 1141920
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 346
+      ID: 358
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1037
+    - __kind: GoContextImplementationType
+      ID: 163
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1802176
@@ -6670,8 +6672,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 124 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 348
+      ID: 360
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1775168
@@ -6679,7 +6683,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 714 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 726 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6687,7 +6691,7 @@ Types:
           Offset: 96
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 970
+      ID: 977
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2364512
@@ -6695,12 +6699,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 976 StructureType net.noReadFrom
+          Type: 983 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 973 PointerType *net.TCPConn
+          Type: 980 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 968
+      ID: 975
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2363968
@@ -6708,20 +6712,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 975 StructureType net.noWriteTo
+          Type: 982 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 973 PointerType *net.TCPConn
+          Type: 980 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 648
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 699
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 796
+      ID: 803
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1059584
@@ -6734,7 +6738,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 794
+      ID: 801
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1057920
@@ -6747,14 +6751,14 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 855
+      ID: 862
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2176896
       GoKind: 21
-      HeaderType: 857 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 864 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 797
+      ID: 804
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1058048
@@ -6767,15 +6771,15 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 366
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 573
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 795
+      ID: 802
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1058304
@@ -6799,7 +6803,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 872 PointerType *net/url.URL
+          Type: 879 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6811,19 +6815,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 850 GoInterfaceType io.ReadCloser
+          Type: 857 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 874 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 881 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6832,16 +6836,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 875 GoMapType net/url.Values
+          Type: 882 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 875 GoMapType net/url.Values
+          Type: 882 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 876 PointerType *mime/multipart.Form
+          Type: 883 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6850,13 +6854,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 878 PointerType *crypto/tls.ConnectionState
+          Type: 885 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 880 GoChannelType <-chan struct {}
+          Type: 887 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 881 PointerType *net/http.Response
+          Type: 888 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6865,15 +6869,15 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 883 PointerType *net/http.pattern
+          Type: 890 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
     - __kind: StructureType
-      ID: 882
+      ID: 889
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2291616
@@ -6896,16 +6900,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 850 GoInterfaceType io.ReadCloser
+          Type: 857 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6914,13 +6918,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 118 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 878 PointerType *crypto/tls.ConnectionState
+          Type: 885 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 117
       Name: net/http.ResponseWriter
@@ -6935,19 +6939,19 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 954
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 921
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 903
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1803712
@@ -6955,10 +6959,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 800 PointerType *net/http.response
+          Type: 807 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6966,31 +6970,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 856
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 269
+      ID: 281
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 852192
       GoKind: 10
     - __kind: BaseType
-      ID: 703
+      ID: 715
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1015968
       GoKind: 10
     - __kind: StructureType
-      ID: 357
+      ID: 369
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1776896
@@ -7001,12 +7005,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 703 BaseType net/http.http2ErrCode
+          Type: 715 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 689
+      ID: 701
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1957536
@@ -7017,16 +7021,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 703 BaseType net/http.http2ErrCode
+          Type: 715 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 363
+      ID: 375
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1639008
@@ -7034,12 +7038,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 703 BaseType net/http.http2ErrCode
+          Type: 715 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 285
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 852384
@@ -7047,28 +7051,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 287 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 286 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 286
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 361
+      ID: 373
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1143072
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 937
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 279
+      ID: 291
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 852576
@@ -7076,18 +7080,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 281 PointerType *net/http.http2headerFieldNameError.str
+          Type: 293 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 280 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 292 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 280
+      ID: 292
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 288
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 852480
@@ -7095,40 +7099,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *net/http.http2headerFieldValueError.str
+          Type: 290 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 289 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 289
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 652
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: net/http.http2missingBody
       GoRuntimeType: 1314368
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 900
+      ID: 907
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1314880
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 567
+      ID: 579
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1314752
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 282
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 852288
@@ -7136,22 +7140,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 284 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 271 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 283 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 283
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 905
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 806
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1219456
@@ -7159,13 +7163,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 846 PointerType *net/http.http2responseWriterState
+          Type: 853 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 854
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 894
+      ID: 901
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1590656
@@ -7173,19 +7177,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 927 PointerType *net/http.http2clientStream
+          Type: 934 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 923
       Name: net/http.noBody
       GoRuntimeType: 1500416
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 563
+      ID: 575
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1592096
@@ -7195,7 +7199,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1894272
@@ -7212,20 +7216,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1030 GoSliceHeaderType []net/http.segment
+          Type: 1037 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 931
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 367
+      ID: 379
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1449536
@@ -7235,7 +7239,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 801
+      ID: 808
       Name: net/http.response
       ByteSize: 232
       GoRuntimeType: 2426560
@@ -7243,16 +7247,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 848 PointerType *net/http.conn
+          Type: 855 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 118 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 850 GoInterfaceType io.ReadCloser
+          Type: 857 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 851 GoSubroutineType context.CancelFunc
+          Type: 858 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7264,19 +7268,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 150 StructureType sync/atomic.Bool
+          Type: 200 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 852 PointerType *bufio.Writer
+          Type: 859 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 854 StructureType net/http.chunkWriter
+          Type: 861 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7300,30 +7304,30 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 150 StructureType sync/atomic.Bool
+          Type: 200 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 860 ArrayType [29]uint8
+          Type: 867 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 861 ArrayType [10]uint8
+          Type: 868 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 862 ArrayType [3]uint8
+          Type: 869 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
-          Type: 863 GoChannelType chan bool
+          Type: 870 GoChannelType chan bool
         - Name: closeNotifyTriggered
           Offset: 224
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1032
+      ID: 1039
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1658688
@@ -7339,7 +7343,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 352
+      ID: 364
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1638848
@@ -7352,17 +7356,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 703
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 650
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1501856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 565
+      ID: 577
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1592256
@@ -7372,7 +7376,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2094400
@@ -7380,22 +7384,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 719 GoInterfaceType net.Conn
+          Type: 731 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 719 GoInterfaceType net.Conn
+          Type: 731 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 350
+      ID: 362
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1323712
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 385
+      ID: 397
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1779968
@@ -7411,7 +7415,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 383
+      ID: 395
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1640128
@@ -7424,11 +7428,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 401
+      ID: 413
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 309
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 855072
@@ -7436,22 +7440,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *net/textproto.ProtocolError.str
+          Type: 311 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType net/textproto.ProtocolError.str
+      Data: 310 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 310
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 708
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 291
+      ID: 303
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 854880
@@ -7459,18 +7463,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 293 PointerType *net/url.EscapeError.str
+          Type: 305 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 292 GoStringDataType net/url.EscapeError.str
+      Data: 304 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 292
+      ID: 304
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 294
+      ID: 306
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 854976
@@ -7478,18 +7482,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 296 PointerType *net/url.InvalidHostError.str
+          Type: 308 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 295 GoStringDataType net/url.InvalidHostError.str
+      Data: 307 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 295
+      ID: 307
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 873
+      ID: 880
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2203904
@@ -7503,7 +7507,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 993 PointerType *net/url.Userinfo
+          Type: 1000 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7529,99 +7533,99 @@ Types:
           Offset: 137
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 1001
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 875
+      ID: 882
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1946912
       GoKind: 21
-      HeaderType: 857 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 864 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 207
+      ID: 250
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 704128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 208 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 251 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 841
+      ID: 848
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 760416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 842 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 849 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 263
+      ID: 266
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 723008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 264 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 267 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 1005
+      ID: 1012
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 718336
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1006 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 1013 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 868
+      ID: 875
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 708640
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 869 StructureType noalg.struct { key string; elem []string }
+      Element: 876 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 241
+      ID: 230
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 722912
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 242 StructureType noalg.struct { key string; elem float64 }
+      Element: 231 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 740
+      ID: 752
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 784160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 741 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 753 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 233
+      ID: 222
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 699136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 234 StructureType noalg.struct { key string; elem interface {} }
+      Element: 223 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 225
+      ID: 214
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 712864
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 226 StructureType noalg.struct { key string; elem string }
+      Element: 215 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 206
+      ID: 249
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1326016
@@ -7632,9 +7636,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 207 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 250 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1372736
@@ -7645,9 +7649,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 841 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 848 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 262
+      ID: 265
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1343168
@@ -7658,9 +7662,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 263 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 266 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 1004
+      ID: 1011
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1336640
@@ -7671,9 +7675,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1005 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 1012 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 867
+      ID: 874
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1327552
@@ -7684,9 +7688,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 868 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 875 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 240
+      ID: 229
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1342912
@@ -7697,9 +7701,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 241 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 230 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 739
+      ID: 751
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1391680
@@ -7710,9 +7714,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 740 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 752 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 232
+      ID: 221
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1324864
@@ -7723,9 +7727,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 233 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 222 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 224
+      ID: 213
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1329984
@@ -7736,9 +7740,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 225 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 208
+      ID: 251
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1325888
@@ -7746,12 +7750,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 209 GoInterfaceType context.canceler
+          Type: 252 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 210 StructureType struct {}
+          Type: 253 StructureType struct {}
     - __kind: StructureType
-      ID: 842
+      ID: 849
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1372608
@@ -7759,12 +7763,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 843 BaseType github.com/cihub/seelog.LogLevel
+          Type: 850 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 264
+      ID: 267
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1343040
@@ -7775,9 +7779,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 265 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 268 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 1006
+      ID: 1013
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1336512
@@ -7788,9 +7792,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1007 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 1014 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1327424
@@ -7801,9 +7805,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 242
+      ID: 231
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1342784
@@ -7816,7 +7820,7 @@ Types:
           Offset: 16
           Type: 15 BaseType float64
     - __kind: StructureType
-      ID: 741
+      ID: 753
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1391552
@@ -7827,9 +7831,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 234
+      ID: 223
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1324736
@@ -7840,9 +7844,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 143 GoEmptyInterfaceType interface {}
+          Type: 168 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 226
+      ID: 215
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1329856
@@ -7855,15 +7859,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 993
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 581
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 164
+      ID: 180
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1143712
@@ -7876,11 +7880,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 654
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 984
+      ID: 991
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2437504
@@ -7888,12 +7892,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 988 StructureType os.noReadFrom
+          Type: 995 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 985 PointerType *os.File
+          Type: 992 PointerType *os.File
     - __kind: StructureType
-      ID: 982
+      ID: 989
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2436704
@@ -7901,32 +7905,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 987 StructureType os.noWriteTo
+          Type: 994 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 985 PointerType *os.File
+          Type: 992 PointerType *os.File
     - __kind: StructureType
-      ID: 988
+      ID: 995
       Name: os.noReadFrom
       GoRuntimeType: 1143584
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 987
+      ID: 994
       Name: os.noWriteTo
       GoRuntimeType: 1143456
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 614
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 735
+      ID: 747
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 604
+      ID: 616
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1753056
@@ -7939,7 +7943,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 138
+      ID: 176
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 2030944
@@ -7950,17 +7954,17 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 161 GoSubroutineType context.CancelCauseFunc
+          Type: 177 GoSubroutineType context.CancelCauseFunc
         - Name: signals
           Offset: 24
-          Type: 162 GoSliceHeaderType []os.Signal
+          Type: 178 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 165 GoChannelType chan os.Signal
+          Type: 181 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 282
+      ID: 294
       Name: os/signal.signalError
       ByteSize: 16
       GoRuntimeType: 852672
@@ -7968,18 +7972,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 284 PointerType *os/signal.signalError.str
+          Type: 296 PointerType *os/signal.signalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 283 GoStringDataType os/signal.signalError.str
+      Data: 295 GoStringDataType os/signal.signalError.str
     - __kind: GoStringDataType
-      ID: 283
+      ID: 295
       Name: os/signal.signalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 337
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 860064
@@ -7987,36 +7991,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *os/user.UnknownGroupIdError.str
+          Type: 339 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 326 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 338 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 338
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 324
+      ID: 336
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 859968
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 391
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 479
+      ID: 491
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 589
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 593
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -8028,7 +8032,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 579
+      ID: 591
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1946464
@@ -8045,7 +8049,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 733 BaseType internal/abi.BoundsErrorCode
+          Type: 745 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -8061,7 +8065,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 644
+      ID: 656
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1811200
@@ -8074,7 +8078,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 545
+      ID: 557
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1017216
@@ -8082,13 +8086,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 547 PointerType *runtime.errorString.str
+          Type: 559 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 546 GoStringDataType runtime.errorString.str
+      Data: 558 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 546
+      ID: 558
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8737,7 +8741,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 200
+      ID: 207
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -8773,7 +8777,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 548
+      ID: 560
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1017312
@@ -8781,13 +8785,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 550 PointerType *runtime.plainError.str
+          Type: 562 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 549 GoStringDataType runtime.plainError.str
+      Data: 561 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 549
+      ID: 561
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8828,7 +8832,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 381
+      ID: 393
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1639808
@@ -8900,7 +8904,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 585
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8912,18 +8916,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 195 PointerType *string.str
+          Type: 202 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 194 GoStringDataType string.str
+      Data: 201 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 194
+      ID: 201
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 768
+      ID: 775
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 2012000
@@ -8931,12 +8935,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2090112
@@ -8944,15 +8948,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 764
+      ID: 771
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 2011488
@@ -8960,12 +8964,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 774
+      ID: 781
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2088960
@@ -8973,15 +8977,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 788
+      ID: 795
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2159520
@@ -8989,18 +8993,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 776
+      ID: 783
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2089248
@@ -9008,15 +9012,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 772
+      ID: 779
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2088672
@@ -9024,15 +9028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 784
+      ID: 791
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2158880
@@ -9040,18 +9044,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 792
+      ID: 799
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2221568
@@ -9059,21 +9063,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 786
+      ID: 793
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2159200
@@ -9081,18 +9085,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 770
+      ID: 777
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 2012256
@@ -9100,12 +9104,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 766
+      ID: 773
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 2011744
@@ -9113,12 +9117,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2089536
@@ -9126,15 +9130,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2159840
@@ -9142,18 +9146,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2089824
@@ -9161,15 +9165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 912
+      ID: 919
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1758240
@@ -9177,18 +9181,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 933 GoInterfaceType io.Reader
+          Type: 940 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 943 GoInterfaceType io.Closer
+          Type: 950 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 210
+      ID: 253
       Name: struct {}
       GoRuntimeType: 866400
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 139
+      ID: 126
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1505856
@@ -9196,12 +9200,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 140 StructureType sync.noCopy
+          Type: 127 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 141 StructureType internal/sync.Mutex
+          Type: 128 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 149
+      ID: 199
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1665792
@@ -9209,15 +9213,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 140 StructureType sync.noCopy
+          Type: 127 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 150 StructureType sync/atomic.Bool
+          Type: 200 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 166
+      ID: 125
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1900320
@@ -9225,7 +9229,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -9234,18 +9238,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 167 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 167 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 140
+      ID: 127
       Name: sync.noCopy
       GoRuntimeType: 1016832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 150
+      ID: 200
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1506976
@@ -9253,12 +9257,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 151 StructureType sync/atomic.noCopy
+          Type: 130 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 167
+      ID: 129
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1507136
@@ -9266,12 +9270,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 151 StructureType sync/atomic.noCopy
+          Type: 130 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 142
+      ID: 184
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1227392
@@ -9279,27 +9283,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 143 GoEmptyInterfaceType interface {}
+          Type: 168 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 151
+      ID: 130
       Name: sync/atomic.noCopy
       GoRuntimeType: 1016928
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 681
+      ID: 693
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1315520
       GoKind: 12
     - __kind: BaseType
-      ID: 756
+      ID: 763
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 1018272
       GoKind: 2
     - __kind: StructureType
-      ID: 203
+      ID: 246
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9321,9 +9325,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 204 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 247 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 837
+      ID: 844
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9345,9 +9349,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 838 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 845 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 259
+      ID: 262
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9369,9 +9373,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 260 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 263 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 1001
+      ID: 1008
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9393,9 +9397,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1002 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 1009 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 864
+      ID: 871
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9417,9 +9421,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 865 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 872 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 237
+      ID: 226
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9441,9 +9445,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 238 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 227 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 736
+      ID: 748
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9465,9 +9469,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 737 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 749 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 229
+      ID: 218
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9489,9 +9493,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 230 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 219 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 221
+      ID: 210
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9513,9 +9517,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 222 GoSwissMapGroupsType groupReference<string,string>
+          Type: 211 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 624
+      ID: 636
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1757280
@@ -9528,13 +9532,13 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 960
+      ID: 967
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1974624
       GoKind: 6
     - __kind: StructureType
-      ID: 159
+      ID: 196
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2035840
@@ -9545,10 +9549,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 213 GoSliceHeaderType []time.zone
+          Type: 256 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 216 GoSliceHeaderType []time.zoneTrans
+          Type: 259 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9560,13 +9564,13 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 214 PointerType *time.zone
+          Type: 257 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 373
+      ID: 385
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 157
+      ID: 194
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2451648
@@ -9580,7 +9584,7 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 158 PointerType *time.Location
+          Type: 195 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9590,7 +9594,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 156
+      ID: 193
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1502976
@@ -9598,12 +9602,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 750 GoChannelType <-chan time.Time
+          Type: 762 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 285
+      ID: 297
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 852768
@@ -9611,22 +9615,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 287 PointerType *time.fileSizeError.str
+          Type: 299 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 286 GoStringDataType time.fileSizeError.str
+      Data: 298 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 286
+      ID: 298
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 371
+      ID: 383
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 215
+      ID: 258
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1663104
@@ -9642,7 +9646,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 218
+      ID: 261
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1807744
@@ -9703,7 +9707,7 @@ Types:
       GoRuntimeType: 601280
       GoKind: 26
     - __kind: StructureType
-      ID: 714
+      ID: 726
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2125600
@@ -9714,10 +9718,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 715 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 727 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 716 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 728 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9732,18 +9736,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 717 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 729 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 717
+      ID: 729
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1018368
       GoKind: 9
     - __kind: StructureType
-      ID: 715
+      ID: 727
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1978208
@@ -9768,17 +9772,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 400
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 716
+      ID: 728
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 602112
       GoKind: 8
     - __kind: StructureType
-      ID: 405
+      ID: 417
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1455456
@@ -9788,13 +9792,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 304
+      ID: 316
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 855360
       GoKind: 2
     - __kind: StructureType
-      ID: 586
+      ID: 598
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1752480
@@ -9807,7 +9811,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 552
+      ID: 564
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1019232

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -121,78 +121,78 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 639 PointerType *crypto/x509.Certificate
+      Pointee: 651 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 681
+      ID: 230
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 107 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 920 PointerType *mime/multipart.FileHeader
+      Pointee: 927 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 925 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 932 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 933 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 940 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 684
+      ID: 233
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 683 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 232 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 923 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 936
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 935 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 938
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 937 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 676
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 675 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 205
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 204 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 213
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 212 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 930 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 943
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 942 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 945
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 944 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 688
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 687 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 199
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 198 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 207
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 206 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 950
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 942 GoSliceDataType []net/http.segment.array
+      Pointee: 949 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 196
+      ID: 209
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType []os.Signal.array
+      Pointee: 208 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -201,77 +201,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 674
+      ID: 686
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 673 GoSliceDataType []string.array
+      Pointee: 685 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 215
+      ID: 226
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []time.zone.array
+      Pointee: 225 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 217
+      ID: 228
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 216 GoSliceDataType []time.zoneTrans.array
+      Pointee: 227 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456928
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 180
+      ID: 187
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []uint8.array
+      Pointee: 186 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 182
+      ID: 189
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []uintptr.array
+      Pointee: 188 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 877856
       GoKind: 22
-      Pointee: 460 GoSliceHeaderType archive/tar.headerError
+      Pointee: 472 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 461 GoSliceDataType archive/tar.headerError.array
+      Pointee: 473 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 845
+      ID: 852
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1164384
       GoKind: 22
-      Pointee: 846 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 853 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1041312
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 837 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 847
+      ID: 854
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1280000
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 855 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1041056
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 835 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -280,57 +280,57 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 132
+      ID: 175
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 133 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 176 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*bucket<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 754 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 209
+      ID: 203
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 916 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 923 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 782
+      ID: 789
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 783 GoHMapBucketType bucket<string,[]string>
+      Pointee: 790 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 164
+      ID: 131
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 165 GoHMapBucketType bucket<string,float64>
+      Pointee: 132 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 644
+      ID: 656
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 657 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 159
+      ID: 126
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 160 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 127 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
-      ID: 154
+      ID: 119
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 155 GoHMapBucketType bucket<string,string>
+      Pointee: 120 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1861248
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType bufio.Writer
+      Pointee: 784 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 109
       Name: '*bytes.Buffer'
@@ -339,351 +339,351 @@ Types:
       GoKind: 22
       Pointee: 110 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 864224
       GoKind: 22
-      Pointee: 264 BaseType compress/flate.CorruptInputError
+      Pointee: 276 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 864320
       GoKind: 22
-      Pointee: 265 GoStringHeaderType compress/flate.InternalError
+      Pointee: 277 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 267
+      ID: 279
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 266 GoStringDataType compress/flate.InternalError.str
+      Pointee: 278 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 1887456
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 885 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1471360
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 866 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 949
+      ID: 158
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1389952
       GoKind: 22
-      Pointee: 124 StructureType context.backgroundCtx
+      Pointee: 159 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 112
+      ID: 169
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1631200
       GoKind: 22
-      Pointee: 113 StructureType context.cancelCtx
+      Pointee: 170 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1122016
       GoKind: 22
-      Pointee: 566 StructureType context.deadlineExceededError
+      Pointee: 578 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 944
+      ID: 144
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1256000
       GoKind: 22
-      Pointee: 125 StructureType context.emptyCtx
+      Pointee: 145 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 114
+      ID: 146
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1256160
       GoKind: 22
-      Pointee: 115 StructureType context.stopCtx
+      Pointee: 147 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 116
+      ID: 177
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1631392
       GoKind: 22
-      Pointee: 117 StructureType context.timerCtx
+      Pointee: 178 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 950
+      ID: 160
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1390112
       GoKind: 22
-      Pointee: 142 StructureType context.todoCtx
+      Pointee: 161 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 118
+      ID: 153
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1389632
       GoKind: 22
-      Pointee: 119 StructureType context.valueCtx
+      Pointee: 154 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 120
+      ID: 156
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1389792
       GoKind: 22
-      Pointee: 121 StructureType context.withoutCancelCtx
+      Pointee: 157 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863264
       GoKind: 22
-      Pointee: 261 BaseType crypto/aes.KeySizeError
+      Pointee: 273 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 395
+      ID: 407
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863456
       GoKind: 22
-      Pointee: 262 BaseType crypto/des.KeySizeError
+      Pointee: 274 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 863744
       GoKind: 22
-      Pointee: 263 BaseType crypto/rc4.KeySizeError
+      Pointee: 275 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 335
+      ID: 347
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 852896
       GoKind: 22
-      Pointee: 238 BaseType crypto/tls.AlertError
+      Pointee: 250 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1017248
       GoKind: 22
-      Pointee: 525 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 537 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2288544
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 915 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 797 StructureType crypto/tls.ConnectionState
+      Pointee: 804 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 333
+      ID: 345
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 852704
       GoKind: 22
-      Pointee: 334 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 346 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 331
+      ID: 343
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 852608
       GoKind: 22
-      Pointee: 332 StructureType crypto/tls.RecordHeaderError
+      Pointee: 344 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1015584
       GoKind: 22
-      Pointee: 492 BaseType crypto/tls.alert
+      Pointee: 504 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1263680
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 643 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 639
+      ID: 651
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1953440
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 652 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 863072
       GoKind: 22
-      Pointee: 391 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 403 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 862592
       GoKind: 22
-      Pointee: 385 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 397 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 386
+      ID: 398
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 862688
       GoKind: 22
-      Pointee: 387 StructureType crypto/x509.HostnameError
+      Pointee: 399 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 862496
       GoKind: 22
-      Pointee: 260 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 272 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 538
+      ID: 550
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1027744
       GoKind: 22
-      Pointee: 539 StructureType crypto/x509.SystemRootsError
+      Pointee: 551 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 863168
       GoKind: 22
-      Pointee: 393 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 405 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 862976
       GoKind: 22
-      Pointee: 389 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 401 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 451
+      ID: 463
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 873632
       GoKind: 22
-      Pointee: 452 StructureType encoding/asn1.StructuralError
+      Pointee: 464 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 873824
       GoKind: 22
-      Pointee: 456 StructureType encoding/asn1.SyntaxError
+      Pointee: 468 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 873728
       GoKind: 22
-      Pointee: 454 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 466 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 336
+      ID: 348
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 852992
       GoKind: 22
-      Pointee: 239 BaseType encoding/base64.CorruptInputError
+      Pointee: 251 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 861440
       GoKind: 22
-      Pointee: 259 BaseType encoding/hex.InvalidByteError
+      Pointee: 271 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 353
+      ID: 365
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 856544
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 366 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 536
+      ID: 548
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1022496
       GoKind: 22
-      Pointee: 537 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 549 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 856160
       GoKind: 22
-      Pointee: 346 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 358 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 351
+      ID: 363
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 856448
       GoKind: 22
-      Pointee: 352 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 364 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 856352
       GoKind: 22
-      Pointee: 350 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 362 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 856256
       GoKind: 22
-      Pointee: 348 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 360 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 856928
       GoKind: 22
-      Pointee: 356 StructureType encoding/json.jsonError
+      Pointee: 368 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 871424
       GoKind: 22
-      Pointee: 447 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 459 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 871328
       GoKind: 22
-      Pointee: 445 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 457 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 871520
       GoKind: 22
-      Pointee: 269 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 281 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 271
+      ID: 283
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 270 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 282 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 449
+      ID: 461
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 871616
       GoKind: 22
-      Pointee: 450 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 462 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -692,19 +692,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 319
+      ID: 331
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 848096
       GoKind: 22
-      Pointee: 320 UnresolvedPointeeType errors.errorString
+      Pointee: 332 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1008544
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType errors.joinError
+      Pointee: 524 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -720,118 +720,118 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 495
+      ID: 507
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 998560
       GoKind: 22
-      Pointee: 496 UnresolvedPointeeType fmt.wrapError
+      Pointee: 508 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 497
+      ID: 509
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 998688
       GoKind: 22
-      Pointee: 498 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 510 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 860960
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 389 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 1921600
       GoKind: 22
-      Pointee: 749 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 756 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 858176
       GoKind: 22
-      Pointee: 359 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 371 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 858272
       GoKind: 22
-      Pointee: 361 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 373 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 857984
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 672 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 364
+      ID: 376
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 858560
       GoKind: 22
-      Pointee: 365 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 377 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 858080
       GoKind: 22
-      Pointee: 662 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 362
+      ID: 374
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 858368
       GoKind: 22
-      Pointee: 253 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 265 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 255
+      ID: 267
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 254 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 266 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 357
+      ID: 369
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 857888
       GoKind: 22
-      Pointee: 250 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 262 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 252
+      ID: 264
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 251 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 263 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 858464
       GoKind: 22
-      Pointee: 256 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 268 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 258
+      ID: 270
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 257 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 269 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 401
+      ID: 413
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 865280
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 414 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
       ByteSize: 8
       GoRuntimeType: 1635040
       GoKind: 22
-      Pointee: 740 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
+      Pointee: 747 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
     - __kind: PointerType
       ID: 107
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -840,773 +840,773 @@ Types:
       GoKind: 22
       Pointee: 108 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 172
+      ID: 139
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1917280
       GoKind: 22
-      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 140 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 167
+      ID: 134
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1129440
       GoKind: 22
-      Pointee: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1807520
       GoKind: 22
-      Pointee: 873 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 880 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1710848
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+      Pointee: 874 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 170
+      ID: 137
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1129568
       GoKind: 22
-      Pointee: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 138 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1130208
       GoKind: 22
-      Pointee: 689 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 696 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 219
+      ID: 222
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1130336
       GoKind: 22
-      Pointee: 220 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 223 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 174
+      ID: 141
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2132544
       GoKind: 22
-      Pointee: 175 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 142 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer'
       ByteSize: 8
       GoRuntimeType: 2118208
       GoKind: 22
-      Pointee: 755 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
+      Pointee: 762 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 606
+      ID: 618
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1151584
       GoKind: 22
-      Pointee: 607 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 619 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 690
+      ID: 697
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1397152
       GoKind: 22
-      Pointee: 691 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 698 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2082816
       GoKind: 22
-      Pointee: 751 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
+      Pointee: 758 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 947
+      ID: 151
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1266560
       GoKind: 22
-      Pointee: 948 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 152 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2083232
       GoKind: 22
-      Pointee: 753 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
+      Pointee: 760 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1031456
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
+      Pointee: 833 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 867488
       GoKind: 22
-      Pointee: 404 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 416 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 410
+      ID: 422
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 868544
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 423 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 868256
       GoKind: 22
-      Pointee: 268 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 280 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 868448
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 421 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 406
+      ID: 418
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 868352
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 419 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 869888
       GoKind: 22
-      Pointee: 419 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 431 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 870080
       GoKind: 22
-      Pointee: 423 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 435 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 869984
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 433 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 869792
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 429 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 678
+      ID: 690
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 677 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 689 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 870464
       GoKind: 22
-      Pointee: 431 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 443 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 870176
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 437 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 870368
       GoKind: 22
-      Pointee: 429 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 441 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 870272
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 439 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 870560
       GoKind: 22
-      Pointee: 433 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 445 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 870848
       GoKind: 22
-      Pointee: 439 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 451 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 870944
       GoKind: 22
-      Pointee: 441 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 453 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 870752
       GoKind: 22
-      Pointee: 437 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 449 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 870656
       GoKind: 22
-      Pointee: 435 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 447 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 871136
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 455 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2233728
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 772 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2216928
       GoKind: 22
-      Pointee: 759 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 766 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2226048
       GoKind: 22
-      Pointee: 761 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 768 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2226688
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 770 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 859712
       GoKind: 22
-      Pointee: 367 StructureType github.com/cihub/seelog.baseError
+      Pointee: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1713312
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 749 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 368
+      ID: 380
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 859808
       GoKind: 22
-      Pointee: 369 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 381 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1269760
       GoKind: 22
-      Pointee: 732 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 739 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 733
+      ID: 740
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1480384
       GoKind: 22
-      Pointee: 734 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 741 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1481152
       GoKind: 22
-      Pointee: 738 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 745 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 860000
       GoKind: 22
-      Pointee: 373 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 385 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1480576
       GoKind: 22
-      Pointee: 736 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 743 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2195264
       GoKind: 22
-      Pointee: 757 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 764 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 859904
       GoKind: 22
-      Pointee: 371 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 383 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 860096
       GoKind: 22
-      Pointee: 375 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 387 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1159648
       GoKind: 22
-      Pointee: 844 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 851 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1642336
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 870 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 634
+      ID: 646
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1281280
       GoKind: 22
-      Pointee: 635 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 647 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 550
+      ID: 562
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1046304
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 563 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 548
+      ID: 560
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1046176
       GoKind: 22
-      Pointee: 549 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 561 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 552
+      ID: 564
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1050656
       GoKind: 22
-      Pointee: 553 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 565 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 554
+      ID: 566
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1050784
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 567 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 544
+      ID: 556
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1035296
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 557 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 861632
       GoKind: 22
-      Pointee: 380 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 392 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 608
+      ID: 620
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1158752
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 621 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 594
+      ID: 606
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1143648
       GoKind: 22
-      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 607 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1143264
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 601 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 530
+      ID: 542
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1020192
       GoKind: 22
-      Pointee: 531 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 543 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 600
+      ID: 612
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1144032
       GoKind: 22
-      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 613 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 529
+      ID: 541
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1020064
       GoKind: 22
-      Pointee: 494 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 506 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 592
+      ID: 604
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1143520
       GoKind: 22
-      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 590
+      ID: 602
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1143392
       GoKind: 22
-      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 603 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 598
+      ID: 610
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1143904
       GoKind: 22
-      Pointee: 599 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 611 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1143776
       GoKind: 22
-      Pointee: 597 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 609 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 604
+      ID: 616
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1144416
       GoKind: 22
-      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 617 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 534
+      ID: 546
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1020448
       GoKind: 22
-      Pointee: 535 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 547 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1020320
       GoKind: 22
-      Pointee: 533 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 545 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 602
+      ID: 614
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1144288
       GoKind: 22
-      Pointee: 603 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 615 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 889088
       GoKind: 22
-      Pointee: 276 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 288 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 278
+      ID: 290
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 289 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 647
+      ID: 659
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1508800
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 660 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 558
+      ID: 570
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1065632
       GoKind: 22
-      Pointee: 559 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 571 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 890336
       GoKind: 22
-      Pointee: 279 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 291 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 616
+      ID: 628
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1196896
       GoKind: 22
-      Pointee: 617 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 629 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 890624
       GoKind: 22
-      Pointee: 478 StructureType golang.org/x/net/http2.connError
+      Pointee: 490 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 890528
       GoKind: 22
-      Pointee: 283 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 295 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 285
+      ID: 297
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 296 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 890816
       GoKind: 22
-      Pointee: 289 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 301 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 291
+      ID: 303
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 290 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 302 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 479
+      ID: 491
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 890720
       GoKind: 22
-      Pointee: 286 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 298 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 288
+      ID: 300
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 287 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 299 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 475
+      ID: 487
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 890432
       GoKind: 22
-      Pointee: 280 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 292 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 282
+      ID: 294
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 293 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 890912
       GoKind: 22
-      Pointee: 482 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 494 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 483
+      ID: 495
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 891008
       GoKind: 22
-      Pointee: 292 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 304 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 884768
       GoKind: 22
-      Pointee: 470 StructureType google.golang.org/grpc.dropError
+      Pointee: 482 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1193824
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 627 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1288800
       GoKind: 22
-      Pointee: 637 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 649 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 887360
       GoKind: 22
-      Pointee: 472 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 484 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1721600
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 876 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 556
+      ID: 568
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1059872
       GoKind: 22
-      Pointee: 557 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 569 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1408032
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 860 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 876512
       GoKind: 22
-      Pointee: 458 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 470 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 546
+      ID: 558
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1039520
       GoKind: 22
-      Pointee: 547 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 559 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 612
+      ID: 624
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1162976
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 625 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1162720
       GoKind: 22
-      Pointee: 611 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 623 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 463
+      ID: 475
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 878816
       GoKind: 22
-      Pointee: 464 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 476 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 465
+      ID: 477
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 878912
       GoKind: 22
-      Pointee: 466 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 478 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 868640
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 425 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 130
+      ID: 173
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 131 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 174 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*hash<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 745 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 752 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 207
+      ID: 201
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 208 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 202 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 914 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 921 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 781 GoHMapHeaderType hash<string,[]string>
+      Pointee: 788 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 162
+      ID: 129
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 163 GoHMapHeaderType hash<string,float64>
+      Pointee: 130 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 642
+      ID: 654
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 643 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 655 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 157
+      ID: 124
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 158 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 152
+      ID: 117
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 153 GoHMapHeaderType hash<string,string>
+      Pointee: 118 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 891776
       GoKind: 22
-      Pointee: 485 UnresolvedPointeeType html/template.Error
+      Pointee: 497 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 96
       Name: '*int'
@@ -1643,269 +1643,269 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 862016
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 394 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 586
+      ID: 598
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1139040
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 599 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2283360
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType internal/poll.FD
+      Pointee: 913 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 584
+      ID: 596
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1138912
       GoKind: 22
-      Pointee: 585 StructureType internal/poll.errNetClosing
+      Pointee: 597 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 321
+      ID: 333
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 848480
       GoKind: 22
-      Pointee: 322 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 334 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1750720
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType io.PipeReader
+      Pointee: 878 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1394112
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType io.SectionReader
+      Pointee: 882 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1009056
       GoKind: 22
-      Pointee: 824 StructureType io.nopCloser
+      Pointee: 831 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1133024
       GoKind: 22
-      Pointee: 842 StructureType io.nopCloserWriterTo
+      Pointee: 849 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1138144
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType io/fs.PathError
+      Pointee: 595 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 864896
       GoKind: 22
-      Pointee: 400 StructureType math/big.ErrNaN
+      Pointee: 412 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 920
+      ID: 927
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853760
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 929 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 795 StructureType mime/multipart.Form
+      Pointee: 802 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1470592
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 862 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1470784
       GoKind: 22
-      Pointee: 857 StructureType mime/multipart.sectionReadCloser
+      Pointee: 864 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 568
+      ID: 580
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1123168
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType net.AddrError
+      Pointee: 581 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1256800
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType net.DNSError
+      Pointee: 634 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2137472
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType net.IPConn
+      Pointee: 889 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 619
+      ID: 631
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1256480
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType net.OpError
+      Pointee: 632 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 570
+      ID: 582
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1123296
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType net.ParseError
+      Pointee: 583 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2168704
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType net.TCPConn
+      Pointee: 897 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2215712
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType net.UDPConn
+      Pointee: 901 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2168192
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType net.UnixConn
+      Pointee: 895 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1122400
       GoKind: 22
-      Pointee: 562 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 574 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 563 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 575 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 499
+      ID: 511
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 999584
       GoKind: 22
-      Pointee: 500 StructureType net.canceledError
+      Pointee: 512 StructureType net.canceledError
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1915840
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType net.conn
+      Pointee: 887 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1744672
       GoKind: 22
-      Pointee: 666 StructureType net.dialResult·1
+      Pointee: 678 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2219360
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType net.netFD
+      Pointee: 903 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 293
+      ID: 305
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 841280
       GoKind: 22
-      Pointee: 294 UnresolvedPointeeType net.notFoundError
+      Pointee: 306 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 945
+      ID: 149
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1256640
       GoKind: 22
-      Pointee: 946 StructureType net.onlyValuesCtx
+      Pointee: 150 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 295
+      ID: 307
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 841952
       GoKind: 22
-      Pointee: 296 StructureType net.result·2
+      Pointee: 308 StructureType net.result·2
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2151840
       GoKind: 22
-      Pointee: 886 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 893 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2151360
       GoKind: 22
-      Pointee: 884 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 891 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1123936
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType net.temporaryError
+      Pointee: 585 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1257120
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType net.timeoutError
+      Pointee: 636 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 301
+      ID: 313
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 844544
       GoKind: 22
-      Pointee: 302 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 314 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 501
+      ID: 513
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1002912
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 514 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 105
       Name: '*net/http.Request'
@@ -1914,507 +1914,507 @@ Types:
       GoKind: 22
       Pointee: 106 StructureType net/http.Request
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1632736
       GoKind: 22
-      Pointee: 800 StructureType net/http.Response
+      Pointee: 807 StructureType net/http.Response
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1710176
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType net/http.body
+      Pointee: 872 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1126624
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 843 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1002784
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 823 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1745792
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType net/http.conn
+      Pointee: 780 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1001632
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 813 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1004832
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 827 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 303
+      ID: 315
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 844736
       GoKind: 22
-      Pointee: 222 BaseType net/http.http2ConnectionError
+      Pointee: 234 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 304
+      ID: 316
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 844832
       GoKind: 22
-      Pointee: 305 StructureType net/http.http2GoAwayError
+      Pointee: 317 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1258080
       GoKind: 22
-      Pointee: 626 StructureType net/http.http2StreamError
+      Pointee: 638 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 1916992
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 857 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 310
+      ID: 322
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 845696
       GoKind: 22
-      Pointee: 311 StructureType net/http.http2connError
+      Pointee: 323 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 307
+      ID: 319
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 845216
       GoKind: 22
-      Pointee: 226 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 238 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 228
+      ID: 240
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 227 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 239 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 845312
       GoKind: 22
-      Pointee: 309 StructureType net/http.http2goAwayFlowError
+      Pointee: 321 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1002528
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 821 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 313
+      ID: 325
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 845888
       GoKind: 22
-      Pointee: 232 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 244 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 234
+      ID: 246
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 233 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 245 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 312
+      ID: 324
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 845792
       GoKind: 22
-      Pointee: 229 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 241 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 231
+      ID: 243
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 230 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 242 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 576
+      ID: 588
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1128160
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 589 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1002272
       GoKind: 22
-      Pointee: 810 StructureType net/http.http2missingBody
+      Pointee: 817 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1005088
       GoKind: 22
-      Pointee: 822 StructureType net/http.http2noBodyReader
+      Pointee: 829 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 507
+      ID: 519
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1004960
       GoKind: 22
-      Pointee: 508 StructureType net/http.http2noCachedConnError
+      Pointee: 520 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 306
+      ID: 318
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 845120
       GoKind: 22
-      Pointee: 223 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 235 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 225
+      ID: 237
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 224 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 236 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1003424
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 825 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 727
+      ID: 734
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1876800
       GoKind: 22
-      Pointee: 728 StructureType net/http.http2responseWriter
+      Pointee: 735 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1455424
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 778 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1002400
       GoKind: 22
-      Pointee: 812 StructureType net/http.http2transportResponseBody
+      Pointee: 819 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1001760
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 815 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1126880
       GoKind: 22
-      Pointee: 840 StructureType net/http.noBody
+      Pointee: 847 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 503
+      ID: 515
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1004576
       GoKind: 22
-      Pointee: 504 StructureType net/http.nothingWrittenError
+      Pointee: 516 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1453504
       GoKind: 22
-      Pointee: 802 StructureType net/http.pattern
+      Pointee: 809 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 803
+      ID: 810
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1001120
       GoKind: 22
-      Pointee: 804 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 811 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1126752
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 845 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 314
+      ID: 326
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 846080
       GoKind: 22
-      Pointee: 315 StructureType net/http.requestBodyReadError
+      Pointee: 327 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 729
+      ID: 736
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2117760
       GoKind: 22
-      Pointee: 730 StructureType net/http.response
+      Pointee: 737 StructureType net/http.response
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367904
       GoKind: 22
-      Pointee: 941 StructureType net/http.segment
+      Pointee: 948 StructureType net/http.segment
     - __kind: PointerType
-      ID: 299
+      ID: 311
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 844448
       GoKind: 22
-      Pointee: 300 StructureType net/http.statusError
+      Pointee: 312 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1259520
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 640 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1128032
       GoKind: 22
-      Pointee: 575 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 587 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 505
+      ID: 517
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1004704
       GoKind: 22
-      Pointee: 506 StructureType net/http.transportReadFromServerError
+      Pointee: 518 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 297
+      ID: 309
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 843680
       GoKind: 22
-      Pointee: 298 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 310 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1066272
       GoKind: 22
-      Pointee: 832 StructureType net/http/httputil.failureToReadBody
+      Pointee: 839 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 327
+      ID: 339
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 850976
       GoKind: 22
-      Pointee: 328 StructureType net/netip.parseAddrError
+      Pointee: 340 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 325
+      ID: 337
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 850880
       GoKind: 22
-      Pointee: 326 StructureType net/netip.parsePrefixError
+      Pointee: 338 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 854240
       GoKind: 22
-      Pointee: 341 UnresolvedPointeeType net/textproto.Error
+      Pointee: 353 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 339
+      ID: 351
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 854144
       GoKind: 22
-      Pointee: 246 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 258 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 248
+      ID: 260
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 247 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 259 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 632
+      ID: 644
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1264160
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType net/url.Error
+      Pointee: 645 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 853088
       GoKind: 22
-      Pointee: 240 GoStringHeaderType net/url.EscapeError
+      Pointee: 252 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 242
+      ID: 254
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 241 GoStringDataType net/url.EscapeError.str
+      Pointee: 253 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 853184
       GoKind: 22
-      Pointee: 243 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 255 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 245
+      ID: 257
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 244 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 256 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2002496
       GoKind: 22
-      Pointee: 791 StructureType net/url.URL
+      Pointee: 798 StructureType net/url.URL
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1141600
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 917 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2259232
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType os.File
+      Pointee: 909 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 509
+      ID: 521
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1006880
       GoKind: 22
-      Pointee: 510 UnresolvedPointeeType os.LinkError
+      Pointee: 522 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 145
+      ID: 166
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 370656
       GoKind: 22
-      Pointee: 146 GoInterfaceType os.Signal
+      Pointee: 167 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1128672
       GoKind: 22
-      Pointee: 579 UnresolvedPointeeType os.SyscallError
+      Pointee: 591 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2255552
       GoKind: 22
-      Pointee: 900 StructureType os.fileWithoutReadFrom
+      Pointee: 907 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2254816
       GoKind: 22
-      Pointee: 898 StructureType os.fileWithoutWriteTo
+      Pointee: 905 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 540
+      ID: 552
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1030048
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType os/exec.Error
+      Pointee: 553 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2004608
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 682 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 542
+      ID: 554
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1030176
       GoKind: 22
-      Pointee: 543 StructureType os/exec.wrappedError
+      Pointee: 555 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 122
+      ID: 162
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1458112
       GoKind: 22
-      Pointee: 123 StructureType os/signal.signalCtx
+      Pointee: 163 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 468
+      ID: 480
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 882848
       GoKind: 22
-      Pointee: 273 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 285 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 275
+      ID: 287
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 286 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 882752
       GoKind: 22
-      Pointee: 272 BaseType os/user.UnknownUserIdError
+      Pointee: 284 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 323
+      ID: 335
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 849344
       GoKind: 22
-      Pointee: 324 UnresolvedPointeeType reflect.ValueError
+      Pointee: 336 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 869120
       GoKind: 22
-      Pointee: 415 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 427 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1011488
       GoKind: 22
-      Pointee: 517 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 529 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1013408
       GoKind: 22
-      Pointee: 522 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 534 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2430,12 +2430,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1011616
       GoKind: 22
-      Pointee: 519 StructureType runtime.boundsError
+      Pointee: 531 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -2451,24 +2451,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 580
+      ID: 592
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1136992
       GoKind: 22
-      Pointee: 581 StructureType runtime.errorAddressString
+      Pointee: 593 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1011232
       GoKind: 22
-      Pointee: 486 GoStringHeaderType runtime.errorString
+      Pointee: 498 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 487 GoStringDataType runtime.errorString.str
+      Pointee: 499 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -2484,24 +2484,24 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 134
+      ID: 121
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 380000
       GoKind: 22
-      Pointee: 135 UnresolvedPointeeType runtime.mapextra
+      Pointee: 122 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 520
+      ID: 532
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1013152
       GoKind: 22
-      Pointee: 489 GoStringHeaderType runtime.plainError
+      Pointee: 501 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 491
+      ID: 503
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 490 GoStringDataType runtime.plainError.str
+      Pointee: 502 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2524,12 +2524,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1010848
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType strconv.NumError
+      Pointee: 526 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -2538,190 +2538,190 @@ Types:
       GoKind: 22
       Pointee: 13 GoStringHeaderType string
     - __kind: PointerType
-      ID: 178
+      ID: 185
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 177 GoStringDataType string.str
+      Pointee: 184 GoStringDataType string.str
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1532800
       GoKind: 22
-      Pointee: 697 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 704 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 710
+      ID: 717
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1657312
       GoKind: 22
-      Pointee: 711 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 718 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1532416
       GoKind: 22
-      Pointee: 693 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 700 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1656544
       GoKind: 22
-      Pointee: 703 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 710 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1727200
       GoKind: 22
-      Pointee: 717 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 724 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1656736
       GoKind: 22
-      Pointee: 705 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 712 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1656352
       GoKind: 22
-      Pointee: 701 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 708 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1726752
       GoKind: 22
-      Pointee: 713 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 720 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1795072
       GoKind: 22
-      Pointee: 721 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 728 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 714
+      ID: 721
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1726976
       GoKind: 22
-      Pointee: 715 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 722 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1532992
       GoKind: 22
-      Pointee: 699 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 706 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1532608
       GoKind: 22
-      Pointee: 695 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 702 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 706
+      ID: 713
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1656928
       GoKind: 22
-      Pointee: 707 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 714 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1727424
       GoKind: 22
-      Pointee: 719 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 726 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 708
+      ID: 715
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1657120
       GoKind: 22
-      Pointee: 709 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 716 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1073536
       GoKind: 22
-      Pointee: 834 StructureType struct { io.Reader; io.Closer }
+      Pointee: 841 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 629
+      ID: 641
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1263040
       GoKind: 22
-      Pointee: 618 BaseType syscall.Errno
+      Pointee: 630 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 686
+      ID: 693
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1013920
       GoKind: 22
-      Pointee: 685 BaseType syscall.Signal
+      Pointee: 692 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1069472
       GoKind: 22
-      Pointee: 561 StructureType text/template.ExecError
+      Pointee: 573 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 140
+      ID: 182
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1458496
       GoKind: 22
-      Pointee: 141 StructureType time.Location
+      Pointee: 183 StructureType time.Location
     - __kind: PointerType
-      ID: 317
+      ID: 329
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 846944
       GoKind: 22
-      Pointee: 318 UnresolvedPointeeType time.ParseError
+      Pointee: 330 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 137
+      ID: 179
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1007392
       GoKind: 22
-      Pointee: 138 StructureType time.Timer
+      Pointee: 180 StructureType time.Timer
     - __kind: PointerType
-      ID: 316
+      ID: 328
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 846848
       GoKind: 22
-      Pointee: 235 GoStringHeaderType time.fileSizeError
+      Pointee: 247 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 237
+      ID: 249
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 236 GoStringDataType time.fileSizeError.str
+      Pointee: 248 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 190
+      ID: 216
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370976
       GoKind: 22
-      Pointee: 191 StructureType time.zone
+      Pointee: 217 StructureType time.zone
     - __kind: PointerType
-      ID: 193
+      ID: 219
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 371040
       GoKind: 22
-      Pointee: 194 StructureType time.zoneTrans
+      Pointee: 220 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -2765,47 +2765,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 329
+      ID: 341
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 851744
       GoKind: 22
-      Pointee: 330 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 342 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 342
+      ID: 354
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 854624
       GoKind: 22
-      Pointee: 343 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 355 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 344
+      ID: 356
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 854720
       GoKind: 22
-      Pointee: 249 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 261 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 526
+      ID: 538
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1018656
       GoKind: 22
-      Pointee: 527 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 539 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1018784
       GoKind: 22
-      Pointee: 493 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 505 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 798
+      ID: 805
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
     - __kind: GoChannelType
-      ID: 679
+      ID: 691
       Name: <-chan time.Time
       GoRuntimeType: 558720
       GoKind: 18
@@ -2884,7 +2884,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 785
+      ID: 792
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 635808
@@ -2893,7 +2893,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 784
+      ID: 791
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 635712
@@ -2956,7 +2956,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 786
+      ID: 793
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 635904
@@ -2974,7 +2974,7 @@ Types:
       HasCount: true
       Element: 12 BaseType uint64
     - __kind: ArrayType
-      ID: 653
+      ID: 665
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 653280
@@ -3001,7 +3001,7 @@ Types:
       HasCount: true
       Element: 81 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 183
+      ID: 190
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
@@ -3010,7 +3010,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 925
+      ID: 932
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473920
@@ -3018,22 +3018,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 926 PointerType **crypto/x509.Certificate
+          Type: 933 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 933 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 940 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 933
+      ID: 940
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 639 PointerType *crypto/x509.Certificate
+      Element: 651 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 680
+      ID: 229
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 464032
@@ -3041,22 +3041,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 681 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 230 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 683 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 232 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 232
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 107 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 918
+      ID: 925
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461664
@@ -3064,22 +3064,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 919 PointerType **mime/multipart.FileHeader
+          Type: 926 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 923 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 930 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 923
+      ID: 930
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 920 PointerType *mime/multipart.FileHeader
+      Element: 927 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 927
+      ID: 934
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 474048
@@ -3087,22 +3087,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 928 PointerType *[]*crypto/x509.Certificate
+          Type: 935 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 935 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 942 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 935
+      ID: 942
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 925 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 932 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 929
+      ID: 936
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457184
@@ -3110,76 +3110,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 930 PointerType *[]uint8
+          Type: 937 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 937 GoSliceDataType [][]uint8.array
+      Data: 944 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 937
+      ID: 944
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 214
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 133 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 176 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 769
+      ID: 776
       Name: '[]bucket<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
-      Element: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      Element: 754 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 224
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 921
+      ID: 928
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 916 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 923 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 789
+      ID: 796
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 783 GoHMapBucketType bucket<string,[]string>
+      Element: 790 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 197
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 165 GoHMapBucketType bucket<string,float64>
+      Element: 132 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 672
+      ID: 684
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 657 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 195
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 160 GoHMapBucketType bucket<string,interface {}>
+      Element: 127 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 193
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 155 GoHMapBucketType bucket<string,string>
+      Element: 120 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 658
+      ID: 670
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 468896
@@ -3194,15 +3194,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 675 GoSliceDataType []float64.array
+      Data: 687 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 675
+      ID: 687
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 19 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 133
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 463584
@@ -3210,22 +3210,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 167 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 204 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 198 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 198
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 168 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 169
+      ID: 136
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 463776
@@ -3233,43 +3233,43 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 170 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 137 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 212 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 206 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 206
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 171 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 138 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 184
+      ID: 210
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 185 GoInterfaceType context.canceler
+      Element: 211 GoInterfaceType context.canceler
     - __kind: ArrayType
-      ID: 766
+      ID: 773
       Name: '[]key<github.com/cihub/seelog.LogLevel>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 767 BaseType github.com/cihub/seelog.LogLevel
+      Element: 774 BaseType github.com/cihub/seelog.LogLevel
     - __kind: ArrayType
-      ID: 197
+      ID: 191
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 939
+      ID: 946
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -3277,22 +3277,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 940 PointerType *net/http.segment
+          Type: 947 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 942 GoSliceDataType []net/http.segment.array
+      Data: 949 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 942
+      ID: 949
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 941 StructureType net/http.segment
+      Element: 948 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 144
+      ID: 165
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 456992
@@ -3300,26 +3300,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 145 PointerType *os.Signal
+          Type: 166 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 195 GoSliceDataType []os.Signal.array
+      Data: 208 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 208
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 146 GoInterfaceType os.Signal
+      Element: 167 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 657
+      ID: 669
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -3334,15 +3334,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 673 GoSliceDataType []string.array
+      Data: 685 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 673
+      ID: 685
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 189
+      ID: 215
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463264
@@ -3350,22 +3350,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 190 PointerType *time.zone
+          Type: 216 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 214 GoSliceDataType []time.zone.array
+      Data: 225 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 225
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 191 StructureType time.zone
+      Element: 217 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 192
+      ID: 218
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463328
@@ -3373,20 +3373,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 193 PointerType *time.zoneTrans
+          Type: 219 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 216 GoSliceDataType []time.zoneTrans.array
+      Data: 227 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 227
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 194 StructureType time.zoneTrans
+      Element: 220 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3403,9 +3403,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 179 GoSliceDataType []uint8.array
+      Data: 186 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 186
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3426,77 +3426,77 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 181 GoSliceDataType []uintptr.array
+      Data: 188 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 188
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 218
+      ID: 221
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 219 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 917
+      ID: 924
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 918 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 925 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 788
+      ID: 795
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 657 GoSliceHeaderType []string
+      Element: 669 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 768
+      ID: 775
       Name: '[]val<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 202
+      ID: 196
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 671
+      ID: 683
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 676 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 200
+      ID: 194
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 128 GoEmptyInterfaceType interface {}
+      Element: 155 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 198
+      ID: 192
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 186
+      ID: 212
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
-      Element: 187 StructureType struct {}
+      Element: 213 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 460
+      ID: 472
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 877952
@@ -3511,27 +3511,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 461 GoSliceDataType archive/tar.headerError.array
+      Data: 473 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 473
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 846
+      ID: 853
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 855
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3541,178 +3541,178 @@ Types:
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 133
+      ID: 176
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 184 ArrayType []key<context.canceler>
+          Type: 210 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 186 ArrayType []val<struct {}>
+          Type: 212 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 132 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 185 GoInterfaceType context.canceler
-      ValueType: 187 StructureType struct {}
+          Type: 175 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 211 GoInterfaceType context.canceler
+      ValueType: 213 StructureType struct {}
     - __kind: GoHMapBucketType
-      ID: 747
+      ID: 754
       Name: bucket<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 766 ArrayType []key<github.com/cihub/seelog.LogLevel>
+          Type: 773 ArrayType []key<github.com/cihub/seelog.LogLevel>
         - Name: values
           Offset: 16
-          Type: 768 ArrayType []val<bool>
+          Type: 775 ArrayType []val<bool>
         - Name: overflow
           Offset: 24
-          Type: 746 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
-      KeyType: 767 BaseType github.com/cihub/seelog.LogLevel
+          Type: 753 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+      KeyType: 774 BaseType github.com/cihub/seelog.LogLevel
       ValueType: 6 BaseType bool
     - __kind: GoHMapBucketType
-      ID: 210
+      ID: 204
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 218 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 221 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 219 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 916
+      ID: 923
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 917 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 924 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 915 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 922 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 918 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 925 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 783
+      ID: 790
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 788 ArrayType []val<[]string>
+          Type: 795 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 782 PointerType *bucket<string,[]string>
+          Type: 789 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 657 GoSliceHeaderType []string
+      ValueType: 669 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 165
+      ID: 132
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 202 ArrayType []val<float64>
+          Type: 196 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 164 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 645
+      ID: 657
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 671 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 683 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 656 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 676 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
-      ID: 160
+      ID: 127
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 200 ArrayType []val<interface {}>
+          Type: 194 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 159 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 128 GoEmptyInterfaceType interface {}
+      ValueType: 155 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 155
+      ID: 120
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 183 ArrayType [8]uint8
+          Type: 190 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 197 ArrayType []key<string>
+          Type: 191 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 198 ArrayType []val<string>
+          Type: 192 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 154 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 784
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3720,12 +3720,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 787
+      ID: 794
       Name: chan bool
       GoRuntimeType: 554944
       GoKind: 18
     - __kind: GoChannelType
-      ID: 147
+      ID: 168
       Name: chan os.Signal
       GoRuntimeType: 561472
       GoKind: 18
@@ -3742,13 +3742,13 @@ Types:
       GoRuntimeType: 543296
       GoKind: 15
     - __kind: BaseType
-      ID: 264
+      ID: 276
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 781280
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 265
+      ID: 277
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 781376
@@ -3756,26 +3756,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 267 PointerType *compress/flate.InternalError.str
+          Type: 279 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 266 GoStringDataType compress/flate.InternalError.str
+      Data: 278 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 266
+      ID: 278
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 885
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 866
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 143
+      ID: 164
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 629760
@@ -3794,19 +3794,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 159
       Name: context.backgroundCtx
       GoRuntimeType: 1708832
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 125 StructureType context.emptyCtx
+          Type: 145 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 113
+      ID: 170
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1872768
@@ -3817,13 +3817,13 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 126 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 127 StructureType sync/atomic.Value
+          Type: 171 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 129 GoMapType map[context.canceler]struct {}
+          Type: 172 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -3833,7 +3833,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 185
+      ID: 211
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1090656
@@ -3846,13 +3846,13 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 566
+      ID: 578
       Name: context.deadlineExceededError
       GoRuntimeType: 1306048
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 145
       Name: context.emptyCtx
       GoRuntimeType: 1435104
       GoKind: 25
@@ -3861,7 +3861,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 115
+      ID: 147
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1732960
@@ -3872,11 +3872,11 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 136 GoSubroutineType func() bool
+          Type: 148 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 117
+      ID: 178
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1451584
@@ -3884,29 +3884,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 113 StructureType context.cancelCtx
+          Type: 170 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 137 PointerType *time.Timer
+          Type: 179 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 139 GoTimeType time.Time
+          Type: 181 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 142
+      ID: 161
       Name: context.todoCtx
       GoRuntimeType: 1709056
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 125 StructureType context.emptyCtx
+          Type: 145 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 154
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1743104
@@ -3917,14 +3917,14 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 157
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1708608
@@ -3936,39 +3936,39 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 261
+      ID: 273
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 780992
       GoKind: 2
     - __kind: BaseType
-      ID: 262
+      ID: 274
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 781088
       GoKind: 2
     - __kind: BaseType
-      ID: 263
+      ID: 275
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 781184
       GoKind: 2
     - __kind: BaseType
-      ID: 238
+      ID: 250
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 778784
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 525
+      ID: 537
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 797
+      ID: 804
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2160960
@@ -3997,13 +3997,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 925 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 932 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 927 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 934 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 929 GoSliceHeaderType [][]uint8
+          Type: 936 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -4015,25 +4015,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 931 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 938 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 932 BaseType crypto/tls.CurveID
+          Type: 939 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 932
+      ID: 939
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778592
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 334
+      ID: 346
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 332
+      ID: 344
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1637536
@@ -4044,26 +4044,26 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 653 ArrayType [5]uint8
+          Type: 665 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 654 GoInterfaceType net.Conn
+          Type: 666 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 492
+      ID: 504
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 967744
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 643
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 652
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 391
+      ID: 403
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1640416
@@ -4071,21 +4071,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 639 PointerType *crypto/x509.Certificate
+          Type: 651 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 663 BaseType crypto/x509.InvalidReason
+          Type: 675 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 385
+      ID: 397
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1097312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 387
+      ID: 399
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1437024
@@ -4093,24 +4093,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 639 PointerType *crypto/x509.Certificate
+          Type: 651 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 260
+      ID: 272
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 780800
       GoKind: 2
     - __kind: BaseType
-      ID: 663
+      ID: 675
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 546688
       GoKind: 2
     - __kind: StructureType
-      ID: 539
+      ID: 551
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1400192
@@ -4120,13 +4120,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 393
+      ID: 405
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1097568
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 389
+      ID: 401
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1640224
@@ -4134,15 +4134,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 639 PointerType *crypto/x509.Certificate
+          Type: 651 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 639 PointerType *crypto/x509.Certificate
+          Type: 651 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 452
+      ID: 464
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1277120
@@ -4152,7 +4152,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 456
+      ID: 468
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1277280
@@ -4162,47 +4162,47 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 454
+      ID: 466
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 239
+      ID: 251
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 778880
       GoKind: 6
     - __kind: BaseType
-      ID: 259
+      ID: 271
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 780608
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 366
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 537
+      ID: 549
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 346
+      ID: 358
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 352
+      ID: 364
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 350
+      ID: 362
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 348
+      ID: 360
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 356
+      ID: 368
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1267200
@@ -4212,15 +4212,15 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 447
+      ID: 459
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 445
+      ID: 457
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 269
+      ID: 281
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 782816
@@ -4228,18 +4228,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 271 PointerType *encoding/xml.UnmarshalError.str
+          Type: 283 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 270 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 282 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 270
+      ID: 282
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 450
+      ID: 462
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4256,11 +4256,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 320
+      ID: 332
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 524
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4276,11 +4276,11 @@ Types:
       GoRuntimeType: 543488
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 496
+      ID: 508
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 498
+      ID: 510
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4290,13 +4290,13 @@ Types:
       GoRuntimeType: 455520
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 792
+      ID: 799
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645600
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 136
+      ID: 148
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 553600
@@ -4308,23 +4308,23 @@ Types:
       GoRuntimeType: 798304
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 931
+      ID: 938
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 983200
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 389
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 749
+      ID: 756
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 1962048
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 359
+      ID: 371
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1638688
@@ -4332,7 +4332,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 655 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 667 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -4340,25 +4340,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 361
+      ID: 373
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 672
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 365
+      ID: 377
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1095904
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 662
+      ID: 674
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 253
+      ID: 265
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 779936
@@ -4366,18 +4366,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 255 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 267 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 254 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 266 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 254
+      ID: 266
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 655
+      ID: 667
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2127168
@@ -4385,13 +4385,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 656 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 668 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 13 GoStringHeaderType string
@@ -4400,7 +4400,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 658 GoSliceHeaderType []float64
+          Type: 670 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 16 BaseType int64
@@ -4409,13 +4409,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 659 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 671 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 661 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 673 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 13 GoStringHeaderType string
@@ -4426,13 +4426,13 @@ Types:
           Offset: 184
           Type: 16 BaseType int64
     - __kind: BaseType
-      ID: 656
+      ID: 668
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 545216
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 250
+      ID: 262
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 779840
@@ -4440,18 +4440,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 252 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 264 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 251 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 263 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 251
+      ID: 263
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 256
+      ID: 268
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 780032
@@ -4459,22 +4459,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 258 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 270 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 257 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 269 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 257
+      ID: 269
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 414
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
-      ID: 740
+      ID: 747
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
       GoRuntimeType: 1733632
       GoKind: 25
@@ -4488,7 +4488,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 148 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -4509,13 +4509,13 @@ Types:
           Type: 16 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 156 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 123 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 161 GoMapType map[string]float64
+          Type: 128 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 12 BaseType uint64
@@ -4530,10 +4530,10 @@ Types:
           Type: 15 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 133 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 169 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 136 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -4545,7 +4545,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 139 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 13 GoStringHeaderType string
@@ -4568,7 +4568,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 173
+      ID: 140
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2125376
@@ -4579,13 +4579,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 174 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 141 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 107 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -4594,16 +4594,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 176 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 143 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 12 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 148 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -4612,12 +4612,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 166 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 133 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 168
+      ID: 135
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1822592
@@ -4634,7 +4634,7 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -4642,7 +4642,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 873
+      ID: 880
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1873280
@@ -4650,29 +4650,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 866 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+          Type: 873 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 876 BaseType time.Duration
+          Type: 883 BaseType time.Duration
     - __kind: GoMapType
-      ID: 156
+      ID: 123
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1007520
       GoKind: 21
-      HeaderType: 158 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 682
+      ID: 231
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542336
       GoKind: 10
     - __kind: StructureType
-      ID: 171
+      ID: 138
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1664384
@@ -4686,16 +4686,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 206 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 200 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 211 GoMapType map[string]interface {}
+          Type: 205 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 689
+      ID: 696
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 220
+      ID: 223
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1822848
@@ -4703,7 +4703,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 687 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 694 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -4718,15 +4718,15 @@ Types:
           Type: 19 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 688 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 695 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 687
+      ID: 694
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965248
       GoKind: 5
     - __kind: StructureType
-      ID: 175
+      ID: 142
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2017536
@@ -4734,16 +4734,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 148 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 680 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 229 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 11 BaseType int
@@ -4758,12 +4758,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 682 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 231 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 107 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 176
+      ID: 143
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847712
@@ -4772,15 +4772,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 755
+      ID: 762
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 607
+      ID: 619
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 722
+      ID: 729
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1265920
@@ -4793,7 +4793,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 691
+      ID: 698
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1436544
@@ -4806,11 +4806,11 @@ Types:
           Offset: 16
           Type: 11 BaseType int
     - __kind: UnresolvedPointeeType
-      ID: 751
+      ID: 758
       Name: github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 948
+    - __kind: GoContextImplementationType
+      ID: 152
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1474624
@@ -4819,38 +4819,40 @@ Types:
         - Name: Context
           Offset: 0
           Type: 111 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 753
+      ID: 760
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 404
+      ID: 416
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 411
+      ID: 423
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1099360
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 268
+      ID: 280
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 782144
       GoKind: 2
     - __kind: StructureType
-      ID: 409
+      ID: 421
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1099232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 407
+      ID: 419
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1437984
@@ -4863,7 +4865,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 419
+      ID: 431
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1438624
@@ -4876,7 +4878,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 423
+      ID: 435
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1641952
@@ -4892,7 +4894,7 @@ Types:
           Offset: 24
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1275680
@@ -4902,7 +4904,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 417
+      ID: 429
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1275360
@@ -4912,14 +4914,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 641
+      ID: 653
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1159008
       GoKind: 21
-      HeaderType: 643 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 655 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 664
+      ID: 676
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1033376
@@ -4934,15 +4936,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 677 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 689 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 677
+      ID: 689
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 431
+      ID: 443
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1438944
@@ -4950,12 +4952,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 641 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 653 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 641 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 653 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 425
+      ID: 437
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1275840
@@ -4965,7 +4967,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 429
+      ID: 441
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1642144
@@ -4976,12 +4978,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 676 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 664 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 676 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 427
+      ID: 439
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1438784
@@ -4994,7 +4996,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 433
+      ID: 445
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1276000
@@ -5002,9 +5004,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 139 GoTimeType time.Time
+          Type: 181 GoTimeType time.Time
     - __kind: StructureType
-      ID: 439
+      ID: 451
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1439264
@@ -5017,7 +5019,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 441
+      ID: 453
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1276320
@@ -5027,7 +5029,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 437
+      ID: 449
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1439104
@@ -5040,7 +5042,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1276160
@@ -5050,7 +5052,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 443
+      ID: 455
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1439424
@@ -5063,29 +5065,29 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: BaseType
-      ID: 767
+      ID: 774
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 780320
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 772
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 759
+      ID: 766
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 761
+      ID: 768
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 770
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 367
+      ID: 379
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1268480
@@ -5095,11 +5097,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 749
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 369
+      ID: 381
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1268640
@@ -5107,17 +5109,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 367 StructureType github.com/cihub/seelog.baseError
+          Type: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 732
+      ID: 739
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 734
+      ID: 741
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 738
+      ID: 745
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1734752
@@ -5125,12 +5127,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 733 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 740 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 743 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 750 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 373
+      ID: 385
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1268960
@@ -5138,9 +5140,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 367 StructureType github.com/cihub/seelog.baseError
+          Type: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 736
+      ID: 743
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1713536
@@ -5148,13 +5150,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 733 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 740 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 757
+      ID: 764
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 371
+      ID: 383
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1268800
@@ -5162,9 +5164,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 367 StructureType github.com/cihub/seelog.baseError
+          Type: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 375
+      ID: 387
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1269120
@@ -5172,9 +5174,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 367 StructureType github.com/cihub/seelog.baseError
+          Type: 379 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 860
+      ID: 867
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1099616
@@ -5187,7 +5189,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 844
+      ID: 851
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1490944
@@ -5195,48 +5197,48 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 860 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 867 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 870
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 635
+      ID: 647
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 563
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 549
+      ID: 561
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 553
+      ID: 565
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 567
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 557
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 380
+      ID: 392
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1270080
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 621
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 595
+      ID: 607
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1756544
@@ -5252,11 +5254,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 601
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 531
+      ID: 543
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1544608
@@ -5269,7 +5271,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 601
+      ID: 613
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1756992
@@ -5285,13 +5287,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 494
+      ID: 506
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 968416
       GoKind: 8
     - __kind: StructureType
-      ID: 593
+      ID: 605
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1756320
@@ -5307,13 +5309,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 667
+      ID: 679
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 779456
       GoKind: 8
     - __kind: StructureType
-      ID: 591
+      ID: 603
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1756096
@@ -5321,15 +5323,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 667 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 679 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 667 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 679 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 599
+      ID: 611
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1673024
@@ -5342,7 +5344,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1756768
@@ -5358,7 +5360,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 605
+      ID: 617
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1473664
@@ -5368,19 +5370,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 535
+      ID: 547
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1218208
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 533
+      ID: 545
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1218080
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 603
+      ID: 615
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1673216
@@ -5393,7 +5395,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 288
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 784736
@@ -5401,22 +5403,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 290 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 277 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 289 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 289
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 660
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 559
+      ID: 571
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1291520
@@ -5426,19 +5428,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 279
+      ID: 291
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 785312
       GoKind: 10
     - __kind: BaseType
-      ID: 646
+      ID: 658
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 980512
       GoKind: 10
     - __kind: StructureType
-      ID: 617
+      ID: 629
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1790368
@@ -5449,12 +5451,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 646 BaseType golang.org/x/net/http2.ErrCode
+          Type: 658 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 478
+      ID: 490
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1446144
@@ -5462,12 +5464,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 646 BaseType golang.org/x/net/http2.ErrCode
+          Type: 658 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 295
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 785504
@@ -5475,18 +5477,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 297 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 284 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 296 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 296
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 289
+      ID: 301
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 785696
@@ -5494,18 +5496,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 291 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 303 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 290 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 302 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 290
+      ID: 302
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 286
+      ID: 298
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 785600
@@ -5513,18 +5515,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 288 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 300 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 287 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 299 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 287
+      ID: 299
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 292
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 785408
@@ -5532,18 +5534,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 294 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 281 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 293 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 293
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 482
+      ID: 494
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1292160
@@ -5553,13 +5555,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 292
+      ID: 304
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 785792
       GoKind: 2
     - __kind: StructureType
-      ID: 470
+      ID: 482
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1287200
@@ -5569,11 +5571,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 627
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 637
+      ID: 649
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1817248
@@ -5589,7 +5591,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 472
+      ID: 484
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1445664
@@ -5602,11 +5604,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 876
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 569
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1407232
@@ -5616,29 +5618,29 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 860
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 458
+      ID: 470
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 547
+      ID: 559
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 625
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 611
+      ID: 623
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1354528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 464
+      ID: 476
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1280480
@@ -5648,7 +5650,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 466
+      ID: 478
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1280640
@@ -5658,11 +5660,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 425
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 131
+      ID: 174
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -5683,20 +5685,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 132 PointerType *bucket<context.canceler,struct {}>
+          Type: 175 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 132 PointerType *bucket<context.canceler,struct {}>
+          Type: 175 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 133 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 188 GoSliceDataType []bucket<context.canceler,struct {}>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 176 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 214 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
-      ID: 745
+      ID: 752
       Name: hash<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       RawFields:
@@ -5717,20 +5719,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 746 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+          Type: 753 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
         - Name: oldbuckets
           Offset: 24
-          Type: 746 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+          Type: 753 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 747 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
-      BucketsType: 769 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 754 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      BucketsType: 776 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
     - __kind: GoHMapHeaderType
-      ID: 208
+      ID: 202
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -5751,20 +5753,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 209 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 203 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 210 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 221 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 204 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 224 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 914
+      ID: 921
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -5785,20 +5787,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 915 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 922 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 915 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 922 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 916 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 921 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 923 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 928 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 781
+      ID: 788
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -5819,20 +5821,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 782 PointerType *bucket<string,[]string>
+          Type: 789 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 782 PointerType *bucket<string,[]string>
+          Type: 789 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 783 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 789 GoSliceDataType []bucket<string,[]string>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 790 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 796 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 163
+      ID: 130
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -5853,20 +5855,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 164 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 164 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 165 GoHMapBucketType bucket<string,float64>
-      BucketsType: 203 GoSliceDataType []bucket<string,float64>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 132 GoHMapBucketType bucket<string,float64>
+      BucketsType: 197 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 643
+      ID: 655
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -5887,20 +5889,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 656 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 644 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 656 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 645 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 672 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 657 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 684 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
-      ID: 158
+      ID: 125
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -5921,20 +5923,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 159 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 159 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 160 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 201 GoSliceDataType []bucket<string,interface {}>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 127 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 195 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 153
+      ID: 118
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -5955,20 +5957,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 154 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 154 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 134 PointerType *runtime.mapextra
-      BucketType: 155 GoHMapBucketType bucket<string,string>
-      BucketsType: 199 GoSliceDataType []bucket<string,string>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 120 GoHMapBucketType bucket<string,string>
+      BucketsType: 193 GoSliceDataType []bucket<string,string>.array
     - __kind: UnresolvedPointeeType
-      ID: 485
+      ID: 497
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -6002,7 +6004,7 @@ Types:
       GoRuntimeType: 542592
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 128
+      ID: 155
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 798016
@@ -6015,7 +6017,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 394
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -6041,21 +6043,21 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 599
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 913
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 585
+      ID: 597
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1323328
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 322
+      ID: 334
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6136,7 +6138,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 861
+      ID: 868
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1009568
@@ -6149,11 +6151,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 878
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 774
+      ID: 781
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1093088
@@ -6166,7 +6168,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 851
+      ID: 858
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1008928
@@ -6179,11 +6181,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 824
+      ID: 831
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1393952
@@ -6191,9 +6193,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 851 GoInterfaceType io.Reader
+          Type: 858 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 842
+      ID: 849
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1459648
@@ -6201,69 +6203,69 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 851 GoInterfaceType io.Reader
+          Type: 858 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 595
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoMapType
-      ID: 129
+      ID: 172
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 897440
       GoKind: 21
-      HeaderType: 131 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 174 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 743
+      ID: 750
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 919936
       GoKind: 21
-      HeaderType: 745 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 752 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 206
+      ID: 200
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 21
-      HeaderType: 208 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 202 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 912
+      ID: 919
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904160
       GoKind: 21
-      HeaderType: 914 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 921 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 911
+      ID: 918
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899360
       GoKind: 21
-      HeaderType: 781 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 788 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 161
+      ID: 128
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 905024
       GoKind: 21
-      HeaderType: 163 GoHMapHeaderType hash<string,float64>
+      HeaderType: 130 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 211
+      ID: 205
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896480
       GoKind: 21
-      HeaderType: 158 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
-      ID: 151
+      ID: 116
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
-      HeaderType: 153 GoHMapHeaderType hash<string,string>
+      HeaderType: 118 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 400
+      ID: 412
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1272480
@@ -6273,11 +6275,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 795
+      ID: 802
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1326048
@@ -6285,16 +6287,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 911 GoMapType map[string][]string
+          Type: 918 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 912 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 919 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 862
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1826432
@@ -6302,16 +6304,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 874 PointerType *io.SectionReader
+          Type: 881 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 861 GoInterfaceType io.Closer
+          Type: 868 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 581
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 654
+      ID: 666
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1435264
@@ -6324,35 +6326,35 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 634
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 889
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 632
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 583
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 901
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 562
+      ID: 574
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1090912
@@ -6360,28 +6362,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 564 PointerType *net.UnknownNetworkError.str
+          Type: 576 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 563 GoStringDataType net.UnknownNetworkError.str
+      Data: 575 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 563
+      ID: 575
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 500
+      ID: 512
       Name: net.canceledError
       GoRuntimeType: 1216032
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 887
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 666
+      ID: 678
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2016832
@@ -6389,7 +6391,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 654 GoInterfaceType net.Conn
+          Type: 666 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -6400,27 +6402,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 903
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: net.noReadFrom
       GoRuntimeType: 1091168
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: net.noWriteTo
       GoRuntimeType: 1091040
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 294
+      ID: 306
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 946
+    - __kind: GoContextImplementationType
+      ID: 150
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1658816
@@ -6432,8 +6434,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 111 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 296
+      ID: 308
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1632160
@@ -6441,7 +6445,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 649 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 661 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -6449,7 +6453,7 @@ Types:
           Offset: 96
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 886
+      ID: 893
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2198528
@@ -6457,12 +6461,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 892 StructureType net.noReadFrom
+          Type: 899 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 889 PointerType *net.TCPConn
+          Type: 896 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2197984
@@ -6470,20 +6474,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 891 StructureType net.noWriteTo
+          Type: 898 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 889 PointerType *net.TCPConn
+          Type: 896 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 585
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 636
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 725
+      ID: 732
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1006752
@@ -6496,7 +6500,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 723
+      ID: 730
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1005344
@@ -6509,14 +6513,14 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 779
+      ID: 786
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1964288
       GoKind: 21
-      HeaderType: 781 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 788 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 726
+      ID: 733
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1005472
@@ -6529,15 +6533,15 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 302
+      ID: 314
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 514
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 724
+      ID: 731
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1005728
@@ -6561,7 +6565,7 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 790 PointerType *net/url.URL
+          Type: 797 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -6573,19 +6577,19 @@ Types:
           Type: 11 BaseType int
         - Name: Header
           Offset: 56
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 774 GoInterfaceType io.ReadCloser
+          Type: 781 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 792 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 799 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 16 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6594,16 +6598,16 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 793 GoMapType net/url.Values
+          Type: 800 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 793 GoMapType net/url.Values
+          Type: 800 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 794 PointerType *mime/multipart.Form
+          Type: 801 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 13 GoStringHeaderType string
@@ -6612,13 +6616,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 796 PointerType *crypto/tls.ConnectionState
+          Type: 803 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 798 GoChannelType <-chan struct {}
+          Type: 805 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 799 PointerType *net/http.Response
+          Type: 806 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 13 GoStringHeaderType string
@@ -6627,15 +6631,15 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 801 PointerType *net/http.pattern
+          Type: 808 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 151 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
     - __kind: StructureType
-      ID: 800
+      ID: 807
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2124032
@@ -6658,16 +6662,16 @@ Types:
           Type: 11 BaseType int
         - Name: Header
           Offset: 56
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 774 GoInterfaceType io.ReadCloser
+          Type: 781 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 16 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6676,13 +6680,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 105 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 796 PointerType *crypto/tls.ConnectionState
+          Type: 803 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 104
       Name: net/http.ResponseWriter
@@ -6697,19 +6701,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 872
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 843
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1660352
@@ -6717,10 +6721,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 729 PointerType *net/http.response
+          Type: 736 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6728,31 +6732,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 780
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 813
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 222
+      ID: 234
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 776384
       GoKind: 10
     - __kind: BaseType
-      ID: 638
+      ID: 650
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 965056
       GoKind: 10
     - __kind: StructureType
-      ID: 305
+      ID: 317
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1633696
@@ -6763,12 +6767,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 638 BaseType net/http.http2ErrCode
+          Type: 650 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 626
+      ID: 638
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1806752
@@ -6779,16 +6783,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 638 BaseType net/http.http2ErrCode
+          Type: 650 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 857
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 311
+      ID: 323
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1435744
@@ -6796,12 +6800,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 638 BaseType net/http.http2ErrCode
+          Type: 650 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 226
+      ID: 238
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 776576
@@ -6809,28 +6813,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 228 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 240 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 227 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 239 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 227
+      ID: 239
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 309
+      ID: 321
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1092192
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 821
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 232
+      ID: 244
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 776768
@@ -6838,18 +6842,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 234 PointerType *net/http.http2headerFieldNameError.str
+          Type: 246 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 233 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 245 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 233
+      ID: 245
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 229
+      ID: 241
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 776672
@@ -6857,40 +6861,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 231 PointerType *net/http.http2headerFieldValueError.str
+          Type: 243 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 230 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 242 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 230
+      ID: 242
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 589
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: net/http.http2missingBody
       GoRuntimeType: 1216288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 822
+      ID: 829
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1216800
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 508
+      ID: 520
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1216672
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 223
+      ID: 235
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 776480
@@ -6898,22 +6902,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 225 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 237 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 224 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 236 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 224
+      ID: 236
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 728
+      ID: 735
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1125984
@@ -6921,13 +6925,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 770 PointerType *net/http.http2responseWriterState
+          Type: 777 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 778
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 812
+      ID: 819
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1391392
@@ -6935,19 +6939,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 849 PointerType *net/http.http2clientStream
+          Type: 856 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 815
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: net/http.noBody
       GoRuntimeType: 1309088
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 504
+      ID: 516
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1392512
@@ -6957,7 +6961,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 802
+      ID: 809
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1745568
@@ -6974,20 +6978,20 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 939 GoSliceHeaderType []net/http.segment
+          Type: 946 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 804
+      ID: 811
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 845
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 315
+      ID: 327
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1260320
@@ -6997,7 +7001,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 730
+      ID: 737
       Name: net/http.response
       ByteSize: 224
       GoRuntimeType: 2257024
@@ -7005,16 +7009,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 772 PointerType *net/http.conn
+          Type: 779 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 105 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 774 GoInterfaceType io.ReadCloser
+          Type: 781 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 143 GoSubroutineType context.CancelFunc
+          Type: 164 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7026,19 +7030,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 126 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 775 StructureType sync/atomic.Bool
+          Type: 782 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 776 PointerType *bufio.Writer
+          Type: 783 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 778 StructureType net/http.chunkWriter
+          Type: 785 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 779 GoMapType net/http.Header
+          Type: 786 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7062,27 +7066,27 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 657 GoSliceHeaderType []string
+          Type: 669 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 775 StructureType sync/atomic.Bool
+          Type: 782 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 784 ArrayType [29]uint8
+          Type: 791 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 785 ArrayType [10]uint8
+          Type: 792 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 786 ArrayType [3]uint8
+          Type: 793 ArrayType [3]uint8
         - Name: closeNotifyCh
           Offset: 208
-          Type: 787 GoChannelType chan bool
+          Type: 794 GoChannelType chan bool
         - Name: didCloseNotify
           Offset: 216
-          Type: 775 StructureType sync/atomic.Bool
+          Type: 782 StructureType sync/atomic.Bool
     - __kind: StructureType
-      ID: 941
+      ID: 948
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1453312
@@ -7098,7 +7102,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 300
+      ID: 312
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1435584
@@ -7111,17 +7115,17 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 640
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 575
+      ID: 587
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1310528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 506
+      ID: 518
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1392672
@@ -7131,17 +7135,17 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 298
+      ID: 310
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 832
+      ID: 839
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1223072
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 328
+      ID: 340
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1636960
@@ -7157,7 +7161,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 326
+      ID: 338
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1436064
@@ -7170,11 +7174,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 341
+      ID: 353
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 246
+      ID: 258
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 779168
@@ -7182,22 +7186,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 248 PointerType *net/textproto.ProtocolError.str
+          Type: 260 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 247 GoStringDataType net/textproto.ProtocolError.str
+      Data: 259 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 247
+      ID: 259
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 645
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 240
+      ID: 252
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 778976
@@ -7205,18 +7209,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 242 PointerType *net/url.EscapeError.str
+          Type: 254 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 241 GoStringDataType net/url.EscapeError.str
+      Data: 253 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 241
+      ID: 253
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 243
+      ID: 255
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 779072
@@ -7224,18 +7228,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 245 PointerType *net/url.InvalidHostError.str
+          Type: 257 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 244 GoStringDataType net/url.InvalidHostError.str
+      Data: 256 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 244
+      ID: 256
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 791
+      ID: 798
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2041568
@@ -7249,7 +7253,7 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 909 PointerType *net/url.Userinfo
+          Type: 916 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 13 GoStringHeaderType string
@@ -7275,26 +7279,26 @@ Types:
           Offset: 128
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 917
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 793
+      ID: 800
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1712416
       GoKind: 21
-      HeaderType: 781 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 788 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 909
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 510
+      ID: 522
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 146
+      ID: 167
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1092832
@@ -7307,11 +7311,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 579
+      ID: 591
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 900
+      ID: 907
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2269248
@@ -7319,12 +7323,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 904 StructureType os.noReadFrom
+          Type: 911 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 901 PointerType *os.File
+          Type: 908 PointerType *os.File
     - __kind: StructureType
-      ID: 898
+      ID: 905
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2268448
@@ -7332,32 +7336,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 903 StructureType os.noWriteTo
+          Type: 910 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 901 PointerType *os.File
+          Type: 908 PointerType *os.File
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: os.noReadFrom
       GoRuntimeType: 1092704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 903
+      ID: 910
       Name: os.noWriteTo
       GoRuntimeType: 1092576
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 553
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 682
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 543
+      ID: 555
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1544992
@@ -7370,7 +7374,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 163
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1873024
@@ -7381,17 +7385,17 @@ Types:
           Type: 111 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 143 GoSubroutineType context.CancelFunc
+          Type: 164 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 144 GoSliceHeaderType []os.Signal
+          Type: 165 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 147 GoChannelType chan os.Signal
+          Type: 168 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 285
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 783968
@@ -7399,36 +7403,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *os/user.UnknownGroupIdError.str
+          Type: 287 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 274 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 286 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 286
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 272
+      ID: 284
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 783872
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 324
+      ID: 336
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 415
+      ID: 427
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 517
+      ID: 529
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 522
+      ID: 534
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7440,7 +7444,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 519
+      ID: 531
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1796192
@@ -7457,9 +7461,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 668 BaseType runtime.boundsErrorCode
+          Type: 680 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 668
+      ID: 680
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 543680
@@ -7479,7 +7483,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 581
+      ID: 593
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1667648
@@ -7492,7 +7496,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 486
+      ID: 498
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 966304
@@ -7500,13 +7504,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 488 PointerType *runtime.errorString.str
+          Type: 500 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 487 GoStringDataType runtime.errorString.str
+      Data: 499 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 487
+      ID: 499
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8083,7 +8087,7 @@ Types:
           Offset: 24
           Type: 30 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 135
+      ID: 122
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -8132,7 +8136,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 489
+      ID: 501
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 966880
@@ -8140,13 +8144,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 491 PointerType *runtime.plainError.str
+          Type: 503 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 490 GoStringDataType runtime.plainError.str
+      Data: 502 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 490
+      ID: 502
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8228,7 +8232,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 526
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8240,18 +8244,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 178 PointerType *string.str
+          Type: 185 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 177 GoStringDataType string.str
+      Data: 184 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 177
+      ID: 184
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 697
+      ID: 704
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1856384
@@ -8259,12 +8263,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 711
+      ID: 718
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1931680
@@ -8272,15 +8276,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 693
+      ID: 700
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1855872
@@ -8288,12 +8292,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 703
+      ID: 710
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1930528
@@ -8301,15 +8305,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 717
+      ID: 724
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2000128
@@ -8317,18 +8321,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 705
+      ID: 712
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1930816
@@ -8336,15 +8340,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 701
+      ID: 708
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1930240
@@ -8352,15 +8356,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 713
+      ID: 720
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1999488
@@ -8368,18 +8372,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 721
+      ID: 728
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2059232
@@ -8387,21 +8391,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 715
+      ID: 722
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1999808
@@ -8409,18 +8413,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 723 GoInterfaceType net/http.Flusher
+          Type: 730 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 699
+      ID: 706
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1856640
@@ -8428,12 +8432,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 695
+      ID: 702
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1856128
@@ -8441,12 +8445,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 707
+      ID: 714
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1931104
@@ -8454,15 +8458,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2000448
@@ -8470,18 +8474,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 725 GoInterfaceType net/http.CloseNotifier
+          Type: 732 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 709
+      ID: 716
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1931392
@@ -8489,15 +8493,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 722 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 729 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 724 GoInterfaceType net/http.Pusher
+          Type: 731 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 726 GoInterfaceType net/http.Hijacker
+          Type: 733 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 834
+      ID: 841
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1556704
@@ -8505,18 +8509,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 851 GoInterfaceType io.Reader
+          Type: 858 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 861 GoInterfaceType io.Closer
+          Type: 868 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 187
+      ID: 213
       Name: struct {}
       GoRuntimeType: 789728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 126
+      ID: 113
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1314208
@@ -8529,7 +8533,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 148
+      ID: 112
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1751168
@@ -8537,7 +8541,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 126 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -8546,12 +8550,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 775
+      ID: 782
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1315488
@@ -8559,12 +8563,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 115 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 149
+      ID: 114
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1315648
@@ -8572,12 +8576,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 115 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 15 BaseType int32
     - __kind: StructureType
-      ID: 127
+      ID: 171
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1134304
@@ -8585,27 +8589,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 128 GoEmptyInterfaceType interface {}
+          Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 150
+      ID: 115
       Name: sync/atomic.noCopy
       GoRuntimeType: 966016
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 618
+      ID: 630
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1217312
       GoKind: 12
     - __kind: BaseType
-      ID: 685
+      ID: 692
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 967072
       GoKind: 2
     - __kind: StructureType
-      ID: 561
+      ID: 573
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1549216
@@ -8618,13 +8622,13 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 876
+      ID: 883
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1822336
       GoKind: 6
     - __kind: StructureType
-      ID: 141
+      ID: 183
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1877952
@@ -8635,10 +8639,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 189 GoSliceHeaderType []time.zone
+          Type: 215 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 192 GoSliceHeaderType []time.zoneTrans
+          Type: 218 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -8650,13 +8654,13 @@ Types:
           Type: 16 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 190 PointerType *time.zone
+          Type: 216 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 318
+      ID: 330
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 139
+      ID: 181
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2281472
@@ -8670,7 +8674,7 @@ Types:
           Type: 16 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 140 PointerType *time.Location
+          Type: 182 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -8680,7 +8684,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 138
+      ID: 180
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1311328
@@ -8688,12 +8692,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 679 GoChannelType <-chan time.Time
+          Type: 691 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 235
+      ID: 247
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 776864
@@ -8701,18 +8705,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 237 PointerType *time.fileSizeError.str
+          Type: 249 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 236 GoStringDataType time.fileSizeError.str
+      Data: 248 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 236
+      ID: 248
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 191
+      ID: 217
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1458304
@@ -8728,7 +8732,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 194
+      ID: 220
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1664192
@@ -8789,7 +8793,7 @@ Types:
       GoRuntimeType: 543616
       GoKind: 26
     - __kind: StructureType
-      ID: 649
+      ID: 661
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1967808
@@ -8800,10 +8804,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 650 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 662 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 651 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 663 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -8818,18 +8822,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 652 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 664 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 652
+      ID: 664
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 967360
       GoKind: 9
     - __kind: StructureType
-      ID: 650
+      ID: 662
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1825664
@@ -8854,17 +8858,17 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 330
+      ID: 342
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 651
+      ID: 663
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 544512
       GoKind: 8
     - __kind: StructureType
-      ID: 343
+      ID: 355
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1265280
@@ -8874,13 +8878,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 249
+      ID: 261
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 779264
       GoKind: 2
     - __kind: StructureType
-      ID: 527
+      ID: 539
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1544416
@@ -8893,7 +8897,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 493
+      ID: 505
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 968224

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -121,124 +121,124 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 675 PointerType *crypto/x509.Certificate
+      Pointee: 687 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 723
+      ID: 262
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 980 PointerType *mime/multipart.FileHeader
+      Pointee: 987 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 139
+      ID: 180
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 140 PointerType *table<context.canceler,struct {}>
+      Pointee: 181 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 789 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 796 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 235
+      ID: 224
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 236 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 225 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 971 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 978 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 830 PointerType *table<string,[]string>
+      Pointee: 837 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 169
+      ID: 136
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 170 PointerType *table<string,float64>
+      Pointee: 137 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 680
+      ID: 692
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 693 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 164
+      ID: 131
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 165 PointerType *table<string,interface {}>
+      Pointee: 132 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 159
+      ID: 126
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 160 PointerType *table<string,string>
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 986 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 993 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 995
+      ID: 1002
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 994 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1001 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 726
+      ID: 265
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 725 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 264 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 984 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 997
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 996 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 999
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 998 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 718
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 717 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 231
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 230 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 239
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 991 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 1004
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1003 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1006
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1005 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 730
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 729 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 220
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 228
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 227 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1011
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1003 GoSliceDataType []net/http.segment.array
+      Pointee: 1010 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 205
+      ID: 230
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []os.Signal.array
+      Pointee: 229 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -247,77 +247,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 716
+      ID: 728
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 715 GoSliceDataType []string.array
+      Pointee: 727 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 241
+      ID: 258
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []time.zone.array
+      Pointee: 257 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 243
+      ID: 260
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []time.zoneTrans.array
+      Pointee: 259 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483424
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 185
+      ID: 192
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []uint8.array
+      Pointee: 191 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 187
+      ID: 194
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []uintptr.array
+      Pointee: 193 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 495
+      ID: 507
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 945248
       GoKind: 22
-      Pointee: 496 GoSliceHeaderType archive/tar.headerError
+      Pointee: 508 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 497 GoSliceDataType archive/tar.headerError.array
+      Pointee: 509 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1245600
       GoKind: 22
-      Pointee: 899 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 906 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1077984
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 890 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1454720
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 908 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1077728
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 888 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -326,12 +326,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1987616
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType bufio.Writer
+      Pointee: 831 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 114
       Name: '*bytes.Buffer'
@@ -340,358 +340,358 @@ Types:
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 433
+      ID: 445
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 930944
       GoKind: 22
-      Pointee: 297 BaseType compress/flate.CorruptInputError
+      Pointee: 309 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 931040
       GoKind: 22
-      Pointee: 298 GoStringHeaderType compress/flate.InternalError
+      Pointee: 310 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 300
+      ID: 312
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 299 GoStringDataType compress/flate.InternalError.str
+      Pointee: 311 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 2015072
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 940 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1654944
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 919 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 1010
+      ID: 163
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1569600
       GoKind: 22
-      Pointee: 129 StructureType context.backgroundCtx
+      Pointee: 164 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 117
+      ID: 174
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1749344
       GoKind: 22
-      Pointee: 118 StructureType context.cancelCtx
+      Pointee: 175 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1202848
       GoKind: 22
-      Pointee: 602 StructureType context.deadlineExceededError
+      Pointee: 614 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1005
+      ID: 149
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1429920
       GoKind: 22
-      Pointee: 130 StructureType context.emptyCtx
+      Pointee: 150 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 119
+      ID: 151
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1430080
       GoKind: 22
-      Pointee: 120 StructureType context.stopCtx
+      Pointee: 152 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 121
+      ID: 182
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1749536
       GoKind: 22
-      Pointee: 122 StructureType context.timerCtx
+      Pointee: 183 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1011
+      ID: 165
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1569760
       GoKind: 22
-      Pointee: 147 StructureType context.todoCtx
+      Pointee: 166 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 123
+      ID: 158
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1569280
       GoKind: 22
-      Pointee: 124 StructureType context.valueCtx
+      Pointee: 159 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 125
+      ID: 161
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1569440
       GoKind: 22
-      Pointee: 126 StructureType context.withoutCancelCtx
+      Pointee: 162 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 429
+      ID: 441
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929696
       GoKind: 22
-      Pointee: 293 BaseType crypto/aes.KeySizeError
+      Pointee: 305 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929888
       GoKind: 22
-      Pointee: 294 BaseType crypto/des.KeySizeError
+      Pointee: 306 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 431
+      ID: 443
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930176
       GoKind: 22
-      Pointee: 295 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 307 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930464
       GoKind: 22
-      Pointee: 296 BaseType crypto/rc4.KeySizeError
+      Pointee: 308 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 368
+      ID: 380
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 270 BaseType crypto/tls.AlertError
+      Pointee: 282 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1055456
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 573 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2430976
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 970 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 850 StructureType crypto/tls.ConnectionState
+      Pointee: 857 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 919232
       GoKind: 22
-      Pointee: 367 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 379 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 364
+      ID: 376
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 919136
       GoKind: 22
-      Pointee: 365 StructureType crypto/tls.RecordHeaderError
+      Pointee: 377 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1053792
       GoKind: 22
-      Pointee: 528 BaseType crypto/tls.alert
+      Pointee: 540 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 666
+      ID: 678
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1437600
       GoKind: 22
-      Pointee: 667 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 679 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 675
+      ID: 687
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2081952
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 688 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 929504
       GoKind: 22
-      Pointee: 426 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 438 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 419
+      ID: 431
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 929024
       GoKind: 22
-      Pointee: 420 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 432 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 421
+      ID: 433
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 929120
       GoKind: 22
-      Pointee: 422 StructureType crypto/x509.HostnameError
+      Pointee: 434 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 928928
       GoKind: 22
-      Pointee: 292 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 304 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1065056
       GoKind: 22
-      Pointee: 575 StructureType crypto/x509.SystemRootsError
+      Pointee: 587 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 929600
       GoKind: 22
-      Pointee: 428 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 440 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 423
+      ID: 435
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 929408
       GoKind: 22
-      Pointee: 424 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 436 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 487
+      ID: 499
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 940928
       GoKind: 22
-      Pointee: 488 StructureType encoding/asn1.StructuralError
+      Pointee: 500 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 491
+      ID: 503
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 941120
       GoKind: 22
-      Pointee: 492 StructureType encoding/asn1.SyntaxError
+      Pointee: 504 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 489
+      ID: 501
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 941024
       GoKind: 22
-      Pointee: 490 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 502 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 919520
       GoKind: 22
-      Pointee: 271 BaseType encoding/base64.CorruptInputError
+      Pointee: 283 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 291 BaseType encoding/hex.InvalidByteError
+      Pointee: 303 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 386
+      ID: 398
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 922880
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 399 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1060576
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 585 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 922496
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 391 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 922784
       GoKind: 22
-      Pointee: 385 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 397 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 382
+      ID: 394
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 922688
       GoKind: 22
-      Pointee: 383 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 395 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 380
+      ID: 392
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 922592
       GoKind: 22
-      Pointee: 381 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 393 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 923264
       GoKind: 22
-      Pointee: 389 StructureType encoding/json.jsonError
+      Pointee: 401 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 482
+      ID: 494
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 938144
       GoKind: 22
-      Pointee: 483 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 495 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 938048
       GoKind: 22
-      Pointee: 481 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 493 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 938240
       GoKind: 22
-      Pointee: 302 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 314 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 304
+      ID: 316
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 303 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 315 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 485
+      ID: 497
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 938336
       GoKind: 22
-      Pointee: 486 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 498 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -700,19 +700,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 352
+      ID: 364
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 914720
       GoKind: 22
-      Pointee: 353 UnresolvedPointeeType errors.errorString
+      Pointee: 365 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 547
+      ID: 559
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1046752
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType errors.joinError
+      Pointee: 560 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -728,118 +728,118 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 531
+      ID: 543
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1036512
       GoKind: 22
-      Pointee: 532 UnresolvedPointeeType fmt.wrapError
+      Pointee: 544 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1036640
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 546 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 409
+      ID: 421
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927296
       GoKind: 22
-      Pointee: 410 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2049792
       GoKind: 22
-      Pointee: 791 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 798 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 924512
       GoKind: 22
-      Pointee: 392 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 404 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 393
+      ID: 405
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 924608
       GoKind: 22
-      Pointee: 394 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 406 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 695
+      ID: 707
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 924320
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 708 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 924896
       GoKind: 22
-      Pointee: 398 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 410 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 697
+      ID: 709
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 710 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 395
+      ID: 407
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 285 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 297 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 287
+      ID: 299
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 286 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 298 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 924224
       GoKind: 22
-      Pointee: 282 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 294 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 284
+      ID: 296
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 283 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 924800
       GoKind: 22
-      Pointee: 288 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 300 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 290
+      ID: 302
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 301 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 437
+      ID: 449
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 932000
       GoKind: 22
-      Pointee: 438 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 450 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
       ByteSize: 8
       GoRuntimeType: 1753184
       GoKind: 22
-      Pointee: 782 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
+      Pointee: 789 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
     - __kind: PointerType
       ID: 112
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -848,728 +848,728 @@ Types:
       GoKind: 22
       Pointee: 113 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 177
+      ID: 144
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2045472
       GoKind: 22
-      Pointee: 178 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 172
+      ID: 139
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1210016
       GoKind: 22
-      Pointee: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 140 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1932096
       GoKind: 22
-      Pointee: 928 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 935 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1829248
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+      Pointee: 927 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 175
+      ID: 142
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1210144
       GoKind: 22
-      Pointee: 176 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 143 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 730
+      ID: 737
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1210784
       GoKind: 22
-      Pointee: 731 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 738 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 250
+      ID: 253
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1210912
       GoKind: 22
-      Pointee: 251 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 254 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 179
+      ID: 146
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2269504
       GoKind: 22
-      Pointee: 180 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 147 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer'
       ByteSize: 8
       GoRuntimeType: 2253856
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
+      Pointee: 804 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 642
+      ID: 654
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1231904
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 655 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1577120
       GoKind: 22
-      Pointee: 733 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 740 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2218080
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
+      Pointee: 800 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1008
+      ID: 156
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1440480
       GoKind: 22
-      Pointee: 1009 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 157 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2218496
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
+      Pointee: 802 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1068384
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
+      Pointee: 886 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 439
+      ID: 451
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 934208
       GoKind: 22
-      Pointee: 440 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 452 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 935264
       GoKind: 22
-      Pointee: 447 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 459 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 934976
       GoKind: 22
-      Pointee: 301 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 313 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 935168
       GoKind: 22
-      Pointee: 445 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 457 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 935072
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 455 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 454
+      ID: 466
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 936608
       GoKind: 22
-      Pointee: 455 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 467 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 458
+      ID: 470
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 936800
       GoKind: 22
-      Pointee: 459 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 471 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 456
+      ID: 468
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 936704
       GoKind: 22
-      Pointee: 457 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 469 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 452
+      ID: 464
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 936512
       GoKind: 22
-      Pointee: 453 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 465 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 720
+      ID: 732
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 731 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 466
+      ID: 478
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 937184
       GoKind: 22
-      Pointee: 467 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 479 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 936896
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 473 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 464
+      ID: 476
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 937088
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 477 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 936992
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 475 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 468
+      ID: 480
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 937280
       GoKind: 22
-      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 481 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 937568
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 487 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 937664
       GoKind: 22
-      Pointee: 477 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 489 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 472
+      ID: 484
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 937472
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 485 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 470
+      ID: 482
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 483 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 937856
       GoKind: 22
-      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 491 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2374080
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 814 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2356608
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 808 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2365120
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 810 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2365760
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 812 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 926048
       GoKind: 22
-      Pointee: 400 StructureType github.com/cihub/seelog.baseError
+      Pointee: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1831488
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 791 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 401
+      ID: 413
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 926144
       GoKind: 22
-      Pointee: 402 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 414 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1443680
       GoKind: 22
-      Pointee: 774 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 781 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1664160
       GoKind: 22
-      Pointee: 776 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 783 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1664928
       GoKind: 22
-      Pointee: 780 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 787 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 926336
       GoKind: 22
-      Pointee: 406 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 418 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1664352
       GoKind: 22
-      Pointee: 778 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 785 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2334368
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 806 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 926240
       GoKind: 22
-      Pointee: 404 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 416 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 926432
       GoKind: 22
-      Pointee: 408 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 420 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1240864
       GoKind: 22
-      Pointee: 897 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 904 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1759136
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 923 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 670
+      ID: 682
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1456000
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 683 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 586
+      ID: 598
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1082976
       GoKind: 22
-      Pointee: 587 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 599 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 584
+      ID: 596
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1082848
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 597 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1087328
       GoKind: 22
-      Pointee: 589 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 601 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 590
+      ID: 602
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1087456
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 603 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 580
+      ID: 592
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1071968
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 593 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 927968
       GoKind: 22
-      Pointee: 413 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 425 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 644
+      ID: 656
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1240096
       GoKind: 22
-      Pointee: 645 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 657 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1223840
       GoKind: 22
-      Pointee: 631 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 624
+      ID: 636
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1223456
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 637 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 566
+      ID: 578
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1058400
       GoKind: 22
-      Pointee: 567 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 579 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1224224
       GoKind: 22
-      Pointee: 637 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 649 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1058272
       GoKind: 22
-      Pointee: 530 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 542 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1223712
       GoKind: 22
-      Pointee: 629 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 626
+      ID: 638
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1223584
       GoKind: 22
-      Pointee: 627 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 639 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 634
+      ID: 646
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1224096
       GoKind: 22
-      Pointee: 635 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 647 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 632
+      ID: 644
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1223968
       GoKind: 22
-      Pointee: 633 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 640
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1224608
       GoKind: 22
-      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 570
+      ID: 582
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1058656
       GoKind: 22
-      Pointee: 571 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 568
+      ID: 580
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1058528
       GoKind: 22
-      Pointee: 569 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 638
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1224480
       GoKind: 22
-      Pointee: 639 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 509
+      ID: 521
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 956672
       GoKind: 22
-      Pointee: 309 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 321 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 311
+      ID: 323
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 310 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 322 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 683
+      ID: 695
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1692192
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 696 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 594
+      ID: 606
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1102176
       GoKind: 22
-      Pointee: 595 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 607 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 957920
       GoKind: 22
-      Pointee: 312 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 324 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 652
+      ID: 664
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1278240
       GoKind: 22
-      Pointee: 653 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 665 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 958208
       GoKind: 22
-      Pointee: 514 StructureType golang.org/x/net/http2.connError
+      Pointee: 526 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 958112
       GoKind: 22
-      Pointee: 316 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 328 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 318
+      ID: 330
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 329 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 958400
       GoKind: 22
-      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 334 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 324
+      ID: 336
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 335 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 958304
       GoKind: 22
-      Pointee: 319 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 331 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 321
+      ID: 333
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 320 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 332 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 958016
       GoKind: 22
-      Pointee: 313 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 325 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 315
+      ID: 327
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 314 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 326 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 958496
       GoKind: 22
-      Pointee: 518 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 530 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 519
+      ID: 531
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 958592
       GoKind: 22
-      Pointee: 325 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 337 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 505
+      ID: 517
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 952352
       GoKind: 22
-      Pointee: 506 StructureType google.golang.org/grpc.dropError
+      Pointee: 518 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1275296
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 663 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 672
+      ID: 684
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1463520
       GoKind: 22
-      Pointee: 673 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 685 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 507
+      ID: 519
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 954944
       GoKind: 22
-      Pointee: 508 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 520 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1839328
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 929 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 592
+      ID: 604
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1096416
       GoKind: 22
-      Pointee: 593 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 605 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1588960
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 913 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 493
+      ID: 505
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 943904
       GoKind: 22
-      Pointee: 494 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 506 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1076576
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 595 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1244192
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 661 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 646
+      ID: 658
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1243936
       GoKind: 22
-      Pointee: 647 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 659 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 499
+      ID: 511
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 946208
       GoKind: 22
-      Pointee: 500 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 512 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 501
+      ID: 513
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 946304
       GoKind: 22
-      Pointee: 502 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 514 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 935360
       GoKind: 22
-      Pointee: 449 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 461 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 520
+      ID: 532
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 959360
       GoKind: 22
-      Pointee: 521 UnresolvedPointeeType html/template.Error
+      Pointee: 533 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -1606,321 +1606,321 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType int8
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 928544
       GoKind: 22
-      Pointee: 417 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 429 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 928448
       GoKind: 22
-      Pointee: 415 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 427 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 622
+      ID: 634
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1218976
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 635 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2424640
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType internal/poll.FD
+      Pointee: 968 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1218848
       GoKind: 22
-      Pointee: 621 StructureType internal/poll.errNetClosing
+      Pointee: 633 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 915104
       GoKind: 22
-      Pointee: 355 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 367 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1871232
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType io.PipeReader
+      Pointee: 933 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1573920
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType io.SectionReader
+      Pointee: 937 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1047264
       GoKind: 22
-      Pointee: 877 StructureType io.nopCloser
+      Pointee: 884 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1213600
       GoKind: 22
-      Pointee: 895 StructureType io.nopCloserWriterTo
+      Pointee: 902 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1218080
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType io/fs.PathError
+      Pointee: 631 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 137
+      ID: 178
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 138 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 179 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 787 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 794 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 233
+      ID: 222
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 234 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 223 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 969 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 976 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 828 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 835 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 167
+      ID: 134
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 168 GoSwissMapHeaderType map<string,float64>
+      Pointee: 135 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 678
+      ID: 690
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 691 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 162
+      ID: 129
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 163 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 157
+      ID: 124
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 158 GoSwissMapHeaderType map<string,string>
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 435
+      ID: 447
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 931616
       GoKind: 22
-      Pointee: 436 StructureType math/big.ErrNaN
+      Pointee: 448 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 990 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 847
+      ID: 854
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 848 StructureType mime/multipart.Form
+      Pointee: 855 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1653984
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 915 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1654176
       GoKind: 22
-      Pointee: 910 StructureType mime/multipart.sectionReadCloser
+      Pointee: 917 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 604
+      ID: 616
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1204000
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType net.AddrError
+      Pointee: 617 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 657
+      ID: 669
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1430720
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType net.DNSError
+      Pointee: 670 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2275808
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net.IPConn
+      Pointee: 944 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 655
+      ID: 667
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1430400
       GoKind: 22
-      Pointee: 656 UnresolvedPointeeType net.OpError
+      Pointee: 668 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 606
+      ID: 618
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1204128
       GoKind: 22
-      Pointee: 607 UnresolvedPointeeType net.ParseError
+      Pointee: 619 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2309376
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType net.TCPConn
+      Pointee: 952 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2355392
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType net.UDPConn
+      Pointee: 956 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2308864
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType net.UnixConn
+      Pointee: 950 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1203232
       GoKind: 22
-      Pointee: 598 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 610 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 600
+      ID: 612
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 599 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 611 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 535
+      ID: 547
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1037536
       GoKind: 22
-      Pointee: 536 StructureType net.canceledError
+      Pointee: 548 StructureType net.canceledError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2043744
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType net.conn
+      Pointee: 942 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 701
+      ID: 713
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1864960
       GoKind: 22
-      Pointee: 702 StructureType net.dialResult·1
+      Pointee: 714 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2359040
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType net.netFD
+      Pointee: 958 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 326
+      ID: 338
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907712
       GoKind: 22
-      Pointee: 327 UnresolvedPointeeType net.notFoundError
+      Pointee: 339 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1006
+      ID: 154
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1430560
       GoKind: 22
-      Pointee: 1007 StructureType net.onlyValuesCtx
+      Pointee: 155 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 328
+      ID: 340
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 908384
       GoKind: 22
-      Pointee: 329 StructureType net.result·2
+      Pointee: 341 StructureType net.result·2
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2292512
       GoKind: 22
-      Pointee: 941 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 948 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2292032
       GoKind: 22
-      Pointee: 939 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 946 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 608
+      ID: 620
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1204768
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType net.temporaryError
+      Pointee: 621 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1431040
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType net.timeoutError
+      Pointee: 672 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 334
+      ID: 346
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 910976
       GoKind: 22
-      Pointee: 335 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 347 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 537
+      ID: 549
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1040992
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 550 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -1929,559 +1929,559 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1750880
       GoKind: 22
-      Pointee: 853 StructureType net/http.Response
+      Pointee: 860 StructureType net/http.Response
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1828352
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType net/http.body
+      Pointee: 925 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1207328
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 896 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1040864
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 876 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1931072
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType net/http.conn
+      Pointee: 827 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1039584
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 866 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1043168
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 880 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 336
+      ID: 348
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 911168
       GoKind: 22
-      Pointee: 254 BaseType net/http.http2ConnectionError
+      Pointee: 266 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 911264
       GoKind: 22
-      Pointee: 338 StructureType net/http.http2GoAwayError
+      Pointee: 350 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1432000
       GoKind: 22
-      Pointee: 662 StructureType net/http.http2StreamError
+      Pointee: 674 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2045184
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 910 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 343
+      ID: 355
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 912320
       GoKind: 22
-      Pointee: 344 StructureType net/http.http2connError
+      Pointee: 356 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 258 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 270 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 260
+      ID: 272
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 259 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 271 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 911840
       GoKind: 22
-      Pointee: 342 StructureType net/http.http2goAwayFlowError
+      Pointee: 354 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1040608
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 874 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 912512
       GoKind: 22
-      Pointee: 264 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 276 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 266
+      ID: 278
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 265 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 277 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 912416
       GoKind: 22
-      Pointee: 261 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 273 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 263
+      ID: 275
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 274 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 612
+      ID: 624
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1208736
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 625 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1040352
       GoKind: 22
-      Pointee: 863 StructureType net/http.http2missingBody
+      Pointee: 870 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1043424
       GoKind: 22
-      Pointee: 875 StructureType net/http.http2noBodyReader
+      Pointee: 882 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 543
+      ID: 555
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1043296
       GoKind: 22
-      Pointee: 544 StructureType net/http.http2noCachedConnError
+      Pointee: 556 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 339
+      ID: 351
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 911648
       GoKind: 22
-      Pointee: 255 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 267 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 257
+      ID: 269
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 256 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 268 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1041504
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 878 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2044608
       GoKind: 22
-      Pointee: 770 StructureType net/http.http2responseWriter
+      Pointee: 777 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1639200
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 825 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1040480
       GoKind: 22
-      Pointee: 865 StructureType net/http.http2transportResponseBody
+      Pointee: 872 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1039840
       GoKind: 22
-      Pointee: 861 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 868 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1207584
       GoKind: 22
-      Pointee: 893 StructureType net/http.noBody
+      Pointee: 900 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1042912
       GoKind: 22
-      Pointee: 540 StructureType net/http.nothingWrittenError
+      Pointee: 552 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1637280
       GoKind: 22
-      Pointee: 855 StructureType net/http.pattern
+      Pointee: 862 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1039200
       GoKind: 22
-      Pointee: 857 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 864 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1207456
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 898 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 912704
       GoKind: 22
-      Pointee: 348 StructureType net/http.requestBodyReadError
+      Pointee: 360 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2253408
       GoKind: 22
-      Pointee: 772 StructureType net/http.response
+      Pointee: 779 StructureType net/http.response
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393440
       GoKind: 22
-      Pointee: 1002 StructureType net/http.segment
+      Pointee: 1009 StructureType net/http.segment
     - __kind: PointerType
-      ID: 332
+      ID: 344
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 910880
       GoKind: 22
-      Pointee: 333 StructureType net/http.statusError
+      Pointee: 345 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 663
+      ID: 675
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1433440
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 676 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1208608
       GoKind: 22
-      Pointee: 611 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 623 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 541
+      ID: 553
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1043040
       GoKind: 22
-      Pointee: 542 StructureType net/http.transportReadFromServerError
+      Pointee: 554 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1866528
       GoKind: 22
-      Pointee: 924 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 931 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 330
+      ID: 342
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 331 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 343 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1102816
       GoKind: 22
-      Pointee: 885 StructureType net/http/httputil.failureToReadBody
+      Pointee: 892 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 361 StructureType net/netip.parseAddrError
+      Pointee: 373 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 917408
       GoKind: 22
-      Pointee: 359 StructureType net/netip.parsePrefixError
+      Pointee: 371 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 373
+      ID: 385
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 920768
       GoKind: 22
-      Pointee: 374 UnresolvedPointeeType net/textproto.Error
+      Pointee: 386 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 920672
       GoKind: 22
-      Pointee: 278 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 290 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 280
+      ID: 292
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 279 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 291 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 668
+      ID: 680
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1438080
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType net/url.Error
+      Pointee: 681 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 919616
       GoKind: 22
-      Pointee: 272 GoStringHeaderType net/url.EscapeError
+      Pointee: 284 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 274
+      ID: 286
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 273 GoStringDataType net/url.EscapeError.str
+      Pointee: 285 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 275 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 287 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 277
+      ID: 289
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 276 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 288 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2159744
       GoKind: 22
-      Pointee: 844 StructureType net/url.URL
+      Pointee: 851 StructureType net/url.URL
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1221536
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 972 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 190
+      ID: 233
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 234 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 818 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 246
+      ID: 249
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 250 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 975 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 982 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 838 StructureType noalg.map.group[string][]string
+      Pointee: 845 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 224
+      ID: 213
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[string]float64
+      Pointee: 214 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 709
+      ID: 721
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 722 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 216
+      ID: 205
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[string]interface {}
+      Pointee: 206 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 208
+      ID: 197
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 209 StructureType noalg.map.group[string]string
+      Pointee: 198 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2400352
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType os.File
+      Pointee: 964 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 545
+      ID: 557
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1045216
       GoKind: 22
-      Pointee: 546 UnresolvedPointeeType os.LinkError
+      Pointee: 558 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 150
+      ID: 171
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 396256
       GoKind: 22
-      Pointee: 151 GoInterfaceType os.Signal
+      Pointee: 172 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1209248
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType os.SyscallError
+      Pointee: 627 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2395936
       GoKind: 22
-      Pointee: 955 StructureType os.fileWithoutReadFrom
+      Pointee: 962 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2395200
       GoKind: 22
-      Pointee: 953 StructureType os.fileWithoutWriteTo
+      Pointee: 960 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 576
+      ID: 588
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1067104
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType os/exec.Error
+      Pointee: 589 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 705
+      ID: 717
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2132416
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 718 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1067232
       GoKind: 22
-      Pointee: 579 StructureType os/exec.wrappedError
+      Pointee: 591 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 127
+      ID: 167
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1641888
       GoKind: 22
-      Pointee: 128 StructureType os/signal.signalCtx
+      Pointee: 168 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 950432
       GoKind: 22
-      Pointee: 306 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 318 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 319 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 503
+      ID: 515
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 950336
       GoKind: 22
-      Pointee: 305 BaseType os/user.UnknownUserIdError
+      Pointee: 317 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 915872
       GoKind: 22
-      Pointee: 357 UnresolvedPointeeType reflect.ValueError
+      Pointee: 369 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 450
+      ID: 462
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 935840
       GoKind: 22
-      Pointee: 451 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 463 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 553
+      ID: 565
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1049824
       GoKind: 22
-      Pointee: 554 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 566 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 557
+      ID: 569
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1051616
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 570 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2497,12 +2497,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 555
+      ID: 567
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1049952
       GoKind: 22
-      Pointee: 556 StructureType runtime.boundsError
+      Pointee: 568 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -2518,24 +2518,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 616
+      ID: 628
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1217440
       GoKind: 22
-      Pointee: 617 StructureType runtime.errorAddressString
+      Pointee: 629 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 551
+      ID: 563
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1049440
       GoKind: 22
-      Pointee: 522 GoStringHeaderType runtime.errorString
+      Pointee: 534 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 523 GoStringDataType runtime.errorString.str
+      Pointee: 535 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2551,17 +2551,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 552
+      ID: 564
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1049568
       GoKind: 22
-      Pointee: 525 GoStringHeaderType runtime.plainError
+      Pointee: 537 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 526 GoStringDataType runtime.plainError.str
+      Pointee: 538 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2591,12 +2591,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1049056
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType strconv.NumError
+      Pointee: 562 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -2605,235 +2605,235 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 183
+      ID: 190
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 182 GoStringDataType string.str
+      Pointee: 189 GoStringDataType string.str
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1716192
       GoKind: 22
-      Pointee: 739 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 746 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1774112
       GoKind: 22
-      Pointee: 753 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 760 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1715808
       GoKind: 22
-      Pointee: 735 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 742 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1773344
       GoKind: 22
-      Pointee: 745 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 752 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1845376
       GoKind: 22
-      Pointee: 759 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 766 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1773536
       GoKind: 22
-      Pointee: 747 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 754 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 742
+      ID: 749
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1773152
       GoKind: 22
-      Pointee: 743 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 750 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1844928
       GoKind: 22
-      Pointee: 755 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 762 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1917376
       GoKind: 22
-      Pointee: 763 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 770 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1845152
       GoKind: 22
-      Pointee: 757 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 764 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 740
+      ID: 747
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1716384
       GoKind: 22
-      Pointee: 741 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 748 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 736
+      ID: 743
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1716000
       GoKind: 22
-      Pointee: 737 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 744 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1773728
       GoKind: 22
-      Pointee: 749 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 756 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1845600
       GoKind: 22
-      Pointee: 761 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 768 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1773920
       GoKind: 22
-      Pointee: 751 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 758 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1109952
       GoKind: 22
-      Pointee: 887 StructureType struct { io.Reader; io.Closer }
+      Pointee: 894 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1436960
       GoKind: 22
-      Pointee: 654 BaseType syscall.Errno
+      Pointee: 666 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1052128
       GoKind: 22
-      Pointee: 727 BaseType syscall.Signal
+      Pointee: 734 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 140
+      ID: 181
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 188 StructureType table<context.canceler,struct {}>
+      Pointee: 231 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 808 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 815 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 236
+      ID: 225
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 244 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 247 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 972 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 979 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 830
+      ID: 837
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 835 StructureType table<string,[]string>
+      Pointee: 842 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 170
+      ID: 137
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 222 StructureType table<string,float64>
+      Pointee: 211 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 681
+      ID: 693
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 707 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 719 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 165
+      ID: 132
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 214 StructureType table<string,interface {}>
+      Pointee: 203 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 160
+      ID: 127
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 206 StructureType table<string,string>
+      Pointee: 195 StructureType table<string,string>
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1106016
       GoKind: 22
-      Pointee: 597 StructureType text/template.ExecError
+      Pointee: 609 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 145
+      ID: 187
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1642272
       GoKind: 22
-      Pointee: 146 StructureType time.Location
+      Pointee: 188 StructureType time.Location
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 913568
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType time.ParseError
+      Pointee: 363 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 142
+      ID: 184
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1045728
       GoKind: 22
-      Pointee: 143 StructureType time.Timer
+      Pointee: 185 StructureType time.Timer
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 913472
       GoKind: 22
-      Pointee: 267 GoStringHeaderType time.fileSizeError
+      Pointee: 279 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 269
+      ID: 281
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType time.fileSizeError.str
+      Pointee: 280 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 199
+      ID: 242
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396576
       GoKind: 22
-      Pointee: 200 StructureType time.zone
+      Pointee: 243 StructureType time.zone
     - __kind: PointerType
-      ID: 202
+      ID: 245
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 203 StructureType time.zoneTrans
+      Pointee: 246 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -2877,47 +2877,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 362
+      ID: 374
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 363 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 375 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 375
+      ID: 387
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 376 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 388 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 377
+      ID: 389
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 921056
       GoKind: 22
-      Pointee: 281 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 293 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1056992
       GoKind: 22
-      Pointee: 563 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 575 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1057120
       GoKind: 22
-      Pointee: 529 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 541 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 851
+      ID: 858
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: GoChannelType
-      ID: 721
+      ID: 733
       Name: <-chan time.Time
       GoRuntimeType: 606496
       GoKind: 18
@@ -3003,7 +3003,7 @@ Types:
       HasCount: true
       Element: 92 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 832
+      ID: 839
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 690688
@@ -3012,7 +3012,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 831
+      ID: 838
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 690592
@@ -3084,7 +3084,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 833
+      ID: 840
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 690784
@@ -3102,7 +3102,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 689
+      ID: 701
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 708864
@@ -3129,7 +3129,7 @@ Types:
       HasCount: true
       Element: 85 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 986
+      ID: 993
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503680
@@ -3137,22 +3137,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 987 PointerType **crypto/x509.Certificate
+          Type: 994 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 994 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1001 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 994
+      ID: 1001
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 675 PointerType *crypto/x509.Certificate
+      Element: 687 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 722
+      ID: 261
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491840
@@ -3160,22 +3160,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 723 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 262 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 725 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 264 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 725
+      ID: 264
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 978
+      ID: 985
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 488960
@@ -3183,76 +3183,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 979 PointerType **mime/multipart.FileHeader
+          Type: 986 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 984 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 991 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 984
+      ID: 991
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 980 PointerType *mime/multipart.FileHeader
+      Element: 987 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 239
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 140 PointerType *table<context.canceler,struct {}>
+      Element: 181 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 815
+      ID: 822
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 789 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 796 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 255
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 236 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 225 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 981
+      ID: 988
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 971 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 978 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 841
+      ID: 848
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 830 PointerType *table<string,[]string>
+      Element: 837 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 217
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 170 PointerType *table<string,float64>
+      Element: 137 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 713
+      ID: 725
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 681 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 693 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 209
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 165 PointerType *table<string,interface {}>
+      Element: 132 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 201
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 160 PointerType *table<string,string>
+      Element: 127 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 988
+      ID: 995
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -3260,22 +3260,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 989 PointerType *[]*crypto/x509.Certificate
+          Type: 996 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 996 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1003 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 996
+      ID: 1003
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 986 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 993 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 990
+      ID: 997
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483808
@@ -3283,22 +3283,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 991 PointerType *[]uint8
+          Type: 998 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 998 GoSliceDataType [][]uint8.array
+      Data: 1005 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 998
+      ID: 1005
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 694
+      ID: 706
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 497792
@@ -3313,15 +3313,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 717 GoSliceDataType []float64.array
+      Data: 729 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 717
+      ID: 729
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 20 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 138
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 491392
@@ -3329,22 +3329,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 172 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 139 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 230 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 219 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 219
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 173 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 140 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 141
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 491584
@@ -3352,22 +3352,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 175 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 142 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 227 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 227
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 176 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 143 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1000
+      ID: 1007
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486400
@@ -3375,76 +3375,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1001 PointerType *net/http.segment
+          Type: 1008 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1003 GoSliceDataType []net/http.segment.array
+      Data: 1010 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1003
+      ID: 1010
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1002 StructureType net/http.segment
+      Element: 1009 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 240
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 191 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 234 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 816
+      ID: 823
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 818 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 256
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 250 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 982
+      ID: 989
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 975 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 982 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 842
+      ID: 849
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 838 StructureType noalg.map.group[string][]string
+      Element: 845 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 218
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 225 StructureType noalg.map.group[string]float64
+      Element: 214 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 726
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 722 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 210
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 217 StructureType noalg.map.group[string]interface {}
+      Element: 206 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 202
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 209 StructureType noalg.map.group[string]string
+      Element: 198 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 170
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 483552
@@ -3452,26 +3452,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *os.Signal
+          Type: 171 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 204 GoSliceDataType []os.Signal.array
+      Data: 229 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 229
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 151 GoInterfaceType os.Signal
+      Element: 172 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 693
+      ID: 705
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498048
@@ -3486,15 +3486,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 715 GoSliceDataType []string.array
+      Data: 727 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 715
+      ID: 727
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 198
+      ID: 241
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 490944
@@ -3502,22 +3502,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 199 PointerType *time.zone
+          Type: 242 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 240 GoSliceDataType []time.zone.array
+      Data: 257 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 257
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 200 StructureType time.zone
+      Element: 243 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 201
+      ID: 244
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491008
@@ -3525,20 +3525,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 202 PointerType *time.zoneTrans
+          Type: 245 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 242 GoSliceDataType []time.zoneTrans.array
+      Data: 259 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 259
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 203 StructureType time.zoneTrans
+      Element: 246 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3555,9 +3555,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []uint8.array
+      Data: 191 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 191
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3578,15 +3578,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType []uintptr.array
+      Data: 193 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 193
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 496
+      ID: 508
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 945344
@@ -3601,27 +3601,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 497 GoSliceDataType archive/tar.headerError.array
+      Data: 509 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 509
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 899
+      ID: 906
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 890
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 908
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 888
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3631,7 +3631,7 @@ Types:
       GoRuntimeType: 591200
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3639,12 +3639,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 834
+      ID: 841
       Name: chan bool
       GoRuntimeType: 602656
       GoKind: 18
     - __kind: GoChannelType
-      ID: 152
+      ID: 173
       Name: chan os.Signal
       GoRuntimeType: 609312
       GoKind: 18
@@ -3661,13 +3661,13 @@ Types:
       GoRuntimeType: 590944
       GoKind: 15
     - __kind: BaseType
-      ID: 297
+      ID: 309
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 846144
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 298
+      ID: 310
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 846240
@@ -3675,26 +3675,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 300 PointerType *compress/flate.InternalError.str
+          Type: 312 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 299 GoStringDataType compress/flate.InternalError.str
+      Data: 311 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 299
+      ID: 311
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 940
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 919
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 148
+      ID: 169
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 685024
@@ -3713,19 +3713,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 129
+      ID: 164
       Name: context.backgroundCtx
       GoRuntimeType: 1826784
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 130 StructureType context.emptyCtx
+          Type: 150 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 118
+      ID: 175
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 2000672
@@ -3736,13 +3736,13 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 131 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 134 StructureType sync/atomic.Value
+          Type: 176 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 136 GoMapType map[context.canceler]struct {}
+          Type: 177 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 16 GoInterfaceType error
@@ -3752,7 +3752,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 194
+      ID: 237
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1127200
@@ -3765,13 +3765,13 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 602
+      ID: 614
       Name: context.deadlineExceededError
       GoRuntimeType: 1480640
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 150
       Name: context.emptyCtx
       GoRuntimeType: 1618240
       GoKind: 25
@@ -3780,7 +3780,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 120
+      ID: 152
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1852800
@@ -3791,11 +3791,11 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 141 GoSubroutineType func() bool
+          Type: 153 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 183
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1635360
@@ -3803,29 +3803,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 118 StructureType context.cancelCtx
+          Type: 175 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 142 PointerType *time.Timer
+          Type: 184 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 144 GoTimeType time.Time
+          Type: 186 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 147
+      ID: 166
       Name: context.todoCtx
       GoRuntimeType: 1827008
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 130 StructureType context.emptyCtx
+          Type: 150 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 159
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1863392
@@ -3836,14 +3836,14 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 160 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 160 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 126
+      ID: 162
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1826560
@@ -3855,45 +3855,45 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 293
+      ID: 305
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845760
       GoKind: 2
     - __kind: BaseType
-      ID: 294
+      ID: 306
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845856
       GoKind: 2
     - __kind: BaseType
-      ID: 295
+      ID: 307
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845952
       GoKind: 2
     - __kind: BaseType
-      ID: 296
+      ID: 308
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 846048
       GoKind: 2
     - __kind: BaseType
-      ID: 270
+      ID: 282
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 843552
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 573
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 970
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 857
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2301632
@@ -3922,13 +3922,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 986 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 993 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 988 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 995 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 990 GoSliceHeaderType [][]uint8
+          Type: 997 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -3940,25 +3940,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 992 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 999 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 993 BaseType crypto/tls.CurveID
+          Type: 1000 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 993
+      ID: 1000
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843360
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 367
+      ID: 379
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 365
+      ID: 377
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1755104
@@ -3969,26 +3969,26 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 689 ArrayType [5]uint8
+          Type: 701 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 690 GoInterfaceType net.Conn
+          Type: 702 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 528
+      ID: 540
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1004224
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 667
+      ID: 679
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 688
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 426
+      ID: 438
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1757216
@@ -3996,21 +3996,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 687 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 699 BaseType crypto/x509.InvalidReason
+          Type: 711 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 420
+      ID: 432
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1133984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 422
+      ID: 434
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1620320
@@ -4018,24 +4018,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 687 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 292
+      ID: 304
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 845568
       GoKind: 2
     - __kind: BaseType
-      ID: 699
+      ID: 711
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 594336
       GoKind: 2
     - __kind: StructureType
-      ID: 575
+      ID: 587
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1580480
@@ -4045,13 +4045,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 428
+      ID: 440
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1134240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 424
+      ID: 436
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1757024
@@ -4059,15 +4059,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 687 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 675 PointerType *crypto/x509.Certificate
+          Type: 687 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 488
+      ID: 500
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1451840
@@ -4077,7 +4077,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 492
+      ID: 504
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1452000
@@ -4087,47 +4087,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 490
+      ID: 502
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 271
+      ID: 283
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 843648
       GoKind: 6
     - __kind: BaseType
-      ID: 291
+      ID: 303
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 845376
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 399
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 585
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 391
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 385
+      ID: 397
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 383
+      ID: 395
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 381
+      ID: 393
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 389
+      ID: 401
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1441120
@@ -4137,15 +4137,15 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 483
+      ID: 495
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 481
+      ID: 493
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 302
+      ID: 314
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 847680
@@ -4153,18 +4153,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 304 PointerType *encoding/xml.UnmarshalError.str
+          Type: 316 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 303 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 315 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 303
+      ID: 315
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 486
+      ID: 498
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4181,11 +4181,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 353
+      ID: 365
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 560
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4201,11 +4201,11 @@ Types:
       GoRuntimeType: 591136
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 532
+      ID: 544
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 546
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4215,13 +4215,13 @@ Types:
       GoRuntimeType: 481952
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 845
+      ID: 852
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701088
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 141
+      ID: 153
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 601312
@@ -4233,23 +4233,23 @@ Types:
       GoRuntimeType: 863360
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 992
+      ID: 999
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1020064
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 410
+      ID: 422
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 791
+      ID: 798
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2091200
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 392
+      ID: 404
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1756064
@@ -4257,7 +4257,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 691 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 703 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4265,25 +4265,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 394
+      ID: 406
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 708
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 398
+      ID: 410
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1132704
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 710
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 285
+      ID: 297
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 844704
@@ -4291,18 +4291,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 287 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 299 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 286 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 298 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 286
+      ID: 298
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 691
+      ID: 703
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2263264
@@ -4310,13 +4310,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 692 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 704 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4325,7 +4325,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 694 GoSliceHeaderType []float64
+          Type: 706 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4334,13 +4334,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 695 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 707 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 697 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 709 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4351,13 +4351,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 692
+      ID: 704
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 592864
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 282
+      ID: 294
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 844608
@@ -4365,18 +4365,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 284 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 296 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 283 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 283
+      ID: 295
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 300
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 844800
@@ -4384,22 +4384,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 302 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 301 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 301
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 438
+      ID: 450
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
       GoRuntimeType: 1853696
       GoKind: 25
@@ -4413,7 +4413,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 153 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -4434,13 +4434,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 161 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 128 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 166 GoMapType map[string]float64
+          Type: 133 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -4455,10 +4455,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 171 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 138 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 174 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 141 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -4470,7 +4470,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 177 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -4493,7 +4493,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 178
+      ID: 145
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2261024
@@ -4504,13 +4504,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 179 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 146 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 154 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4519,16 +4519,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 181 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 148 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 153 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -4537,12 +4537,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 171 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 138 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 173
+      ID: 140
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1946400
@@ -4559,7 +4559,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4567,7 +4567,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 928
+      ID: 935
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 2001184
@@ -4575,29 +4575,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 919 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+          Type: 926 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 931 BaseType time.Duration
+          Type: 938 BaseType time.Duration
     - __kind: GoMapType
-      ID: 161
+      ID: 128
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1299296
       GoKind: 21
-      HeaderType: 163 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 724
+      ID: 263
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 589984
       GoKind: 10
     - __kind: StructureType
-      ID: 176
+      ID: 143
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1781184
@@ -4611,16 +4611,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 232 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 221 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 237 GoMapType map[string]interface {}
+          Type: 226 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 731
+      ID: 738
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 251
+      ID: 254
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1946656
@@ -4628,7 +4628,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 729 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 736 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4643,15 +4643,15 @@ Types:
           Type: 20 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 730 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 737 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 729
+      ID: 736
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1001728
       GoKind: 5
     - __kind: StructureType
-      ID: 180
+      ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2148160
@@ -4659,16 +4659,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 153 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 722 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 261 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -4683,12 +4683,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 724 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 263 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 181
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914336
@@ -4697,15 +4697,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 804
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 655
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 764
+      ID: 771
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1439840
@@ -4718,7 +4718,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 733
+      ID: 740
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1619840
@@ -4731,11 +4731,11 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1009
+    - __kind: GoContextImplementationType
+      ID: 157
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1658016
@@ -4744,38 +4744,40 @@ Types:
         - Name: Context
           Offset: 0
           Type: 116 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 802
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 440
+      ID: 452
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 447
+      ID: 459
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1135904
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 301
+      ID: 313
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 2
     - __kind: StructureType
-      ID: 445
+      ID: 457
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1135776
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 443
+      ID: 455
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1621120
@@ -4788,7 +4790,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 455
+      ID: 467
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1621760
@@ -4801,7 +4803,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 459
+      ID: 471
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1758752
@@ -4817,7 +4819,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 457
+      ID: 469
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1450400
@@ -4827,7 +4829,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 453
+      ID: 465
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1450080
@@ -4837,14 +4839,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 677
+      ID: 689
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1522880
       GoKind: 21
-      HeaderType: 679 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 691 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 700
+      ID: 712
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1070304
@@ -4859,15 +4861,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 719 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 731 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 719
+      ID: 731
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 467
+      ID: 479
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1622080
@@ -4875,12 +4877,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 689 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 677 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 689 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 461
+      ID: 473
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1450560
@@ -4890,7 +4892,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 465
+      ID: 477
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1758944
@@ -4901,12 +4903,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 712 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 712 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 463
+      ID: 475
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1621920
@@ -4919,7 +4921,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 469
+      ID: 481
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1450720
@@ -4927,9 +4929,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 144 GoTimeType time.Time
+          Type: 186 GoTimeType time.Time
     - __kind: StructureType
-      ID: 475
+      ID: 487
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1622400
@@ -4942,7 +4944,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 477
+      ID: 489
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1451040
@@ -4952,7 +4954,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 473
+      ID: 485
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1622240
@@ -4965,7 +4967,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 471
+      ID: 483
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1450880
@@ -4975,7 +4977,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 479
+      ID: 491
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1622560
@@ -4988,29 +4990,29 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 814
+      ID: 821
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 845088
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 814
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 400
+      ID: 412
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1442400
@@ -5020,11 +5022,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 791
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 402
+      ID: 414
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1442560
@@ -5032,17 +5034,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 400 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 774
+      ID: 781
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 776
+      ID: 783
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1855040
@@ -5050,12 +5052,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 775 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 782 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 785 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 792 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 406
+      ID: 418
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1442880
@@ -5063,9 +5065,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 400 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1831712
@@ -5073,13 +5075,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 775 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 782 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 806
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 404
+      ID: 416
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1442720
@@ -5087,9 +5089,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 400 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 408
+      ID: 420
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1443040
@@ -5097,9 +5099,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 400 StructureType github.com/cihub/seelog.baseError
+          Type: 412 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 913
+      ID: 920
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1136160
@@ -5112,7 +5114,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1674144
@@ -5120,48 +5122,48 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 913 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 920 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 923
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 683
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 587
+      ID: 599
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 597
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 589
+      ID: 601
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 603
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 593
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 413
+      ID: 425
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1444000
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 645
+      ID: 657
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 631
+      ID: 643
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1877728
@@ -5177,11 +5179,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 637
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 567
+      ID: 579
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1728768
@@ -5194,7 +5196,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 637
+      ID: 649
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1878176
@@ -5210,13 +5212,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 530
+      ID: 542
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1004896
       GoKind: 8
     - __kind: StructureType
-      ID: 629
+      ID: 641
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1877504
@@ -5232,13 +5234,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 703
+      ID: 715
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 844224
       GoKind: 8
     - __kind: StructureType
-      ID: 627
+      ID: 639
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1877280
@@ -5246,15 +5248,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 715 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 703 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 715 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 635
+      ID: 647
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1789440
@@ -5267,7 +5269,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 633
+      ID: 645
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1877952
@@ -5283,7 +5285,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 641
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1657056
@@ -5293,19 +5295,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 571
+      ID: 583
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1300704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 569
+      ID: 581
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1300576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 639
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1789632
@@ -5318,7 +5320,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 309
+      ID: 321
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 849600
@@ -5326,22 +5328,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 311 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 323 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 310 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 322 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 310
+      ID: 322
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 696
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 595
+      ID: 607
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1466240
@@ -5351,19 +5353,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 312
+      ID: 324
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 850176
       GoKind: 10
     - __kind: BaseType
-      ID: 682
+      ID: 694
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1017088
       GoKind: 10
     - __kind: StructureType
-      ID: 653
+      ID: 665
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1911776
@@ -5374,12 +5376,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 682 BaseType golang.org/x/net/http2.ErrCode
+          Type: 694 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 514
+      ID: 526
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1629280
@@ -5387,12 +5389,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 682 BaseType golang.org/x/net/http2.ErrCode
+          Type: 694 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 328
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850368
@@ -5400,18 +5402,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 330 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 329 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 329
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 334
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 850560
@@ -5419,18 +5421,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 336 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 323 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 335 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 335
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 319
+      ID: 331
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 850464
@@ -5438,18 +5440,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 321 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 333 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 320 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 332 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 320
+      ID: 332
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 313
+      ID: 325
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850272
@@ -5457,18 +5459,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 315 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 327 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 314 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 326 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 314
+      ID: 326
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 518
+      ID: 530
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1466880
@@ -5478,13 +5480,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 325
+      ID: 337
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 2
     - __kind: StructureType
-      ID: 506
+      ID: 518
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1461920
@@ -5494,11 +5496,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 663
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 673
+      ID: 685
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1941056
@@ -5514,7 +5516,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 508
+      ID: 520
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1628800
@@ -5527,11 +5529,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 593
+      ID: 605
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1588160
@@ -5541,29 +5543,29 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 913
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 494
+      ID: 506
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 595
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 661
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 647
+      ID: 659
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1532480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 500
+      ID: 512
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1455200
@@ -5573,7 +5575,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 502
+      ID: 514
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1455360
@@ -5583,137 +5585,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 449
+      ID: 461
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 232
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 233 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 197 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 234 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 240 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 809
+      ID: 816
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 810 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 817 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 816 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 818 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 823 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 245
+      ID: 248
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 246 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 249 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 250 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 256 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 973
+      ID: 980
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 974 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 981 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 975 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 982 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 982 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 989 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 836
+      ID: 843
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 837 PointerType *noalg.map.group[string][]string
+          Type: 844 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 838 StructureType noalg.map.group[string][]string
-      GroupSliceType: 842 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 845 StructureType noalg.map.group[string][]string
+      GroupSliceType: 849 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 212
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[string]float64
+          Type: 213 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[string]float64
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 214 StructureType noalg.map.group[string]float64
+      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 708
+      ID: 720
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 709 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 721 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 714 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 722 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 726 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 204
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[string]interface {}
+          Type: 205 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 206 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 210 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 207
+      ID: 196
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 208 PointerType *noalg.map.group[string]string
+          Type: 197 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 209 StructureType noalg.map.group[string]string
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 198 StructureType noalg.map.group[string]string
+      GroupSliceType: 202 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 521
+      ID: 533
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5747,7 +5749,7 @@ Types:
       GoRuntimeType: 590240
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 135
+      ID: 160
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863072
@@ -5760,7 +5762,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 417
+      ID: 429
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5786,25 +5788,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 415
+      ID: 427
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 635
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 968
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 621
+      ID: 633
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1497920
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 355
+      ID: 367
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5885,7 +5887,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 133
+      ID: 120
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1512320
@@ -5898,7 +5900,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 914
+      ID: 921
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1047776
@@ -5911,11 +5913,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 933
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 821
+      ID: 828
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1129632
@@ -5928,7 +5930,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 904
+      ID: 911
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1047136
@@ -5941,11 +5943,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 937
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 884
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1573760
@@ -5953,9 +5955,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 904 GoInterfaceType io.Reader
+          Type: 911 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1643424
@@ -5963,13 +5965,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 904 GoInterfaceType io.Reader
+          Type: 911 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 631
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 138
+      ID: 179
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -5982,7 +5984,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 139 PointerType **table<context.canceler,struct {}>
+          Type: 180 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5998,10 +6000,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 196 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 191 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 239 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 234 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 787
+      ID: 794
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6014,7 +6016,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 788 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 795 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6030,10 +6032,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 815 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 811 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 822 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 818 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 234
+      ID: 223
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6046,7 +6048,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 235 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 224 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6062,10 +6064,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 247 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 255 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 250 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 969
+      ID: 976
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6078,7 +6080,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 970 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 977 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6094,10 +6096,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 981 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 975 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 988 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 982 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 828
+      ID: 835
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6110,7 +6112,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 829 PointerType **table<string,[]string>
+          Type: 836 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6126,10 +6128,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 841 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 838 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 848 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 845 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 168
+      ID: 135
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6142,7 +6144,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 169 PointerType **table<string,float64>
+          Type: 136 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6158,10 +6160,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<string,float64>.array
-      GroupType: 225 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 217 GoSliceDataType []*table<string,float64>.array
+      GroupType: 214 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 679
+      ID: 691
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6174,7 +6176,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 680 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 692 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6190,10 +6192,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 713 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 710 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 725 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 722 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 163
+      ID: 130
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6206,7 +6208,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 164 PointerType **table<string,interface {}>
+          Type: 131 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6222,10 +6224,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 217 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 209 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 206 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 158
+      ID: 125
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6238,7 +6240,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 159 PointerType **table<string,string>
+          Type: 126 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6254,66 +6256,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<string,string>.array
-      GroupType: 209 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 201 GoSliceDataType []*table<string,string>.array
+      GroupType: 198 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 136
+      ID: 177
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1146656
       GoKind: 21
-      HeaderType: 138 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 179 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 785
+      ID: 792
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1164576
       GoKind: 21
-      HeaderType: 787 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 794 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 232
+      ID: 221
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1153056
       GoKind: 21
-      HeaderType: 234 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 223 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 967
+      ID: 974
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1152288
       GoKind: 21
-      HeaderType: 969 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 976 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 966
+      ID: 973
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1147680
       GoKind: 21
-      HeaderType: 828 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 835 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 166
+      ID: 133
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1152928
       GoKind: 21
-      HeaderType: 168 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 135 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 237
+      ID: 226
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1146272
       GoKind: 21
-      HeaderType: 163 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 156
+      ID: 123
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1148704
       GoKind: 21
-      HeaderType: 158 GoSwissMapHeaderType map<string,string>
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 436
+      ID: 448
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1447200
@@ -6323,11 +6325,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 990
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 848
+      ID: 855
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1500800
@@ -6335,16 +6337,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 966 GoMapType map[string][]string
+          Type: 973 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 967 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 974 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1949984
@@ -6352,16 +6354,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 929 PointerType *io.SectionReader
+          Type: 936 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 914 GoInterfaceType io.Closer
+          Type: 921 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 617
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 690
+      ID: 702
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1618400
@@ -6374,35 +6376,35 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 670
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 656
+      ID: 668
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 607
+      ID: 619
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 950
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 598
+      ID: 610
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1127456
@@ -6410,28 +6412,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 600 PointerType *net.UnknownNetworkError.str
+          Type: 612 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 599 GoStringDataType net.UnknownNetworkError.str
+      Data: 611 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 599
+      ID: 611
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 536
+      ID: 548
       Name: net.canceledError
       GoRuntimeType: 1298272
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 942
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 702
+      ID: 714
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2147104
@@ -6439,7 +6441,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 690 GoInterfaceType net.Conn
+          Type: 702 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -6450,27 +6452,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 947
+      ID: 954
       Name: net.noReadFrom
       GoRuntimeType: 1127712
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 946
+      ID: 953
       Name: net.noWriteTo
       GoRuntimeType: 1127584
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 327
+      ID: 339
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1007
+    - __kind: GoContextImplementationType
+      ID: 155
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1775424
@@ -6482,8 +6484,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 116 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 329
+      ID: 341
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1750304
@@ -6491,7 +6495,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 685 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 697 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6499,7 +6503,7 @@ Types:
           Offset: 96
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 941
+      ID: 948
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2337632
@@ -6507,12 +6511,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 947 StructureType net.noReadFrom
+          Type: 954 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 944 PointerType *net.TCPConn
+          Type: 951 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 939
+      ID: 946
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2337088
@@ -6520,20 +6524,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 946 StructureType net.noWriteTo
+          Type: 953 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 944 PointerType *net.TCPConn
+          Type: 951 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 621
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 672
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 767
+      ID: 774
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1045088
@@ -6546,7 +6550,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 765
+      ID: 772
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1043680
@@ -6559,14 +6563,14 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 826
+      ID: 833
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2147456
       GoKind: 21
-      HeaderType: 828 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 835 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 768
+      ID: 775
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1043808
@@ -6579,15 +6583,15 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 335
+      ID: 347
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 550
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 766
+      ID: 773
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1044064
@@ -6611,7 +6615,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 843 PointerType *net/url.URL
+          Type: 850 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6623,19 +6627,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 821 GoInterfaceType io.ReadCloser
+          Type: 828 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 845 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 852 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6644,16 +6648,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 846 GoMapType net/url.Values
+          Type: 853 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 846 GoMapType net/url.Values
+          Type: 853 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 847 PointerType *mime/multipart.Form
+          Type: 854 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6662,13 +6666,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 849 PointerType *crypto/tls.ConnectionState
+          Type: 856 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 851 GoChannelType <-chan struct {}
+          Type: 858 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 852 PointerType *net/http.Response
+          Type: 859 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6677,15 +6681,15 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 854 PointerType *net/http.pattern
+          Type: 861 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 156 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2259680
@@ -6708,16 +6712,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 821 GoInterfaceType io.ReadCloser
+          Type: 828 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6726,13 +6730,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 110 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 849 PointerType *crypto/tls.ConnectionState
+          Type: 856 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 109
       Name: net/http.ResponseWriter
@@ -6747,19 +6751,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 896
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 876
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 832
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1776960
@@ -6767,10 +6771,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 771 PointerType *net/http.response
+          Type: 778 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6778,31 +6782,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 866
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 254
+      ID: 266
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 841152
       GoKind: 10
     - __kind: BaseType
-      ID: 674
+      ID: 686
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1001536
       GoKind: 10
     - __kind: StructureType
-      ID: 338
+      ID: 350
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1752032
@@ -6813,12 +6817,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 686 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 674
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1931328
@@ -6829,16 +6833,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 686 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 344
+      ID: 356
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1618880
@@ -6846,12 +6850,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 674 BaseType net/http.http2ErrCode
+          Type: 686 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 258
+      ID: 270
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841344
@@ -6859,28 +6863,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 260 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 272 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 259 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 271 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 259
+      ID: 271
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 342
+      ID: 354
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1128736
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 264
+      ID: 276
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 841536
@@ -6888,18 +6892,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 266 PointerType *net/http.http2headerFieldNameError.str
+          Type: 278 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 265 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 277 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 265
+      ID: 277
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 273
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 841440
@@ -6907,40 +6911,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *net/http.http2headerFieldValueError.str
+          Type: 275 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 262 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 274 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 274
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 625
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 863
+      ID: 870
       Name: net/http.http2missingBody
       GoRuntimeType: 1298528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1299040
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 544
+      ID: 556
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1298912
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 255
+      ID: 267
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841248
@@ -6948,22 +6952,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 257 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 269 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 256 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 268 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 256
+      ID: 268
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 878
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 770
+      ID: 777
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1206688
@@ -6971,13 +6975,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 817 PointerType *net/http.http2responseWriterState
+          Type: 824 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 865
+      ID: 872
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1571040
@@ -6985,19 +6989,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 902 PointerType *net/http.http2clientStream
+          Type: 909 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 861
+      ID: 868
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: net/http.noBody
       GoRuntimeType: 1483680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 540
+      ID: 552
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1572320
@@ -7007,7 +7011,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 855
+      ID: 862
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1865856
@@ -7024,20 +7028,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1000 GoSliceHeaderType []net/http.segment
+          Type: 1007 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 857
+      ID: 864
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 898
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 348
+      ID: 360
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1434240
@@ -7047,7 +7051,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 772
+      ID: 779
       Name: net/http.response
       ByteSize: 224
       GoRuntimeType: 2398144
@@ -7055,16 +7059,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 819 PointerType *net/http.conn
+          Type: 826 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 110 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 821 GoInterfaceType io.ReadCloser
+          Type: 828 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 148 GoSubroutineType context.CancelFunc
+          Type: 169 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7076,19 +7080,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 131 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 822 StructureType sync/atomic.Bool
+          Type: 829 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 823 PointerType *bufio.Writer
+          Type: 830 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 825 StructureType net/http.chunkWriter
+          Type: 832 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 826 GoMapType net/http.Header
+          Type: 833 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7112,27 +7116,27 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 822 StructureType sync/atomic.Bool
+          Type: 829 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 831 ArrayType [29]uint8
+          Type: 838 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 832 ArrayType [10]uint8
+          Type: 839 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 833 ArrayType [3]uint8
+          Type: 840 ArrayType [3]uint8
         - Name: closeNotifyCh
           Offset: 208
-          Type: 834 GoChannelType chan bool
+          Type: 841 GoChannelType chan bool
         - Name: didCloseNotify
           Offset: 216
-          Type: 822 StructureType sync/atomic.Bool
+          Type: 829 StructureType sync/atomic.Bool
     - __kind: StructureType
-      ID: 1002
+      ID: 1009
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1637088
@@ -7148,7 +7152,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 333
+      ID: 345
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1618720
@@ -7161,17 +7165,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 676
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 611
+      ID: 623
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1485280
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 542
+      ID: 554
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1572480
@@ -7181,7 +7185,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 924
+      ID: 931
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2063872
@@ -7189,22 +7193,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 690 GoInterfaceType net.Conn
+          Type: 702 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 690 GoInterfaceType net.Conn
+          Type: 702 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 331
+      ID: 343
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1307744
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 361
+      ID: 373
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1754720
@@ -7220,7 +7224,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 359
+      ID: 371
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1619360
@@ -7233,11 +7237,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 374
+      ID: 386
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 278
+      ID: 290
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 843936
@@ -7245,22 +7249,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 280 PointerType *net/textproto.ProtocolError.str
+          Type: 292 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 279 GoStringDataType net/textproto.ProtocolError.str
+      Data: 291 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 279
+      ID: 291
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 681
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 272
+      ID: 284
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 843744
@@ -7268,18 +7272,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 274 PointerType *net/url.EscapeError.str
+          Type: 286 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 273 GoStringDataType net/url.EscapeError.str
+      Data: 285 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 273
+      ID: 285
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 275
+      ID: 287
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 843840
@@ -7287,18 +7291,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 277 PointerType *net/url.InvalidHostError.str
+          Type: 289 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 276 GoStringDataType net/url.InvalidHostError.str
+      Data: 288 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 276
+      ID: 288
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 844
+      ID: 851
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2172992
@@ -7312,7 +7316,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 964 PointerType *net/url.Userinfo
+          Type: 971 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7338,99 +7342,99 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 972
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 846
+      ID: 853
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1920064
       GoKind: 21
-      HeaderType: 828 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 835 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 192
+      ID: 235
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 692512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 236 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 812
+      ID: 819
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 747424
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 813 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 820 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 248
+      ID: 251
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 249 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 252 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 976
+      ID: 983
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 977 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 984 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 839
+      ID: 846
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 840 StructureType noalg.struct { key string; elem []string }
+      Element: 847 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 226
+      ID: 215
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key string; elem float64 }
+      Element: 216 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 711
+      ID: 723
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 771456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 712 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 724 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 218
+      ID: 207
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key string; elem interface {} }
+      Element: 208 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 210
+      ID: 199
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 211 StructureType noalg.struct { key string; elem string }
+      Element: 200 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 191
+      ID: 234
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1310048
@@ -7441,9 +7445,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 235 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 811
+      ID: 818
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1357024
@@ -7454,9 +7458,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 812 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 819 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 247
+      ID: 250
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1327200
@@ -7467,9 +7471,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 248 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 251 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 975
+      ID: 982
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1320928
@@ -7480,9 +7484,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 976 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 983 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 838
+      ID: 845
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1311456
@@ -7493,9 +7497,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 839 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 846 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 225
+      ID: 214
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1326944
@@ -7506,9 +7510,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 215 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 710
+      ID: 722
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1375968
@@ -7519,9 +7523,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 711 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 723 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 217
+      ID: 206
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1308896
@@ -7532,9 +7536,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 207 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 209
+      ID: 198
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1313760
@@ -7545,9 +7549,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 210 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 199 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 193
+      ID: 236
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1309920
@@ -7555,12 +7559,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 194 GoInterfaceType context.canceler
+          Type: 237 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 195 StructureType struct {}
+          Type: 238 StructureType struct {}
     - __kind: StructureType
-      ID: 813
+      ID: 820
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1356896
@@ -7568,12 +7572,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 814 BaseType github.com/cihub/seelog.LogLevel
+          Type: 821 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 249
+      ID: 252
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1327072
@@ -7584,9 +7588,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 250 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 253 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 977
+      ID: 984
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1320800
@@ -7597,9 +7601,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 978 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 985 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1311328
@@ -7610,9 +7614,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 693 GoSliceHeaderType []string
+          Type: 705 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 227
+      ID: 216
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1326816
@@ -7625,7 +7629,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 712
+      ID: 724
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1375840
@@ -7636,9 +7640,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 700 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 712 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 219
+      ID: 208
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1308768
@@ -7649,9 +7653,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 160 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 211
+      ID: 200
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1313632
@@ -7664,15 +7668,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 964
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 546
+      ID: 558
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 172
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1129376
@@ -7685,11 +7689,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 627
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 955
+      ID: 962
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2408800
@@ -7697,12 +7701,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 959 StructureType os.noReadFrom
+          Type: 966 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 956 PointerType *os.File
+          Type: 963 PointerType *os.File
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2408000
@@ -7710,32 +7714,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 958 StructureType os.noWriteTo
+          Type: 965 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 956 PointerType *os.File
+          Type: 963 PointerType *os.File
     - __kind: StructureType
-      ID: 959
+      ID: 966
       Name: os.noReadFrom
       GoRuntimeType: 1129248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 958
+      ID: 965
       Name: os.noWriteTo
       GoRuntimeType: 1129120
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 589
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 718
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 579
+      ID: 591
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1729152
@@ -7748,7 +7752,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 168
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 2000928
@@ -7759,17 +7763,17 @@ Types:
           Type: 116 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 148 GoSubroutineType context.CancelFunc
+          Type: 169 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 149 GoSliceHeaderType []os.Signal
+          Type: 170 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 152 GoChannelType chan os.Signal
+          Type: 173 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 318
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 848832
@@ -7777,36 +7781,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *os/user.UnknownGroupIdError.str
+          Type: 320 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 319 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 319
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 305
+      ID: 317
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 848736
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 357
+      ID: 369
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 451
+      ID: 463
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 554
+      ID: 566
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 570
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7818,7 +7822,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 556
+      ID: 568
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1919616
@@ -7835,9 +7839,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 704 BaseType runtime.boundsErrorCode
+          Type: 716 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 704
+      ID: 716
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 591328
@@ -7857,7 +7861,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 617
+      ID: 629
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1784256
@@ -7870,7 +7874,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 522
+      ID: 534
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1002784
@@ -7878,13 +7882,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 524 PointerType *runtime.errorString.str
+          Type: 536 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 523 GoStringDataType runtime.errorString.str
+      Data: 535 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 523
+      ID: 535
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8540,7 +8544,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 525
+      ID: 537
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1002880
@@ -8548,13 +8552,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 527 PointerType *runtime.plainError.str
+          Type: 539 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 526 GoStringDataType runtime.plainError.str
+      Data: 538 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 526
+      ID: 538
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8640,7 +8644,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 562
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8652,18 +8656,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 183 PointerType *string.str
+          Type: 190 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 182 GoStringDataType string.str
+      Data: 189 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 182
+      ID: 189
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 739
+      ID: 746
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1982240
@@ -8671,12 +8675,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 753
+      ID: 760
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2059584
@@ -8684,15 +8688,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 735
+      ID: 742
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1981728
@@ -8700,12 +8704,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 745
+      ID: 752
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2058432
@@ -8713,15 +8717,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2128640
@@ -8729,18 +8733,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 747
+      ID: 754
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2058720
@@ -8748,15 +8752,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 743
+      ID: 750
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2058144
@@ -8764,15 +8768,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 755
+      ID: 762
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2128000
@@ -8780,18 +8784,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 763
+      ID: 770
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2190272
@@ -8799,21 +8803,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 757
+      ID: 764
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2128320
@@ -8821,18 +8825,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 765 GoInterfaceType net/http.Flusher
+          Type: 772 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 741
+      ID: 748
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1982496
@@ -8840,12 +8844,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 737
+      ID: 744
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1981984
@@ -8853,12 +8857,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 749
+      ID: 756
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2059008
@@ -8866,15 +8870,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2128960
@@ -8882,18 +8886,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 767 GoInterfaceType net/http.CloseNotifier
+          Type: 774 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 751
+      ID: 758
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2059296
@@ -8901,15 +8905,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 764 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 771 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 766 GoInterfaceType net/http.Pusher
+          Type: 773 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 768 GoInterfaceType net/http.Hijacker
+          Type: 775 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 887
+      ID: 894
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1734144
@@ -8917,18 +8921,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 904 GoInterfaceType io.Reader
+          Type: 911 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 914 GoInterfaceType io.Closer
+          Type: 921 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 195
+      ID: 238
       Name: struct {}
       GoRuntimeType: 854496
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 131
+      ID: 118
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1488960
@@ -8936,12 +8940,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 132 StructureType sync.noCopy
+          Type: 119 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 133 StructureType internal/sync.Mutex
+          Type: 120 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 153
+      ID: 117
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1871680
@@ -8949,7 +8953,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 131 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -8958,18 +8962,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 154 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 154 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 132
+      ID: 119
       Name: sync.noCopy
       GoRuntimeType: 1002400
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 822
+      ID: 829
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1490080
@@ -8977,12 +8981,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 155 StructureType sync/atomic.noCopy
+          Type: 122 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 154
+      ID: 121
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1490240
@@ -8990,12 +8994,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 155 StructureType sync/atomic.noCopy
+          Type: 122 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 134
+      ID: 176
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1214880
@@ -9003,27 +9007,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 135 GoEmptyInterfaceType interface {}
+          Type: 160 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 155
+      ID: 122
       Name: sync/atomic.noCopy
       GoRuntimeType: 1002496
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 654
+      ID: 666
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1299808
       GoKind: 12
     - __kind: BaseType
-      ID: 727
+      ID: 734
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 1003744
       GoKind: 2
     - __kind: StructureType
-      ID: 188
+      ID: 231
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9045,9 +9049,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 232 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 808
+      ID: 815
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9069,9 +9073,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 809 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 816 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 244
+      ID: 247
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9093,9 +9097,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 245 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 248 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 972
+      ID: 979
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9117,9 +9121,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 973 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 980 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9141,9 +9145,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 836 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 843 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 222
+      ID: 211
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9165,9 +9169,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 212 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 707
+      ID: 719
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9189,9 +9193,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 708 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 720 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 214
+      ID: 203
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9213,9 +9217,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 204 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 206
+      ID: 195
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9237,9 +9241,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 207 GoSwissMapGroupsType groupReference<string,string>
+          Type: 196 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1733376
@@ -9252,13 +9256,13 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 931
+      ID: 938
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1946144
       GoKind: 6
     - __kind: StructureType
-      ID: 146
+      ID: 188
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2005280
@@ -9269,10 +9273,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 198 GoSliceHeaderType []time.zone
+          Type: 241 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 201 GoSliceHeaderType []time.zoneTrans
+          Type: 244 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9284,13 +9288,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 199 PointerType *time.zone
+          Type: 242 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 363
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 144
+      ID: 186
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2423680
@@ -9304,7 +9308,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 145 PointerType *time.Location
+          Type: 187 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9314,7 +9318,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 143
+      ID: 185
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1486080
@@ -9322,12 +9326,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 721 GoChannelType <-chan time.Time
+          Type: 733 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 279
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 841632
@@ -9335,18 +9339,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *time.fileSizeError.str
+          Type: 281 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType time.fileSizeError.str
+      Data: 280 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 280
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 200
+      ID: 243
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1642080
@@ -9362,7 +9366,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 203
+      ID: 246
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1780992
@@ -9423,7 +9427,7 @@ Types:
       GoRuntimeType: 591264
       GoKind: 26
     - __kind: StructureType
-      ID: 685
+      ID: 697
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2096000
@@ -9434,10 +9438,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 686 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 698 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 687 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 699 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9452,18 +9456,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 688 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 700 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 688
+      ID: 700
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1003840
       GoKind: 9
     - __kind: StructureType
-      ID: 686
+      ID: 698
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1949216
@@ -9488,17 +9492,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 363
+      ID: 375
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 687
+      ID: 699
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 592160
       GoKind: 8
     - __kind: StructureType
-      ID: 376
+      ID: 388
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1439200
@@ -9508,13 +9512,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 281
+      ID: 293
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 844032
       GoKind: 2
     - __kind: StructureType
-      ID: 563
+      ID: 575
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1728576
@@ -9527,7 +9531,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 529
+      ID: 541
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1004704

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -121,23 +121,23 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 694 PointerType *crypto/x509.Certificate
+      Pointee: 706 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 742
+      ID: 267
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 114 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 999 PointerType *mime/multipart.FileHeader
+      Pointee: 1006 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
       ID: 65
       Name: '**runtime.p'
@@ -145,111 +145,111 @@ Types:
       GoKind: 22
       Pointee: 66 PointerType *runtime.p
     - __kind: PointerType
-      ID: 141
+      ID: 182
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 142 PointerType *table<context.canceler,struct {}>
+      Pointee: 183 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 808 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 815 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 240
+      ID: 229
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 241 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 230 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 990 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 997 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 849 PointerType *table<string,[]string>
+      Pointee: 856 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 171
+      ID: 138
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<string,float64>
+      Pointee: 139 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 699
+      ID: 711
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 712 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 166
+      ID: 133
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 167 PointerType *table<string,interface {}>
+      Pointee: 134 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 161
+      ID: 128
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 162 PointerType *table<string,string>
+      Pointee: 129 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1006 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 1013 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 1014 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1021 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 745
+      ID: 270
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 744 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 269 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 1004
+      ID: 1011
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 1003 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 1010 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 192
+      ID: 199
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []*runtime.p.array
-    - __kind: PointerType
-      ID: 1017
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 1016 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 1019
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 1018 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 737
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 736 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 236
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 235 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 244
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 198 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 1024
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1023 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1026
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1025 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 749
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 748 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 225
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 224 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 233
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 232 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1031
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1023 GoSliceDataType []net/http.segment.array
+      Pointee: 1030 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 210
+      ID: 235
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []os.Signal.array
+      Pointee: 234 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -258,77 +258,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 735
+      ID: 747
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 734 GoSliceDataType []string.array
+      Pointee: 746 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 246
+      ID: 263
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType []time.zone.array
+      Pointee: 262 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 248
+      ID: 265
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []time.zoneTrans.array
+      Pointee: 264 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 486400
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 187
+      ID: 194
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []uint8.array
+      Pointee: 193 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 189
+      ID: 196
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []uintptr.array
+      Pointee: 195 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 949920
       GoKind: 22
-      Pointee: 509 GoSliceHeaderType archive/tar.headerError
+      Pointee: 521 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 510 GoSliceDataType archive/tar.headerError.array
+      Pointee: 522 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1249824
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 923 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1082656
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 909 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1459040
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 927 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1082400
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 907 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -337,12 +337,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1995808
       GoKind: 22
-      Pointee: 843 UnresolvedPointeeType bufio.Writer
+      Pointee: 850 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 116
       Name: '*bytes.Buffer'
@@ -351,372 +351,372 @@ Types:
       GoKind: 22
       Pointee: 117 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 935616
       GoKind: 22
-      Pointee: 305 BaseType compress/flate.CorruptInputError
+      Pointee: 317 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 447
+      ID: 459
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 935712
       GoKind: 22
-      Pointee: 306 GoStringHeaderType compress/flate.InternalError
+      Pointee: 318 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType compress/flate.InternalError.str
+      Pointee: 319 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 951
+      ID: 958
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 2024064
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 959 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1660000
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 938 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 1030
+      ID: 165
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1574752
       GoKind: 22
-      Pointee: 131 StructureType context.backgroundCtx
+      Pointee: 166 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 119
+      ID: 176
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1756320
       GoKind: 22
-      Pointee: 120 StructureType context.cancelCtx
+      Pointee: 177 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1206816
       GoKind: 22
-      Pointee: 619 StructureType context.deadlineExceededError
+      Pointee: 631 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1025
+      ID: 151
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1433760
       GoKind: 22
-      Pointee: 132 StructureType context.emptyCtx
+      Pointee: 152 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 121
+      ID: 153
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1433920
       GoKind: 22
-      Pointee: 122 StructureType context.stopCtx
+      Pointee: 154 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 123
+      ID: 184
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1756512
       GoKind: 22
-      Pointee: 124 StructureType context.timerCtx
+      Pointee: 185 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1031
+      ID: 167
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1574912
       GoKind: 22
-      Pointee: 149 StructureType context.todoCtx
+      Pointee: 168 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 125
+      ID: 160
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1574432
       GoKind: 22
-      Pointee: 126 StructureType context.valueCtx
+      Pointee: 161 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 127
+      ID: 163
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1574592
       GoKind: 22
-      Pointee: 128 StructureType context.withoutCancelCtx
+      Pointee: 164 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 934368
       GoKind: 22
-      Pointee: 301 BaseType crypto/aes.KeySizeError
+      Pointee: 313 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 443
+      ID: 455
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 934560
       GoKind: 22
-      Pointee: 302 BaseType crypto/des.KeySizeError
+      Pointee: 314 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 934848
       GoKind: 22
-      Pointee: 303 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 315 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 597
+      ID: 609
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1079328
       GoKind: 22
-      Pointee: 598 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 610 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 445
+      ID: 457
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 935136
       GoKind: 22
-      Pointee: 304 BaseType crypto/rc4.KeySizeError
+      Pointee: 316 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 380
+      ID: 392
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 924096
       GoKind: 22
-      Pointee: 275 BaseType crypto/tls.AlertError
+      Pointee: 287 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 573
+      ID: 585
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1059744
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 586 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 981
+      ID: 988
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2435232
       GoKind: 22
-      Pointee: 982 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 989 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 869 StructureType crypto/tls.ConnectionState
+      Pointee: 876 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 923808
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 389 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 375 StructureType crypto/tls.RecordHeaderError
+      Pointee: 387 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1058080
       GoKind: 22
-      Pointee: 541 BaseType crypto/tls.alert
+      Pointee: 553 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 923904
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 391 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 683
+      ID: 695
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1442240
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 696 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 694
+      ID: 706
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2088896
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 707 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 934176
       GoKind: 22
-      Pointee: 439 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 451 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 933696
       GoKind: 22
-      Pointee: 433 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 445 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 933792
       GoKind: 22
-      Pointee: 435 StructureType crypto/x509.HostnameError
+      Pointee: 447 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 431
+      ID: 443
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 933600
       GoKind: 22
-      Pointee: 300 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 312 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 589
+      ID: 601
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1069600
       GoKind: 22
-      Pointee: 590 StructureType crypto/x509.SystemRootsError
+      Pointee: 602 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 934272
       GoKind: 22
-      Pointee: 441 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 453 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 934080
       GoKind: 22
-      Pointee: 437 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 449 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 945600
       GoKind: 22
-      Pointee: 501 StructureType encoding/asn1.StructuralError
+      Pointee: 513 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 945792
       GoKind: 22
-      Pointee: 505 StructureType encoding/asn1.SyntaxError
+      Pointee: 517 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 945696
       GoKind: 22
-      Pointee: 503 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 515 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 924192
       GoKind: 22
-      Pointee: 276 BaseType encoding/base64.CorruptInputError
+      Pointee: 288 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 423
+      ID: 435
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 932352
       GoKind: 22
-      Pointee: 296 BaseType encoding/hex.InvalidByteError
+      Pointee: 308 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927552
       GoKind: 22
-      Pointee: 399 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 411 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 585
+      ID: 597
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1064864
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 598 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927168
       GoKind: 22
-      Pointee: 391 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 403 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 927456
       GoKind: 22
-      Pointee: 397 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 409 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 927360
       GoKind: 22
-      Pointee: 395 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 407 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 927264
       GoKind: 22
-      Pointee: 393 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 405 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 927936
       GoKind: 22
-      Pointee: 401 StructureType encoding/json.jsonError
+      Pointee: 413 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 495
+      ID: 507
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 942816
       GoKind: 22
-      Pointee: 496 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 508 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 493
+      ID: 505
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 942720
       GoKind: 22
-      Pointee: 494 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 506 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 497
+      ID: 509
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 942912
       GoKind: 22
-      Pointee: 310 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 322 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 312
+      ID: 324
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 323 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 943008
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 511 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -725,19 +725,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 361 UnresolvedPointeeType errors.errorString
+      Pointee: 373 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1051040
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType errors.joinError
+      Pointee: 573 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -753,118 +753,118 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 544
+      ID: 556
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1040672
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType fmt.wrapError
+      Pointee: 557 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 546
+      ID: 558
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1040800
       GoKind: 22
-      Pointee: 547 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 559 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 421
+      ID: 433
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 422 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 434 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2057312
       GoKind: 22
-      Pointee: 810 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 817 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 929184
       GoKind: 22
-      Pointee: 404 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 416 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 929280
       GoKind: 22
-      Pointee: 406 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 418 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 714
+      ID: 726
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 928992
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 727 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 409
+      ID: 421
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 929568
       GoKind: 22
-      Pointee: 410 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 422 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 716
+      ID: 728
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 929088
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 729 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 929376
       GoKind: 22
-      Pointee: 290 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 302 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 292
+      ID: 304
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 291 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 303 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 402
+      ID: 414
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 928896
       GoKind: 22
-      Pointee: 287 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 299 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 289
+      ID: 301
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 300 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 929472
       GoKind: 22
-      Pointee: 293 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 305 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 295
+      ID: 307
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 294 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 450
+      ID: 462
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 936672
       GoKind: 22
-      Pointee: 451 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 463 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
       ByteSize: 8
       GoRuntimeType: 1760160
       GoKind: 22
-      Pointee: 801 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
+      Pointee: 808 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
     - __kind: PointerType
       ID: 114
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -873,728 +873,728 @@ Types:
       GoKind: 22
       Pointee: 115 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 179
+      ID: 146
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2053568
       GoKind: 22
-      Pointee: 180 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 147 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 174
+      ID: 141
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1213856
       GoKind: 22
-      Pointee: 175 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 142 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1939296
       GoKind: 22
-      Pointee: 947 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 954 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1836992
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+      Pointee: 946 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 177
+      ID: 144
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1213984
       GoKind: 22
-      Pointee: 178 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1214624
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 757 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 255
+      ID: 258
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1214752
       GoKind: 22
-      Pointee: 256 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 259 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 181
+      ID: 148
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2276800
       GoKind: 22
-      Pointee: 182 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 149 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer'
       ByteSize: 8
       GoRuntimeType: 2261568
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
+      Pointee: 823 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1235744
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 672 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1582272
       GoKind: 22
-      Pointee: 752 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 759 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2226656
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
+      Pointee: 819 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1028
+      ID: 158
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1444960
       GoKind: 22
-      Pointee: 1029 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2227072
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
+      Pointee: 821 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1072928
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
+      Pointee: 905 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 452
+      ID: 464
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 938880
       GoKind: 22
-      Pointee: 453 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 465 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 939936
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 472 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 454
+      ID: 466
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 939648
       GoKind: 22
-      Pointee: 309 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 321 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 939840
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 470 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 939744
       GoKind: 22
-      Pointee: 456 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 468 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 941280
       GoKind: 22
-      Pointee: 468 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 941472
       GoKind: 22
-      Pointee: 472 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 941376
       GoKind: 22
-      Pointee: 470 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 465
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 941184
       GoKind: 22
-      Pointee: 466 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 739
+      ID: 751
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 750 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 479
+      ID: 491
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 941856
       GoKind: 22
-      Pointee: 480 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 492 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 941568
       GoKind: 22
-      Pointee: 474 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 941760
       GoKind: 22
-      Pointee: 478 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 490 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 475
+      ID: 487
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 941664
       GoKind: 22
-      Pointee: 476 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 488 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 941952
       GoKind: 22
-      Pointee: 482 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 494 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 487
+      ID: 499
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 942240
       GoKind: 22
-      Pointee: 488 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 500 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 489
+      ID: 501
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 942336
       GoKind: 22
-      Pointee: 490 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 502 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 485
+      ID: 497
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 942144
       GoKind: 22
-      Pointee: 486 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 498 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 483
+      ID: 495
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 942048
       GoKind: 22
-      Pointee: 484 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 496 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 491
+      ID: 503
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 942528
       GoKind: 22
-      Pointee: 492 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 504 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2378528
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 833 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2361696
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 827 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2370208
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 829 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2370848
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 831 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 930720
       GoKind: 22
-      Pointee: 412 StructureType github.com/cihub/seelog.baseError
+      Pointee: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1839232
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 810 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 413
+      ID: 425
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 930816
       GoKind: 22
-      Pointee: 414 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 426 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1448160
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 800 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1669216
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 802 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1669984
       GoKind: 22
-      Pointee: 799 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 806 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 417
+      ID: 429
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 931008
       GoKind: 22
-      Pointee: 418 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 430 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1669408
       GoKind: 22
-      Pointee: 797 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 804 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2339456
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 825 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 415
+      ID: 427
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 930912
       GoKind: 22
-      Pointee: 416 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 428 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 419
+      ID: 431
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 931104
       GoKind: 22
-      Pointee: 420 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 432 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1244960
       GoKind: 22
-      Pointee: 914 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 921 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1766112
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 942 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 687
+      ID: 699
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1460320
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 700 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1087648
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 616 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1087520
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 614 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 605
+      ID: 617
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1092000
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 618 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 607
+      ID: 619
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1092128
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 620 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 595
+      ID: 607
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1076512
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 608 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 932544
       GoKind: 22
-      Pointee: 425 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 437 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1244192
       GoKind: 22
-      Pointee: 662 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 674 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 647
+      ID: 659
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1227680
       GoKind: 22
-      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 641
+      ID: 653
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1227296
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 654 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 579
+      ID: 591
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1062688
       GoKind: 22
-      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 653
+      ID: 665
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1228064
       GoKind: 22
-      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1062560
       GoKind: 22
-      Pointee: 543 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 555 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 645
+      ID: 657
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1227552
       GoKind: 22
-      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 643
+      ID: 655
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1227424
       GoKind: 22
-      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 651
+      ID: 663
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1227936
       GoKind: 22
-      Pointee: 652 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 649
+      ID: 661
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1227808
       GoKind: 22
-      Pointee: 650 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 657
+      ID: 669
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1228448
       GoKind: 22
-      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 670 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 583
+      ID: 595
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1062944
       GoKind: 22
-      Pointee: 584 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 596 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 581
+      ID: 593
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1062816
       GoKind: 22
-      Pointee: 582 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 655
+      ID: 667
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1228320
       GoKind: 22
-      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 522
+      ID: 534
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 961344
       GoKind: 22
-      Pointee: 317 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 329 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 319
+      ID: 331
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 318 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 702
+      ID: 714
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1697440
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 715 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 611
+      ID: 623
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1106848
       GoKind: 22
-      Pointee: 612 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 624 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 962592
       GoKind: 22
-      Pointee: 320 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 332 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1282464
       GoKind: 22
-      Pointee: 670 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 682 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 526
+      ID: 538
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 962880
       GoKind: 22
-      Pointee: 527 StructureType golang.org/x/net/http2.connError
+      Pointee: 539 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 525
+      ID: 537
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 962784
       GoKind: 22
-      Pointee: 324 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 336 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 326
+      ID: 338
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 325 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 529
+      ID: 541
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 963072
       GoKind: 22
-      Pointee: 330 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 342 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 332
+      ID: 344
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 331 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 962976
       GoKind: 22
-      Pointee: 327 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 339 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 329
+      ID: 341
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 328 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 962688
       GoKind: 22
-      Pointee: 321 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 333 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 323
+      ID: 335
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 322 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 530
+      ID: 542
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 963168
       GoKind: 22
-      Pointee: 531 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 543 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 963264
       GoKind: 22
-      Pointee: 333 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 345 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 957024
       GoKind: 22
-      Pointee: 519 StructureType google.golang.org/grpc.dropError
+      Pointee: 531 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1279520
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 680 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 689
+      ID: 701
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1467840
       GoKind: 22
-      Pointee: 690 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 702 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 520
+      ID: 532
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 959616
       GoKind: 22
-      Pointee: 521 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 533 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1846624
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 948 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 609
+      ID: 621
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1101088
       GoKind: 22
-      Pointee: 610 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 622 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1594112
       GoKind: 22
-      Pointee: 925 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 932 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 948576
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 519 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 599
+      ID: 611
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1081248
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 612 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1248416
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 678 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 663
+      ID: 675
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1248160
       GoKind: 22
-      Pointee: 664 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 676 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 950880
       GoKind: 22
-      Pointee: 513 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 525 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 514
+      ID: 526
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 950976
       GoKind: 22
-      Pointee: 515 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 527 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 461
+      ID: 473
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 940032
       GoKind: 22
-      Pointee: 462 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 474 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 964032
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType html/template.Error
+      Pointee: 546 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 102
       Name: '*int'
@@ -1631,347 +1631,347 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType int8
     - __kind: PointerType
-      ID: 691
+      ID: 703
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2262912
       GoKind: 22
-      Pointee: 692 UnresolvedPointeeType internal/abi.Type
+      Pointee: 704 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 429
+      ID: 441
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 933216
       GoKind: 22
-      Pointee: 430 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 442 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 933120
       GoKind: 22
-      Pointee: 428 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 440 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 639
+      ID: 651
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1222816
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 652 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2429952
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType internal/poll.FD
+      Pointee: 987 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 637
+      ID: 649
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1222688
       GoKind: 22
-      Pointee: 638 StructureType internal/poll.errNetClosing
+      Pointee: 650 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 362
+      ID: 374
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 919392
       GoKind: 22
-      Pointee: 363 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 375 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 933024
       GoKind: 22
-      Pointee: 297 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 309 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 299
+      ID: 311
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 310 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1068576
       GoKind: 22
-      Pointee: 588 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 600 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1880448
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType io.PipeReader
+      Pointee: 952 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1579072
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType io.SectionReader
+      Pointee: 956 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1051552
       GoKind: 22
-      Pointee: 896 StructureType io.nopCloser
+      Pointee: 903 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1217440
       GoKind: 22
-      Pointee: 912 StructureType io.nopCloserWriterTo
+      Pointee: 919 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 635
+      ID: 647
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1221664
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType io/fs.PathError
+      Pointee: 648 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 139
+      ID: 180
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 140 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 181 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 806 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 813 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 238
+      ID: 227
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 239 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 228 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 988 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 995 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 847 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 854 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 169
+      ID: 136
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<string,float64>
+      Pointee: 137 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 697
+      ID: 709
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 710 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 164
+      ID: 131
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 165 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 159
+      ID: 126
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 160 GoSwissMapHeaderType map<string,string>
+      Pointee: 127 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 936288
       GoKind: 22
-      Pointee: 449 StructureType math/big.ErrNaN
+      Pointee: 461 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 999
+      ID: 1006
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 1009 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 867 StructureType mime/multipart.Form
+      Pointee: 874 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1659040
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 934 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1659232
       GoKind: 22
-      Pointee: 929 StructureType mime/multipart.sectionReadCloser
+      Pointee: 936 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1207968
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType net.AddrError
+      Pointee: 634 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 674
+      ID: 686
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1434560
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType net.DNSError
+      Pointee: 687 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 955
+      ID: 962
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2281280
       GoKind: 22
-      Pointee: 956 UnresolvedPointeeType net.IPConn
+      Pointee: 963 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 672
+      ID: 684
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1434240
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType net.OpError
+      Pointee: 685 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1208096
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType net.ParseError
+      Pointee: 636 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2313952
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType net.TCPConn
+      Pointee: 971 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2360480
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType net.UDPConn
+      Pointee: 975 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2313440
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType net.UnixConn
+      Pointee: 969 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1207200
       GoKind: 22
-      Pointee: 615 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 627 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 617
+      ID: 629
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 616 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 628 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 548
+      ID: 560
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1041696
       GoKind: 22
-      Pointee: 549 StructureType net.canceledError
+      Pointee: 561 StructureType net.canceledError
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2051840
       GoKind: 22
-      Pointee: 954 UnresolvedPointeeType net.conn
+      Pointee: 961 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 720
+      ID: 732
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1874176
       GoKind: 22
-      Pointee: 721 StructureType net.dialResult·1
+      Pointee: 733 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2364128
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType net.netFD
+      Pointee: 977 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 334
+      ID: 346
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 912000
       GoKind: 22
-      Pointee: 335 UnresolvedPointeeType net.notFoundError
+      Pointee: 347 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1026
+      ID: 156
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1434400
       GoKind: 22
-      Pointee: 1027 StructureType net.onlyValuesCtx
+      Pointee: 157 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 336
+      ID: 348
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 912672
       GoKind: 22
-      Pointee: 337 StructureType net.result·2
+      Pointee: 349 StructureType net.result·2
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2297088
       GoKind: 22
-      Pointee: 960 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 967 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 957
+      ID: 964
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2296608
       GoKind: 22
-      Pointee: 958 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 965 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1208736
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType net.temporaryError
+      Pointee: 638 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 676
+      ID: 688
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1434880
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType net.timeoutError
+      Pointee: 689 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 342
+      ID: 354
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 915264
       GoKind: 22
-      Pointee: 343 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 355 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 550
+      ID: 562
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1045152
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 563 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 112
       Name: '*net/http.Request'
@@ -1980,559 +1980,559 @@ Types:
       GoKind: 22
       Pointee: 113 StructureType net/http.Request
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1757856
       GoKind: 22
-      Pointee: 872 StructureType net/http.Response
+      Pointee: 879 StructureType net/http.Response
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1836096
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType net/http.body
+      Pointee: 944 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1211296
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 915 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1045024
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 895 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1938272
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType net/http.conn
+      Pointee: 846 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1043744
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 885 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1047328
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 899 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 344
+      ID: 356
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 259 BaseType net/http.http2ConnectionError
+      Pointee: 271 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 915552
       GoKind: 22
-      Pointee: 346 StructureType net/http.http2GoAwayError
+      Pointee: 358 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 678
+      ID: 690
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1435840
       GoKind: 22
-      Pointee: 679 StructureType net/http.http2StreamError
+      Pointee: 691 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2053280
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 929 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 351
+      ID: 363
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 352 StructureType net/http.http2connError
+      Pointee: 364 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916032
       GoKind: 22
-      Pointee: 263 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 275 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 265
+      ID: 277
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 276 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 916128
       GoKind: 22
-      Pointee: 350 StructureType net/http.http2goAwayFlowError
+      Pointee: 362 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1044768
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 893 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 916800
       GoKind: 22
-      Pointee: 269 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 281 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 271
+      ID: 283
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 270 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 282 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 353
+      ID: 365
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 916704
       GoKind: 22
-      Pointee: 266 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 278 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 268
+      ID: 280
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 279 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 629
+      ID: 641
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1212576
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 642 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1044512
       GoKind: 22
-      Pointee: 882 StructureType net/http.http2missingBody
+      Pointee: 889 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1047584
       GoKind: 22
-      Pointee: 894 StructureType net/http.http2noBodyReader
+      Pointee: 901 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 556
+      ID: 568
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1047456
       GoKind: 22
-      Pointee: 557 StructureType net/http.http2noCachedConnError
+      Pointee: 569 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 915936
       GoKind: 22
-      Pointee: 260 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 272 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 262
+      ID: 274
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 261 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 273 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1045664
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 897 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2052704
       GoKind: 22
-      Pointee: 789 StructureType net/http.http2responseWriter
+      Pointee: 796 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1644064
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 844 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1044640
       GoKind: 22
-      Pointee: 884 StructureType net/http.http2transportResponseBody
+      Pointee: 891 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1044000
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 887 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1211424
       GoKind: 22
-      Pointee: 910 StructureType net/http.noBody
+      Pointee: 917 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 552
+      ID: 564
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1047072
       GoKind: 22
-      Pointee: 553 StructureType net/http.nothingWrittenError
+      Pointee: 565 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1642144
       GoKind: 22
-      Pointee: 874 StructureType net/http.pattern
+      Pointee: 881 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 875
+      ID: 882
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1043360
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 883 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1436160
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 925 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 916992
       GoKind: 22
-      Pointee: 356 StructureType net/http.requestBodyReadError
+      Pointee: 368 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2276352
       GoKind: 22
-      Pointee: 791 StructureType net/http.response
+      Pointee: 798 StructureType net/http.response
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396288
       GoKind: 22
-      Pointee: 1022 StructureType net/http.segment
+      Pointee: 1029 StructureType net/http.segment
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 915168
       GoKind: 22
-      Pointee: 341 StructureType net/http.statusError
+      Pointee: 353 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 680
+      ID: 692
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1437440
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 693 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1212448
       GoKind: 22
-      Pointee: 628 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 640 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 554
+      ID: 566
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1047200
       GoKind: 22
-      Pointee: 555 StructureType net/http.transportReadFromServerError
+      Pointee: 567 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1875744
       GoKind: 22
-      Pointee: 943 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 950 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 339 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 351 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1107488
       GoKind: 22
-      Pointee: 904 StructureType net/http/httputil.failureToReadBody
+      Pointee: 911 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 922080
       GoKind: 22
-      Pointee: 371 StructureType net/netip.parseAddrError
+      Pointee: 383 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 368
+      ID: 380
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 921984
       GoKind: 22
-      Pointee: 369 StructureType net/netip.parsePrefixError
+      Pointee: 381 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType net/textproto.Error
+      Pointee: 398 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 925344
       GoKind: 22
-      Pointee: 283 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 295 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 285
+      ID: 297
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 296 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 685
+      ID: 697
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1442560
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType net/url.Error
+      Pointee: 698 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 382
+      ID: 394
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 924288
       GoKind: 22
-      Pointee: 277 GoStringHeaderType net/url.EscapeError
+      Pointee: 289 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 279
+      ID: 291
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType net/url.EscapeError.str
+      Pointee: 290 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 924384
       GoKind: 22
-      Pointee: 280 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 292 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 282
+      ID: 294
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 293 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2166560
       GoKind: 22
-      Pointee: 863 StructureType net/url.URL
+      Pointee: 870 StructureType net/url.URL
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1225376
       GoKind: 22
-      Pointee: 984 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 991 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 195
+      ID: 238
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 239 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 837 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 251
+      ID: 254
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 255 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 994 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 1001 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 857 StructureType noalg.map.group[string][]string
+      Pointee: 864 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 229
+      ID: 218
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 230 StructureType noalg.map.group[string]float64
+      Pointee: 219 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 728
+      ID: 740
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 741 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 221
+      ID: 210
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 222 StructureType noalg.map.group[string]interface {}
+      Pointee: 211 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 213
+      ID: 202
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 214 StructureType noalg.map.group[string]string
+      Pointee: 203 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2406304
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType os.File
+      Pointee: 983 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 558
+      ID: 570
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1049504
       GoKind: 22
-      Pointee: 559 UnresolvedPointeeType os.LinkError
+      Pointee: 571 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 152
+      ID: 173
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 399104
       GoKind: 22
-      Pointee: 153 GoInterfaceType os.Signal
+      Pointee: 174 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 631
+      ID: 643
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1212960
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType os.SyscallError
+      Pointee: 644 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2404064
       GoKind: 22
-      Pointee: 974 StructureType os.fileWithoutReadFrom
+      Pointee: 981 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2403328
       GoKind: 22
-      Pointee: 972 StructureType os.fileWithoutWriteTo
+      Pointee: 979 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 591
+      ID: 603
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1071648
       GoKind: 22
-      Pointee: 592 UnresolvedPointeeType os/exec.Error
+      Pointee: 604 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 724
+      ID: 736
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2140640
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 737 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 593
+      ID: 605
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1071776
       GoKind: 22
-      Pointee: 594 StructureType os/exec.wrappedError
+      Pointee: 606 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 129
+      ID: 169
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1646752
       GoKind: 22
-      Pointee: 130 StructureType os/signal.signalCtx
+      Pointee: 170 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 955104
       GoKind: 22
-      Pointee: 314 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 326 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 316
+      ID: 328
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 315 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 327 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 955008
       GoKind: 22
-      Pointee: 313 BaseType os/user.UnknownUserIdError
+      Pointee: 325 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 364
+      ID: 376
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 365 UnresolvedPointeeType reflect.ValueError
+      Pointee: 377 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 463
+      ID: 475
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 940512
       GoKind: 22
-      Pointee: 464 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 476 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 566
+      ID: 578
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1054112
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 579 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 570
+      ID: 582
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1055904
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 583 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2548,12 +2548,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 568
+      ID: 580
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1054240
       GoKind: 22
-      Pointee: 569 StructureType runtime.boundsError
+      Pointee: 581 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -2569,24 +2569,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 633
+      ID: 645
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1221152
       GoKind: 22
-      Pointee: 634 StructureType runtime.errorAddressString
+      Pointee: 646 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1053728
       GoKind: 22
-      Pointee: 535 GoStringHeaderType runtime.errorString
+      Pointee: 547 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 537
+      ID: 549
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType runtime.errorString.str
+      Pointee: 548 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2607,19 +2607,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1055264
       GoKind: 22
-      Pointee: 190 UnresolvedPointeeType runtime.p
+      Pointee: 197 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1053856
       GoKind: 22
-      Pointee: 538 GoStringHeaderType runtime.plainError
+      Pointee: 550 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 540
+      ID: 552
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 539 GoStringDataType runtime.plainError.str
+      Pointee: 551 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2635,12 +2635,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 921696
       GoKind: 22
-      Pointee: 367 StructureType runtime.synctestDeadlockError
+      Pointee: 379 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -2656,12 +2656,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1053344
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType strconv.NumError
+      Pointee: 575 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -2670,235 +2670,235 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 185
+      ID: 192
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 184 GoStringDataType string.str
+      Pointee: 191 GoStringDataType string.str
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1721824
       GoKind: 22
-      Pointee: 758 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 765 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1781088
       GoKind: 22
-      Pointee: 772 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 779 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 753
+      ID: 760
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1721440
       GoKind: 22
-      Pointee: 754 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 761 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1780320
       GoKind: 22
-      Pointee: 764 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 771 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1853344
       GoKind: 22
-      Pointee: 778 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 785 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1780512
       GoKind: 22
-      Pointee: 766 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 773 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1780128
       GoKind: 22
-      Pointee: 762 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 769 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1852896
       GoKind: 22
-      Pointee: 774 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 781 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1925024
       GoKind: 22
-      Pointee: 782 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 789 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1853120
       GoKind: 22
-      Pointee: 776 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 783 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1722016
       GoKind: 22
-      Pointee: 760 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 767 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1721632
       GoKind: 22
-      Pointee: 756 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 763 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1780704
       GoKind: 22
-      Pointee: 768 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 775 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1853568
       GoKind: 22
-      Pointee: 780 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 787 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1780896
       GoKind: 22
-      Pointee: 770 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 777 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1114624
       GoKind: 22
-      Pointee: 906 StructureType struct { io.Reader; io.Closer }
+      Pointee: 913 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 682
+      ID: 694
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1441440
       GoKind: 22
-      Pointee: 671 BaseType syscall.Errno
+      Pointee: 683 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1056416
       GoKind: 22
-      Pointee: 746 BaseType syscall.Signal
+      Pointee: 753 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 142
+      ID: 183
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 193 StructureType table<context.canceler,struct {}>
+      Pointee: 236 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 827 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 834 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 241
+      ID: 230
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 249 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 252 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 990
+      ID: 997
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 991 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 998 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 854 StructureType table<string,[]string>
+      Pointee: 861 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 172
+      ID: 139
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 227 StructureType table<string,float64>
+      Pointee: 216 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 700
+      ID: 712
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 726 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 738 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 167
+      ID: 134
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 219 StructureType table<string,interface {}>
+      Pointee: 208 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 162
+      ID: 129
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 211 StructureType table<string,string>
+      Pointee: 200 StructureType table<string,string>
     - __kind: PointerType
-      ID: 613
+      ID: 625
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1110688
       GoKind: 22
-      Pointee: 614 StructureType text/template.ExecError
+      Pointee: 626 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 147
+      ID: 189
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1647136
       GoKind: 22
-      Pointee: 148 StructureType time.Location
+      Pointee: 190 StructureType time.Location
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 917856
       GoKind: 22
-      Pointee: 359 UnresolvedPointeeType time.ParseError
+      Pointee: 371 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 144
+      ID: 186
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1050016
       GoKind: 22
-      Pointee: 145 StructureType time.Timer
+      Pointee: 187 StructureType time.Timer
     - __kind: PointerType
-      ID: 357
+      ID: 369
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 917760
       GoKind: 22
-      Pointee: 272 GoStringHeaderType time.fileSizeError
+      Pointee: 284 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 274
+      ID: 286
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 273 GoStringDataType time.fileSizeError.str
+      Pointee: 285 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 204
+      ID: 247
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399360
       GoKind: 22
-      Pointee: 205 StructureType time.zone
+      Pointee: 248 StructureType time.zone
     - __kind: PointerType
-      ID: 207
+      ID: 250
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399424
       GoKind: 22
-      Pointee: 208 StructureType time.zoneTrans
+      Pointee: 251 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -2942,47 +2942,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 922848
       GoKind: 22
-      Pointee: 373 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 385 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 925632
       GoKind: 22
-      Pointee: 388 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 400 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 389
+      ID: 401
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 925728
       GoKind: 22
-      Pointee: 286 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 298 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1061280
       GoKind: 22
-      Pointee: 576 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 588 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1061408
       GoKind: 22
-      Pointee: 542 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 554 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 870
+      ID: 877
       Name: <-chan struct {}
       GoRuntimeType: 607040
       GoKind: 18
     - __kind: GoChannelType
-      ID: 740
+      ID: 752
       Name: <-chan time.Time
       GoRuntimeType: 610304
       GoKind: 18
@@ -3061,7 +3061,7 @@ Types:
       HasCount: true
       Element: 95 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 851
+      ID: 858
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 694560
@@ -3070,7 +3070,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 850
+      ID: 857
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 694464
@@ -3142,7 +3142,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 852
+      ID: 859
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 694656
@@ -3160,7 +3160,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 708
+      ID: 720
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 712448
@@ -3187,7 +3187,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1006
+      ID: 1013
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507264
@@ -3195,22 +3195,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1007 PointerType **crypto/x509.Certificate
+          Type: 1014 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1014 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1021 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1014
+      ID: 1021
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 694 PointerType *crypto/x509.Certificate
+      Element: 706 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 741
+      ID: 266
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 495072
@@ -3218,22 +3218,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 742 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 267 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 744 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 269 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 744
+      ID: 269
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 114 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 997
+      ID: 1004
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 492064
@@ -3241,20 +3241,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 998 PointerType **mime/multipart.FileHeader
+          Type: 1005 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1003 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 1010 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 1003
+      ID: 1010
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 999 PointerType *mime/multipart.FileHeader
+      Element: 1006 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 64
       Name: '[]*runtime.p'
@@ -3271,69 +3271,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 191 GoSliceDataType []*runtime.p.array
+      Data: 198 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 198
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 66 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 244
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 142 PointerType *table<context.canceler,struct {}>
+      Element: 183 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 834
+      ID: 841
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 808 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 815 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 260
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 241 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 230 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 1000
+      ID: 1007
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 990 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 997 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 860
+      ID: 867
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 849 PointerType *table<string,[]string>
+      Element: 856 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 222
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 172 PointerType *table<string,float64>
+      Element: 139 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 732
+      ID: 744
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 700 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 712 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 214
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 167 PointerType *table<string,interface {}>
+      Element: 134 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 206
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 162 PointerType *table<string,string>
+      Element: 129 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 1008
+      ID: 1015
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 507328
@@ -3341,22 +3341,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1009 PointerType *[]*crypto/x509.Certificate
+          Type: 1016 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1016 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1023 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1016
+      ID: 1023
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1006 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 1013 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 1010
+      ID: 1017
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 486720
@@ -3364,22 +3364,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1011 PointerType *[]uint8
+          Type: 1018 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1018 GoSliceDataType [][]uint8.array
+      Data: 1025 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 1018
+      ID: 1025
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 713
+      ID: 725
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 501024
@@ -3394,15 +3394,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 736 GoSliceDataType []float64.array
+      Data: 748 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 736
+      ID: 748
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 173
+      ID: 140
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 494624
@@ -3410,22 +3410,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 174 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 141 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 235 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 224 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 224
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 175 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 142 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 176
+      ID: 143
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 494816
@@ -3433,22 +3433,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 177 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 243 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 232 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 232
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 178 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1020
+      ID: 1027
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 489440
@@ -3456,76 +3456,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1021 PointerType *net/http.segment
+          Type: 1028 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1023 GoSliceDataType []net/http.segment.array
+      Data: 1030 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1023
+      ID: 1030
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1022 StructureType net/http.segment
+      Element: 1029 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 245
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 196 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 239 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 835
+      ID: 842
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 837 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 261
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 255 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 1001
+      ID: 1008
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 994 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 1001 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 861
+      ID: 868
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 857 StructureType noalg.map.group[string][]string
+      Element: 864 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 223
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 230 StructureType noalg.map.group[string]float64
+      Element: 219 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 733
+      ID: 745
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 741 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 215
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 222 StructureType noalg.map.group[string]interface {}
+      Element: 211 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 207
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 214 StructureType noalg.map.group[string]string
+      Element: 203 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 151
+      ID: 172
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 486528
@@ -3533,26 +3533,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 152 PointerType *os.Signal
+          Type: 173 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 209 GoSliceDataType []os.Signal.array
+      Data: 234 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 234
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 153 GoInterfaceType os.Signal
+      Element: 174 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 712
+      ID: 724
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -3567,15 +3567,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 734 GoSliceDataType []string.array
+      Data: 746 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 734
+      ID: 746
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 203
+      ID: 246
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494176
@@ -3583,22 +3583,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 204 PointerType *time.zone
+          Type: 247 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 245 GoSliceDataType []time.zone.array
+      Data: 262 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 262
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 205 StructureType time.zone
+      Element: 248 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 206
+      ID: 249
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494240
@@ -3606,20 +3606,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 207 PointerType *time.zoneTrans
+          Type: 250 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 247 GoSliceDataType []time.zoneTrans.array
+      Data: 264 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 264
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 208 StructureType time.zoneTrans
+      Element: 251 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3636,9 +3636,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 186 GoSliceDataType []uint8.array
+      Data: 193 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 193
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3659,15 +3659,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 188 GoSliceDataType []uintptr.array
+      Data: 195 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 195
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 509
+      ID: 521
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 950016
@@ -3682,27 +3682,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 510 GoSliceDataType archive/tar.headerError.array
+      Data: 522 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 510
+      ID: 522
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 923
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 909
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 907
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3712,7 +3712,7 @@ Types:
       GoRuntimeType: 595008
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 843
+      ID: 850
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3720,12 +3720,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 853
+      ID: 860
       Name: chan bool
       GoRuntimeType: 606464
       GoKind: 18
     - __kind: GoChannelType
-      ID: 154
+      ID: 175
       Name: chan os.Signal
       GoRuntimeType: 613376
       GoKind: 18
@@ -3742,13 +3742,13 @@ Types:
       GoRuntimeType: 594752
       GoKind: 15
     - __kind: BaseType
-      ID: 305
+      ID: 317
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 849568
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 318
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 849664
@@ -3756,26 +3756,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *compress/flate.InternalError.str
+          Type: 320 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType compress/flate.InternalError.str
+      Data: 319 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 319
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 959
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 150
+      ID: 171
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 688800
@@ -3794,19 +3794,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 131
+      ID: 166
       Name: context.backgroundCtx
       GoRuntimeType: 1834528
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 132 StructureType context.emptyCtx
+          Type: 152 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 120
+      ID: 177
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 2009120
@@ -3817,23 +3817,23 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 133 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 136 StructureType sync/atomic.Value
+          Type: 178 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 138 GoMapType map[context.canceler]struct {}
+          Type: 179 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 136 StructureType sync/atomic.Value
+          Type: 178 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 16 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 199
+      ID: 242
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1132032
@@ -3846,13 +3846,13 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 619
+      ID: 631
       Name: context.deadlineExceededError
       GoRuntimeType: 1485152
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 132
+      ID: 152
       Name: context.emptyCtx
       GoRuntimeType: 1622464
       GoKind: 25
@@ -3861,7 +3861,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 154
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1861568
@@ -3872,11 +3872,11 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 143 GoSubroutineType func() bool
+          Type: 155 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 185
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1640224
@@ -3884,29 +3884,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 120 StructureType context.cancelCtx
+          Type: 177 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 144 PointerType *time.Timer
+          Type: 186 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 146 GoTimeType time.Time
+          Type: 188 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 149
+      ID: 168
       Name: context.todoCtx
       GoRuntimeType: 1834752
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 132 StructureType context.emptyCtx
+          Type: 152 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 126
+      ID: 161
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1872608
@@ -3917,14 +3917,14 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 137 GoEmptyInterfaceType interface {}
+          Type: 162 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 137 GoEmptyInterfaceType interface {}
+          Type: 162 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 164
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1834304
@@ -3936,51 +3936,51 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 301
+      ID: 313
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849184
       GoKind: 2
     - __kind: BaseType
-      ID: 302
+      ID: 314
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849280
       GoKind: 2
     - __kind: BaseType
-      ID: 303
+      ID: 315
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849376
       GoKind: 2
     - __kind: StructureType
-      ID: 598
+      ID: 610
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1309024
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 304
+      ID: 316
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 849472
       GoKind: 2
     - __kind: BaseType
-      ID: 275
+      ID: 287
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 846880
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 586
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 982
+      ID: 989
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2322656
@@ -4000,7 +4000,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 1005 BaseType crypto/tls.CurveID
+          Type: 1012 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4012,13 +4012,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 1006 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 1013 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 1008 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 1015 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 1010 GoSliceHeaderType [][]uint8
+          Type: 1017 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -4030,25 +4030,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 1012 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 1019 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 1013 BaseType crypto/tls.SignatureScheme
+          Type: 1020 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 1005
+      ID: 1012
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 846592
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 389
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 375
+      ID: 387
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1762080
@@ -4059,36 +4059,36 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 708 ArrayType [5]uint8
+          Type: 720 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 709 GoInterfaceType net.Conn
+          Type: 721 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 1013
+      ID: 1020
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 846688
       GoKind: 9
     - __kind: BaseType
-      ID: 541
+      ID: 553
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1008608
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 391
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 696
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 707
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 439
+      ID: 451
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1764192
@@ -4096,21 +4096,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 706 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 718 BaseType crypto/x509.InvalidReason
+          Type: 730 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 433
+      ID: 445
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1138816
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1625024
@@ -4118,24 +4118,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 706 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 300
+      ID: 312
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 848992
       GoKind: 2
     - __kind: BaseType
-      ID: 718
+      ID: 730
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 598144
       GoKind: 2
     - __kind: StructureType
-      ID: 590
+      ID: 602
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1585792
@@ -4145,13 +4145,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 441
+      ID: 453
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1139072
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 437
+      ID: 449
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1764000
@@ -4159,15 +4159,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 706 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 694 PointerType *crypto/x509.Certificate
+          Type: 706 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1456160
@@ -4177,7 +4177,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 505
+      ID: 517
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1456320
@@ -4187,47 +4187,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 503
+      ID: 515
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 276
+      ID: 288
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 846976
       GoKind: 6
     - __kind: BaseType
-      ID: 296
+      ID: 308
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 848704
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 399
+      ID: 411
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 598
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 391
+      ID: 403
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 397
+      ID: 409
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 395
+      ID: 407
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 393
+      ID: 405
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 401
+      ID: 413
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1445600
@@ -4237,15 +4237,15 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 496
+      ID: 508
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 494
+      ID: 506
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 322
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 851104
@@ -4253,18 +4253,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *encoding/xml.UnmarshalError.str
+          Type: 324 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 311 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 323 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 323
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 511
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4281,11 +4281,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 361
+      ID: 373
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 573
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4301,11 +4301,11 @@ Types:
       GoRuntimeType: 594944
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 557
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 547
+      ID: 559
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4315,13 +4315,13 @@ Types:
       GoRuntimeType: 484800
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 864
+      ID: 871
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 704864
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 143
+      ID: 155
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 605120
@@ -4333,23 +4333,23 @@ Types:
       GoRuntimeType: 866784
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 1012
+      ID: 1019
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1024448
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 422
+      ID: 434
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2098144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 404
+      ID: 416
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1763040
@@ -4357,7 +4357,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 710 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 722 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4365,25 +4365,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 406
+      ID: 418
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 727
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 410
+      ID: 422
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1137536
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 729
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 290
+      ID: 302
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 848032
@@ -4391,18 +4391,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 292 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 304 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 291 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 303 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 291
+      ID: 303
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 710
+      ID: 722
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2270528
@@ -4410,13 +4410,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 711 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 723 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4425,7 +4425,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 713 GoSliceHeaderType []float64
+          Type: 725 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4434,13 +4434,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 714 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 726 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 716 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 728 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4451,13 +4451,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 711
+      ID: 723
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 596672
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 299
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 847936
@@ -4465,18 +4465,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 301 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 288 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 300 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 300
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 293
+      ID: 305
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 848128
@@ -4484,22 +4484,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 295 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 307 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 294 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 294
+      ID: 306
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 451
+      ID: 463
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
-      ID: 801
+      ID: 808
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
       GoRuntimeType: 1862464
       GoKind: 25
@@ -4513,7 +4513,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 155 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -4534,13 +4534,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 163 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 130 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 168 GoMapType map[string]float64
+          Type: 135 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -4555,10 +4555,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 173 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 140 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 176 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 143 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -4570,7 +4570,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 179 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 146 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -4593,7 +4593,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 180
+      ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2269184
@@ -4604,13 +4604,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 181 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 148 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 114 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 156 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4619,16 +4619,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 183 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 150 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 155 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -4637,12 +4637,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 173 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 140 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 175
+      ID: 142
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1954848
@@ -4659,7 +4659,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4667,7 +4667,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 947
+      ID: 954
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 2009632
@@ -4675,29 +4675,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 938 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+          Type: 945 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 950 BaseType time.Duration
+          Type: 957 BaseType time.Duration
     - __kind: GoMapType
-      ID: 163
+      ID: 130
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1303776
       GoKind: 21
-      HeaderType: 165 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 743
+      ID: 268
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 593792
       GoKind: 10
     - __kind: StructureType
-      ID: 178
+      ID: 145
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1789120
@@ -4711,16 +4711,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 237 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 226 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 242 GoMapType map[string]interface {}
+          Type: 231 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 757
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 256
+      ID: 259
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1955104
@@ -4728,7 +4728,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 748 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 755 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4743,15 +4743,15 @@ Types:
           Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 749 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 756 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 748
+      ID: 755
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1006016
       GoKind: 5
     - __kind: StructureType
-      ID: 182
+      ID: 149
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2154976
@@ -4759,16 +4759,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 155 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 741 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 266 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -4783,12 +4783,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 743 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 268 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 114 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 183
+      ID: 150
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 918624
@@ -4797,15 +4797,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 672
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 783
+      ID: 790
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1444320
@@ -4818,7 +4818,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 752
+      ID: 759
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1624544
@@ -4831,11 +4831,11 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 819
       Name: github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1029
+    - __kind: GoContextImplementationType
+      ID: 159
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1663072
@@ -4844,38 +4844,40 @@ Types:
         - Name: Context
           Offset: 0
           Type: 118 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 821
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 905
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 453
+      ID: 465
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 460
+      ID: 472
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1140736
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 309
+      ID: 321
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 850432
       GoKind: 2
     - __kind: StructureType
-      ID: 458
+      ID: 470
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1140608
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 456
+      ID: 468
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1625824
@@ -4888,7 +4890,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 468
+      ID: 480
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1626464
@@ -4901,7 +4903,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 472
+      ID: 484
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1765728
@@ -4917,7 +4919,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 470
+      ID: 482
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1454720
@@ -4927,7 +4929,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 466
+      ID: 478
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1454400
@@ -4937,14 +4939,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 696
+      ID: 708
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1528192
       GoKind: 21
-      HeaderType: 698 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 710 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 719
+      ID: 731
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1074848
@@ -4959,15 +4961,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 738 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 750 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 738
+      ID: 750
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 480
+      ID: 492
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1626784
@@ -4975,12 +4977,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 708 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 696 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 708 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 474
+      ID: 486
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1454880
@@ -4990,7 +4992,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 478
+      ID: 490
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1765920
@@ -5001,12 +5003,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 731 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 731 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 476
+      ID: 488
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1626624
@@ -5019,7 +5021,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 482
+      ID: 494
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1455040
@@ -5027,9 +5029,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 146 GoTimeType time.Time
+          Type: 188 GoTimeType time.Time
     - __kind: StructureType
-      ID: 488
+      ID: 500
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1627104
@@ -5042,7 +5044,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 490
+      ID: 502
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1455360
@@ -5052,7 +5054,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 486
+      ID: 498
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1626944
@@ -5065,7 +5067,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 484
+      ID: 496
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1455200
@@ -5075,7 +5077,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 492
+      ID: 504
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1627264
@@ -5088,29 +5090,29 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 833
+      ID: 840
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 848416
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 412
+      ID: 424
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1446880
@@ -5120,11 +5122,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 414
+      ID: 426
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1447040
@@ -5132,17 +5134,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 412 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 802
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 806
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1863808
@@ -5150,12 +5152,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 794 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 801 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 804 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 811 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 418
+      ID: 430
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1447360
@@ -5163,9 +5165,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 412 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 797
+      ID: 804
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1839456
@@ -5173,13 +5175,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 794 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 801 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 416
+      ID: 428
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1447200
@@ -5187,9 +5189,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 412 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 420
+      ID: 432
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1447520
@@ -5197,9 +5199,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 412 StructureType github.com/cihub/seelog.baseError
+          Type: 424 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 932
+      ID: 939
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1140992
@@ -5212,7 +5214,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 914
+      ID: 921
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1679200
@@ -5220,48 +5222,48 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 932 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 939 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 942
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 700
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 616
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 614
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 618
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 620
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 608
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 425
+      ID: 437
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1448480
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 662
+      ID: 674
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 648
+      ID: 660
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1886496
@@ -5277,11 +5279,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 654
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 592
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1734400
@@ -5294,7 +5296,7 @@ Types:
           Offset: 1
           Type: 19 BaseType int8
     - __kind: StructureType
-      ID: 654
+      ID: 666
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1886944
@@ -5310,13 +5312,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 543
+      ID: 555
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1009280
       GoKind: 8
     - __kind: StructureType
-      ID: 646
+      ID: 658
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1886272
@@ -5332,13 +5334,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 722
+      ID: 734
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 847552
       GoKind: 8
     - __kind: StructureType
-      ID: 644
+      ID: 656
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1886048
@@ -5346,15 +5348,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 734 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 722 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 734 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 652
+      ID: 664
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1797376
@@ -5367,7 +5369,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 650
+      ID: 662
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1886720
@@ -5383,7 +5385,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 658
+      ID: 670
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1662112
@@ -5393,19 +5395,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 584
+      ID: 596
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1305184
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 582
+      ID: 594
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1305056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 656
+      ID: 668
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1797568
@@ -5418,7 +5420,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 317
+      ID: 329
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 853024
@@ -5426,22 +5428,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 319 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 331 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 318 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 318
+      ID: 330
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 715
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 612
+      ID: 624
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1470560
@@ -5451,19 +5453,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 320
+      ID: 332
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 853600
       GoKind: 10
     - __kind: BaseType
-      ID: 701
+      ID: 713
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1021472
       GoKind: 10
     - __kind: StructureType
-      ID: 670
+      ID: 682
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1919872
@@ -5474,12 +5476,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 701 BaseType golang.org/x/net/http2.ErrCode
+          Type: 713 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 527
+      ID: 539
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1633984
@@ -5487,12 +5489,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 701 BaseType golang.org/x/net/http2.ErrCode
+          Type: 713 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 324
+      ID: 336
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 853792
@@ -5500,18 +5502,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 326 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 338 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 325 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 325
+      ID: 337
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 330
+      ID: 342
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 853984
@@ -5519,18 +5521,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 332 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 344 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 331 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 331
+      ID: 343
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 327
+      ID: 339
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 853888
@@ -5538,18 +5540,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 329 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 341 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 328 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 328
+      ID: 340
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 321
+      ID: 333
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 853696
@@ -5557,18 +5559,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 323 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 335 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 322 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 322
+      ID: 334
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 531
+      ID: 543
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1471200
@@ -5578,13 +5580,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 333
+      ID: 345
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 854080
       GoKind: 2
     - __kind: StructureType
-      ID: 519
+      ID: 531
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1466240
@@ -5594,11 +5596,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 680
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 690
+      ID: 702
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1949024
@@ -5614,7 +5616,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 521
+      ID: 533
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1633504
@@ -5627,11 +5629,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 948
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 610
+      ID: 622
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1593312
@@ -5641,29 +5643,29 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 925
+      ID: 932
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 519
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 612
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 678
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 664
+      ID: 676
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1537792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 513
+      ID: 525
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1459520
@@ -5673,7 +5675,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 515
+      ID: 527
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1459680
@@ -5683,137 +5685,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 462
+      ID: 474
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 237
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 238 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 202 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 239 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 828
+      ID: 835
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 829 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 836 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 835 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 837 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 842 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 250
+      ID: 253
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 251 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 254 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 258 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 255 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 992
+      ID: 999
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 993 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 1000 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 994 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 1001 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 1001 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 1008 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 855
+      ID: 862
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 856 PointerType *noalg.map.group[string][]string
+          Type: 863 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 857 StructureType noalg.map.group[string][]string
-      GroupSliceType: 861 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 864 StructureType noalg.map.group[string][]string
+      GroupSliceType: 868 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 228
+      ID: 217
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 229 PointerType *noalg.map.group[string]float64
+          Type: 218 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 230 StructureType noalg.map.group[string]float64
-      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 219 StructureType noalg.map.group[string]float64
+      GroupSliceType: 223 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 727
+      ID: 739
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 728 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 740 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 733 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 741 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 745 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 220
+      ID: 209
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 221 PointerType *noalg.map.group[string]interface {}
+          Type: 210 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 222 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 226 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 211 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 215 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 212
+      ID: 201
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 213 PointerType *noalg.map.group[string]string
+          Type: 202 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 214 StructureType noalg.map.group[string]string
-      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 203 StructureType noalg.map.group[string]string
+      GroupSliceType: 207 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 546
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5847,7 +5849,7 @@ Types:
       GoRuntimeType: 594048
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 137
+      ID: 162
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 866496
@@ -5860,11 +5862,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 692
+      ID: 704
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 430
+      ID: 442
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5890,25 +5892,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 428
+      ID: 440
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 652
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 987
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 650
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1503232
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 363
+      ID: 375
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5989,7 +5991,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 309
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 848896
@@ -5997,18 +5999,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 311 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 310 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 310
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 588
+      ID: 600
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1584832
@@ -6016,9 +6018,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 691 PointerType *internal/abi.Type
+          Type: 703 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 135
+      ID: 122
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1517472
@@ -6031,7 +6033,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 933
+      ID: 940
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1052064
@@ -6044,11 +6046,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 840
+      ID: 847
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1134464
@@ -6061,7 +6063,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 923
+      ID: 930
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1051424
@@ -6074,11 +6076,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 896
+      ID: 903
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1578912
@@ -6086,9 +6088,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 923 GoInterfaceType io.Reader
+          Type: 930 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 912
+      ID: 919
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1648288
@@ -6096,13 +6098,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 923 GoInterfaceType io.Reader
+          Type: 930 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 648
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 140
+      ID: 181
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -6115,7 +6117,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 141 PointerType **table<context.canceler,struct {}>
+          Type: 182 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6134,10 +6136,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 201 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 196 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 244 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 239 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 806
+      ID: 813
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6150,7 +6152,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 807 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 814 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6169,10 +6171,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 834 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 830 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 841 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 837 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 239
+      ID: 228
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6185,7 +6187,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 240 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 229 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6204,10 +6206,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 257 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 252 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 260 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 255 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 988
+      ID: 995
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6220,7 +6222,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 989 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 996 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6239,10 +6241,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1000 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 994 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 1007 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 1001 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 847
+      ID: 854
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6255,7 +6257,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 848 PointerType **table<string,[]string>
+          Type: 855 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6274,10 +6276,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 860 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 857 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 867 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 864 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 137
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6290,7 +6292,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<string,float64>
+          Type: 138 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6309,10 +6311,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 233 GoSliceDataType []*table<string,float64>.array
-      GroupType: 230 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 222 GoSliceDataType []*table<string,float64>.array
+      GroupType: 219 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 698
+      ID: 710
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6325,7 +6327,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 699 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 711 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6344,10 +6346,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 732 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 729 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 744 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 741 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 165
+      ID: 132
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6360,7 +6362,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 166 PointerType **table<string,interface {}>
+          Type: 133 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6379,10 +6381,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 225 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 222 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 214 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 211 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 160
+      ID: 127
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6395,7 +6397,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 161 PointerType **table<string,string>
+          Type: 128 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6414,66 +6416,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 217 GoSliceDataType []*table<string,string>.array
-      GroupType: 214 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 206 GoSliceDataType []*table<string,string>.array
+      GroupType: 203 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 138
+      ID: 179
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1151488
       GoKind: 21
-      HeaderType: 140 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 181 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 804
+      ID: 811
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1168928
       GoKind: 21
-      HeaderType: 806 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 813 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 237
+      ID: 226
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1157632
       GoKind: 21
-      HeaderType: 239 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 228 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 986
+      ID: 993
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1156864
       GoKind: 21
-      HeaderType: 988 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 995 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 985
+      ID: 992
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1152512
       GoKind: 21
-      HeaderType: 847 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 854 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 168
+      ID: 135
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1157504
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 137 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 242
+      ID: 231
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1151104
       GoKind: 21
-      HeaderType: 165 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 158
+      ID: 125
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1153536
       GoKind: 21
-      HeaderType: 160 GoSwissMapHeaderType map<string,string>
+      HeaderType: 127 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 449
+      ID: 461
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1451360
@@ -6483,11 +6485,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1009
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 867
+      ID: 874
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1505952
@@ -6495,16 +6497,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 985 GoMapType map[string][]string
+          Type: 992 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 986 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 993 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 934
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 929
+      ID: 936
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1958944
@@ -6512,16 +6514,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 948 PointerType *io.SectionReader
+          Type: 955 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 933 GoInterfaceType io.Closer
+          Type: 940 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 634
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 709
+      ID: 721
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1622624
@@ -6534,35 +6536,35 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 687
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 956
+      ID: 963
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 685
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 636
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 971
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 975
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 969
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 615
+      ID: 627
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1132288
@@ -6570,28 +6572,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 617 PointerType *net.UnknownNetworkError.str
+          Type: 629 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 616 GoStringDataType net.UnknownNetworkError.str
+      Data: 628 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 616
+      ID: 628
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 549
+      ID: 561
       Name: net.canceledError
       GoRuntimeType: 1302752
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 954
+      ID: 961
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 721
+      ID: 733
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2153920
@@ -6599,7 +6601,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 709 GoInterfaceType net.Conn
+          Type: 721 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -6610,27 +6612,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 977
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 966
+      ID: 973
       Name: net.noReadFrom
       GoRuntimeType: 1132544
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 965
+      ID: 972
       Name: net.noWriteTo
       GoRuntimeType: 1132416
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 335
+      ID: 347
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1027
+    - __kind: GoContextImplementationType
+      ID: 157
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1783360
@@ -6642,8 +6644,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 118 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 337
+      ID: 349
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1757280
@@ -6651,7 +6655,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 704 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 716 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6659,7 +6663,7 @@ Types:
           Offset: 96
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 960
+      ID: 967
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2342720
@@ -6667,12 +6671,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 966 StructureType net.noReadFrom
+          Type: 973 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 963 PointerType *net.TCPConn
+          Type: 970 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 958
+      ID: 965
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2342176
@@ -6680,20 +6684,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 965 StructureType net.noWriteTo
+          Type: 972 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 963 PointerType *net.TCPConn
+          Type: 970 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 638
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 689
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 786
+      ID: 793
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1049376
@@ -6706,7 +6710,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 784
+      ID: 791
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1047840
@@ -6719,14 +6723,14 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 845
+      ID: 852
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2154272
       GoKind: 21
-      HeaderType: 847 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 854 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 787
+      ID: 794
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1047968
@@ -6739,15 +6743,15 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 343
+      ID: 355
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 563
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 785
+      ID: 792
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1048224
@@ -6771,7 +6775,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 862 PointerType *net/url.URL
+          Type: 869 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6783,19 +6787,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 840 GoInterfaceType io.ReadCloser
+          Type: 847 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 864 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 871 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6804,16 +6808,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 865 GoMapType net/url.Values
+          Type: 872 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 865 GoMapType net/url.Values
+          Type: 872 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 866 PointerType *mime/multipart.Form
+          Type: 873 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6822,13 +6826,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 868 PointerType *crypto/tls.ConnectionState
+          Type: 875 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 870 GoChannelType <-chan struct {}
+          Type: 877 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 871 PointerType *net/http.Response
+          Type: 878 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6837,15 +6841,15 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 873 PointerType *net/http.pattern
+          Type: 880 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 158 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
     - __kind: StructureType
-      ID: 872
+      ID: 879
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2267840
@@ -6868,16 +6872,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 840 GoInterfaceType io.ReadCloser
+          Type: 847 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6886,13 +6890,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 112 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 868 PointerType *crypto/tls.ConnectionState
+          Type: 875 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 111
       Name: net/http.ResponseWriter
@@ -6907,19 +6911,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 844
+      ID: 851
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1784896
@@ -6927,10 +6931,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 790 PointerType *net/http.response
+          Type: 797 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6938,31 +6942,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 846
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 885
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 899
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 259
+      ID: 271
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 844576
       GoKind: 10
     - __kind: BaseType
-      ID: 693
+      ID: 705
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1005824
       GoKind: 10
     - __kind: StructureType
-      ID: 346
+      ID: 358
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1759008
@@ -6973,12 +6977,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 705 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 679
+      ID: 691
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1938528
@@ -6989,16 +6993,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 705 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 352
+      ID: 364
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1623104
@@ -7006,12 +7010,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 693 BaseType net/http.http2ErrCode
+          Type: 705 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 263
+      ID: 275
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 844768
@@ -7019,28 +7023,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 265 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 277 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 264 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 276 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 264
+      ID: 276
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 350
+      ID: 362
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1133568
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 269
+      ID: 281
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 844960
@@ -7048,18 +7052,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 271 PointerType *net/http.http2headerFieldNameError.str
+          Type: 283 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 270 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 282 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 270
+      ID: 282
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 278
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 844864
@@ -7067,40 +7071,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *net/http.http2headerFieldValueError.str
+          Type: 280 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 267 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 279 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 279
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 642
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 882
+      ID: 889
       Name: net/http.http2missingBody
       GoRuntimeType: 1303008
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 894
+      ID: 901
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1303520
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 557
+      ID: 569
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1303392
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 260
+      ID: 272
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 844672
@@ -7108,22 +7112,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 262 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 274 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 261 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 273 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 261
+      ID: 273
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 789
+      ID: 796
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1210656
@@ -7131,13 +7135,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 836 PointerType *net/http.http2responseWriterState
+          Type: 843 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 844
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1576192
@@ -7145,19 +7149,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 921 PointerType *net/http.http2clientStream
+          Type: 928 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 887
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: net/http.noBody
       GoRuntimeType: 1488192
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 553
+      ID: 565
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1577472
@@ -7167,7 +7171,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 874
+      ID: 881
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1875072
@@ -7184,20 +7188,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1020 GoSliceHeaderType []net/http.segment
+          Type: 1027 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 883
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 356
+      ID: 368
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1438240
@@ -7207,7 +7211,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 791
+      ID: 798
       Name: net/http.response
       ByteSize: 232
       GoRuntimeType: 2405536
@@ -7215,16 +7219,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 838 PointerType *net/http.conn
+          Type: 845 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 112 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 840 GoInterfaceType io.ReadCloser
+          Type: 847 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 150 GoSubroutineType context.CancelFunc
+          Type: 171 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7236,19 +7240,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 133 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 841 StructureType sync/atomic.Bool
+          Type: 848 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 842 PointerType *bufio.Writer
+          Type: 849 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 844 StructureType net/http.chunkWriter
+          Type: 851 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 845 GoMapType net/http.Header
+          Type: 852 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7272,30 +7276,30 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 841 StructureType sync/atomic.Bool
+          Type: 848 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 850 ArrayType [29]uint8
+          Type: 857 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 851 ArrayType [10]uint8
+          Type: 858 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 852 ArrayType [3]uint8
+          Type: 859 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 133 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
-          Type: 853 GoChannelType chan bool
+          Type: 860 GoChannelType chan bool
         - Name: closeNotifyTriggered
           Offset: 224
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1022
+      ID: 1029
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1641952
@@ -7311,7 +7315,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 341
+      ID: 353
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1622944
@@ -7324,17 +7328,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 693
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 628
+      ID: 640
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1489792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 555
+      ID: 567
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1577632
@@ -7344,7 +7348,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 943
+      ID: 950
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2071392
@@ -7352,22 +7356,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 709 GoInterfaceType net.Conn
+          Type: 721 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 709 GoInterfaceType net.Conn
+          Type: 721 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 339
+      ID: 351
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1312224
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 371
+      ID: 383
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1761696
@@ -7383,7 +7387,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 369
+      ID: 381
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1624064
@@ -7396,11 +7400,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 398
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 295
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 847264
@@ -7408,22 +7412,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *net/textproto.ProtocolError.str
+          Type: 297 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 284 GoStringDataType net/textproto.ProtocolError.str
+      Data: 296 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 296
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 698
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 289
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 847072
@@ -7431,18 +7435,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *net/url.EscapeError.str
+          Type: 291 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 278 GoStringDataType net/url.EscapeError.str
+      Data: 290 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 290
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 292
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 847168
@@ -7450,18 +7454,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *net/url.InvalidHostError.str
+          Type: 294 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 281 GoStringDataType net/url.InvalidHostError.str
+      Data: 293 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 293
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 863
+      ID: 870
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2180864
@@ -7475,7 +7479,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 983 PointerType *net/url.Userinfo
+          Type: 990 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7501,99 +7505,99 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 984
+      ID: 991
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 865
+      ID: 872
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1927712
       GoKind: 21
-      HeaderType: 847 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 854 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 197
+      ID: 240
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 696384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 198 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 241 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 831
+      ID: 838
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 751552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 832 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 839 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 253
+      ID: 256
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 715104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 254 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 257 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 995
+      ID: 1002
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 710720
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 996 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 1003 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 858
+      ID: 865
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 859 StructureType noalg.struct { key string; elem []string }
+      Element: 866 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 231
+      ID: 220
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 715008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 232 StructureType noalg.struct { key string; elem float64 }
+      Element: 221 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 730
+      ID: 742
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 776448
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 731 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 743 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 223
+      ID: 212
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 692352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 224 StructureType noalg.struct { key string; elem interface {} }
+      Element: 213 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 215
+      ID: 204
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 216 StructureType noalg.struct { key string; elem string }
+      Element: 205 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 196
+      ID: 239
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1314528
@@ -7604,9 +7608,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 240 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 830
+      ID: 837
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1361248
@@ -7617,9 +7621,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 831 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 838 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 252
+      ID: 255
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1331296
@@ -7630,9 +7634,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 253 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 256 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 994
+      ID: 1001
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1325024
@@ -7643,9 +7647,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 995 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 1002 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1315936
@@ -7656,9 +7660,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 858 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 865 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 230
+      ID: 219
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1331040
@@ -7669,9 +7673,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 231 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 220 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 729
+      ID: 741
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1380192
@@ -7682,9 +7686,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 730 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 742 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 222
+      ID: 211
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1313376
@@ -7695,9 +7699,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 223 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 212 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 214
+      ID: 203
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1318368
@@ -7708,9 +7712,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 215 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 204 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 198
+      ID: 241
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1314400
@@ -7718,12 +7722,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 199 GoInterfaceType context.canceler
+          Type: 242 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 200 StructureType struct {}
+          Type: 243 StructureType struct {}
     - __kind: StructureType
-      ID: 832
+      ID: 839
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1361120
@@ -7731,12 +7735,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 833 BaseType github.com/cihub/seelog.LogLevel
+          Type: 840 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 254
+      ID: 257
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1331168
@@ -7747,9 +7751,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 255 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 258 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 996
+      ID: 1003
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1324896
@@ -7760,9 +7764,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 997 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 1004 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 859
+      ID: 866
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1315808
@@ -7773,9 +7777,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 712 GoSliceHeaderType []string
+          Type: 724 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 232
+      ID: 221
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1330912
@@ -7788,7 +7792,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 731
+      ID: 743
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1380064
@@ -7799,9 +7803,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 719 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 731 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 224
+      ID: 213
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1313248
@@ -7812,9 +7816,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 137 GoEmptyInterfaceType interface {}
+          Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 216
+      ID: 205
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1318240
@@ -7827,15 +7831,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 983
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 559
+      ID: 571
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 174
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1134208
@@ -7848,11 +7852,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 644
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 974
+      ID: 981
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2415680
@@ -7860,12 +7864,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 978 StructureType os.noReadFrom
+          Type: 985 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 975 PointerType *os.File
+          Type: 982 PointerType *os.File
     - __kind: StructureType
-      ID: 972
+      ID: 979
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2414880
@@ -7873,32 +7877,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 977 StructureType os.noWriteTo
+          Type: 984 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 975 PointerType *os.File
+          Type: 982 PointerType *os.File
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: os.noReadFrom
       GoRuntimeType: 1134080
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 977
+      ID: 984
       Name: os.noWriteTo
       GoRuntimeType: 1133952
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 592
+      ID: 604
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 737
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 594
+      ID: 606
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1734784
@@ -7911,7 +7915,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 170
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 2009376
@@ -7922,17 +7926,17 @@ Types:
           Type: 118 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 150 GoSubroutineType context.CancelFunc
+          Type: 171 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 151 GoSliceHeaderType []os.Signal
+          Type: 172 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 154 GoChannelType chan os.Signal
+          Type: 175 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 314
+      ID: 326
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 852256
@@ -7940,36 +7944,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 316 PointerType *os/user.UnknownGroupIdError.str
+          Type: 328 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 315 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 327 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 315
+      ID: 327
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 313
+      ID: 325
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 852160
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 365
+      ID: 377
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 464
+      ID: 476
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 579
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 583
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7981,7 +7985,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 569
+      ID: 581
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1927264
@@ -7998,9 +8002,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 723 BaseType runtime.boundsErrorCode
+          Type: 735 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 723
+      ID: 735
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 595136
@@ -8020,7 +8024,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 634
+      ID: 646
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1792384
@@ -8033,7 +8037,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 547
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1007072
@@ -8041,13 +8045,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *runtime.errorString.str
+          Type: 549 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 536 GoStringDataType runtime.errorString.str
+      Data: 548 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 548
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8674,7 +8678,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 190
+      ID: 197
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -8710,7 +8714,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 538
+      ID: 550
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1007168
@@ -8718,13 +8722,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 540 PointerType *runtime.plainError.str
+          Type: 552 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 539 GoStringDataType runtime.plainError.str
+      Data: 551 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 539
+      ID: 551
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8765,7 +8769,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 367
+      ID: 379
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1623744
@@ -8823,7 +8827,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 575
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8835,18 +8839,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 185 PointerType *string.str
+          Type: 192 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 184 GoStringDataType string.str
+      Data: 191 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 184
+      ID: 191
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 758
+      ID: 765
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1990688
@@ -8854,12 +8858,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 772
+      ID: 779
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2066816
@@ -8867,15 +8871,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 754
+      ID: 761
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1990176
@@ -8883,12 +8887,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 764
+      ID: 771
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2065664
@@ -8896,15 +8900,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2136544
@@ -8912,18 +8916,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 766
+      ID: 773
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2065952
@@ -8931,15 +8935,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 762
+      ID: 769
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2065376
@@ -8947,15 +8951,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 774
+      ID: 781
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2135904
@@ -8963,18 +8967,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2198528
@@ -8982,21 +8986,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 776
+      ID: 783
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2136224
@@ -9004,18 +9008,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 784 GoInterfaceType net/http.Flusher
+          Type: 791 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 760
+      ID: 767
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1990944
@@ -9023,12 +9027,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 756
+      ID: 763
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1990432
@@ -9036,12 +9040,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 768
+      ID: 775
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2066240
@@ -9049,15 +9053,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2136864
@@ -9065,18 +9069,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 786 GoInterfaceType net/http.CloseNotifier
+          Type: 793 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 770
+      ID: 777
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2066528
@@ -9084,15 +9088,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 783 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 790 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Pusher
+          Type: 792 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 787 GoInterfaceType net/http.Hijacker
+          Type: 794 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1739968
@@ -9100,18 +9104,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 923 GoInterfaceType io.Reader
+          Type: 930 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 933 GoInterfaceType io.Closer
+          Type: 940 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 200
+      ID: 243
       Name: struct {}
       GoRuntimeType: 857920
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 133
+      ID: 120
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1493632
@@ -9119,12 +9123,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 134 StructureType sync.noCopy
+          Type: 121 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 135 StructureType internal/sync.Mutex
+          Type: 122 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 155
+      ID: 119
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1880896
@@ -9132,7 +9136,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 133 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -9141,18 +9145,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 156 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 156 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 134
+      ID: 121
       Name: sync.noCopy
       GoRuntimeType: 1006688
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1494752
@@ -9160,12 +9164,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 157 StructureType sync/atomic.noCopy
+          Type: 124 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 156
+      ID: 123
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1494912
@@ -9173,12 +9177,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 157 StructureType sync/atomic.noCopy
+          Type: 124 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 136
+      ID: 178
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1218592
@@ -9186,27 +9190,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 137 GoEmptyInterfaceType interface {}
+          Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 157
+      ID: 124
       Name: sync/atomic.noCopy
       GoRuntimeType: 1006784
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 671
+      ID: 683
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1304288
       GoKind: 12
     - __kind: BaseType
-      ID: 746
+      ID: 753
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 1008128
       GoKind: 2
     - __kind: StructureType
-      ID: 193
+      ID: 236
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9228,9 +9232,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 237 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 827
+      ID: 834
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9252,9 +9256,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 828 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 835 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 249
+      ID: 252
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9276,9 +9280,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 250 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 253 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 991
+      ID: 998
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9300,9 +9304,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 992 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 999 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9324,9 +9328,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 855 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 862 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 227
+      ID: 216
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9348,9 +9352,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 228 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 217 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 726
+      ID: 738
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9372,9 +9376,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 727 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 739 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 219
+      ID: 208
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9396,9 +9400,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 220 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 209 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 211
+      ID: 200
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9420,9 +9424,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 212 GoSwissMapGroupsType groupReference<string,string>
+          Type: 201 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 614
+      ID: 626
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1739008
@@ -9435,13 +9439,13 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 950
+      ID: 957
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1954592
       GoKind: 6
     - __kind: StructureType
-      ID: 148
+      ID: 190
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2013984
@@ -9452,10 +9456,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 203 GoSliceHeaderType []time.zone
+          Type: 246 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 206 GoSliceHeaderType []time.zoneTrans
+          Type: 249 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9467,13 +9471,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 204 PointerType *time.zone
+          Type: 247 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 359
+      ID: 371
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 146
+      ID: 188
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2428992
@@ -9487,7 +9491,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 147 PointerType *time.Location
+          Type: 189 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9497,7 +9501,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 145
+      ID: 187
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1490752
@@ -9505,12 +9509,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 740 GoChannelType <-chan time.Time
+          Type: 752 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 272
+      ID: 284
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 845056
@@ -9518,18 +9522,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 274 PointerType *time.fileSizeError.str
+          Type: 286 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 273 GoStringDataType time.fileSizeError.str
+      Data: 285 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 273
+      ID: 285
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 205
+      ID: 248
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1646944
@@ -9545,7 +9549,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 208
+      ID: 251
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1788928
@@ -9606,7 +9610,7 @@ Types:
       GoRuntimeType: 595072
       GoKind: 26
     - __kind: StructureType
-      ID: 704
+      ID: 716
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2103264
@@ -9617,10 +9621,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 717 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 706 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 718 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9635,18 +9639,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 719 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 707
+      ID: 719
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1008224
       GoKind: 9
     - __kind: StructureType
-      ID: 705
+      ID: 717
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1958176
@@ -9671,17 +9675,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 373
+      ID: 385
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 706
+      ID: 718
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 595968
       GoKind: 8
     - __kind: StructureType
-      ID: 388
+      ID: 400
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1443680
@@ -9691,13 +9695,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 286
+      ID: 298
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 847360
       GoKind: 2
     - __kind: StructureType
-      ID: 576
+      ID: 588
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1734208
@@ -9710,7 +9714,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 542
+      ID: 554
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1009088

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.26rc1.yaml
@@ -121,23 +121,23 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 704 PointerType *crypto/x509.Certificate
+      Pointee: 716 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 752
+      ID: 277
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
       Pointee: 120 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1009 PointerType *mime/multipart.FileHeader
+      Pointee: 1016 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
       ID: 69
       Name: '**runtime.p'
@@ -145,111 +145,111 @@ Types:
       GoKind: 22
       Pointee: 70 PointerType *runtime.p
     - __kind: PointerType
-      ID: 147
+      ID: 188
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 148 PointerType *table<context.canceler,struct {}>
+      Pointee: 189 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 818 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 825 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 250
+      ID: 239
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 251 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 240 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 999
+      ID: 1006
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 1000 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 1007 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 859 PointerType *table<string,[]string>
+      Pointee: 866 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 144
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 182 PointerType *table<string,float64>
+      Pointee: 145 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 709
+      ID: 721
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 710 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 722 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 176
+      ID: 139
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<string,interface {}>
+      Pointee: 140 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 171
+      ID: 134
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 172 PointerType *table<string,string>
+      Pointee: 135 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1016 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 1023 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 1025
+      ID: 1032
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 1024 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1031 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 755
+      ID: 280
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 754 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 279 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 1014
+      ID: 1021
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 1013 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 1020 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 202
+      ID: 209
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []*runtime.p.array
-    - __kind: PointerType
-      ID: 1027
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 1026 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 1029
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 1028 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 747
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 746 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 246
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
-      ByteSize: 8
-      Pointee: 245 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
-    - __kind: PointerType
-      ID: 254
-      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 253 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 208 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 1034
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1033 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1036
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1035 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 759
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 758 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 235
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 234 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 243
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1041
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1033 GoSliceDataType []net/http.segment.array
+      Pointee: 1040 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 220
+      ID: 245
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []os.Signal.array
+      Pointee: 244 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -258,77 +258,77 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 745
+      ID: 757
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 744 GoSliceDataType []string.array
+      Pointee: 756 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 256
+      ID: 273
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 255 GoSliceDataType []time.zone.array
+      Pointee: 272 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 258
+      ID: 275
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []time.zoneTrans.array
+      Pointee: 274 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 492160
       GoKind: 22
       Pointee: 41 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 197
+      ID: 204
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []uint8.array
+      Pointee: 203 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 199
+      ID: 206
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []uintptr.array
+      Pointee: 205 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 959488
       GoKind: 22
-      Pointee: 519 GoSliceHeaderType archive/tar.headerError
+      Pointee: 531 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 520 GoSliceDataType archive/tar.headerError.array
+      Pointee: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1259808
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 929 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1091616
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 915 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1470400
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 933 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1091360
       GoKind: 22
-      Pointee: 906 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 913 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 12
       Name: '*bool'
@@ -337,12 +337,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 2016320
       GoKind: 22
-      Pointee: 853 UnresolvedPointeeType bufio.Writer
+      Pointee: 860 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 122
       Name: '*bytes.Buffer'
@@ -358,353 +358,353 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 402
+      ID: 414
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 934720
       GoKind: 22
-      Pointee: 300 BaseType compress/flate.CorruptInputError
+      Pointee: 312 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 934816
       GoKind: 22
-      Pointee: 301 GoStringHeaderType compress/flate.InternalError
+      Pointee: 313 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 303
+      ID: 315
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 302 GoStringDataType compress/flate.InternalError.str
+      Pointee: 314 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 2040512
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 969 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1676160
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 948 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 125
+      ID: 197
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 1773824
       GoKind: 22
-      Pointee: 126 StructureType context.afterFuncCtx
+      Pointee: 198 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 1040
+      ID: 171
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1588160
       GoKind: 22
-      Pointee: 152 StructureType context.backgroundCtx
+      Pointee: 172 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 127
+      ID: 182
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1773248
       GoKind: 22
-      Pointee: 128 StructureType context.cancelCtx
+      Pointee: 183 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1215136
       GoKind: 22
-      Pointee: 629 StructureType context.deadlineExceededError
+      Pointee: 641 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1035
+      ID: 157
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1444640
       GoKind: 22
-      Pointee: 153 StructureType context.emptyCtx
+      Pointee: 158 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 129
+      ID: 159
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1444800
       GoKind: 22
-      Pointee: 130 StructureType context.stopCtx
+      Pointee: 160 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 131
+      ID: 190
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1773440
       GoKind: 22
-      Pointee: 132 StructureType context.timerCtx
+      Pointee: 191 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1041
+      ID: 173
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1588320
       GoKind: 22
-      Pointee: 160 StructureType context.todoCtx
+      Pointee: 174 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 133
+      ID: 166
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1587840
       GoKind: 22
-      Pointee: 134 StructureType context.valueCtx
+      Pointee: 167 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 135
+      ID: 169
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1588000
       GoKind: 22
-      Pointee: 136 StructureType context.withoutCancelCtx
+      Pointee: 170 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 944512
       GoKind: 22
-      Pointee: 319 BaseType crypto/aes.KeySizeError
+      Pointee: 331 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 944704
       GoKind: 22
-      Pointee: 320 BaseType crypto/des.KeySizeError
+      Pointee: 332 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 461
+      ID: 473
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 944992
       GoKind: 22
-      Pointee: 321 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 333 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 607
+      ID: 619
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1088288
       GoKind: 22
-      Pointee: 608 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 620 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 945280
       GoKind: 22
-      Pointee: 322 BaseType crypto/rc4.KeySizeError
+      Pointee: 334 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 932800
       GoKind: 22
-      Pointee: 289 BaseType crypto/tls.AlertError
+      Pointee: 301 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 583
+      ID: 595
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1069344
       GoKind: 22
-      Pointee: 584 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 596 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2457984
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 999 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 932416
       GoKind: 22
-      Pointee: 879 StructureType crypto/tls.ConnectionState
+      Pointee: 886 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 932896
       GoKind: 22
-      Pointee: 393 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 405 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 389
+      ID: 401
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 932704
       GoKind: 22
-      Pointee: 390 StructureType crypto/tls.RecordHeaderError
+      Pointee: 402 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1067680
       GoKind: 22
-      Pointee: 551 BaseType crypto/tls.alert
+      Pointee: 563 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 932992
       GoKind: 22
-      Pointee: 395 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 407 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 693
+      ID: 705
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1452640
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 706 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 704
+      ID: 716
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2078368
       GoKind: 22
-      Pointee: 705 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 717 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 944128
       GoKind: 22
-      Pointee: 456 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 468 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 449
+      ID: 461
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 943168
       GoKind: 22
-      Pointee: 450 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 462 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 451
+      ID: 463
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 943648
       GoKind: 22
-      Pointee: 452 StructureType crypto/x509.HostnameError
+      Pointee: 464 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 943072
       GoKind: 22
-      Pointee: 318 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 330 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 599
+      ID: 611
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1079328
       GoKind: 22
-      Pointee: 600 StructureType crypto/x509.SystemRootsError
+      Pointee: 612 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 944224
       GoKind: 22
-      Pointee: 458 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 470 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 944032
       GoKind: 22
-      Pointee: 454 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 466 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 954880
       GoKind: 22
-      Pointee: 511 StructureType encoding/asn1.StructuralError
+      Pointee: 523 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 514
+      ID: 526
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 955072
       GoKind: 22
-      Pointee: 515 StructureType encoding/asn1.SyntaxError
+      Pointee: 527 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 954976
       GoKind: 22
-      Pointee: 513 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 525 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 933184
       GoKind: 22
-      Pointee: 290 BaseType encoding/base64.CorruptInputError
+      Pointee: 302 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 941824
       GoKind: 22
-      Pointee: 314 BaseType encoding/hex.InvalidByteError
+      Pointee: 326 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 415
+      ID: 427
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 937024
       GoKind: 22
-      Pointee: 416 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 428 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 595
+      ID: 607
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1074464
       GoKind: 22
-      Pointee: 596 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 608 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 936640
       GoKind: 22
-      Pointee: 408 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 420 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 413
+      ID: 425
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 936928
       GoKind: 22
-      Pointee: 414 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 426 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 936832
       GoKind: 22
-      Pointee: 412 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 424 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 409
+      ID: 421
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 936736
       GoKind: 22
-      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 422 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 417
+      ID: 429
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 418 StructureType encoding/json.jsonError
+      Pointee: 430 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 952288
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 521 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -713,19 +713,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 927712
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType errors.errorString
+      Pointee: 387 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 570
+      ID: 582
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1060512
       GoKind: 22
-      Pointee: 571 UnresolvedPointeeType errors.joinError
+      Pointee: 583 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -741,118 +741,118 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 554
+      ID: 566
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1049888
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType fmt.wrapError
+      Pointee: 567 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 556
+      ID: 568
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1050016
       GoKind: 22
-      Pointee: 557 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 569 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 941344
       GoKind: 22
-      Pointee: 439 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 451 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2079520
       GoKind: 22
-      Pointee: 820 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 827 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 938656
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 433 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 938752
       GoKind: 22
-      Pointee: 423 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 435 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 724
+      ID: 736
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 938464
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 737 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 939040
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 439 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 726
+      ID: 738
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 938560
       GoKind: 22
-      Pointee: 727 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 739 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 938848
       GoKind: 22
-      Pointee: 308 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 320 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 310
+      ID: 322
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 309 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 321 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 419
+      ID: 431
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 938368
       GoKind: 22
-      Pointee: 305 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 317 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 307
+      ID: 319
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 318 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 938944
       GoKind: 22
-      Pointee: 311 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 323 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 313
+      ID: 325
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 312 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 324 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 465
+      ID: 477
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 946336
       GoKind: 22
-      Pointee: 466 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 478 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer'
       ByteSize: 8
       GoRuntimeType: 1777856
       GoKind: 22
-      Pointee: 811 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
+      Pointee: 818 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
     - __kind: PointerType
       ID: 120
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -861,728 +861,728 @@ Types:
       GoKind: 22
       Pointee: 121 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 189
+      ID: 152
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2075200
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 153 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 184
+      ID: 147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1221920
       GoKind: 22
-      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1958272
       GoKind: 22
-      Pointee: 957 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 964 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1855392
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+      Pointee: 956 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 187
+      ID: 150
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1222048
       GoKind: 22
-      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1222688
       GoKind: 22
-      Pointee: 760 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 767 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 265
+      ID: 268
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1222816
       GoKind: 22
-      Pointee: 266 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 269 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 191
+      ID: 154
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2299776
       GoKind: 22
-      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 155 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer'
       ByteSize: 8
       GoRuntimeType: 2285440
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
+      Pointee: 833 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1244960
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 682 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1596800
       GoKind: 22
-      Pointee: 762 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 769 StructureType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2249280
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
+      Pointee: 829 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1038
+      ID: 164
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1456000
       GoKind: 22
-      Pointee: 1039 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 165 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2249696
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
+      Pointee: 831 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1082400
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
+      Pointee: 911 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 948544
       GoKind: 22
-      Pointee: 468 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 480 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 949600
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 487 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 949312
       GoKind: 22
-      Pointee: 323 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 335 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 472
+      ID: 484
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 949504
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 485 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 470
+      ID: 482
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 949408
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 483 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 482
+      ID: 494
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 950944
       GoKind: 22
-      Pointee: 483 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 495 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 486
+      ID: 498
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 951136
       GoKind: 22
-      Pointee: 487 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 499 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 951040
       GoKind: 22
-      Pointee: 485 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 497 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 950848
       GoKind: 22
-      Pointee: 481 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 493 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 749
+      ID: 761
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 748 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 760 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 494
+      ID: 506
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 951520
       GoKind: 22
-      Pointee: 495 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 507 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 951232
       GoKind: 22
-      Pointee: 489 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 501 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 492
+      ID: 504
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 951424
       GoKind: 22
-      Pointee: 493 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 505 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 490
+      ID: 502
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 951328
       GoKind: 22
-      Pointee: 491 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 503 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 951616
       GoKind: 22
-      Pointee: 497 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 509 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 951904
       GoKind: 22
-      Pointee: 503 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 515 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 952000
       GoKind: 22
-      Pointee: 505 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 517 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 951808
       GoKind: 22
-      Pointee: 501 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 513 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 951712
       GoKind: 22
-      Pointee: 499 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 511 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 952192
       GoKind: 22
-      Pointee: 507 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 519 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2399488
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 843 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2383296
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 837 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2391808
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 839 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2392448
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 841 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 940192
       GoKind: 22
-      Pointee: 429 StructureType github.com/cihub/seelog.baseError
+      Pointee: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1857856
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 820 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 940288
       GoKind: 22
-      Pointee: 431 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 443 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1459200
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 810 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1685184
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 812 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1685952
       GoKind: 22
-      Pointee: 809 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 816 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 940480
       GoKind: 22
-      Pointee: 435 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 447 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1685376
       GoKind: 22
-      Pointee: 807 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 814 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2360992
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 835 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 940384
       GoKind: 22
-      Pointee: 433 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 445 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 940576
       GoKind: 22
-      Pointee: 437 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 449 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1254176
       GoKind: 22
-      Pointee: 920 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 927 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1784192
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 952 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 697
+      ID: 709
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1471680
       GoKind: 22
-      Pointee: 698 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 710 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 613
+      ID: 625
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1096608
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 626 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 611
+      ID: 623
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1096480
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 624 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 615
+      ID: 627
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1100960
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 628 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 617
+      ID: 629
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1101088
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 630 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 605
+      ID: 617
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1085472
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 618 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 942016
       GoKind: 22
-      Pointee: 442 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 454 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 671
+      ID: 683
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1253664
       GoKind: 22
-      Pointee: 672 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 684 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 657
+      ID: 669
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1237024
       GoKind: 22
-      Pointee: 658 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 670 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 651
+      ID: 663
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1236640
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 664 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 589
+      ID: 601
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1072288
       GoKind: 22
-      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 602 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 663
+      ID: 675
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1237408
       GoKind: 22
-      Pointee: 664 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 676 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1072160
       GoKind: 22
-      Pointee: 553 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 565 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 655
+      ID: 667
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1236896
       GoKind: 22
-      Pointee: 656 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 653
+      ID: 665
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1236768
       GoKind: 22
-      Pointee: 654 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1237280
       GoKind: 22
-      Pointee: 662 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 674 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1237152
       GoKind: 22
-      Pointee: 660 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 672 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1237792
       GoKind: 22
-      Pointee: 668 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 680 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 593
+      ID: 605
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1072544
       GoKind: 22
-      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 606 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 591
+      ID: 603
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1072416
       GoKind: 22
-      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 604 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1237664
       GoKind: 22
-      Pointee: 666 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 678 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 970912
       GoKind: 22
-      Pointee: 328 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 340 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 330
+      ID: 342
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 341 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 712
+      ID: 724
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1714752
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 725 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1115808
       GoKind: 22
-      Pointee: 622 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 634 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 972160
       GoKind: 22
-      Pointee: 331 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 343 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 679
+      ID: 691
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1292320
       GoKind: 22
-      Pointee: 680 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 692 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 536
+      ID: 548
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 972448
       GoKind: 22
-      Pointee: 537 StructureType golang.org/x/net/http2.connError
+      Pointee: 549 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 535
+      ID: 547
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 972352
       GoKind: 22
-      Pointee: 335 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 347 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 336 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 348 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 972640
       GoKind: 22
-      Pointee: 341 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 353 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 343
+      ID: 355
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 342 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 354 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 538
+      ID: 550
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 972544
       GoKind: 22
-      Pointee: 338 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 350 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 339 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 351 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 534
+      ID: 546
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 972256
       GoKind: 22
-      Pointee: 332 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 344 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 334
+      ID: 346
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 333 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 345 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 540
+      ID: 552
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 972736
       GoKind: 22
-      Pointee: 541 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 553 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 542
+      ID: 554
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 972832
       GoKind: 22
-      Pointee: 344 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 356 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 966592
       GoKind: 22
-      Pointee: 529 StructureType google.golang.org/grpc.dropError
+      Pointee: 541 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 677
+      ID: 689
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1289376
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 690 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 699
+      ID: 711
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1479200
       GoKind: 22
-      Pointee: 700 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 712 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 530
+      ID: 542
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 969184
       GoKind: 22
-      Pointee: 531 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 543 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1865472
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 958 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 619
+      ID: 631
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1110048
       GoKind: 22
-      Pointee: 620 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 632 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1608960
       GoKind: 22
-      Pointee: 935 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 942 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 958144
       GoKind: 22
-      Pointee: 517 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 529 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 609
+      ID: 621
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1090208
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 622 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 675
+      ID: 687
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1258400
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 688 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 673
+      ID: 685
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1258144
       GoKind: 22
-      Pointee: 674 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 686 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 522
+      ID: 534
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 960448
       GoKind: 22
-      Pointee: 523 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 535 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 960544
       GoKind: 22
-      Pointee: 525 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 537 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 949696
       GoKind: 22
-      Pointee: 477 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 489 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 543
+      ID: 555
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 973600
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType html/template.Error
+      Pointee: 556 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 107
       Name: '*int'
@@ -1619,54 +1619,54 @@ Types:
       GoKind: 22
       Pointee: 21 BaseType int8
     - __kind: PointerType
-      ID: 701
+      ID: 713
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2272544
       GoKind: 22
-      Pointee: 702 UnresolvedPointeeType internal/abi.Type
+      Pointee: 714 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 942688
       GoKind: 22
-      Pointee: 447 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 459 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 942592
       GoKind: 22
-      Pointee: 445 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 457 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 649
+      ID: 661
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1231264
       GoKind: 22
-      Pointee: 650 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 662 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2452672
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType internal/poll.FD
+      Pointee: 997 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 647
+      ID: 659
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1231136
       GoKind: 22
-      Pointee: 648 StructureType internal/poll.errNetClosing
+      Pointee: 660 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 928096
       GoKind: 22
-      Pointee: 377 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 389 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -1675,305 +1675,305 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 443
+      ID: 455
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 942496
       GoKind: 22
-      Pointee: 315 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 327 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 317
+      ID: 329
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 316 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 328 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 597
+      ID: 609
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1078176
       GoKind: 22
-      Pointee: 598 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 610 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 386
+      ID: 398
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 931744
       GoKind: 22
-      Pointee: 288 BaseType internal/strconv.Error
+      Pointee: 300 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1899296
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType io.PipeReader
+      Pointee: 962 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1593280
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType io.SectionReader
+      Pointee: 966 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1061024
       GoKind: 22
-      Pointee: 902 StructureType io.nopCloser
+      Pointee: 909 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1225504
       GoKind: 22
-      Pointee: 918 StructureType io.nopCloserWriterTo
+      Pointee: 925 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 645
+      ID: 657
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1230112
       GoKind: 22
-      Pointee: 646 UnresolvedPointeeType io/fs.PathError
+      Pointee: 658 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 145
+      ID: 186
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 146 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 187 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 816 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 823 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 248
+      ID: 237
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 249 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 238 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 998 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 1005 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 857 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 864 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 179
+      ID: 142
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 180 GoSwissMapHeaderType map<string,float64>
+      Pointee: 143 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 707
+      ID: 719
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 708 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 720 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 174
+      ID: 137
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 169
+      ID: 132
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 170 GoSwissMapHeaderType map<string,string>
+      Pointee: 133 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 463
+      ID: 475
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 945952
       GoKind: 22
-      Pointee: 464 StructureType math/big.ErrNaN
+      Pointee: 476 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 933952
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 1019 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 934048
       GoKind: 22
-      Pointee: 877 StructureType mime/multipart.Form
+      Pointee: 884 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1675008
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 944 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1675200
       GoKind: 22
-      Pointee: 939 StructureType mime/multipart.sectionReadCloser
+      Pointee: 946 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 631
+      ID: 643
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1216288
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType net.AddrError
+      Pointee: 644 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 684
+      ID: 696
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1445440
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType net.DNSError
+      Pointee: 697 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2304704
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType net.IPConn
+      Pointee: 973 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 682
+      ID: 694
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1445120
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType net.OpError
+      Pointee: 695 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 633
+      ID: 645
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1216416
       GoKind: 22
-      Pointee: 634 UnresolvedPointeeType net.ParseError
+      Pointee: 646 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2335936
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType net.TCPConn
+      Pointee: 981 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2381472
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType net.UDPConn
+      Pointee: 985 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2335424
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType net.UnixConn
+      Pointee: 979 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1215520
       GoKind: 22
-      Pointee: 625 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 637 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 626 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 638 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 558
+      ID: 570
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1050912
       GoKind: 22
-      Pointee: 559 StructureType net.canceledError
+      Pointee: 571 StructureType net.canceledError
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2073184
       GoKind: 22
-      Pointee: 964 UnresolvedPointeeType net.conn
+      Pointee: 971 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 730
+      ID: 742
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1892800
       GoKind: 22
-      Pointee: 731 StructureType net.dialResult·1
+      Pointee: 743 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2385728
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType net.netFD
+      Pointee: 987 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 920512
       GoKind: 22
-      Pointee: 346 UnresolvedPointeeType net.notFoundError
+      Pointee: 358 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1036
+      ID: 162
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1445280
       GoKind: 22
-      Pointee: 1037 StructureType net.onlyValuesCtx
+      Pointee: 163 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 348 StructureType net.result·2
+      Pointee: 360 StructureType net.result·2
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2320512
       GoKind: 22
-      Pointee: 970 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 977 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2320032
       GoKind: 22
-      Pointee: 968 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 975 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 635
+      ID: 647
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1217056
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType net.temporaryError
+      Pointee: 648 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 686
+      ID: 698
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1445760
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType net.timeoutError
+      Pointee: 699 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 353
+      ID: 365
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 366 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1054624
       GoKind: 22
-      Pointee: 561 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 573 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 118
       Name: '*net/http.Request'
@@ -1982,571 +1982,571 @@ Types:
       GoKind: 22
       Pointee: 119 StructureType net/http.Request
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1774976
       GoKind: 22
-      Pointee: 882 StructureType net/http.Response
+      Pointee: 889 StructureType net/http.Response
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1854496
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType net/http.body
+      Pointee: 954 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1219360
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 921 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1054496
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 903 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1956480
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType net/http.conn
+      Pointee: 856 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1053216
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 895 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1591840
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 939 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 923968
       GoKind: 22
-      Pointee: 269 BaseType net/http.http2ConnectionError
+      Pointee: 281 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 924064
       GoKind: 22
-      Pointee: 357 StructureType net/http.http2GoAwayError
+      Pointee: 369 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 688
+      ID: 700
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1446560
       GoKind: 22
-      Pointee: 689 StructureType net/http.http2StreamError
+      Pointee: 701 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2074912
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 935 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 362
+      ID: 374
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 363 StructureType net/http.http2connError
+      Pointee: 375 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 359
+      ID: 371
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 924544
       GoKind: 22
-      Pointee: 273 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 285 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 275
+      ID: 287
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 286 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 924640
       GoKind: 22
-      Pointee: 361 StructureType net/http.http2goAwayFlowError
+      Pointee: 373 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1590240
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 937 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 925312
       GoKind: 22
-      Pointee: 279 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 291 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 281
+      ID: 293
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 280 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 292 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 364
+      ID: 376
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 925216
       GoKind: 22
-      Pointee: 276 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 288 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 278
+      ID: 290
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 289 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 639
+      ID: 651
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1220640
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 652 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1054112
       GoKind: 22
-      Pointee: 892 StructureType net/http.http2missingBody
+      Pointee: 899 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1056928
       GoKind: 22
-      Pointee: 900 StructureType net/http.http2noBodyReader
+      Pointee: 907 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 566
+      ID: 578
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1056800
       GoKind: 22
-      Pointee: 567 StructureType net/http.http2noCachedConnError
+      Pointee: 579 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 270 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 282 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 272
+      ID: 284
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 283 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1055136
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 905 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2074336
       GoKind: 22
-      Pointee: 799 StructureType net/http.http2responseWriter
+      Pointee: 806 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1660032
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 854 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1054240
       GoKind: 22
-      Pointee: 894 StructureType net/http.http2transportResponseBody
+      Pointee: 901 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1053472
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 897 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1219488
       GoKind: 22
-      Pointee: 916 StructureType net/http.noBody
+      Pointee: 923 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1056544
       GoKind: 22
-      Pointee: 563 StructureType net/http.nothingWrittenError
+      Pointee: 575 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1658304
       GoKind: 22
-      Pointee: 884 StructureType net/http.pattern
+      Pointee: 891 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1052832
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 893 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1446880
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 931 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 925504
       GoKind: 22
-      Pointee: 367 StructureType net/http.requestBodyReadError
+      Pointee: 379 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2299328
       GoKind: 22
-      Pointee: 801 StructureType net/http.response
+      Pointee: 808 StructureType net/http.response
     - __kind: PointerType
-      ID: 1031
+      ID: 1038
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 401344
       GoKind: 22
-      Pointee: 1032 StructureType net/http.segment
+      Pointee: 1039 StructureType net/http.segment
     - __kind: PointerType
-      ID: 351
+      ID: 363
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 923680
       GoKind: 22
-      Pointee: 352 StructureType net/http.statusError
+      Pointee: 364 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 690
+      ID: 702
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1448000
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 703 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 637
+      ID: 649
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1220512
       GoKind: 22
-      Pointee: 638 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 650 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1056672
       GoKind: 22
-      Pointee: 565 StructureType net/http.transportReadFromServerError
+      Pointee: 577 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1894144
       GoKind: 22
-      Pointee: 953 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 960 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 350 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 362 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1116448
       GoKind: 22
-      Pointee: 910 StructureType net/http/httputil.failureToReadBody
+      Pointee: 917 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 930976
       GoKind: 22
-      Pointee: 385 StructureType net/netip.parseAddrError
+      Pointee: 397 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 382
+      ID: 394
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 930880
       GoKind: 22
-      Pointee: 383 StructureType net/netip.parsePrefixError
+      Pointee: 395 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 934432
       GoKind: 22
-      Pointee: 401 UnresolvedPointeeType net/textproto.Error
+      Pointee: 413 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 934336
       GoKind: 22
-      Pointee: 297 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 309 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 299
+      ID: 311
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 298 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 310 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 695
+      ID: 707
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1452960
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType net/url.Error
+      Pointee: 708 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 933280
       GoKind: 22
-      Pointee: 291 GoStringHeaderType net/url.EscapeError
+      Pointee: 303 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 293
+      ID: 305
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 292 GoStringDataType net/url.EscapeError.str
+      Pointee: 304 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 933376
       GoKind: 22
-      Pointee: 294 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 306 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 296
+      ID: 308
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 295 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 307 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2202720
       GoKind: 22
-      Pointee: 873 StructureType net/url.URL
+      Pointee: 880 StructureType net/url.URL
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1234208
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 1001 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 205
+      ID: 248
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 206 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 249 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 847 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 261
+      ID: 264
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 265 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 1004 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 1011 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 867 StructureType noalg.map.group[string][]string
+      Pointee: 874 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 239
+      ID: 228
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 240 StructureType noalg.map.group[string]float64
+      Pointee: 229 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 738
+      ID: 750
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 751 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 231
+      ID: 220
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 232 StructureType noalg.map.group[string]interface {}
+      Pointee: 221 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 223
+      ID: 212
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 224 StructureType noalg.map.group[string]string
+      Pointee: 213 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2427296
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType os.File
+      Pointee: 993 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 568
+      ID: 580
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1058976
       GoKind: 22
-      Pointee: 569 UnresolvedPointeeType os.LinkError
+      Pointee: 581 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 163
+      ID: 179
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 404288
       GoKind: 22
-      Pointee: 164 GoInterfaceType os.Signal
+      Pointee: 180 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 641
+      ID: 653
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1221024
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType os.SyscallError
+      Pointee: 654 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2425024
       GoKind: 22
-      Pointee: 984 StructureType os.fileWithoutReadFrom
+      Pointee: 991 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 981
+      ID: 988
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2424288
       GoKind: 22
-      Pointee: 982 StructureType os.fileWithoutWriteTo
+      Pointee: 989 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1081120
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType os/exec.Error
+      Pointee: 614 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 734
+      ID: 746
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2162464
       GoKind: 22
-      Pointee: 735 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 747 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1081248
       GoKind: 22
-      Pointee: 604 StructureType os/exec.wrappedError
+      Pointee: 616 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 137
+      ID: 175
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1662336
       GoKind: 22
-      Pointee: 138 StructureType os/signal.signalCtx
+      Pointee: 176 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 368
+      ID: 380
       Name: '*os/signal.signalError'
       ByteSize: 8
       GoRuntimeType: 926272
       GoKind: 22
-      Pointee: 282 GoStringHeaderType os/signal.signalError
+      Pointee: 294 GoStringHeaderType os/signal.signalError
     - __kind: PointerType
-      ID: 284
+      ID: 296
       Name: '*os/signal.signalError.str'
       ByteSize: 8
-      Pointee: 283 GoStringDataType os/signal.signalError.str
+      Pointee: 295 GoStringDataType os/signal.signalError.str
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 964672
       GoKind: 22
-      Pointee: 325 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 337 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 327
+      ID: 339
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 338 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 526
+      ID: 538
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 964576
       GoKind: 22
-      Pointee: 324 BaseType os/user.UnknownUserIdError
+      Pointee: 336 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 928864
       GoKind: 22
-      Pointee: 379 UnresolvedPointeeType reflect.ValueError
+      Pointee: 391 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 950176
       GoKind: 22
-      Pointee: 479 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 491 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 576
+      ID: 588
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1064864
       GoKind: 22
-      Pointee: 577 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 589 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 580
+      ID: 592
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1065504
       GoKind: 22
-      Pointee: 581 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 593 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -2562,12 +2562,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1064992
       GoKind: 22
-      Pointee: 579 StructureType runtime.boundsError
+      Pointee: 591 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -2583,24 +2583,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 643
+      ID: 655
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1229600
       GoKind: 22
-      Pointee: 644 StructureType runtime.errorAddressString
+      Pointee: 656 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1063200
       GoKind: 22
-      Pointee: 545 GoStringHeaderType runtime.errorString
+      Pointee: 557 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 547
+      ID: 559
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 546 GoStringDataType runtime.errorString.str
+      Pointee: 558 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -2621,19 +2621,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1064608
       GoKind: 22
-      Pointee: 200 UnresolvedPointeeType runtime.p
+      Pointee: 207 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1063328
       GoKind: 22
-      Pointee: 548 GoStringHeaderType runtime.plainError
+      Pointee: 560 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 550
+      ID: 562
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 549 GoStringDataType runtime.plainError.str
+      Pointee: 561 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -2649,12 +2649,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 380
+      ID: 392
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 930592
       GoKind: 22
-      Pointee: 381 StructureType runtime.synctestDeadlockError
+      Pointee: 393 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -2677,12 +2677,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1062816
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType strconv.NumError
+      Pointee: 585 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -2691,242 +2691,242 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 195
+      ID: 202
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 194 GoStringDataType string.str
+      Pointee: 201 GoStringDataType string.str
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1738944
       GoKind: 22
-      Pointee: 768 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 775 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1799168
       GoKind: 22
-      Pointee: 782 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 789 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1738560
       GoKind: 22
-      Pointee: 764 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 771 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1798400
       GoKind: 22
-      Pointee: 774 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 781 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1871744
       GoKind: 22
-      Pointee: 788 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 795 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1798592
       GoKind: 22
-      Pointee: 776 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 783 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1798208
       GoKind: 22
-      Pointee: 772 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 779 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1871296
       GoKind: 22
-      Pointee: 784 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 791 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1943424
       GoKind: 22
-      Pointee: 792 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 799 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1871520
       GoKind: 22
-      Pointee: 786 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 793 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1739136
       GoKind: 22
-      Pointee: 770 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 777 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1738752
       GoKind: 22
-      Pointee: 766 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 773 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1798784
       GoKind: 22
-      Pointee: 778 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 785 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1871968
       GoKind: 22
-      Pointee: 790 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 797 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1798976
       GoKind: 22
-      Pointee: 780 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 787 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1123360
       GoKind: 22
-      Pointee: 912 StructureType struct { io.Reader; io.Closer }
+      Pointee: 919 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 692
+      ID: 704
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1451840
       GoKind: 22
-      Pointee: 681 BaseType syscall.Errno
+      Pointee: 693 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1066016
       GoKind: 22
-      Pointee: 756 BaseType syscall.Signal
+      Pointee: 763 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 148
+      ID: 189
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 203 StructureType table<context.canceler,struct {}>
+      Pointee: 246 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 837 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 844 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 251
+      ID: 240
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 259 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 262 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 1000
+      ID: 1007
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 1001 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 1008 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 864 StructureType table<string,[]string>
+      Pointee: 871 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 145
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 237 StructureType table<string,float64>
+      Pointee: 226 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 710
+      ID: 722
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 736 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 748 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 177
+      ID: 140
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 229 StructureType table<string,interface {}>
+      Pointee: 218 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 172
+      ID: 135
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 221 StructureType table<string,string>
+      Pointee: 210 StructureType table<string,string>
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1119648
       GoKind: 22
-      Pointee: 624 StructureType text/template.ExecError
+      Pointee: 636 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 158
+      ID: 195
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1662720
       GoKind: 22
-      Pointee: 159 StructureType time.Location
+      Pointee: 196 StructureType time.Location
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 926560
       GoKind: 22
-      Pointee: 373 UnresolvedPointeeType time.ParseError
+      Pointee: 385 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 155
+      ID: 192
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1059488
       GoKind: 22
-      Pointee: 156 StructureType time.Timer
+      Pointee: 193 StructureType time.Timer
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 926368
       GoKind: 22
-      Pointee: 285 GoStringHeaderType time.fileSizeError
+      Pointee: 297 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 287
+      ID: 299
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 286 GoStringDataType time.fileSizeError.str
+      Pointee: 298 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 926464
       GoKind: 22
-      Pointee: 371 UnresolvedPointeeType time.parseDurationError
+      Pointee: 383 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 214
+      ID: 257
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 404544
       GoKind: 22
-      Pointee: 215 StructureType time.zone
+      Pointee: 258 StructureType time.zone
     - __kind: PointerType
-      ID: 217
+      ID: 260
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 404608
       GoKind: 22
-      Pointee: 218 StructureType time.zoneTrans
+      Pointee: 261 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -2970,47 +2970,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 931840
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 400 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 404
+      ID: 416
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 935104
       GoKind: 22
-      Pointee: 405 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 417 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 406
+      ID: 418
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 935200
       GoKind: 22
-      Pointee: 304 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 316 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 585
+      ID: 597
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1070880
       GoKind: 22
-      Pointee: 586 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 598 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1071008
       GoKind: 22
-      Pointee: 552 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 564 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 880
+      ID: 887
       Name: <-chan struct {}
       GoRuntimeType: 613440
       GoKind: 18
     - __kind: GoChannelType
-      ID: 750
+      ID: 762
       Name: <-chan time.Time
       GoRuntimeType: 619136
       GoKind: 18
@@ -3089,7 +3089,7 @@ Types:
       HasCount: true
       Element: 98 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 861
+      ID: 868
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 702048
@@ -3098,7 +3098,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 860
+      ID: 867
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 701952
@@ -3170,7 +3170,7 @@ Types:
       HasCount: true
       Element: 35 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 862
+      ID: 869
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 702144
@@ -3188,7 +3188,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 718
+      ID: 730
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 719712
@@ -3215,7 +3215,7 @@ Types:
       HasCount: true
       Element: 91 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1016
+      ID: 1023
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 513216
@@ -3223,22 +3223,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1017 PointerType **crypto/x509.Certificate
+          Type: 1024 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1024 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1031 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1024
+      ID: 1031
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 704 PointerType *crypto/x509.Certificate
+      Element: 716 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 751
+      ID: 276
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 501088
@@ -3246,22 +3246,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 752 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 277 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 754 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 279 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 754
+      ID: 279
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 120 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 1007
+      ID: 1014
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 498144
@@ -3269,20 +3269,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1008 PointerType **mime/multipart.FileHeader
+          Type: 1015 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1013 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 1020 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 1013
+      ID: 1020
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1009 PointerType *mime/multipart.FileHeader
+      Element: 1016 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 68
       Name: '[]*runtime.p'
@@ -3299,69 +3299,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 201 GoSliceDataType []*runtime.p.array
+      Data: 208 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 208
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 70 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 254
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 148 PointerType *table<context.canceler,struct {}>
+      Element: 189 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 844
+      ID: 851
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 818 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 825 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 270
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 251 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 240 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 1010
+      ID: 1017
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1000 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 1007 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 870
+      ID: 877
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 859 PointerType *table<string,[]string>
+      Element: 866 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 232
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 182 PointerType *table<string,float64>
+      Element: 145 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 742
+      ID: 754
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 710 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 722 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 224
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 177 PointerType *table<string,interface {}>
+      Element: 140 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 216
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 172 PointerType *table<string,string>
+      Element: 135 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 1018
+      ID: 1025
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 513280
@@ -3369,22 +3369,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1019 PointerType *[]*crypto/x509.Certificate
+          Type: 1026 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1026 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1033 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1026
+      ID: 1033
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1016 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 1023 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 1020
+      ID: 1027
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 492480
@@ -3392,22 +3392,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1021 PointerType *[]uint8
+          Type: 1028 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1028 GoSliceDataType [][]uint8.array
+      Data: 1035 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 1028
+      ID: 1035
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 41 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 723
+      ID: 735
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 507104
@@ -3422,15 +3422,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 746 GoSliceDataType []float64.array
+      Data: 758 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 746
+      ID: 758
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 16 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 183
+      ID: 146
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 500640
@@ -3438,22 +3438,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 245 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 234 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 234
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 186
+      ID: 149
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 500832
@@ -3461,22 +3461,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 253 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 242 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 242
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1030
+      ID: 1037
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 495456
@@ -3484,76 +3484,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1031 PointerType *net/http.segment
+          Type: 1038 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1033 GoSliceDataType []net/http.segment.array
+      Data: 1040 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1033
+      ID: 1040
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1032 StructureType net/http.segment
+      Element: 1039 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 255
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 206 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 249 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 845
+      ID: 852
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 847 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 271
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 265 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 1011
+      ID: 1018
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1004 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 1011 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 871
+      ID: 878
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 867 StructureType noalg.map.group[string][]string
+      Element: 874 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 233
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 240 StructureType noalg.map.group[string]float64
+      Element: 229 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 743
+      ID: 755
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 751 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 225
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 232 StructureType noalg.map.group[string]interface {}
+      Element: 221 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 217
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 224 StructureType noalg.map.group[string]string
+      Element: 213 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 162
+      ID: 178
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 492288
@@ -3561,26 +3561,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 163 PointerType *os.Signal
+          Type: 179 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 219 GoSliceDataType []os.Signal.array
+      Data: 244 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 244
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 164 GoInterfaceType os.Signal
+      Element: 180 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 43
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 722
+      ID: 734
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 507360
@@ -3595,15 +3595,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 744 GoSliceDataType []string.array
+      Data: 756 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 744
+      ID: 756
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 213
+      ID: 256
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 500192
@@ -3611,22 +3611,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 214 PointerType *time.zone
+          Type: 257 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 255 GoSliceDataType []time.zone.array
+      Data: 272 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 272
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 215 StructureType time.zone
+      Element: 258 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 216
+      ID: 259
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 500256
@@ -3634,20 +3634,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 217 PointerType *time.zoneTrans
+          Type: 260 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 257 GoSliceDataType []time.zoneTrans.array
+      Data: 274 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 274
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 218 StructureType time.zoneTrans
+      Element: 261 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 41
       Name: '[]uint8'
@@ -3664,9 +3664,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 196 GoSliceDataType []uint8.array
+      Data: 203 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 203
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3687,15 +3687,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 198 GoSliceDataType []uintptr.array
+      Data: 205 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 205
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 519
+      ID: 531
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 959584
@@ -3710,27 +3710,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 520 GoSliceDataType archive/tar.headerError.array
+      Data: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 532
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 933
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 906
+      ID: 913
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3740,7 +3740,7 @@ Types:
       GoRuntimeType: 600960
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 853
+      ID: 860
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3748,12 +3748,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 863
+      ID: 870
       Name: chan bool
       GoRuntimeType: 612928
       GoKind: 18
     - __kind: GoChannelType
-      ID: 165
+      ID: 181
       Name: chan os.Signal
       GoRuntimeType: 619840
       GoKind: 18
@@ -3770,13 +3770,13 @@ Types:
       GoRuntimeType: 600704
       GoKind: 15
     - __kind: BaseType
-      ID: 300
+      ID: 312
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 854528
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 301
+      ID: 313
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 854624
@@ -3784,32 +3784,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 303 PointerType *compress/flate.InternalError.str
+          Type: 315 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 302 GoStringDataType compress/flate.InternalError.str
+      Data: 314 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 302
+      ID: 314
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 969
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 948
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 161
+      ID: 177
       Name: context.CancelCauseFunc
       ByteSize: 8
       GoRuntimeType: 850784
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 851
+      ID: 858
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 695328
@@ -3828,7 +3828,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 126
+      ID: 198
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 1773632
@@ -3836,29 +3836,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 128 StructureType context.cancelCtx
+          Type: 183 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 149 StructureType sync.Once
+          Type: 199 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 152
+      ID: 172
       Name: context.backgroundCtx
       GoRuntimeType: 1853152
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 153 StructureType context.emptyCtx
+          Type: 158 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 183
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 2029888
@@ -3869,23 +3869,23 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 142 StructureType sync/atomic.Value
+          Type: 184 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 144 GoMapType map[context.canceler]struct {}
+          Type: 185 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 142 StructureType sync/atomic.Value
+          Type: 184 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 17 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 209
+      ID: 252
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1140800
@@ -3898,13 +3898,13 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 629
+      ID: 641
       Name: context.deadlineExceededError
       GoRuntimeType: 1496640
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 153
+      ID: 158
       Name: context.emptyCtx
       GoRuntimeType: 1637792
       GoKind: 25
@@ -3913,7 +3913,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 160
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1880416
@@ -3924,11 +3924,11 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 154 GoSubroutineType func() bool
+          Type: 161 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 132
+      ID: 191
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1656192
@@ -3936,29 +3936,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 128 StructureType context.cancelCtx
+          Type: 183 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 155 PointerType *time.Timer
+          Type: 192 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 157 GoTimeType time.Time
+          Type: 194 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 160
+      ID: 174
       Name: context.todoCtx
       GoRuntimeType: 1853376
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 153 StructureType context.emptyCtx
+          Type: 158 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 134
+      ID: 167
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1891232
@@ -3969,14 +3969,14 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 143 GoEmptyInterfaceType interface {}
+          Type: 168 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 143 GoEmptyInterfaceType interface {}
+          Type: 168 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 136
+      ID: 170
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1852928
@@ -3988,51 +3988,51 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 319
+      ID: 331
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 856640
       GoKind: 2
     - __kind: BaseType
-      ID: 320
+      ID: 332
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 856736
       GoKind: 2
     - __kind: BaseType
-      ID: 321
+      ID: 333
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 856832
       GoKind: 2
     - __kind: StructureType
-      ID: 608
+      ID: 620
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1319776
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 322
+      ID: 334
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 856928
       GoKind: 2
     - __kind: BaseType
-      ID: 289
+      ID: 301
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 854048
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 584
+      ID: 596
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 999
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 879
+      ID: 886
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2343616
@@ -4052,7 +4052,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 1015 BaseType crypto/tls.CurveID
+          Type: 1022 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4064,13 +4064,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 1016 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 1023 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 1018 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 1025 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 1020 GoSliceHeaderType [][]uint8
+          Type: 1027 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 41 GoSliceHeaderType []uint8
@@ -4085,22 +4085,22 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 1022 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 1029 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 184
-          Type: 1023 BaseType crypto/tls.SignatureScheme
+          Type: 1030 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 1015
+      ID: 1022
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 853760
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 393
+      ID: 405
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 390
+      ID: 402
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1779776
@@ -4111,36 +4111,36 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 718 ArrayType [5]uint8
+          Type: 730 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 719 GoInterfaceType net.Conn
+          Type: 731 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 1023
+      ID: 1030
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 853856
       GoKind: 9
     - __kind: BaseType
-      ID: 551
+      ID: 563
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1018016
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 395
+      ID: 407
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 706
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 705
+      ID: 717
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 456
+      ID: 468
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1781888
@@ -4148,21 +4148,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 704 PointerType *crypto/x509.Certificate
+          Type: 716 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 728 BaseType crypto/x509.InvalidReason
+          Type: 740 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 450
+      ID: 462
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1147968
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 452
+      ID: 464
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1640672
@@ -4170,24 +4170,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 704 PointerType *crypto/x509.Certificate
+          Type: 716 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 318
+      ID: 330
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 856352
       GoKind: 2
     - __kind: BaseType
-      ID: 728
+      ID: 740
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 604032
       GoKind: 2
     - __kind: StructureType
-      ID: 600
+      ID: 612
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1600320
@@ -4197,13 +4197,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 458
+      ID: 470
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1148224
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 454
+      ID: 466
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1781696
@@ -4211,15 +4211,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 704 PointerType *crypto/x509.Certificate
+          Type: 716 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 704 PointerType *crypto/x509.Certificate
+          Type: 716 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 511
+      ID: 523
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1467520
@@ -4229,7 +4229,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 515
+      ID: 527
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1467680
@@ -4239,47 +4239,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 513
+      ID: 525
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 290
+      ID: 302
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 854144
       GoKind: 6
     - __kind: BaseType
-      ID: 314
+      ID: 326
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 856064
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 416
+      ID: 428
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 596
+      ID: 608
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 408
+      ID: 420
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 414
+      ID: 426
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 412
+      ID: 424
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 410
+      ID: 422
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 418
+      ID: 430
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1456640
@@ -4289,7 +4289,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 521
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4306,11 +4306,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 387
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 571
+      ID: 583
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4326,11 +4326,11 @@ Types:
       GoRuntimeType: 600896
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 567
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 557
+      ID: 569
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4340,13 +4340,13 @@ Types:
       GoRuntimeType: 490496
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 874
+      ID: 881
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 712416
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 154
+      ID: 161
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 610944
@@ -4358,23 +4358,23 @@ Types:
       GoRuntimeType: 870880
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 1022
+      ID: 1029
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1033952
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 439
+      ID: 451
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 820
+      ID: 827
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2120000
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1780736
@@ -4382,7 +4382,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 720 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 732 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4390,25 +4390,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 423
+      ID: 435
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 737
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 427
+      ID: 439
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1146560
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 727
+      ID: 739
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 308
+      ID: 320
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 855392
@@ -4416,18 +4416,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 310 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 322 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 309 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 321 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 309
+      ID: 321
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 720
+      ID: 732
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2293504
@@ -4435,13 +4435,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 721 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 733 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4450,7 +4450,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 723 GoSliceHeaderType []float64
+          Type: 735 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4459,13 +4459,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 724 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 736 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 726 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 738 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4476,13 +4476,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 721
+      ID: 733
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 602560
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 305
+      ID: 317
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 855296
@@ -4490,18 +4490,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 307 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 319 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 306 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 318 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 306
+      ID: 318
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 311
+      ID: 323
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 855488
@@ -4509,22 +4509,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 313 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 325 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 312 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 324 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 312
+      ID: 324
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 466
+      ID: 478
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: StructureType
-      ID: 811
+      ID: 818
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.NoopTracer
       GoRuntimeType: 1881088
       GoKind: 25
@@ -4538,7 +4538,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 166 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -4559,13 +4559,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 173 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 136 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 178 GoMapType map[string]float64
+          Type: 141 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -4580,10 +4580,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 183 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 186 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 149 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -4595,7 +4595,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 152 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -4618,7 +4618,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 190
+      ID: 153
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2292160
@@ -4629,13 +4629,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 154 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 120 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 167 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4644,16 +4644,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 193 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 156 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 166 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -4662,12 +4662,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 183 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 185
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1974080
@@ -4684,7 +4684,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -4692,7 +4692,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 957
+      ID: 964
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 2030400
@@ -4700,29 +4700,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 948 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
+          Type: 955 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 960 BaseType time.Duration
+          Type: 967 BaseType time.Duration
     - __kind: GoMapType
-      ID: 173
+      ID: 136
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1314400
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 753
+      ID: 278
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 599744
       GoKind: 10
     - __kind: StructureType
-      ID: 188
+      ID: 151
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1807360
@@ -4736,16 +4736,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 247 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 236 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 252 GoMapType map[string]interface {}
+          Type: 241 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 760
+      ID: 767
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 266
+      ID: 269
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1974336
@@ -4753,7 +4753,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 758 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 765 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4768,15 +4768,15 @@ Types:
           Type: 16 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 759 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 766 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 758
+      ID: 765
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1015424
       GoKind: 5
     - __kind: StructureType
-      ID: 192
+      ID: 155
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2176800
@@ -4784,16 +4784,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 166 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 751 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 276 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -4808,12 +4808,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 753 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 278 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 120 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 193
+      ID: 156
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 927328
@@ -4822,15 +4822,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.tracer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 682
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 793
+      ID: 800
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1455360
@@ -4843,7 +4843,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 762
+      ID: 769
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1640032
@@ -4856,11 +4856,11 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: github.com/DataDog/dd-trace-go/v2/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1039
+    - __kind: GoContextImplementationType
+      ID: 165
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1679040
@@ -4869,38 +4869,40 @@ Types:
         - Name: Context
           Offset: 0
           Type: 124 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 911
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 468
+      ID: 480
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 475
+      ID: 487
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1149632
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 323
+      ID: 335
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 857696
       GoKind: 2
     - __kind: StructureType
-      ID: 473
+      ID: 485
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1149504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 471
+      ID: 483
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1641792
@@ -4913,7 +4915,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 483
+      ID: 495
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1642432
@@ -4926,7 +4928,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 487
+      ID: 499
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1783808
@@ -4942,7 +4944,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 485
+      ID: 497
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1466080
@@ -4952,7 +4954,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 481
+      ID: 493
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1465760
@@ -4962,14 +4964,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 706
+      ID: 718
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1541920
       GoKind: 21
-      HeaderType: 708 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 720 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 729
+      ID: 741
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1084320
@@ -4984,15 +4986,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 748 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 760 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 748
+      ID: 760
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 495
+      ID: 507
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1642752
@@ -5000,12 +5002,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 706 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 718 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 706 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 718 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 489
+      ID: 501
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1466240
@@ -5015,7 +5017,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 493
+      ID: 505
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1784000
@@ -5026,12 +5028,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 491
+      ID: 503
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1642592
@@ -5044,7 +5046,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 497
+      ID: 509
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1466400
@@ -5052,9 +5054,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 157 GoTimeType time.Time
+          Type: 194 GoTimeType time.Time
     - __kind: StructureType
-      ID: 503
+      ID: 515
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1643072
@@ -5067,7 +5069,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 505
+      ID: 517
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1466720
@@ -5077,7 +5079,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1642912
@@ -5090,7 +5092,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 499
+      ID: 511
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1466560
@@ -5100,7 +5102,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 507
+      ID: 519
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1643232
@@ -5113,29 +5115,29 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 843
+      ID: 850
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 855776
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 843
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 839
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 841
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 429
+      ID: 441
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1457920
@@ -5145,11 +5147,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 431
+      ID: 443
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1458080
@@ -5157,17 +5159,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 429 StructureType github.com/cihub/seelog.baseError
+          Type: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 816
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1882432
@@ -5175,12 +5177,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 804 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 811 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 814 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 821 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1458400
@@ -5188,9 +5190,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 429 StructureType github.com/cihub/seelog.baseError
+          Type: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 807
+      ID: 814
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1858080
@@ -5198,13 +5200,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 804 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 811 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 433
+      ID: 445
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1458240
@@ -5212,9 +5214,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 429 StructureType github.com/cihub/seelog.baseError
+          Type: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 437
+      ID: 449
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1458560
@@ -5222,9 +5224,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 429 StructureType github.com/cihub/seelog.baseError
+          Type: 441 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 942
+      ID: 949
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1149888
@@ -5237,7 +5239,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 920
+      ID: 927
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1695936
@@ -5245,48 +5247,48 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 942 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 949 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 698
+      ID: 710
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 626
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 624
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 628
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 630
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 618
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 442
+      ID: 454
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1459520
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 672
+      ID: 684
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 658
+      ID: 670
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1905344
@@ -5302,11 +5304,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 664
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 602
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1752096
@@ -5319,7 +5321,7 @@ Types:
           Offset: 1
           Type: 21 BaseType int8
     - __kind: StructureType
-      ID: 664
+      ID: 676
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1905792
@@ -5335,13 +5337,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 553
+      ID: 565
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1018688
       GoKind: 8
     - __kind: StructureType
-      ID: 656
+      ID: 668
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1905120
@@ -5357,13 +5359,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 732
+      ID: 744
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 854912
       GoKind: 8
     - __kind: StructureType
-      ID: 654
+      ID: 666
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1904896
@@ -5371,15 +5373,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 732 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 744 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 732 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 744 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 662
+      ID: 674
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1816192
@@ -5392,7 +5394,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 660
+      ID: 672
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1905568
@@ -5408,7 +5410,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 668
+      ID: 680
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1678080
@@ -5418,19 +5420,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 594
+      ID: 606
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1315680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 592
+      ID: 604
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1315552
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 666
+      ID: 678
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1816384
@@ -5443,7 +5445,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 340
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 860192
@@ -5451,22 +5453,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 342 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 329 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 341 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 341
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 725
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 622
+      ID: 634
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1481920
@@ -5476,19 +5478,19 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 331
+      ID: 343
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 860768
       GoKind: 10
     - __kind: BaseType
-      ID: 711
+      ID: 723
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1030976
       GoKind: 10
     - __kind: StructureType
-      ID: 680
+      ID: 692
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1938272
@@ -5499,12 +5501,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 711 BaseType golang.org/x/net/http2.ErrCode
+          Type: 723 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 537
+      ID: 549
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1649952
@@ -5512,12 +5514,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 711 BaseType golang.org/x/net/http2.ErrCode
+          Type: 723 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 335
+      ID: 347
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 860960
@@ -5525,18 +5527,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 337 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 349 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 336 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 348 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 336
+      ID: 348
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 341
+      ID: 353
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 861152
@@ -5544,18 +5546,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 343 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 355 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 342 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 354 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 342
+      ID: 354
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 338
+      ID: 350
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 861056
@@ -5563,18 +5565,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 340 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 352 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 339 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 351 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 339
+      ID: 351
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 332
+      ID: 344
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 860864
@@ -5582,18 +5584,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 334 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 346 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 333 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 345 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 333
+      ID: 345
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 541
+      ID: 553
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1482560
@@ -5603,13 +5605,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 344
+      ID: 356
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 861248
       GoKind: 2
     - __kind: StructureType
-      ID: 529
+      ID: 541
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1477600
@@ -5619,11 +5621,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 690
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 700
+      ID: 712
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1968512
@@ -5639,7 +5641,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 531
+      ID: 543
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1649472
@@ -5652,11 +5654,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 620
+      ID: 632
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1608160
@@ -5666,29 +5668,29 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 935
+      ID: 942
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 517
+      ID: 529
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 622
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 688
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 674
+      ID: 686
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1551680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 523
+      ID: 535
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1470880
@@ -5698,7 +5700,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 525
+      ID: 537
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1471040
@@ -5708,137 +5710,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 477
+      ID: 489
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 204
+      ID: 247
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 205 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 248 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 206 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 212 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 249 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 838
+      ID: 845
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 839 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 846 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 845 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 847 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 852 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 260
+      ID: 263
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 261 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 264 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 268 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 265 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 271 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 1002
+      ID: 1009
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1003 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 1010 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1004 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 1011 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 1011 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 1018 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 865
+      ID: 872
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 866 PointerType *noalg.map.group[string][]string
+          Type: 873 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 867 StructureType noalg.map.group[string][]string
-      GroupSliceType: 871 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 874 StructureType noalg.map.group[string][]string
+      GroupSliceType: 878 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 238
+      ID: 227
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 239 PointerType *noalg.map.group[string]float64
+          Type: 228 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 240 StructureType noalg.map.group[string]float64
-      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 229 StructureType noalg.map.group[string]float64
+      GroupSliceType: 233 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 737
+      ID: 749
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 738 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 750 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 743 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 751 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 755 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 230
+      ID: 219
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 231 PointerType *noalg.map.group[string]interface {}
+          Type: 220 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 232 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 221 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 222
+      ID: 211
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 223 PointerType *noalg.map.group[string]string
+          Type: 212 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 224 StructureType noalg.map.group[string]string
-      GroupSliceType: 228 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 213 StructureType noalg.map.group[string]string
+      GroupSliceType: 217 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 556
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5872,7 +5874,7 @@ Types:
       GoRuntimeType: 600000
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 143
+      ID: 168
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 874720
@@ -5885,17 +5887,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 733
+      ID: 745
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 603456
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 702
+      ID: 714
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 447
+      ID: 459
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5921,25 +5923,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 445
+      ID: 457
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 650
+      ID: 662
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 997
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 648
+      ID: 660
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1515520
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 377
+      ID: 389
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6011,7 +6013,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 315
+      ID: 327
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 856256
@@ -6019,18 +6021,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 317 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 329 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 316 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 328 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 316
+      ID: 328
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 598
+      ID: 610
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1599360
@@ -6038,15 +6040,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 701 PointerType *internal/abi.Type
+          Type: 713 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 288
+      ID: 300
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 853568
       GoKind: 2
     - __kind: StructureType
-      ID: 141
+      ID: 128
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1530720
@@ -6059,7 +6061,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 943
+      ID: 950
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1061536
@@ -6072,11 +6074,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 850
+      ID: 857
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1143232
@@ -6089,7 +6091,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 933
+      ID: 940
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1060896
@@ -6102,11 +6104,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 966
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 902
+      ID: 909
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1593120
@@ -6114,9 +6116,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 933 GoInterfaceType io.Reader
+          Type: 940 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 918
+      ID: 925
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1663872
@@ -6124,13 +6126,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 933 GoInterfaceType io.Reader
+          Type: 940 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 646
+      ID: 658
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 146
+      ID: 187
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -6143,7 +6145,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 147 PointerType **table<context.canceler,struct {}>
+          Type: 188 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6162,10 +6164,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 211 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 206 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 254 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 249 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 816
+      ID: 823
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6178,7 +6180,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 817 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 824 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6197,10 +6199,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 844 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 840 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 851 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 847 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 249
+      ID: 238
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6213,7 +6215,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 250 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 239 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6232,10 +6234,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 267 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 262 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 270 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 265 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 998
+      ID: 1005
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6248,7 +6250,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 999 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 1006 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6267,10 +6269,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1010 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 1004 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 1017 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 1011 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 857
+      ID: 864
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6283,7 +6285,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 858 PointerType **table<string,[]string>
+          Type: 865 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6302,10 +6304,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 870 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 867 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 877 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 874 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 180
+      ID: 143
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6318,7 +6320,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 181 PointerType **table<string,float64>
+          Type: 144 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6337,10 +6339,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 243 GoSliceDataType []*table<string,float64>.array
-      GroupType: 240 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 232 GoSliceDataType []*table<string,float64>.array
+      GroupType: 229 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 708
+      ID: 720
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6353,7 +6355,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 709 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 721 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6372,10 +6374,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 742 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 739 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 754 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 751 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 138
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6388,7 +6390,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<string,interface {}>
+          Type: 139 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6407,10 +6409,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 232 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 224 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 221 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 170
+      ID: 133
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6423,7 +6425,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 171 PointerType **table<string,string>
+          Type: 134 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6442,66 +6444,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 227 GoSliceDataType []*table<string,string>.array
-      GroupType: 224 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 216 GoSliceDataType []*table<string,string>.array
+      GroupType: 213 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 144
+      ID: 185
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1160384
       GoKind: 21
-      HeaderType: 146 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 187 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 814
+      ID: 821
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1177344
       GoKind: 21
-      HeaderType: 816 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 823 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 247
+      ID: 236
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1166528
       GoKind: 21
-      HeaderType: 249 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 238 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 996
+      ID: 1003
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1165760
       GoKind: 21
-      HeaderType: 998 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 1005 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 995
+      ID: 1002
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1161408
       GoKind: 21
-      HeaderType: 857 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 864 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 178
+      ID: 141
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1166400
       GoKind: 21
-      HeaderType: 180 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 143 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 252
+      ID: 241
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1160000
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 168
+      ID: 131
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1162432
       GoKind: 21
-      HeaderType: 170 GoSwissMapHeaderType map<string,string>
+      HeaderType: 133 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 464
+      ID: 476
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1462720
@@ -6511,11 +6513,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1019
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 884
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1518560
@@ -6523,16 +6525,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 995 GoMapType map[string][]string
+          Type: 1002 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 996 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 1003 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 939
+      ID: 946
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1978432
@@ -6540,16 +6542,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 958 PointerType *io.SectionReader
+          Type: 965 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 943 GoInterfaceType io.Closer
+          Type: 950 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 644
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 719
+      ID: 731
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1637952
@@ -6562,35 +6564,35 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 697
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 973
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 695
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 634
+      ID: 646
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 981
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 985
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 979
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 625
+      ID: 637
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1141056
@@ -6598,28 +6600,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 627 PointerType *net.UnknownNetworkError.str
+          Type: 639 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 626 GoStringDataType net.UnknownNetworkError.str
+      Data: 638 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 626
+      ID: 638
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 559
+      ID: 571
       Name: net.canceledError
       GoRuntimeType: 1313120
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 964
+      ID: 971
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 731
+      ID: 743
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2175744
@@ -6627,7 +6629,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 719 GoInterfaceType net.Conn
+          Type: 731 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -6638,27 +6640,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 987
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 976
+      ID: 983
       Name: net.noReadFrom
       GoRuntimeType: 1141312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 975
+      ID: 982
       Name: net.noWriteTo
       GoRuntimeType: 1141184
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 346
+      ID: 358
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1037
+    - __kind: GoContextImplementationType
+      ID: 163
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1801600
@@ -6670,8 +6672,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 124 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 348
+      ID: 360
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1774592
@@ -6679,7 +6683,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 714 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 726 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6687,7 +6691,7 @@ Types:
           Offset: 96
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 970
+      ID: 977
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2363712
@@ -6695,12 +6699,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 976 StructureType net.noReadFrom
+          Type: 983 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 973 PointerType *net.TCPConn
+          Type: 980 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 968
+      ID: 975
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2363168
@@ -6708,20 +6712,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 975 StructureType net.noWriteTo
+          Type: 982 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 973 PointerType *net.TCPConn
+          Type: 980 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 648
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 699
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 796
+      ID: 803
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1058848
@@ -6734,7 +6738,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 794
+      ID: 801
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1057184
@@ -6747,14 +6751,14 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 855
+      ID: 862
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2176096
       GoKind: 21
-      HeaderType: 857 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 864 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 797
+      ID: 804
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1057312
@@ -6767,15 +6771,15 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 366
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 561
+      ID: 573
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 795
+      ID: 802
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1057568
@@ -6799,7 +6803,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 872 PointerType *net/url.URL
+          Type: 879 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6811,19 +6815,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 850 GoInterfaceType io.ReadCloser
+          Type: 857 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 874 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 881 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6832,16 +6836,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 875 GoMapType net/url.Values
+          Type: 882 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 875 GoMapType net/url.Values
+          Type: 882 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 876 PointerType *mime/multipart.Form
+          Type: 883 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6850,13 +6854,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 878 PointerType *crypto/tls.ConnectionState
+          Type: 885 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 880 GoChannelType <-chan struct {}
+          Type: 887 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 881 PointerType *net/http.Response
+          Type: 888 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6865,15 +6869,15 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 883 PointerType *net/http.pattern
+          Type: 890 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 168 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
     - __kind: StructureType
-      ID: 882
+      ID: 889
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2290816
@@ -6896,16 +6900,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 850 GoInterfaceType io.ReadCloser
+          Type: 857 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6914,13 +6918,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 118 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 878 PointerType *crypto/tls.ConnectionState
+          Type: 885 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 117
       Name: net/http.ResponseWriter
@@ -6935,19 +6939,19 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 954
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 921
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 903
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1803136
@@ -6955,10 +6959,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 800 PointerType *net/http.response
+          Type: 807 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6966,31 +6970,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 856
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 269
+      ID: 281
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 851552
       GoKind: 10
     - __kind: BaseType
-      ID: 703
+      ID: 715
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1015232
       GoKind: 10
     - __kind: StructureType
-      ID: 357
+      ID: 369
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1776320
@@ -7001,12 +7005,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 703 BaseType net/http.http2ErrCode
+          Type: 715 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 689
+      ID: 701
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1956736
@@ -7017,16 +7021,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 703 BaseType net/http.http2ErrCode
+          Type: 715 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 363
+      ID: 375
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1638432
@@ -7034,12 +7038,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 703 BaseType net/http.http2ErrCode
+          Type: 715 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 285
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 851744
@@ -7047,28 +7051,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 287 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 286 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 286
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 361
+      ID: 373
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1142336
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 937
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 279
+      ID: 291
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 851936
@@ -7076,18 +7080,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 281 PointerType *net/http.http2headerFieldNameError.str
+          Type: 293 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 280 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 292 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 280
+      ID: 292
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 288
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 851840
@@ -7095,40 +7099,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *net/http.http2headerFieldValueError.str
+          Type: 290 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 289 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 289
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 652
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: net/http.http2missingBody
       GoRuntimeType: 1313632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 900
+      ID: 907
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1314144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 567
+      ID: 579
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1314016
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 282
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 851648
@@ -7136,22 +7140,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 284 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 271 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 283 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 283
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 905
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 806
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1218720
@@ -7159,13 +7163,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 846 PointerType *net/http.http2responseWriterState
+          Type: 853 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 854
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 894
+      ID: 901
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1590080
@@ -7173,19 +7177,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 927 PointerType *net/http.http2clientStream
+          Type: 934 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 923
       Name: net/http.noBody
       GoRuntimeType: 1499680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 563
+      ID: 575
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1591520
@@ -7195,7 +7199,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1893696
@@ -7212,20 +7216,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1030 GoSliceHeaderType []net/http.segment
+          Type: 1037 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 931
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 367
+      ID: 379
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1448800
@@ -7235,7 +7239,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 801
+      ID: 808
       Name: net/http.response
       ByteSize: 232
       GoRuntimeType: 2425760
@@ -7243,16 +7247,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 848 PointerType *net/http.conn
+          Type: 855 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 118 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 850 GoInterfaceType io.ReadCloser
+          Type: 857 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 851 GoSubroutineType context.CancelFunc
+          Type: 858 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7264,19 +7268,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 150 StructureType sync/atomic.Bool
+          Type: 200 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 852 PointerType *bufio.Writer
+          Type: 859 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 854 StructureType net/http.chunkWriter
+          Type: 861 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 855 GoMapType net/http.Header
+          Type: 862 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7300,30 +7304,30 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 150 StructureType sync/atomic.Bool
+          Type: 200 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 860 ArrayType [29]uint8
+          Type: 867 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 861 ArrayType [10]uint8
+          Type: 868 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 862 ArrayType [3]uint8
+          Type: 869 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
-          Type: 863 GoChannelType chan bool
+          Type: 870 GoChannelType chan bool
         - Name: closeNotifyTriggered
           Offset: 224
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1032
+      ID: 1039
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1658112
@@ -7339,7 +7343,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 352
+      ID: 364
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1638272
@@ -7352,17 +7356,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 703
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 650
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1501120
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 565
+      ID: 577
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1591680
@@ -7372,7 +7376,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2093600
@@ -7380,22 +7384,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 719 GoInterfaceType net.Conn
+          Type: 731 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 719 GoInterfaceType net.Conn
+          Type: 731 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 350
+      ID: 362
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1322976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 385
+      ID: 397
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1779392
@@ -7411,7 +7415,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 383
+      ID: 395
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1639552
@@ -7424,11 +7428,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 401
+      ID: 413
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 297
+      ID: 309
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 854432
@@ -7436,22 +7440,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 299 PointerType *net/textproto.ProtocolError.str
+          Type: 311 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 298 GoStringDataType net/textproto.ProtocolError.str
+      Data: 310 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 298
+      ID: 310
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 708
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 291
+      ID: 303
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 854240
@@ -7459,18 +7463,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 293 PointerType *net/url.EscapeError.str
+          Type: 305 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 292 GoStringDataType net/url.EscapeError.str
+      Data: 304 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 292
+      ID: 304
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 294
+      ID: 306
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 854336
@@ -7478,18 +7482,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 296 PointerType *net/url.InvalidHostError.str
+          Type: 308 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 295 GoStringDataType net/url.InvalidHostError.str
+      Data: 307 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 295
+      ID: 307
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 873
+      ID: 880
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2203104
@@ -7503,7 +7507,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 993 PointerType *net/url.Userinfo
+          Type: 1000 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7529,99 +7533,99 @@ Types:
           Offset: 137
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 1001
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 875
+      ID: 882
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1946112
       GoKind: 21
-      HeaderType: 857 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 864 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 207
+      ID: 250
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 703872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 208 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 251 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 841
+      ID: 848
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 759680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 842 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 849 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 263
+      ID: 266
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 722752
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 264 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 267 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 1005
+      ID: 1012
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 718080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1006 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 1013 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 868
+      ID: 875
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 708384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 869 StructureType noalg.struct { key string; elem []string }
+      Element: 876 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 241
+      ID: 230
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 722656
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 242 StructureType noalg.struct { key string; elem float64 }
+      Element: 231 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 740
+      ID: 752
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 783616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 741 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 753 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 233
+      ID: 222
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 698880
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 234 StructureType noalg.struct { key string; elem interface {} }
+      Element: 223 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 225
+      ID: 214
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 712608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 226 StructureType noalg.struct { key string; elem string }
+      Element: 215 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 206
+      ID: 249
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1325280
@@ -7632,9 +7636,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 207 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 250 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1372000
@@ -7645,9 +7649,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 841 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 848 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 262
+      ID: 265
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1342432
@@ -7658,9 +7662,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 263 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 266 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 1004
+      ID: 1011
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1335904
@@ -7671,9 +7675,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1005 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 1012 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 867
+      ID: 874
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1326816
@@ -7684,9 +7688,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 868 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 875 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 240
+      ID: 229
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1342176
@@ -7697,9 +7701,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 241 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 230 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 739
+      ID: 751
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1390944
@@ -7710,9 +7714,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 740 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 752 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 232
+      ID: 221
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1324128
@@ -7723,9 +7727,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 233 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 222 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 224
+      ID: 213
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1329248
@@ -7736,9 +7740,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 225 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 214 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 208
+      ID: 251
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1325152
@@ -7746,12 +7750,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 209 GoInterfaceType context.canceler
+          Type: 252 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 210 StructureType struct {}
+          Type: 253 StructureType struct {}
     - __kind: StructureType
-      ID: 842
+      ID: 849
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1371872
@@ -7759,12 +7763,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 843 BaseType github.com/cihub/seelog.LogLevel
+          Type: 850 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 264
+      ID: 267
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1342304
@@ -7775,9 +7779,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 265 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 268 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 1006
+      ID: 1013
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1335776
@@ -7788,9 +7792,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1007 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 1014 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1326688
@@ -7801,9 +7805,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 722 GoSliceHeaderType []string
+          Type: 734 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 242
+      ID: 231
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1342048
@@ -7816,7 +7820,7 @@ Types:
           Offset: 16
           Type: 16 BaseType float64
     - __kind: StructureType
-      ID: 741
+      ID: 753
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1390816
@@ -7827,9 +7831,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 729 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 234
+      ID: 223
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1324000
@@ -7840,9 +7844,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 143 GoEmptyInterfaceType interface {}
+          Type: 168 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 226
+      ID: 215
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1329120
@@ -7855,15 +7859,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 993
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 569
+      ID: 581
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 164
+      ID: 180
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1142976
@@ -7876,11 +7880,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 654
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 984
+      ID: 991
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2436704
@@ -7888,12 +7892,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 988 StructureType os.noReadFrom
+          Type: 995 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 985 PointerType *os.File
+          Type: 992 PointerType *os.File
     - __kind: StructureType
-      ID: 982
+      ID: 989
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2435904
@@ -7901,32 +7905,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 987 StructureType os.noWriteTo
+          Type: 994 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 985 PointerType *os.File
+          Type: 992 PointerType *os.File
     - __kind: StructureType
-      ID: 988
+      ID: 995
       Name: os.noReadFrom
       GoRuntimeType: 1142848
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 987
+      ID: 994
       Name: os.noWriteTo
       GoRuntimeType: 1142720
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 614
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 735
+      ID: 747
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 604
+      ID: 616
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1752480
@@ -7939,7 +7943,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 138
+      ID: 176
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 2030144
@@ -7950,17 +7954,17 @@ Types:
           Type: 124 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 161 GoSubroutineType context.CancelCauseFunc
+          Type: 177 GoSubroutineType context.CancelCauseFunc
         - Name: signals
           Offset: 24
-          Type: 162 GoSliceHeaderType []os.Signal
+          Type: 178 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 165 GoChannelType chan os.Signal
+          Type: 181 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 282
+      ID: 294
       Name: os/signal.signalError
       ByteSize: 16
       GoRuntimeType: 852032
@@ -7968,18 +7972,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 284 PointerType *os/signal.signalError.str
+          Type: 296 PointerType *os/signal.signalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 283 GoStringDataType os/signal.signalError.str
+      Data: 295 GoStringDataType os/signal.signalError.str
     - __kind: GoStringDataType
-      ID: 283
+      ID: 295
       Name: os/signal.signalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 337
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 859424
@@ -7987,36 +7991,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *os/user.UnknownGroupIdError.str
+          Type: 339 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 326 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 338 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 338
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 324
+      ID: 336
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 859328
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 379
+      ID: 391
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 479
+      ID: 491
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 577
+      ID: 589
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 581
+      ID: 593
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -8028,7 +8032,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 579
+      ID: 591
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1945664
@@ -8045,7 +8049,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 733 BaseType internal/abi.BoundsErrorCode
+          Type: 745 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -8061,7 +8065,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 644
+      ID: 656
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1810624
@@ -8074,7 +8078,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 545
+      ID: 557
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1016480
@@ -8082,13 +8086,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 547 PointerType *runtime.errorString.str
+          Type: 559 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 546 GoStringDataType runtime.errorString.str
+      Data: 558 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 546
+      ID: 558
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8737,7 +8741,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 200
+      ID: 207
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -8773,7 +8777,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 548
+      ID: 560
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1016576
@@ -8781,13 +8785,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 550 PointerType *runtime.plainError.str
+          Type: 562 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 549 GoStringDataType runtime.plainError.str
+      Data: 561 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 549
+      ID: 561
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8828,7 +8832,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 381
+      ID: 393
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1639232
@@ -8900,7 +8904,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 585
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8912,18 +8916,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 195 PointerType *string.str
+          Type: 202 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 194 GoStringDataType string.str
+      Data: 201 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 194
+      ID: 201
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 768
+      ID: 775
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 2011200
@@ -8931,12 +8935,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2089312
@@ -8944,15 +8948,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 764
+      ID: 771
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 2010688
@@ -8960,12 +8964,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 774
+      ID: 781
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2088160
@@ -8973,15 +8977,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 788
+      ID: 795
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2158720
@@ -8989,18 +8993,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 776
+      ID: 783
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2088448
@@ -9008,15 +9012,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 772
+      ID: 779
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2087872
@@ -9024,15 +9028,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 784
+      ID: 791
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2158080
@@ -9040,18 +9044,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 792
+      ID: 799
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2220768
@@ -9059,21 +9063,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 786
+      ID: 793
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2158400
@@ -9081,18 +9085,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 794 GoInterfaceType net/http.Flusher
+          Type: 801 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 770
+      ID: 777
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 2011456
@@ -9100,12 +9104,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 766
+      ID: 773
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 2010944
@@ -9113,12 +9117,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2088736
@@ -9126,15 +9130,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2159040
@@ -9142,18 +9146,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 796 GoInterfaceType net/http.CloseNotifier
+          Type: 803 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2089024
@@ -9161,15 +9165,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 793 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 800 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 795 GoInterfaceType net/http.Pusher
+          Type: 802 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 797 GoInterfaceType net/http.Hijacker
+          Type: 804 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 912
+      ID: 919
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1757664
@@ -9177,18 +9181,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 933 GoInterfaceType io.Reader
+          Type: 940 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 943 GoInterfaceType io.Closer
+          Type: 950 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 210
+      ID: 253
       Name: struct {}
       GoRuntimeType: 865760
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 139
+      ID: 126
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1505120
@@ -9196,12 +9200,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 140 StructureType sync.noCopy
+          Type: 127 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 141 StructureType internal/sync.Mutex
+          Type: 128 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 149
+      ID: 199
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1665216
@@ -9209,15 +9213,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 140 StructureType sync.noCopy
+          Type: 127 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 150 StructureType sync/atomic.Bool
+          Type: 200 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 166
+      ID: 125
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1899744
@@ -9225,7 +9229,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 139 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -9234,18 +9238,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 167 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 167 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 140
+      ID: 127
       Name: sync.noCopy
       GoRuntimeType: 1016096
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 150
+      ID: 200
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1506240
@@ -9253,12 +9257,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 151 StructureType sync/atomic.noCopy
+          Type: 130 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 167
+      ID: 129
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1506400
@@ -9266,12 +9270,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 151 StructureType sync/atomic.noCopy
+          Type: 130 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 142
+      ID: 184
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1226656
@@ -9279,27 +9283,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 143 GoEmptyInterfaceType interface {}
+          Type: 168 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 151
+      ID: 130
       Name: sync/atomic.noCopy
       GoRuntimeType: 1016192
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 681
+      ID: 693
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1314784
       GoKind: 12
     - __kind: BaseType
-      ID: 756
+      ID: 763
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 1017536
       GoKind: 2
     - __kind: StructureType
-      ID: 203
+      ID: 246
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9321,9 +9325,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 204 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 247 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 837
+      ID: 844
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9345,9 +9349,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 838 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 845 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 259
+      ID: 262
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9369,9 +9373,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 260 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 263 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 1001
+      ID: 1008
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9393,9 +9397,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1002 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 1009 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 864
+      ID: 871
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9417,9 +9421,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 865 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 872 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 237
+      ID: 226
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9441,9 +9445,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 238 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 227 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 736
+      ID: 748
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9465,9 +9469,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 737 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 749 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 229
+      ID: 218
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9489,9 +9493,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 230 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 219 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 221
+      ID: 210
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9513,9 +9517,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 222 GoSwissMapGroupsType groupReference<string,string>
+          Type: 211 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 624
+      ID: 636
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1756704
@@ -9528,13 +9532,13 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 960
+      ID: 967
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1973824
       GoKind: 6
     - __kind: StructureType
-      ID: 159
+      ID: 196
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2035040
@@ -9545,10 +9549,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 213 GoSliceHeaderType []time.zone
+          Type: 256 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 216 GoSliceHeaderType []time.zoneTrans
+          Type: 259 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9560,13 +9564,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 214 PointerType *time.zone
+          Type: 257 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 373
+      ID: 385
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 157
+      ID: 194
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2451712
@@ -9580,7 +9584,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 158 PointerType *time.Location
+          Type: 195 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9590,7 +9594,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 156
+      ID: 193
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1502240
@@ -9598,12 +9602,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 750 GoChannelType <-chan time.Time
+          Type: 762 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 285
+      ID: 297
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 852128
@@ -9611,22 +9615,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 287 PointerType *time.fileSizeError.str
+          Type: 299 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 286 GoStringDataType time.fileSizeError.str
+      Data: 298 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 286
+      ID: 298
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 371
+      ID: 383
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 215
+      ID: 258
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1662528
@@ -9642,7 +9646,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 218
+      ID: 261
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1807168
@@ -9703,7 +9707,7 @@ Types:
       GoRuntimeType: 601024
       GoKind: 26
     - __kind: StructureType
-      ID: 714
+      ID: 726
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2124800
@@ -9714,10 +9718,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 715 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 727 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 716 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 728 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9732,18 +9736,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 717 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 729 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 717
+      ID: 729
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1017632
       GoKind: 9
     - __kind: StructureType
-      ID: 715
+      ID: 727
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1977408
@@ -9768,17 +9772,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 400
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 716
+      ID: 728
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 601856
       GoKind: 8
     - __kind: StructureType
-      ID: 405
+      ID: 417
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1454720
@@ -9788,13 +9792,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 304
+      ID: 316
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 854720
       GoKind: 2
     - __kind: StructureType
-      ID: 586
+      ID: 598
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1751904
@@ -9807,7 +9811,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 552
+      ID: 564
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1018496

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -137,78 +137,78 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 628 PointerType *crypto/x509.Certificate
+      Pointee: 640 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 670
+      ID: 231
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 905 PointerType *mime/multipart.FileHeader
+      Pointee: 912 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 910 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 917 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 918 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 925 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 673
+      ID: 234
       Name: '*[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       ByteSize: 8
-      Pointee: 672 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Pointee: 233 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 908 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 921
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 920 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 923
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 922 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 665
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 664 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 206
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
-      ByteSize: 8
-      Pointee: 205 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
-    - __kind: PointerType
-      ID: 214
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 213 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 915 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 928
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 927 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 930
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 929 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 677
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 676 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 200
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
+      ByteSize: 8
+      Pointee: 199 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+    - __kind: PointerType
+      ID: 208
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 207 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 935
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 927 GoSliceDataType []net/http.segment.array
+      Pointee: 934 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 197
+      ID: 210
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []os.Signal.array
+      Pointee: 209 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -217,77 +217,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 663
+      ID: 675
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 662 GoSliceDataType []string.array
+      Pointee: 674 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 216
+      ID: 227
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []time.zone.array
+      Pointee: 226 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 218
+      ID: 229
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []time.zoneTrans.array
+      Pointee: 228 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452512
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 181
+      ID: 188
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []uint8.array
+      Pointee: 187 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 183
+      ID: 190
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []uintptr.array
+      Pointee: 189 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 872416
       GoKind: 22
-      Pointee: 468 GoSliceHeaderType archive/tar.headerError
+      Pointee: 480 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 470
+      ID: 482
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 469 GoSliceDataType archive/tar.headerError.array
+      Pointee: 481 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 830
+      ID: 837
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1168352
       GoKind: 22
-      Pointee: 831 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 838 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1040576
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 822 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1261088
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 840 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1040320
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 820 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -296,57 +296,57 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 131
+      ID: 176
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 132 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 177 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 733
+      ID: 740
       Name: '*bucket<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 741 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 210
+      ID: 204
       Name: '*bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 901 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 908 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 768 GoHMapBucketType bucket<string,[]string>
+      Pointee: 775 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 165
+      ID: 131
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 166 GoHMapBucketType bucket<string,float64>
+      Pointee: 132 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 633
+      ID: 645
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 646 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 160
+      ID: 126
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 161 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 127 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
-      ID: 155
+      ID: 119
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 156 GoHMapBucketType bucket<string,string>
+      Pointee: 120 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1814720
       GoKind: 22
-      Pointee: 762 UnresolvedPointeeType bufio.Writer
+      Pointee: 769 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 107
       Name: '*bytes.Buffer'
@@ -355,351 +355,351 @@ Types:
       GoKind: 22
       Pointee: 108 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 846784
       GoKind: 22
-      Pointee: 265 BaseType compress/flate.CorruptInputError
+      Pointee: 277 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 846880
       GoKind: 22
-      Pointee: 266 GoStringHeaderType compress/flate.InternalError
+      Pointee: 278 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 268
+      ID: 280
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType compress/flate.InternalError.str
+      Pointee: 279 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 1843200
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 870 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1434464
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 851 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 934
+      ID: 159
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1354304
       GoKind: 22
-      Pointee: 123 StructureType context.backgroundCtx
+      Pointee: 160 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 111
+      ID: 170
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1589376
       GoKind: 22
-      Pointee: 112 StructureType context.cancelCtx
+      Pointee: 171 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1094880
       GoKind: 22
-      Pointee: 561 StructureType context.deadlineExceededError
+      Pointee: 573 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 929
+      ID: 145
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1225888
       GoKind: 22
-      Pointee: 124 StructureType context.emptyCtx
+      Pointee: 146 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 113
+      ID: 147
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1226048
       GoKind: 22
-      Pointee: 114 StructureType context.stopCtx
+      Pointee: 148 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 115
+      ID: 178
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1589568
       GoKind: 22
-      Pointee: 116 StructureType context.timerCtx
+      Pointee: 179 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 935
+      ID: 161
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1354464
       GoKind: 22
-      Pointee: 141 StructureType context.todoCtx
+      Pointee: 162 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 117
+      ID: 154
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1353984
       GoKind: 22
-      Pointee: 118 StructureType context.valueCtx
+      Pointee: 155 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 119
+      ID: 157
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1354144
       GoKind: 22
-      Pointee: 120 StructureType context.withoutCancelCtx
+      Pointee: 158 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 845824
       GoKind: 22
-      Pointee: 262 BaseType crypto/aes.KeySizeError
+      Pointee: 274 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 846016
       GoKind: 22
-      Pointee: 263 BaseType crypto/des.KeySizeError
+      Pointee: 275 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 389
+      ID: 401
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 846304
       GoKind: 22
-      Pointee: 264 BaseType crypto/rc4.KeySizeError
+      Pointee: 276 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 336
+      ID: 348
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 836512
       GoKind: 22
-      Pointee: 239 BaseType crypto/tls.AlertError
+      Pointee: 251 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 993600
       GoKind: 22
-      Pointee: 522 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 534 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2222208
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 900 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 782 StructureType crypto/tls.ConnectionState
+      Pointee: 789 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 334
+      ID: 346
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 836320
       GoKind: 22
-      Pointee: 335 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 347 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 332
+      ID: 344
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 836224
       GoKind: 22
-      Pointee: 333 StructureType crypto/tls.RecordHeaderError
+      Pointee: 345 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 520
+      ID: 532
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 991936
       GoKind: 22
-      Pointee: 489 BaseType crypto/tls.alert
+      Pointee: 501 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1233568
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 634 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1905280
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 641 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 845632
       GoKind: 22
-      Pointee: 384 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 396 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 377
+      ID: 389
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 845152
       GoKind: 22
-      Pointee: 378 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 390 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 845248
       GoKind: 22
-      Pointee: 380 StructureType crypto/x509.HostnameError
+      Pointee: 392 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 845056
       GoKind: 22
-      Pointee: 261 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 273 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 535
+      ID: 547
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1002560
       GoKind: 22
-      Pointee: 536 StructureType crypto/x509.SystemRootsError
+      Pointee: 548 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 845728
       GoKind: 22
-      Pointee: 386 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 398 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 845536
       GoKind: 22
-      Pointee: 382 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 394 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 855040
       GoKind: 22
-      Pointee: 427 StructureType encoding/asn1.StructuralError
+      Pointee: 439 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 855232
       GoKind: 22
-      Pointee: 431 StructureType encoding/asn1.SyntaxError
+      Pointee: 443 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 855136
       GoKind: 22
-      Pointee: 429 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 441 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 836608
       GoKind: 22
-      Pointee: 240 BaseType encoding/base64.CorruptInputError
+      Pointee: 252 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 844000
       GoKind: 22
-      Pointee: 260 BaseType encoding/hex.InvalidByteError
+      Pointee: 272 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 840352
       GoKind: 22
-      Pointee: 357 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 369 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 998592
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 546 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839968
       GoKind: 22
-      Pointee: 349 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 361 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 840256
       GoKind: 22
-      Pointee: 355 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 367 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 352
+      ID: 364
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 840160
       GoKind: 22
-      Pointee: 353 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 365 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 840064
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 363 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 840736
       GoKind: 22
-      Pointee: 359 StructureType encoding/json.jsonError
+      Pointee: 371 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 866272
       GoKind: 22
-      Pointee: 458 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 470 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 866176
       GoKind: 22
-      Pointee: 456 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 468 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 866368
       GoKind: 22
-      Pointee: 274 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 286 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 276
+      ID: 288
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 275 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 287 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 866464
       GoKind: 22
-      Pointee: 461 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 473 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -708,19 +708,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 320
+      ID: 332
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 831712
       GoKind: 22
-      Pointee: 321 UnresolvedPointeeType errors.errorString
+      Pointee: 333 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 984896
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType errors.joinError
+      Pointee: 521 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -736,837 +736,837 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 492
+      ID: 504
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 974912
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType fmt.wrapError
+      Pointee: 505 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 494
+      ID: 506
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 975040
       GoKind: 22
-      Pointee: 495 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 507 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 843520
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 382 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 1874880
       GoKind: 22
-      Pointee: 736 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 743 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 361
+      ID: 373
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 842080
       GoKind: 22
-      Pointee: 362 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 374 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 842176
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 376 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 841888
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 661 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 367
+      ID: 379
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 842464
       GoKind: 22
-      Pointee: 368 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 380 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 841984
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 663 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 842272
       GoKind: 22
-      Pointee: 254 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 266 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 256
+      ID: 268
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 255 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 267 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 841792
       GoKind: 22
-      Pointee: 251 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 263 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 253
+      ID: 265
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 252 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 264 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 842368
       GoKind: 22
-      Pointee: 257 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 269 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 259
+      ID: 271
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 258 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 270 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 433
+      ID: 445
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 855712
       GoKind: 22
-      Pointee: 434 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 446 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 855616
       GoKind: 22
-      Pointee: 269 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 281 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 852448
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 413 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 404
+      ID: 416
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 852640
       GoKind: 22
-      Pointee: 405 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 417 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 402
+      ID: 414
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 852544
       GoKind: 22
-      Pointee: 403 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 415 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 852352
       GoKind: 22
-      Pointee: 399 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 411 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 666 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 678 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 853024
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 425 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 406
+      ID: 418
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 852736
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 419 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 410
+      ID: 422
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 852928
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 423 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 852832
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 421 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 853120
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 427 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 853408
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 433 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 853504
       GoKind: 22
-      Pointee: 423 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 435 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 853312
       GoKind: 22
-      Pointee: 419 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 431 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 853216
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 429 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 853696
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 437 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2166752
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 757 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2152352
       GoKind: 22
-      Pointee: 744 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 751 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 745
+      ID: 752
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2159712
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 753 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2160352
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 755 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 443
+      ID: 455
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 863488
       GoKind: 22
-      Pointee: 444 StructureType github.com/cihub/seelog.baseError
+      Pointee: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1676384
       GoKind: 22
-      Pointee: 729 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 736 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 445
+      ID: 457
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 863584
       GoKind: 22
-      Pointee: 446 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 458 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1251808
       GoKind: 22
-      Pointee: 721 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 728 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1469216
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 730 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1469984
       GoKind: 22
-      Pointee: 727 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 734 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 449
+      ID: 461
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 863776
       GoKind: 22
-      Pointee: 450 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 462 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 724
+      ID: 731
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1469408
       GoKind: 22
-      Pointee: 725 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 732 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2132416
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 749 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 447
+      ID: 459
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 863680
       GoKind: 22
-      Pointee: 448 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 460 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 451
+      ID: 463
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 863872
       GoKind: 22
-      Pointee: 452 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 464 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 828
+      ID: 835
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1160032
       GoKind: 22
-      Pointee: 829 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 836 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 847
+      ID: 854
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1609728
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 855 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 547
+      ID: 559
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1022784
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 560 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1022912
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 562 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 541
+      ID: 553
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1007552
       GoKind: 22
-      Pointee: 542 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 554 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 844192
       GoKind: 22
-      Pointee: 373 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 385 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 543
+      ID: 555
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1010496
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 556 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 589
+      ID: 601
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1117920
       GoKind: 22
-      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 602 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 583
+      ID: 595
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1117536
       GoKind: 22
-      Pointee: 584 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 596 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 997568
       GoKind: 22
-      Pointee: 528 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 540 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 595
+      ID: 607
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1118304
       GoKind: 22
-      Pointee: 596 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 608 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 526
+      ID: 538
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 997440
       GoKind: 22
-      Pointee: 491 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 503 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1117792
       GoKind: 22
-      Pointee: 588 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 600 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 585
+      ID: 597
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1117664
       GoKind: 22
-      Pointee: 586 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 598 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 593
+      ID: 605
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1118176
       GoKind: 22
-      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 606 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 591
+      ID: 603
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1118048
       GoKind: 22
-      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 604 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 599
+      ID: 611
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1118688
       GoKind: 22
-      Pointee: 600 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 612 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 531
+      ID: 543
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 997824
       GoKind: 22
-      Pointee: 532 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 544 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 529
+      ID: 541
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 997696
       GoKind: 22
-      Pointee: 530 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 542 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 597
+      ID: 609
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1118560
       GoKind: 22
-      Pointee: 598 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 610 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 466
+      ID: 478
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871648
       GoKind: 22
-      Pointee: 277 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 289 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 279
+      ID: 291
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 290 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1468256
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 649 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 553
+      ID: 565
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1039680
       GoKind: 22
-      Pointee: 554 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 566 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 873664
       GoKind: 22
-      Pointee: 280 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 292 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 607
+      ID: 619
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1170016
       GoKind: 22
-      Pointee: 608 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 620 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 22
-      Pointee: 475 StructureType golang.org/x/net/http2.connError
+      Pointee: 487 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 873856
       GoKind: 22
-      Pointee: 284 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 296 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 286
+      ID: 298
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 297 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 22
-      Pointee: 290 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 302 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 292
+      ID: 304
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 291 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 303 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 22
-      Pointee: 287 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 299 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 289
+      ID: 301
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 300 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 472
+      ID: 484
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 873760
       GoKind: 22
-      Pointee: 281 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 293 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 283
+      ID: 295
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 282 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 294 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 22
-      Pointee: 479 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 491 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 22
-      Pointee: 293 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 305 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 865696
       GoKind: 22
-      Pointee: 454 StructureType google.golang.org/grpc.dropError
+      Pointee: 466 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 605
+      ID: 617
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1166688
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 618 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1257568
       GoKind: 22
-      Pointee: 626 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 638 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 464
+      ID: 476
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869920
       GoKind: 22
-      Pointee: 465 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 477 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1679072
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 861 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 551
+      ID: 563
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1033920
       GoKind: 22
-      Pointee: 552 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 564 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1372544
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 845 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 435
+      ID: 447
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 857920
       GoKind: 22
-      Pointee: 436 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 448 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 545
+      ID: 557
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1012032
       GoKind: 22
-      Pointee: 546 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 558 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1133152
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 616 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1132896
       GoKind: 22
-      Pointee: 602 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 614 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 839008
       GoKind: 22
-      Pointee: 347 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 359 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1361664
       GoKind: 22
-      Pointee: 680 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 687 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 168
+      ID: 134
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1115872
       GoKind: 22
-      Pointee: 169 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Pointee: 135 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1760832
       GoKind: 22
-      Pointee: 858 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 865 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1669216
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+      Pointee: 859 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 147
+      ID: 141
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoRuntimeType: 2158432
       GoKind: 22
-      Pointee: 148 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 111 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 173
+      ID: 139
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext'
       ByteSize: 8
       GoRuntimeType: 1834848
       GoKind: 22
-      Pointee: 174 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+      Pointee: 140 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
     - __kind: PointerType
-      ID: 171
+      ID: 137
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1102432
       GoKind: 22
-      Pointee: 172 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Pointee: 138 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 677
+      ID: 684
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1103072
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 685 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 220
+      ID: 223
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1103200
       GoKind: 22
-      Pointee: 221 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 224 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 175
+      ID: 142
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2072448
       GoKind: 22
-      Pointee: 176 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+      Pointee: 143 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2024064
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
+      Pointee: 747 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 932
+      ID: 152
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1236928
       GoKind: 22
-      Pointee: 933 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
+      Pointee: 153 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2007776
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
+      Pointee: 745 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1005632
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
+      Pointee: 818 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 850720
       GoKind: 22
-      Pointee: 395 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 407 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 437
+      ID: 449
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 858496
       GoKind: 22
-      Pointee: 438 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 450 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 439
+      ID: 451
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 858592
       GoKind: 22
-      Pointee: 440 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 452 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 867232
       GoKind: 22
-      Pointee: 463 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 475 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 129
+      ID: 174
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 130 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 175 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*hash<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 732 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 739 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 208
+      ID: 202
       Name: '*hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 209 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 203 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 899 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 906 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 766 GoHMapHeaderType hash<string,[]string>
+      Pointee: 773 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 163
+      ID: 129
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 164 GoHMapHeaderType hash<string,float64>
+      Pointee: 130 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 631
+      ID: 643
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 632 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 644 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 158
+      ID: 124
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 159 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 153
+      ID: 117
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 154 GoHMapHeaderType hash<string,string>
+      Pointee: 118 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 875104
       GoKind: 22
-      Pointee: 482 UnresolvedPointeeType html/template.Error
+      Pointee: 494 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 95
       Name: '*int'
@@ -1603,269 +1603,269 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 844576
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 387 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 581
+      ID: 593
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1111648
       GoKind: 22
-      Pointee: 582 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 594 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2217056
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType internal/poll.FD
+      Pointee: 898 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 579
+      ID: 591
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1111520
       GoKind: 22
-      Pointee: 580 StructureType internal/poll.errNetClosing
+      Pointee: 592 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 322
+      ID: 334
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 832096
       GoKind: 22
-      Pointee: 323 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 335 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1706496
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType io.PipeReader
+      Pointee: 863 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1358464
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType io.SectionReader
+      Pointee: 867 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 985408
       GoKind: 22
-      Pointee: 809 StructureType io.nopCloser
+      Pointee: 816 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 826
+      ID: 833
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1105632
       GoKind: 22
-      Pointee: 827 StructureType io.nopCloserWriterTo
+      Pointee: 834 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1110752
       GoKind: 22
-      Pointee: 578 UnresolvedPointeeType io/fs.PathError
+      Pointee: 590 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 847456
       GoKind: 22
-      Pointee: 393 StructureType math/big.ErrNaN
+      Pointee: 405 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837376
       GoKind: 22
-      Pointee: 907 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 914 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 780 StructureType mime/multipart.Form
+      Pointee: 787 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1433696
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 847 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1433888
       GoKind: 22
-      Pointee: 842 StructureType mime/multipart.sectionReadCloser
+      Pointee: 849 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 563
+      ID: 575
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1096032
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType net.AddrError
+      Pointee: 576 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 612
+      ID: 624
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1226688
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType net.DNSError
+      Pointee: 625 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2076480
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType net.IPConn
+      Pointee: 874 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1226368
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType net.OpError
+      Pointee: 623 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1096160
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType net.ParseError
+      Pointee: 578 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2106784
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType net.TCPConn
+      Pointee: 882 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2150528
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType net.UDPConn
+      Pointee: 886 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2106272
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net.UnixConn
+      Pointee: 880 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1095264
       GoKind: 22
-      Pointee: 557 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 569 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 570 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 975936
       GoKind: 22
-      Pointee: 497 StructureType net.canceledError
+      Pointee: 509 StructureType net.canceledError
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1870272
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType net.conn
+      Pointee: 872 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 654
+      ID: 666
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1700672
       GoKind: 22
-      Pointee: 655 StructureType net.dialResult·1
+      Pointee: 667 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2153568
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType net.netFD
+      Pointee: 888 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 294
+      ID: 306
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 824896
       GoKind: 22
-      Pointee: 295 UnresolvedPointeeType net.notFoundError
+      Pointee: 307 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 930
+      ID: 150
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1226528
       GoKind: 22
-      Pointee: 931 StructureType net.onlyValuesCtx
+      Pointee: 151 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 296
+      ID: 308
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 825568
       GoKind: 22
-      Pointee: 297 StructureType net.result·2
+      Pointee: 309 StructureType net.result·2
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2092320
       GoKind: 22
-      Pointee: 871 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 878 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2091840
       GoKind: 22
-      Pointee: 869 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 876 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1096800
       GoKind: 22
-      Pointee: 568 UnresolvedPointeeType net.temporaryError
+      Pointee: 580 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1227008
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType net.timeoutError
+      Pointee: 627 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 302
+      ID: 314
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 828160
       GoKind: 22
-      Pointee: 303 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 315 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 979264
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 511 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 105
       Name: '*net/http.Request'
@@ -1874,507 +1874,507 @@ Types:
       GoKind: 22
       Pointee: 106 StructureType net/http.Request
     - __kind: PointerType
-      ID: 784
+      ID: 791
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1590912
       GoKind: 22
-      Pointee: 785 StructureType net/http.Response
+      Pointee: 792 StructureType net/http.Response
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1668544
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType net/http.body
+      Pointee: 857 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 820
+      ID: 827
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1099488
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 828 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 979136
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 808 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1701792
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType net/http.conn
+      Pointee: 765 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 977984
       GoKind: 22
-      Pointee: 791 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 798 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 981184
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 812 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 304
+      ID: 316
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 828352
       GoKind: 22
-      Pointee: 223 BaseType net/http.http2ConnectionError
+      Pointee: 235 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 305
+      ID: 317
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 828448
       GoKind: 22
-      Pointee: 306 StructureType net/http.http2GoAwayError
+      Pointee: 318 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 616
+      ID: 628
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1227968
       GoKind: 22
-      Pointee: 617 StructureType net/http.http2StreamError
+      Pointee: 629 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 1871424
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 842 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 311
+      ID: 323
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 829312
       GoKind: 22
-      Pointee: 312 StructureType net/http.http2connError
+      Pointee: 324 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 828832
       GoKind: 22
-      Pointee: 227 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 239 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 229
+      ID: 241
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 228 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 240 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 309
+      ID: 321
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 828928
       GoKind: 22
-      Pointee: 310 StructureType net/http.http2goAwayFlowError
+      Pointee: 322 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 978880
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 806 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 314
+      ID: 326
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 829504
       GoKind: 22
-      Pointee: 233 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 245 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 235
+      ID: 247
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 234 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 246 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 313
+      ID: 325
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 829408
       GoKind: 22
-      Pointee: 230 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 242 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 232
+      ID: 244
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 231 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 243 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 571
+      ID: 583
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1101024
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 584 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 978624
       GoKind: 22
-      Pointee: 795 StructureType net/http.http2missingBody
+      Pointee: 802 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 981440
       GoKind: 22
-      Pointee: 807 StructureType net/http.http2noBodyReader
+      Pointee: 814 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 981312
       GoKind: 22
-      Pointee: 505 StructureType net/http.http2noCachedConnError
+      Pointee: 517 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 307
+      ID: 319
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 828736
       GoKind: 22
-      Pointee: 224 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 236 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 226
+      ID: 238
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 225 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 237 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 979776
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 810 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1832832
       GoKind: 22
-      Pointee: 717 StructureType net/http.http2responseWriter
+      Pointee: 724 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1418144
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 763 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 978752
       GoKind: 22
-      Pointee: 797 StructureType net/http.http2transportResponseBody
+      Pointee: 804 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 978112
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 800 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 824
+      ID: 831
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1099744
       GoKind: 22
-      Pointee: 825 StructureType net/http.noBody
+      Pointee: 832 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 980928
       GoKind: 22
-      Pointee: 501 StructureType net/http.nothingWrittenError
+      Pointee: 513 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1416224
       GoKind: 22
-      Pointee: 787 StructureType net/http.pattern
+      Pointee: 794 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 977472
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 796 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1099616
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 830 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 315
+      ID: 327
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 829696
       GoKind: 22
-      Pointee: 316 StructureType net/http.requestBodyReadError
+      Pointee: 328 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2059008
       GoKind: 22
-      Pointee: 719 StructureType net/http.response
+      Pointee: 726 StructureType net/http.response
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364000
       GoKind: 22
-      Pointee: 926 StructureType net/http.segment
+      Pointee: 933 StructureType net/http.segment
     - __kind: PointerType
-      ID: 300
+      ID: 312
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 828064
       GoKind: 22
-      Pointee: 301 StructureType net/http.statusError
+      Pointee: 313 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1229408
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 631 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 569
+      ID: 581
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1100896
       GoKind: 22
-      Pointee: 570 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 582 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 981056
       GoKind: 22
-      Pointee: 503 StructureType net/http.transportReadFromServerError
+      Pointee: 515 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 298
+      ID: 310
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 827296
       GoKind: 22
-      Pointee: 299 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 311 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 816
+      ID: 823
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1040960
       GoKind: 22
-      Pointee: 817 StructureType net/http/httputil.failureToReadBody
+      Pointee: 824 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 328
+      ID: 340
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 834592
       GoKind: 22
-      Pointee: 329 StructureType net/netip.parseAddrError
+      Pointee: 341 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 326
+      ID: 338
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 834496
       GoKind: 22
-      Pointee: 327 StructureType net/netip.parsePrefixError
+      Pointee: 339 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 837856
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType net/textproto.Error
+      Pointee: 354 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 837760
       GoKind: 22
-      Pointee: 247 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 259 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 249
+      ID: 261
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 248 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 260 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1234048
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType net/url.Error
+      Pointee: 636 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836704
       GoKind: 22
-      Pointee: 241 GoStringHeaderType net/url.EscapeError
+      Pointee: 253 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 243
+      ID: 255
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 242 GoStringDataType net/url.EscapeError.str
+      Pointee: 254 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 339
+      ID: 351
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836800
       GoKind: 22
-      Pointee: 244 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 256 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 246
+      ID: 258
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 245 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 257 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1949216
       GoKind: 22
-      Pointee: 776 StructureType net/url.URL
+      Pointee: 783 StructureType net/url.URL
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1114208
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 902 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2192928
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType os.File
+      Pointee: 894 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 983232
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType os.LinkError
+      Pointee: 519 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 144
+      ID: 167
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 366752
       GoKind: 22
-      Pointee: 145 GoInterfaceType os.Signal
+      Pointee: 168 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 573
+      ID: 585
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1101536
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType os.SyscallError
+      Pointee: 586 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2189248
       GoKind: 22
-      Pointee: 885 StructureType os.fileWithoutReadFrom
+      Pointee: 892 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2188512
       GoKind: 22
-      Pointee: 883 StructureType os.fileWithoutWriteTo
+      Pointee: 890 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 537
+      ID: 549
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1005888
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType os/exec.Error
+      Pointee: 550 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 658
+      ID: 670
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1951328
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 671 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1006016
       GoKind: 22
-      Pointee: 540 StructureType os/exec.wrappedError
+      Pointee: 552 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 121
+      ID: 163
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1420832
       GoKind: 22
-      Pointee: 122 StructureType os/signal.signalCtx
+      Pointee: 164 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 862528
       GoKind: 22
-      Pointee: 271 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 283 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 273
+      ID: 285
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 284 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 862432
       GoKind: 22
-      Pointee: 270 BaseType os/user.UnknownUserIdError
+      Pointee: 282 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 324
+      ID: 336
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 832960
       GoKind: 22
-      Pointee: 325 UnresolvedPointeeType reflect.ValueError
+      Pointee: 337 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 851680
       GoKind: 22
-      Pointee: 397 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 409 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 987840
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 526 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 989760
       GoKind: 22
-      Pointee: 519 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 531 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2390,12 +2390,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 987968
       GoKind: 22
-      Pointee: 516 StructureType runtime.boundsError
+      Pointee: 528 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -2411,24 +2411,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1109600
       GoKind: 22
-      Pointee: 576 StructureType runtime.errorAddressString
+      Pointee: 588 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 987584
       GoKind: 22
-      Pointee: 483 GoStringHeaderType runtime.errorString
+      Pointee: 495 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 485
+      ID: 497
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 484 GoStringDataType runtime.errorString.str
+      Pointee: 496 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -2444,24 +2444,24 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 133
+      ID: 121
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375520
       GoKind: 22
-      Pointee: 134 UnresolvedPointeeType runtime.mapextra
+      Pointee: 122 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 989504
       GoKind: 22
-      Pointee: 486 GoStringHeaderType runtime.plainError
+      Pointee: 498 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 487 GoStringDataType runtime.plainError.str
+      Pointee: 499 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2484,12 +2484,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 987200
       GoKind: 22
-      Pointee: 511 UnresolvedPointeeType strconv.NumError
+      Pointee: 523 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -2498,190 +2498,190 @@ Types:
       GoKind: 22
       Pointee: 13 GoStringHeaderType string
     - __kind: PointerType
-      ID: 179
+      ID: 186
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 178 GoStringDataType string.str
+      Pointee: 185 GoStringDataType string.str
     - __kind: PointerType
-      ID: 685
+      ID: 692
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1495904
       GoKind: 22
-      Pointee: 686 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 693 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 699
+      ID: 706
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1615680
       GoKind: 22
-      Pointee: 700 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 707 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 681
+      ID: 688
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1495520
       GoKind: 22
-      Pointee: 682 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 689 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 691
+      ID: 698
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1614912
       GoKind: 22
-      Pointee: 692 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 699 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 705
+      ID: 712
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1684896
       GoKind: 22
-      Pointee: 706 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 713 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 693
+      ID: 700
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1615104
       GoKind: 22
-      Pointee: 694 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 701 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1614720
       GoKind: 22
-      Pointee: 690 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 697 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 701
+      ID: 708
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1684448
       GoKind: 22
-      Pointee: 702 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 709 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 709
+      ID: 716
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1750176
       GoKind: 22
-      Pointee: 710 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 717 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 703
+      ID: 710
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1684672
       GoKind: 22
-      Pointee: 704 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 711 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1496096
       GoKind: 22
-      Pointee: 688 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 695 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1495712
       GoKind: 22
-      Pointee: 684 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 691 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 695
+      ID: 702
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1615296
       GoKind: 22
-      Pointee: 696 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 703 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 707
+      ID: 714
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1685120
       GoKind: 22
-      Pointee: 708 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 715 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 697
+      ID: 704
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1615488
       GoKind: 22
-      Pointee: 698 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 705 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1048224
       GoKind: 22
-      Pointee: 819 StructureType struct { io.Reader; io.Closer }
+      Pointee: 826 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1232928
       GoKind: 22
-      Pointee: 609 BaseType syscall.Errno
+      Pointee: 621 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 675
+      ID: 682
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 990272
       GoKind: 22
-      Pointee: 674 BaseType syscall.Signal
+      Pointee: 681 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 555
+      ID: 567
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1044160
       GoKind: 22
-      Pointee: 556 StructureType text/template.ExecError
+      Pointee: 568 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 139
+      ID: 183
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1421216
       GoKind: 22
-      Pointee: 140 StructureType time.Location
+      Pointee: 184 StructureType time.Location
     - __kind: PointerType
-      ID: 318
+      ID: 330
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 830560
       GoKind: 22
-      Pointee: 319 UnresolvedPointeeType time.ParseError
+      Pointee: 331 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 136
+      ID: 180
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 983744
       GoKind: 22
-      Pointee: 137 StructureType time.Timer
+      Pointee: 181 StructureType time.Timer
     - __kind: PointerType
-      ID: 317
+      ID: 329
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 830464
       GoKind: 22
-      Pointee: 236 GoStringHeaderType time.fileSizeError
+      Pointee: 248 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 238
+      ID: 250
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 237 GoStringDataType time.fileSizeError.str
+      Pointee: 249 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 191
+      ID: 217
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367072
       GoKind: 22
-      Pointee: 192 StructureType time.zone
+      Pointee: 218 StructureType time.zone
     - __kind: PointerType
-      ID: 194
+      ID: 220
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 195 StructureType time.zoneTrans
+      Pointee: 221 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -2725,47 +2725,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 330
+      ID: 342
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 835360
       GoKind: 22
-      Pointee: 331 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 343 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 343
+      ID: 355
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 838240
       GoKind: 22
-      Pointee: 344 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 356 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 838336
       GoKind: 22
-      Pointee: 250 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 262 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 995008
       GoKind: 22
-      Pointee: 524 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 536 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 525
+      ID: 537
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 995136
       GoKind: 22
-      Pointee: 490 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 502 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 783
+      ID: 790
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
     - __kind: GoChannelType
-      ID: 668
+      ID: 680
       Name: <-chan time.Time
       GoRuntimeType: 549952
       GoKind: 18
@@ -2844,7 +2844,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 770
+      ID: 777
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 624224
@@ -2853,7 +2853,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 769
+      ID: 776
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 624128
@@ -2916,7 +2916,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 771
+      ID: 778
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 624320
@@ -2934,7 +2934,7 @@ Types:
       HasCount: true
       Element: 12 BaseType uint64
     - __kind: ArrayType
-      ID: 642
+      ID: 654
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 641792
@@ -2961,7 +2961,7 @@ Types:
       HasCount: true
       Element: 81 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 184
+      ID: 191
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
@@ -2970,7 +2970,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 910
+      ID: 917
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469536
@@ -2978,22 +2978,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 911 PointerType **crypto/x509.Certificate
+          Type: 918 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 918 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 925 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 918
+      ID: 925
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 628 PointerType *crypto/x509.Certificate
+      Element: 640 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 669
+      ID: 230
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 24
       GoRuntimeType: 459776
@@ -3001,22 +3001,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 670 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 231 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 672 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Data: 233 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: GoSliceDataType
-      ID: 672
+      ID: 233
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Element: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: GoSliceHeaderType
-      ID: 903
+      ID: 910
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457376
@@ -3024,22 +3024,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 904 PointerType **mime/multipart.FileHeader
+          Type: 911 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 908 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 915 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 908
+      ID: 915
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 905 PointerType *mime/multipart.FileHeader
+      Element: 912 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 912
+      ID: 919
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -3047,22 +3047,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 913 PointerType *[]*crypto/x509.Certificate
+          Type: 920 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 920 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 927 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 920
+      ID: 927
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 910 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 917 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 914
+      ID: 921
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452832
@@ -3070,76 +3070,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 915 PointerType *[]uint8
+          Type: 922 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 922 GoSliceDataType [][]uint8.array
+      Data: 929 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 922
+      ID: 929
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 215
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 132 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 177 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 754
+      ID: 761
       Name: '[]bucket<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
-      Element: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      Element: 741 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 225
       Name: '[]bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 906
+      ID: 913
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 901 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 908 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 774
+      ID: 781
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 768 GoHMapBucketType bucket<string,[]string>
+      Element: 775 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 198
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 166 GoHMapBucketType bucket<string,float64>
+      Element: 132 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 661
+      ID: 673
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 646 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 196
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 161 GoHMapBucketType bucket<string,interface {}>
+      Element: 127 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 194
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 156 GoHMapBucketType bucket<string,string>
+      Element: 120 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 647
+      ID: 659
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 464448
@@ -3154,15 +3154,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 664 GoSliceDataType []float64.array
+      Data: 676 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 664
+      ID: 676
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 19 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 133
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 24
       GoRuntimeType: 459520
@@ -3170,22 +3170,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 134 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 205 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 199 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 199
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 169 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Element: 135 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 170
+      ID: 136
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 459712
@@ -3193,43 +3193,43 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 171 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 137 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 213 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 207 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 207
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 172 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Element: 138 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 185
+      ID: 211
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 186 GoInterfaceType context.canceler
+      Element: 212 GoInterfaceType context.canceler
     - __kind: ArrayType
-      ID: 751
+      ID: 758
       Name: '[]key<github.com/cihub/seelog.LogLevel>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 752 BaseType github.com/cihub/seelog.LogLevel
+      Element: 759 BaseType github.com/cihub/seelog.LogLevel
     - __kind: ArrayType
-      ID: 198
+      ID: 192
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 924
+      ID: 931
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454816
@@ -3237,22 +3237,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 925 PointerType *net/http.segment
+          Type: 932 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 927 GoSliceDataType []net/http.segment.array
+      Data: 934 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 927
+      ID: 934
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 926 StructureType net/http.segment
+      Element: 933 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 166
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 452704
@@ -3260,26 +3260,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *os.Signal
+          Type: 167 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 196 GoSliceDataType []os.Signal.array
+      Data: 209 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 209
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 145 GoInterfaceType os.Signal
+      Element: 168 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 646
+      ID: 658
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -3294,15 +3294,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 662 GoSliceDataType []string.array
+      Data: 674 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 662
+      ID: 674
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 190
+      ID: 216
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459040
@@ -3310,22 +3310,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 191 PointerType *time.zone
+          Type: 217 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 215 GoSliceDataType []time.zone.array
+      Data: 226 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 226
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 192 StructureType time.zone
+      Element: 218 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 193
+      ID: 219
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459104
@@ -3333,20 +3333,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 194 PointerType *time.zoneTrans
+          Type: 220 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 217 GoSliceDataType []time.zoneTrans.array
+      Data: 228 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 228
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 195 StructureType time.zoneTrans
+      Element: 221 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3363,9 +3363,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 180 GoSliceDataType []uint8.array
+      Data: 187 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 187
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3386,77 +3386,77 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 182 GoSliceDataType []uintptr.array
+      Data: 189 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 189
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 219
+      ID: 222
       Name: '[]val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 220 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 223 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 902
+      ID: 909
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 903 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 910 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 773
+      ID: 780
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 646 GoSliceHeaderType []string
+      Element: 658 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 753
+      ID: 760
       Name: '[]val<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 203
+      ID: 197
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 660
+      ID: 672
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 665 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 201
+      ID: 195
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 127 GoEmptyInterfaceType interface {}
+      Element: 156 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 199
+      ID: 193
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 187
+      ID: 213
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
-      Element: 188 StructureType struct {}
+      Element: 214 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 468
+      ID: 480
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 872512
@@ -3471,27 +3471,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 469 GoSliceDataType archive/tar.headerError.array
+      Data: 481 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 481
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 831
+      ID: 838
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 822
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 840
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3501,178 +3501,178 @@ Types:
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 132
+      ID: 177
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<context.canceler>
+          Type: 211 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 187 ArrayType []val<struct {}>
+          Type: 213 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 131 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 186 GoInterfaceType context.canceler
-      ValueType: 188 StructureType struct {}
+          Type: 176 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 212 GoInterfaceType context.canceler
+      ValueType: 214 StructureType struct {}
     - __kind: GoHMapBucketType
-      ID: 734
+      ID: 741
       Name: bucket<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 751 ArrayType []key<github.com/cihub/seelog.LogLevel>
+          Type: 758 ArrayType []key<github.com/cihub/seelog.LogLevel>
         - Name: values
           Offset: 16
-          Type: 753 ArrayType []val<bool>
+          Type: 760 ArrayType []val<bool>
         - Name: overflow
           Offset: 24
-          Type: 733 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
-      KeyType: 752 BaseType github.com/cihub/seelog.LogLevel
+          Type: 740 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+      KeyType: 759 BaseType github.com/cihub/seelog.LogLevel
       ValueType: 6 BaseType bool
     - __kind: GoHMapBucketType
-      ID: 211
+      ID: 205
       Name: bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 219 ArrayType []val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 222 ArrayType []val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 220 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      ValueType: 223 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 901
+      ID: 908
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 902 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 909 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 900 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 907 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 903 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 910 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 768
+      ID: 775
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 773 ArrayType []val<[]string>
+          Type: 780 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 767 PointerType *bucket<string,[]string>
+          Type: 774 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 646 GoSliceHeaderType []string
+      ValueType: 658 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 166
+      ID: 132
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 203 ArrayType []val<float64>
+          Type: 197 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 165 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 634
+      ID: 646
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 660 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 672 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 645 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 665 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
-      ID: 161
+      ID: 127
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 201 ArrayType []val<interface {}>
+          Type: 195 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 160 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 127 GoEmptyInterfaceType interface {}
+      ValueType: 156 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 156
+      ID: 120
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 199 ArrayType []val<string>
+          Type: 193 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 155 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 762
+      ID: 769
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3680,12 +3680,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 772
+      ID: 779
       Name: chan bool
       GoRuntimeType: 546176
       GoKind: 18
     - __kind: GoChannelType
-      ID: 146
+      ID: 169
       Name: chan os.Signal
       GoRuntimeType: 552704
       GoKind: 18
@@ -3702,13 +3702,13 @@ Types:
       GoRuntimeType: 534336
       GoKind: 15
     - __kind: BaseType
-      ID: 265
+      ID: 277
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 768832
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 278
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 768928
@@ -3716,26 +3716,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *compress/flate.InternalError.str
+          Type: 280 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 267 GoStringDataType compress/flate.InternalError.str
+      Data: 279 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 279
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 870
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 851
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 142
+      ID: 165
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 618176
@@ -3754,19 +3754,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 160
       Name: context.backgroundCtx
       GoRuntimeType: 1667200
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 124 StructureType context.emptyCtx
+          Type: 146 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 112
+      ID: 171
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1827776
@@ -3777,13 +3777,13 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 125 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 126 StructureType sync/atomic.Value
+          Type: 172 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 128 GoMapType map[context.canceler]struct {}
+          Type: 173 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -3793,7 +3793,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 186
+      ID: 212
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1064704
@@ -3806,13 +3806,13 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 561
+      ID: 573
       Name: context.deadlineExceededError
       GoRuntimeType: 1274816
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 146
       Name: context.emptyCtx
       GoRuntimeType: 1399456
       GoKind: 25
@@ -3821,7 +3821,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 114
+      ID: 148
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1690848
@@ -3832,11 +3832,11 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 135 GoSubroutineType func() bool
+          Type: 149 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 116
+      ID: 179
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1414304
@@ -3844,29 +3844,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 112 StructureType context.cancelCtx
+          Type: 171 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 136 PointerType *time.Timer
+          Type: 180 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 138 GoTimeType time.Time
+          Type: 182 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 141
+      ID: 162
       Name: context.todoCtx
       GoRuntimeType: 1667424
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 124 StructureType context.emptyCtx
+          Type: 146 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 118
+      ID: 155
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1699104
@@ -3877,14 +3877,14 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 120
+      ID: 158
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1666976
@@ -3896,39 +3896,39 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 262
+      ID: 274
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
     - __kind: BaseType
-      ID: 263
+      ID: 275
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768640
       GoKind: 2
     - __kind: BaseType
-      ID: 264
+      ID: 276
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768736
       GoKind: 2
     - __kind: BaseType
-      ID: 239
+      ID: 251
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 766240
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 522
+      ID: 534
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 900
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2100000
@@ -3957,13 +3957,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 910 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 917 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 912 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 919 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 914 GoSliceHeaderType [][]uint8
+          Type: 921 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -3975,25 +3975,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 916 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 923 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 917 BaseType crypto/tls.CurveID
+          Type: 924 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 917
+      ID: 924
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766048
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 335
+      ID: 347
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 333
+      ID: 345
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1595520
@@ -4004,26 +4004,26 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 642 ArrayType [5]uint8
+          Type: 654 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 643 GoInterfaceType net.Conn
+          Type: 655 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 489
+      ID: 501
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 944896
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 634
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 641
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 384
+      ID: 396
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1598400
@@ -4031,21 +4031,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 628 PointerType *crypto/x509.Certificate
+          Type: 640 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 652 BaseType crypto/x509.InvalidReason
+          Type: 664 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 378
+      ID: 390
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1070848
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 380
+      ID: 392
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1401376
@@ -4053,24 +4053,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 628 PointerType *crypto/x509.Certificate
+          Type: 640 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 261
+      ID: 273
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 768352
       GoKind: 2
     - __kind: BaseType
-      ID: 652
+      ID: 664
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537344
       GoKind: 2
     - __kind: StructureType
-      ID: 536
+      ID: 548
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1364864
@@ -4080,13 +4080,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 386
+      ID: 398
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1071104
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 382
+      ID: 394
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1598208
@@ -4094,15 +4094,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 628 PointerType *crypto/x509.Certificate
+          Type: 640 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 628 PointerType *crypto/x509.Certificate
+          Type: 640 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 427
+      ID: 439
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1245408
@@ -4112,7 +4112,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 431
+      ID: 443
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1245568
@@ -4122,47 +4122,47 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 429
+      ID: 441
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 240
+      ID: 252
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 766336
       GoKind: 6
     - __kind: BaseType
-      ID: 260
+      ID: 272
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 768160
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 357
+      ID: 369
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 546
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 349
+      ID: 361
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 355
+      ID: 367
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 353
+      ID: 365
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 363
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 359
+      ID: 371
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1237088
@@ -4172,15 +4172,15 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 458
+      ID: 470
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 456
+      ID: 468
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 274
+      ID: 286
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 771520
@@ -4188,18 +4188,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 276 PointerType *encoding/xml.UnmarshalError.str
+          Type: 288 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 275 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 287 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 275
+      ID: 287
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 461
+      ID: 473
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4216,11 +4216,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 321
+      ID: 333
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 521
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4236,11 +4236,11 @@ Types:
       GoRuntimeType: 534528
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 505
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 495
+      ID: 507
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4250,13 +4250,13 @@ Types:
       GoRuntimeType: 451168
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 777
+      ID: 784
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634112
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 135
+      ID: 149
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 544960
@@ -4268,23 +4268,23 @@ Types:
       GoRuntimeType: 785664
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 916
+      ID: 923
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960256
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 382
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 736
+      ID: 743
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 1915200
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 362
+      ID: 374
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1596864
@@ -4292,7 +4292,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 644 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 656 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -4300,25 +4300,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 376
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 661
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 368
+      ID: 380
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1069824
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 663
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 254
+      ID: 266
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 767584
@@ -4326,18 +4326,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 256 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 268 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 255 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 267 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 255
+      ID: 267
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 644
+      ID: 656
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2067520
@@ -4345,13 +4345,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 645 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 657 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 13 GoStringHeaderType string
@@ -4360,7 +4360,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 647 GoSliceHeaderType []float64
+          Type: 659 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4369,13 +4369,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 648 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 660 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 650 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 662 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 13 GoStringHeaderType string
@@ -4386,13 +4386,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 645
+      ID: 657
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 536128
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 251
+      ID: 263
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 767488
@@ -4400,18 +4400,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 253 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 265 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 252 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 264 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 252
+      ID: 264
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 257
+      ID: 269
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 767680
@@ -4419,30 +4419,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 259 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 271 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 258 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 270 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 258
+      ID: 270
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 434
+      ID: 446
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1073664
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 269
+      ID: 281
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 770080
       GoKind: 2
     - __kind: StructureType
-      ID: 401
+      ID: 413
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1402336
@@ -4455,7 +4455,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 405
+      ID: 417
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1600128
@@ -4471,7 +4471,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 403
+      ID: 415
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1243968
@@ -4481,7 +4481,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 399
+      ID: 411
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1243648
@@ -4491,14 +4491,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 630
+      ID: 642
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1129568
       GoKind: 21
-      HeaderType: 632 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 644 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 653
+      ID: 665
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1006912
@@ -4513,15 +4513,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 666 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 678 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 666
+      ID: 678
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 413
+      ID: 425
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1402656
@@ -4529,12 +4529,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 630 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 642 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 630 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 642 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 407
+      ID: 419
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1244128
@@ -4544,7 +4544,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 411
+      ID: 423
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1600320
@@ -4555,12 +4555,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 665 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 665 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 409
+      ID: 421
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1402496
@@ -4573,7 +4573,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 415
+      ID: 427
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1244288
@@ -4581,9 +4581,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 138 GoTimeType time.Time
+          Type: 182 GoTimeType time.Time
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1402976
@@ -4596,7 +4596,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 423
+      ID: 435
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1244608
@@ -4606,7 +4606,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 419
+      ID: 431
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1402816
@@ -4619,7 +4619,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 417
+      ID: 429
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1244448
@@ -4629,7 +4629,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 425
+      ID: 437
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1403136
@@ -4642,29 +4642,29 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 752
+      ID: 759
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 770944
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 757
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 744
+      ID: 751
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 753
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 755
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 444
+      ID: 456
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1250528
@@ -4674,11 +4674,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 729
+      ID: 736
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 446
+      ID: 458
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1250688
@@ -4686,17 +4686,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 444 StructureType github.com/cihub/seelog.baseError
+          Type: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 721
+      ID: 728
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 730
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 727
+      ID: 734
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1693536
@@ -4704,12 +4704,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 722 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 729 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 730 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 737 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 450
+      ID: 462
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1251008
@@ -4717,9 +4717,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 444 StructureType github.com/cihub/seelog.baseError
+          Type: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 725
+      ID: 732
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1676608
@@ -4727,13 +4727,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 722 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 729 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 749
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 448
+      ID: 460
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1250848
@@ -4741,9 +4741,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 444 StructureType github.com/cihub/seelog.baseError
+          Type: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 452
+      ID: 464
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1251168
@@ -4751,9 +4751,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 444 StructureType github.com/cihub/seelog.baseError
+          Type: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 845
+      ID: 852
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1078528
@@ -4766,7 +4766,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 829
+      ID: 836
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1475936
@@ -4774,36 +4774,36 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 845 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 852 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 855
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 560
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 562
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 542
+      ID: 554
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 373
+      ID: 385
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1238368
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 556
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 602
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1712768
@@ -4819,11 +4819,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 584
+      ID: 596
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 528
+      ID: 540
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1503296
@@ -4836,7 +4836,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 596
+      ID: 608
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1713216
@@ -4852,13 +4852,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 491
+      ID: 503
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 946048
       GoKind: 8
     - __kind: StructureType
-      ID: 588
+      ID: 600
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1712544
@@ -4874,13 +4874,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 656
+      ID: 668
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 767104
       GoKind: 8
     - __kind: StructureType
-      ID: 586
+      ID: 598
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1712320
@@ -4888,15 +4888,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 656 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 668 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 656 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 668 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 594
+      ID: 606
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1632352
@@ -4909,7 +4909,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 592
+      ID: 604
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1712992
@@ -4925,7 +4925,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 600
+      ID: 612
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1438112
@@ -4935,19 +4935,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 532
+      ID: 544
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1189792
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 530
+      ID: 542
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1189664
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 598
+      ID: 610
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1632544
@@ -4960,7 +4960,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 289
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 772192
@@ -4968,22 +4968,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 291 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 278 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 290 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 290
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 649
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 554
+      ID: 566
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1260288
@@ -4993,19 +4993,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 280
+      ID: 292
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 772768
       GoKind: 10
     - __kind: BaseType
-      ID: 635
+      ID: 647
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 957568
       GoKind: 10
     - __kind: StructureType
-      ID: 608
+      ID: 620
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1745472
@@ -5016,12 +5016,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 635 BaseType golang.org/x/net/http2.ErrCode
+          Type: 647 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 475
+      ID: 487
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1409856
@@ -5029,12 +5029,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 635 BaseType golang.org/x/net/http2.ErrCode
+          Type: 647 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 296
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 772960
@@ -5042,18 +5042,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 298 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 285 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 297 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 297
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 290
+      ID: 302
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 773152
@@ -5061,18 +5061,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 292 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 304 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 291 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 303 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 291
+      ID: 303
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 299
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 773056
@@ -5080,18 +5080,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 301 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 288 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 300 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 300
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 281
+      ID: 293
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 772864
@@ -5099,18 +5099,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 283 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 295 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 282 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 294 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 282
+      ID: 294
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 479
+      ID: 491
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1261568
@@ -5120,13 +5120,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 293
+      ID: 305
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 773248
       GoKind: 2
     - __kind: StructureType
-      ID: 454
+      ID: 466
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1255968
@@ -5136,11 +5136,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 618
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 626
+      ID: 638
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1770048
@@ -5156,7 +5156,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 465
+      ID: 477
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1408896
@@ -5169,11 +5169,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 861
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 552
+      ID: 564
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1371744
@@ -5183,33 +5183,33 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 845
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 436
+      ID: 448
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 546
+      ID: 558
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 616
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 602
+      ID: 614
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1320896
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 347
+      ID: 359
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 711
+      ID: 718
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1235648
@@ -5222,7 +5222,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 680
+      ID: 687
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1400896
@@ -5248,7 +5248,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 169
+      ID: 135
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
       ByteSize: 56
       GoRuntimeType: 1781216
@@ -5265,7 +5265,7 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -5273,7 +5273,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 858
+      ID: 865
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1828288
@@ -5281,29 +5281,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 851 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+          Type: 858 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 861 BaseType time.Duration
+          Type: 868 BaseType time.Duration
     - __kind: GoMapType
-      ID: 157
+      ID: 123
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 983872
       GoKind: 21
-      HeaderType: 159 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 859
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 671
+      ID: 232
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 533376
       GoKind: 10
     - __kind: DDTraceSpanType
-      ID: 148
+      ID: 111
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
       ByteSize: 288
       GoRuntimeType: 2185696
@@ -5311,7 +5311,7 @@ Types:
       RawFields:
         - Name: RWMutex
           Offset: 0
-          Type: 149 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: Name
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -5332,13 +5332,13 @@ Types:
           Type: 15 BaseType int64
         - Name: Meta
           Offset: 104
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: MetaStruct
           Offset: 112
-          Type: 157 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
+          Type: 123 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
         - Name: Metrics
           Offset: 120
-          Type: 162 GoMapType map[string]float64
+          Type: 128 GoMapType map[string]float64
         - Name: SpanID
           Offset: 128
           Type: 12 BaseType uint64
@@ -5353,10 +5353,10 @@ Types:
           Type: 14 BaseType int32
         - Name: SpanLinks
           Offset: 160
-          Type: 167 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 133 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: SpanEvents
           Offset: 184
-          Type: 170 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 136 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -5368,7 +5368,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 173 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+          Type: 139 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
         - Name: integration
           Offset: 224
           Type: 13 GoStringHeaderType string
@@ -5391,7 +5391,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 174
+      ID: 140
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
       ByteSize: 160
       GoRuntimeType: 2040288
@@ -5402,10 +5402,10 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 175 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+          Type: 142 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: errors
           Offset: 24
           Type: 14 BaseType int32
@@ -5417,16 +5417,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 177 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
+          Type: 144 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 12 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 149 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -5435,9 +5435,9 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 167 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 133 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: StructureType
-      ID: 172
+      ID: 138
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1623520
@@ -5451,16 +5451,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 207 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 201 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 212 GoMapType map[string]interface {}
+          Type: 206 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 685
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 221
+      ID: 224
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1776864
@@ -5468,7 +5468,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 676 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
+          Type: 683 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -5483,15 +5483,15 @@ Types:
           Type: 19 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 677 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+          Type: 684 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 676
+      ID: 683
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 942400
       GoKind: 5
     - __kind: StructureType
-      ID: 176
+      ID: 143
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 1962912
@@ -5499,16 +5499,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 149 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 669 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 230 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: tags
           Offset: 48
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 11 BaseType int
@@ -5523,12 +5523,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 671 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
+          Type: 232 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: ArrayType
-      ID: 177
+      ID: 144
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 831328
@@ -5537,11 +5537,11 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 747
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 933
+    - __kind: GoContextImplementationType
+      ID: 153
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1438688
@@ -5550,20 +5550,22 @@ Types:
         - Name: Context
           Offset: 0
           Type: 110 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 745
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 818
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 395
+      ID: 407
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 438
+      ID: 450
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1247808
@@ -5573,7 +5575,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 440
+      ID: 452
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1247968
@@ -5583,11 +5585,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 463
+      ID: 475
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 130
+      ID: 175
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -5608,20 +5610,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 131 PointerType *bucket<context.canceler,struct {}>
+          Type: 176 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 131 PointerType *bucket<context.canceler,struct {}>
+          Type: 176 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 132 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 189 GoSliceDataType []bucket<context.canceler,struct {}>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 177 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 215 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
-      ID: 732
+      ID: 739
       Name: hash<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       RawFields:
@@ -5642,20 +5644,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 733 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+          Type: 740 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
         - Name: oldbuckets
           Offset: 24
-          Type: 733 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+          Type: 740 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
-      BucketsType: 754 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 741 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      BucketsType: 761 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
     - __kind: GoHMapHeaderType
-      ID: 209
+      ID: 203
       Name: hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -5676,20 +5678,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 222 GoSliceDataType []bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 225 GoSliceDataType []bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 899
+      ID: 906
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -5710,20 +5712,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 900 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 907 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 900 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 907 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 901 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 906 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 908 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 913 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 766
+      ID: 773
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -5744,20 +5746,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 767 PointerType *bucket<string,[]string>
+          Type: 774 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 767 PointerType *bucket<string,[]string>
+          Type: 774 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 768 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 774 GoSliceDataType []bucket<string,[]string>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 775 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 781 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 164
+      ID: 130
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -5778,20 +5780,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 165 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 165 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 166 GoHMapBucketType bucket<string,float64>
-      BucketsType: 204 GoSliceDataType []bucket<string,float64>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 132 GoHMapBucketType bucket<string,float64>
+      BucketsType: 198 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 632
+      ID: 644
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -5812,20 +5814,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 645 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 645 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 661 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 646 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 673 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
-      ID: 159
+      ID: 125
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -5846,20 +5848,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 160 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 160 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 161 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 202 GoSliceDataType []bucket<string,interface {}>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 127 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 196 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 154
+      ID: 118
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -5880,20 +5882,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 155 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 155 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 156 GoHMapBucketType bucket<string,string>
-      BucketsType: 200 GoSliceDataType []bucket<string,string>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 120 GoHMapBucketType bucket<string,string>
+      BucketsType: 194 GoSliceDataType []bucket<string,string>.array
     - __kind: UnresolvedPointeeType
-      ID: 482
+      ID: 494
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5927,7 +5929,7 @@ Types:
       GoRuntimeType: 533632
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 127
+      ID: 156
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785376
@@ -5940,7 +5942,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 387
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5966,21 +5968,21 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 582
+      ID: 594
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 898
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 592
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1291616
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 323
+      ID: 335
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6061,7 +6063,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 846
+      ID: 853
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 985920
@@ -6074,11 +6076,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 759
+      ID: 766
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1067136
@@ -6091,7 +6093,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 836
+      ID: 843
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 985280
@@ -6104,11 +6106,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 816
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1358304
@@ -6116,9 +6118,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 836 GoInterfaceType io.Reader
+          Type: 843 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 827
+      ID: 834
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1422752
@@ -6126,69 +6128,69 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 836 GoInterfaceType io.Reader
+          Type: 843 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 578
+      ID: 590
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoMapType
-      ID: 128
+      ID: 173
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 880576
       GoKind: 21
-      HeaderType: 130 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 175 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 730
+      ID: 737
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 918048
       GoKind: 21
-      HeaderType: 732 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 739 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 207
+      ID: 201
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 888352
       GoKind: 21
-      HeaderType: 209 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 203 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 897
+      ID: 904
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887296
       GoKind: 21
-      HeaderType: 899 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 906 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 896
+      ID: 903
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882496
       GoKind: 21
-      HeaderType: 766 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 773 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 162
+      ID: 128
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 888256
       GoKind: 21
-      HeaderType: 164 GoHMapHeaderType hash<string,float64>
+      HeaderType: 130 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 212
+      ID: 206
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 880096
       GoKind: 21
-      HeaderType: 159 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
-      ID: 152
+      ID: 116
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
-      HeaderType: 154 GoHMapHeaderType hash<string,string>
+      HeaderType: 118 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 393
+      ID: 405
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1240768
@@ -6198,11 +6200,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 907
+      ID: 914
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1294336
@@ -6210,16 +6212,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 896 GoMapType map[string][]string
+          Type: 903 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 897 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 904 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 847
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 849
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1780192
@@ -6227,16 +6229,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 859 PointerType *io.SectionReader
+          Type: 866 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 846 GoInterfaceType io.Closer
+          Type: 853 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 576
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 643
+      ID: 655
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1399616
@@ -6249,35 +6251,35 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 625
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 623
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 578
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 569
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1064960
@@ -6285,28 +6287,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *net.UnknownNetworkError.str
+          Type: 571 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 558 GoStringDataType net.UnknownNetworkError.str
+      Data: 570 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 570
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 497
+      ID: 509
       Name: net.canceledError
       GoRuntimeType: 1187360
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 872
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 667
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1962208
@@ -6314,7 +6316,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 643 GoInterfaceType net.Conn
+          Type: 655 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -6325,27 +6327,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 888
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 884
       Name: net.noReadFrom
       GoRuntimeType: 1065216
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 876
+      ID: 883
       Name: net.noWriteTo
       GoRuntimeType: 1065088
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 295
+      ID: 307
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 931
+    - __kind: GoContextImplementationType
+      ID: 151
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1617952
@@ -6357,8 +6359,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 110 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 297
+      ID: 309
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1590336
@@ -6366,7 +6370,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 638 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 650 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -6374,7 +6378,7 @@ Types:
           Offset: 96
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2135680
@@ -6382,12 +6386,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 877 StructureType net.noReadFrom
+          Type: 884 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 874 PointerType *net.TCPConn
+          Type: 881 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2135136
@@ -6395,20 +6399,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 876 StructureType net.noWriteTo
+          Type: 883 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 874 PointerType *net.TCPConn
+          Type: 881 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 568
+      ID: 580
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 627
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 714
+      ID: 721
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 983104
@@ -6421,7 +6425,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 712
+      ID: 719
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 981696
@@ -6434,14 +6438,14 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 764
+      ID: 771
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1917440
       GoKind: 21
-      HeaderType: 766 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 773 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 715
+      ID: 722
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 981824
@@ -6454,15 +6458,15 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 303
+      ID: 315
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 511
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 713
+      ID: 720
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 982080
@@ -6486,7 +6490,7 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 775 PointerType *net/url.URL
+          Type: 782 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -6498,19 +6502,19 @@ Types:
           Type: 11 BaseType int
         - Name: Header
           Offset: 56
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 759 GoInterfaceType io.ReadCloser
+          Type: 766 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 777 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 784 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6519,16 +6523,16 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 778 GoMapType net/url.Values
+          Type: 785 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 778 GoMapType net/url.Values
+          Type: 785 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 779 PointerType *mime/multipart.Form
+          Type: 786 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 13 GoStringHeaderType string
@@ -6537,13 +6541,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 781 PointerType *crypto/tls.ConnectionState
+          Type: 788 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 783 GoChannelType <-chan struct {}
+          Type: 790 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 784 PointerType *net/http.Response
+          Type: 791 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 13 GoStringHeaderType string
@@ -6552,15 +6556,15 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 786 PointerType *net/http.pattern
+          Type: 793 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
     - __kind: StructureType
-      ID: 785
+      ID: 792
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2064832
@@ -6583,16 +6587,16 @@ Types:
           Type: 11 BaseType int
         - Name: Header
           Offset: 56
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 759 GoInterfaceType io.ReadCloser
+          Type: 766 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6601,13 +6605,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 105 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 781 PointerType *crypto/tls.ConnectionState
+          Type: 788 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 104
       Name: net/http.ResponseWriter
@@ -6622,19 +6626,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 857
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 828
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 763
+      ID: 770
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1619488
@@ -6642,10 +6646,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 718 PointerType *net/http.response
+          Type: 725 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6653,31 +6657,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 765
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 791
+      ID: 798
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 223
+      ID: 235
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 764128
       GoKind: 10
     - __kind: BaseType
-      ID: 627
+      ID: 639
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 942208
       GoKind: 10
     - __kind: StructureType
-      ID: 306
+      ID: 318
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1591872
@@ -6688,12 +6692,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 627 BaseType net/http.http2ErrCode
+          Type: 639 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 617
+      ID: 629
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1760064
@@ -6704,16 +6708,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 627 BaseType net/http.http2ErrCode
+          Type: 639 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 842
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 312
+      ID: 324
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1400096
@@ -6721,12 +6725,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 627 BaseType net/http.http2ErrCode
+          Type: 639 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 227
+      ID: 239
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 764320
@@ -6734,28 +6738,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 229 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 241 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 228 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 240 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 228
+      ID: 240
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 310
+      ID: 322
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1066240
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 806
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 233
+      ID: 245
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 764512
@@ -6763,18 +6767,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 235 PointerType *net/http.http2headerFieldNameError.str
+          Type: 247 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 234 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 246 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 234
+      ID: 246
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 230
+      ID: 242
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 764416
@@ -6782,40 +6786,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 232 PointerType *net/http.http2headerFieldValueError.str
+          Type: 244 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 231 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 243 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 231
+      ID: 243
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 584
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 795
+      ID: 802
       Name: net/http.http2missingBody
       GoRuntimeType: 1187616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 807
+      ID: 814
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1188128
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 505
+      ID: 517
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1188000
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 224
+      ID: 236
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 764224
@@ -6823,22 +6827,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 226 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 238 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 225 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 237 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 225
+      ID: 237
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 717
+      ID: 724
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1098848
@@ -6846,13 +6850,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 755 PointerType *net/http.http2responseWriterState
+          Type: 762 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 763
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 797
+      ID: 804
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1355744
@@ -6860,19 +6864,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 834 PointerType *net/http.http2clientStream
+          Type: 841 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 832
       Name: net/http.noBody
       GoRuntimeType: 1277856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1356864
@@ -6882,7 +6886,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 787
+      ID: 794
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1701568
@@ -6899,20 +6903,20 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 924 GoSliceHeaderType []net/http.segment
+          Type: 931 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 796
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 830
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 316
+      ID: 328
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1230208
@@ -6922,7 +6926,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: net/http.response
       ByteSize: 224
       GoRuntimeType: 2190720
@@ -6930,16 +6934,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 757 PointerType *net/http.conn
+          Type: 764 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 105 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 759 GoInterfaceType io.ReadCloser
+          Type: 766 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 165 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -6951,19 +6955,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 125 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 760 StructureType sync/atomic.Bool
+          Type: 767 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 761 PointerType *bufio.Writer
+          Type: 768 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 763 StructureType net/http.chunkWriter
+          Type: 770 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -6987,27 +6991,27 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 760 StructureType sync/atomic.Bool
+          Type: 767 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 769 ArrayType [29]uint8
+          Type: 776 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 770 ArrayType [10]uint8
+          Type: 777 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 771 ArrayType [3]uint8
+          Type: 778 ArrayType [3]uint8
         - Name: closeNotifyCh
           Offset: 208
-          Type: 772 GoChannelType chan bool
+          Type: 779 GoChannelType chan bool
         - Name: didCloseNotify
           Offset: 216
-          Type: 760 StructureType sync/atomic.Bool
+          Type: 767 StructureType sync/atomic.Bool
     - __kind: StructureType
-      ID: 926
+      ID: 933
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1416032
@@ -7023,7 +7027,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 301
+      ID: 313
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1399936
@@ -7036,17 +7040,17 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 631
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 570
+      ID: 582
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1279296
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 503
+      ID: 515
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1357024
@@ -7056,17 +7060,17 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 299
+      ID: 311
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 817
+      ID: 824
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1194528
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 329
+      ID: 341
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1594944
@@ -7082,7 +7086,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 327
+      ID: 339
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1400416
@@ -7095,11 +7099,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 354
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 247
+      ID: 259
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 766624
@@ -7107,22 +7111,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 249 PointerType *net/textproto.ProtocolError.str
+          Type: 261 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 248 GoStringDataType net/textproto.ProtocolError.str
+      Data: 260 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 248
+      ID: 260
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 636
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 241
+      ID: 253
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 766432
@@ -7130,18 +7134,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 243 PointerType *net/url.EscapeError.str
+          Type: 255 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 242 GoStringDataType net/url.EscapeError.str
+      Data: 254 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 242
+      ID: 254
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 244
+      ID: 256
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 766528
@@ -7149,18 +7153,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 246 PointerType *net/url.InvalidHostError.str
+          Type: 258 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 245 GoStringDataType net/url.InvalidHostError.str
+      Data: 257 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 245
+      ID: 257
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 776
+      ID: 783
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1986272
@@ -7174,7 +7178,7 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 894 PointerType *net/url.Userinfo
+          Type: 901 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 13 GoStringHeaderType string
@@ -7200,26 +7204,26 @@ Types:
           Offset: 128
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 902
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 778
+      ID: 785
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1670784
       GoKind: 21
-      HeaderType: 766 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 773 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 894
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 519
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 145
+      ID: 168
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1066880
@@ -7232,11 +7236,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 586
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2202944
@@ -7244,12 +7248,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 889 StructureType os.noReadFrom
+          Type: 896 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 886 PointerType *os.File
+          Type: 893 PointerType *os.File
     - __kind: StructureType
-      ID: 883
+      ID: 890
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2202144
@@ -7257,32 +7261,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 888 StructureType os.noWriteTo
+          Type: 895 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 886 PointerType *os.File
+          Type: 893 PointerType *os.File
     - __kind: StructureType
-      ID: 889
+      ID: 896
       Name: os.noReadFrom
       GoRuntimeType: 1066752
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 888
+      ID: 895
       Name: os.noWriteTo
       GoRuntimeType: 1066624
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 550
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 671
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 540
+      ID: 552
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1503488
@@ -7295,7 +7299,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 164
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1828032
@@ -7306,17 +7310,17 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 165 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 143 GoSliceHeaderType []os.Signal
+          Type: 166 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 146 GoChannelType chan os.Signal
+          Type: 169 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 283
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 770848
@@ -7324,36 +7328,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *os/user.UnknownGroupIdError.str
+          Type: 285 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 272 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 284 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 284
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 270
+      ID: 282
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 770752
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 325
+      ID: 337
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 397
+      ID: 409
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 526
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 519
+      ID: 531
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7365,7 +7369,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 516
+      ID: 528
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1750624
@@ -7382,9 +7386,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 657 BaseType runtime.boundsErrorCode
+          Type: 669 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 657
+      ID: 669
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 534720
@@ -7404,7 +7408,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 576
+      ID: 588
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1626592
@@ -7417,7 +7421,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 483
+      ID: 495
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 943456
@@ -7425,13 +7429,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 485 PointerType *runtime.errorString.str
+          Type: 497 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 484 GoStringDataType runtime.errorString.str
+      Data: 496 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 484
+      ID: 496
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8008,7 +8012,7 @@ Types:
           Offset: 24
           Type: 30 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 134
+      ID: 122
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -8057,7 +8061,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 486
+      ID: 498
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 944032
@@ -8065,13 +8069,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 488 PointerType *runtime.plainError.str
+          Type: 500 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 487 GoStringDataType runtime.plainError.str
+      Data: 499 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 487
+      ID: 499
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8153,7 +8157,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 511
+      ID: 523
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8165,18 +8169,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 179 PointerType *string.str
+          Type: 186 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 178 GoStringDataType string.str
+      Data: 185 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 178
+      ID: 185
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 686
+      ID: 693
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1810144
@@ -8184,12 +8188,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 700
+      ID: 707
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1885248
@@ -8197,15 +8201,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 682
+      ID: 689
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1809632
@@ -8213,12 +8217,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 692
+      ID: 699
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1884096
@@ -8226,15 +8230,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 706
+      ID: 713
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1947200
@@ -8242,18 +8246,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 694
+      ID: 701
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1884384
@@ -8261,15 +8265,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 690
+      ID: 697
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1883808
@@ -8277,15 +8281,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 702
+      ID: 709
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1946560
@@ -8293,18 +8297,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 710
+      ID: 717
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2005088
@@ -8312,21 +8316,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 704
+      ID: 711
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1946880
@@ -8334,18 +8338,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 688
+      ID: 695
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1810400
@@ -8353,12 +8357,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 684
+      ID: 691
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1809888
@@ -8366,12 +8370,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 696
+      ID: 703
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1884672
@@ -8379,15 +8383,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 708
+      ID: 715
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1947520
@@ -8395,18 +8399,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 698
+      ID: 705
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1884960
@@ -8414,15 +8418,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 819
+      ID: 826
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1515200
@@ -8430,18 +8434,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 836 GoInterfaceType io.Reader
+          Type: 843 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 846 GoInterfaceType io.Closer
+          Type: 853 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 188
+      ID: 214
       Name: struct {}
       GoRuntimeType: 777184
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 125
+      ID: 113
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1282496
@@ -8454,7 +8458,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 149
+      ID: 112
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1706944
@@ -8462,7 +8466,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 125 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -8471,12 +8475,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 150 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 150 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 760
+      ID: 767
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1283776
@@ -8484,12 +8488,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 151 StructureType sync/atomic.noCopy
+          Type: 115 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 150
+      ID: 114
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1283936
@@ -8497,12 +8501,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 151 StructureType sync/atomic.noCopy
+          Type: 115 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 126
+      ID: 172
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1106912
@@ -8510,27 +8514,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 151
+      ID: 115
       Name: sync/atomic.noCopy
       GoRuntimeType: 943168
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 609
+      ID: 621
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1188640
       GoKind: 12
     - __kind: BaseType
-      ID: 674
+      ID: 681
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 944224
       GoKind: 2
     - __kind: StructureType
-      ID: 556
+      ID: 568
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1507712
@@ -8543,13 +8547,13 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 861
+      ID: 868
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1776608
       GoKind: 6
     - __kind: StructureType
-      ID: 140
+      ID: 184
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1833984
@@ -8560,10 +8564,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 190 GoSliceHeaderType []time.zone
+          Type: 216 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 193 GoSliceHeaderType []time.zoneTrans
+          Type: 219 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -8575,13 +8579,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 191 PointerType *time.zone
+          Type: 217 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 319
+      ID: 331
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 138
+      ID: 182
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2215168
@@ -8595,7 +8599,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 139 PointerType *time.Location
+          Type: 183 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -8605,7 +8609,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 137
+      ID: 181
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1280096
@@ -8613,12 +8617,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 668 GoChannelType <-chan time.Time
+          Type: 680 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 236
+      ID: 248
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 764608
@@ -8626,18 +8630,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 238 PointerType *time.fileSizeError.str
+          Type: 250 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 237 GoStringDataType time.fileSizeError.str
+      Data: 249 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 237
+      ID: 249
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 192
+      ID: 218
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1421024
@@ -8653,7 +8657,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 195
+      ID: 221
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1623328
@@ -8714,7 +8718,7 @@ Types:
       GoRuntimeType: 534656
       GoKind: 26
     - __kind: StructureType
-      ID: 638
+      ID: 650
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1920960
@@ -8725,10 +8729,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 639 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 651 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 640 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 652 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -8743,18 +8747,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 641 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 653 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 641
+      ID: 653
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 944512
       GoKind: 9
     - __kind: StructureType
-      ID: 639
+      ID: 651
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1779424
@@ -8779,17 +8783,17 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 331
+      ID: 343
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 640
+      ID: 652
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 535552
       GoKind: 8
     - __kind: StructureType
-      ID: 344
+      ID: 356
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1235168
@@ -8799,13 +8803,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 250
+      ID: 262
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 766720
       GoKind: 2
     - __kind: StructureType
-      ID: 524
+      ID: 536
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1502912
@@ -8818,7 +8822,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 490
+      ID: 502
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 945376

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -137,124 +137,124 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 972
+      ID: 979
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 664 PointerType *crypto/x509.Certificate
+      Pointee: 676 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 712
+      ID: 263
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 965 PointerType *mime/multipart.FileHeader
+      Pointee: 972 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 138
+      ID: 181
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 139 PointerType *table<context.canceler,struct {}>
+      Pointee: 182 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 776 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 783 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 236
+      ID: 225
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 237 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 226 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 955
+      ID: 962
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 956 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 963 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 815 PointerType *table<string,[]string>
+      Pointee: 822 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 170
+      ID: 136
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 171 PointerType *table<string,float64>
+      Pointee: 137 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 670 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 682 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 165
+      ID: 131
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 166 PointerType *table<string,interface {}>
+      Pointee: 132 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 160
+      ID: 126
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 161 PointerType *table<string,string>
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 971 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 978 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 979 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 986 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 715
+      ID: 266
       Name: '*[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       ByteSize: 8
-      Pointee: 714 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Pointee: 265 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 969 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 982
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 981 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 984
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 983 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 707
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 706 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 232
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
-      ByteSize: 8
-      Pointee: 231 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
-    - __kind: PointerType
-      ID: 240
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 239 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 976 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 989
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 988 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 991
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 990 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 719
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 718 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 221
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
+      ByteSize: 8
+      Pointee: 220 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+    - __kind: PointerType
+      ID: 229
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 228 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 996
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 988 GoSliceDataType []net/http.segment.array
+      Pointee: 995 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 206
+      ID: 231
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []os.Signal.array
+      Pointee: 230 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -263,77 +263,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 705
+      ID: 717
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 704 GoSliceDataType []string.array
+      Pointee: 716 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 242
+      ID: 259
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []time.zone.array
+      Pointee: 258 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 244
+      ID: 261
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []time.zoneTrans.array
+      Pointee: 260 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478304
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 186
+      ID: 193
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []uint8.array
+      Pointee: 192 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 188
+      ID: 195
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []uintptr.array
+      Pointee: 194 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 503
+      ID: 515
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 939104
       GoKind: 22
-      Pointee: 504 GoSliceHeaderType archive/tar.headerError
+      Pointee: 516 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 505 GoSliceDataType archive/tar.headerError.array
+      Pointee: 517 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1247712
       GoKind: 22
-      Pointee: 884 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 891 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 867
+      ID: 874
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1074912
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 875 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1434560
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 893 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1074656
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 873 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -342,12 +342,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1937376
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType bufio.Writer
+      Pointee: 816 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 112
       Name: '*bytes.Buffer'
@@ -356,358 +356,358 @@ Types:
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 912512
       GoKind: 22
-      Pointee: 298 BaseType compress/flate.CorruptInputError
+      Pointee: 310 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 912608
       GoKind: 22
-      Pointee: 299 GoStringHeaderType compress/flate.InternalError
+      Pointee: 311 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 301
+      ID: 313
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 300 GoStringDataType compress/flate.InternalError.str
+      Pointee: 312 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 1968096
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 925 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1616000
       GoKind: 22
-      Pointee: 897 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 904 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 995
+      ID: 164
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1532224
       GoKind: 22
-      Pointee: 128 StructureType context.backgroundCtx
+      Pointee: 165 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 116
+      ID: 175
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1704512
       GoKind: 22
-      Pointee: 117 StructureType context.cancelCtx
+      Pointee: 176 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1173728
       GoKind: 22
-      Pointee: 597 StructureType context.deadlineExceededError
+      Pointee: 609 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 990
+      ID: 150
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1398560
       GoKind: 22
-      Pointee: 129 StructureType context.emptyCtx
+      Pointee: 151 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 118
+      ID: 152
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1398720
       GoKind: 22
-      Pointee: 119 StructureType context.stopCtx
+      Pointee: 153 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 120
+      ID: 183
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1704704
       GoKind: 22
-      Pointee: 121 StructureType context.timerCtx
+      Pointee: 184 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 996
+      ID: 166
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1532384
       GoKind: 22
-      Pointee: 146 StructureType context.todoCtx
+      Pointee: 167 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 122
+      ID: 159
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1531904
       GoKind: 22
-      Pointee: 123 StructureType context.valueCtx
+      Pointee: 160 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 124
+      ID: 162
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1532064
       GoKind: 22
-      Pointee: 125 StructureType context.withoutCancelCtx
+      Pointee: 163 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911264
       GoKind: 22
-      Pointee: 294 BaseType crypto/aes.KeySizeError
+      Pointee: 306 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 423
+      ID: 435
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911456
       GoKind: 22
-      Pointee: 295 BaseType crypto/des.KeySizeError
+      Pointee: 307 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911744
       GoKind: 22
-      Pointee: 296 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 308 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 912032
       GoKind: 22
-      Pointee: 297 BaseType crypto/rc4.KeySizeError
+      Pointee: 309 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 902048
       GoKind: 22
-      Pointee: 271 BaseType crypto/tls.AlertError
+      Pointee: 283 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 557
+      ID: 569
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1029472
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 570 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 947
+      ID: 954
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2356352
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 955 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 835 StructureType crypto/tls.ConnectionState
+      Pointee: 842 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 367
+      ID: 379
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 901856
       GoKind: 22
-      Pointee: 368 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 380 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 901760
       GoKind: 22
-      Pointee: 366 StructureType crypto/tls.RecordHeaderError
+      Pointee: 378 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 556
+      ID: 568
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1027808
       GoKind: 22
-      Pointee: 525 BaseType crypto/tls.alert
+      Pointee: 537 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 657
+      ID: 669
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1406240
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 670 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 664
+      ID: 676
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2031072
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 677 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 911072
       GoKind: 22
-      Pointee: 419 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 431 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 910592
       GoKind: 22
-      Pointee: 413 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 425 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 415 StructureType crypto/x509.HostnameError
+      Pointee: 427 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 910496
       GoKind: 22
-      Pointee: 293 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 305 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 571
+      ID: 583
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1037792
       GoKind: 22
-      Pointee: 572 StructureType crypto/x509.SystemRootsError
+      Pointee: 584 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 911168
       GoKind: 22
-      Pointee: 421 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 433 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 910976
       GoKind: 22
-      Pointee: 417 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 429 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 921440
       GoKind: 22
-      Pointee: 463 StructureType encoding/asn1.StructuralError
+      Pointee: 475 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 466
+      ID: 478
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 921632
       GoKind: 22
-      Pointee: 467 StructureType encoding/asn1.SyntaxError
+      Pointee: 479 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 464
+      ID: 476
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 921536
       GoKind: 22
-      Pointee: 465 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 477 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 902144
       GoKind: 22
-      Pointee: 272 BaseType encoding/base64.CorruptInputError
+      Pointee: 284 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 404
+      ID: 416
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 909344
       GoKind: 22
-      Pointee: 292 BaseType encoding/hex.InvalidByteError
+      Pointee: 304 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 389
+      ID: 401
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 905696
       GoKind: 22
-      Pointee: 390 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 402 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 569
+      ID: 581
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1034464
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 582 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 905312
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 394 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 905600
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 400 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 905504
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 398 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 905408
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 396 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 906080
       GoKind: 22
-      Pointee: 392 StructureType encoding/json.jsonError
+      Pointee: 404 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 493
+      ID: 505
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932960
       GoKind: 22
-      Pointee: 494 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 506 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 491
+      ID: 503
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 932864
       GoKind: 22
-      Pointee: 492 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 504 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 495
+      ID: 507
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 933056
       GoKind: 22
-      Pointee: 307 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 319 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 309
+      ID: 321
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 320 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 933152
       GoKind: 22
-      Pointee: 497 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 509 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -716,19 +716,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 353
+      ID: 365
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 897344
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType errors.errorString
+      Pointee: 366 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 544
+      ID: 556
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1020768
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType errors.joinError
+      Pointee: 557 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -744,792 +744,792 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1010528
       GoKind: 22
-      Pointee: 529 UnresolvedPointeeType fmt.wrapError
+      Pointee: 541 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 530
+      ID: 542
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1010656
       GoKind: 22
-      Pointee: 531 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 543 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 402
+      ID: 414
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 908864
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 415 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2000352
       GoKind: 22
-      Pointee: 778 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 785 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 907424
       GoKind: 22
-      Pointee: 395 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 407 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 907520
       GoKind: 22
-      Pointee: 397 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 409 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 684
+      ID: 696
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 907232
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 697 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 907808
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 413 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 686
+      ID: 698
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 907328
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 699 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 907616
       GoKind: 22
-      Pointee: 286 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 298 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 288
+      ID: 300
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 287 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 299 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 393
+      ID: 405
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 907136
       GoKind: 22
-      Pointee: 283 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 295 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 285
+      ID: 297
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 296 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 907712
       GoKind: 22
-      Pointee: 289 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 301 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 291
+      ID: 303
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 290 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 302 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 922208
       GoKind: 22
-      Pointee: 470 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 482 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 468
+      ID: 480
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 922112
       GoKind: 22
-      Pointee: 302 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 314 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 437 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 449 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 918464
       GoKind: 22
-      Pointee: 441 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 453 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 918368
       GoKind: 22
-      Pointee: 439 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 451 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 918176
       GoKind: 22
-      Pointee: 435 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 447 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 709
+      ID: 721
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 708 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 720 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 449 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 461 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 918560
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 455 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 918752
       GoKind: 22
-      Pointee: 447 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 459 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 918656
       GoKind: 22
-      Pointee: 445 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 457 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 450
+      ID: 462
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 918944
       GoKind: 22
-      Pointee: 451 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 463 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 456
+      ID: 468
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 919232
       GoKind: 22
-      Pointee: 457 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 458
+      ID: 470
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 919328
       GoKind: 22
-      Pointee: 459 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 471 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 454
+      ID: 466
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 919136
       GoKind: 22
-      Pointee: 455 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 467 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 452
+      ID: 464
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 919040
       GoKind: 22
-      Pointee: 453 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 465 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 919520
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 473 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2298816
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 799 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2283744
       GoKind: 22
-      Pointee: 786 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 793 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2291136
       GoKind: 22
-      Pointee: 788 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 795 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2291776
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 797 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 479
+      ID: 491
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 930176
       GoKind: 22
-      Pointee: 480 StructureType github.com/cihub/seelog.baseError
+      Pointee: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1791136
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 778 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 930272
       GoKind: 22
-      Pointee: 482 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 494 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1425280
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 770 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1650368
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 772 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1651136
       GoKind: 22
-      Pointee: 769 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 776 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 485
+      ID: 497
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 930464
       GoKind: 22
-      Pointee: 486 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 498 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1650560
       GoKind: 22
-      Pointee: 767 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 774 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2263232
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 791 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 483
+      ID: 495
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 930368
       GoKind: 22
-      Pointee: 484 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 496 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 487
+      ID: 499
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 930560
       GoKind: 22
-      Pointee: 488 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 500 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1239520
       GoKind: 22
-      Pointee: 882 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 889 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1723520
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 908 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 583
+      ID: 595
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1057248
       GoKind: 22
-      Pointee: 584 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 596 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 585
+      ID: 597
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1057376
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 598 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1042144
       GoKind: 22
-      Pointee: 578 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 590 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 909536
       GoKind: 22
-      Pointee: 406 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 418 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 579
+      ID: 591
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1045600
       GoKind: 22
-      Pointee: 580 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 592 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1196128
       GoKind: 22
-      Pointee: 626 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 638 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 619
+      ID: 631
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1195744
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 632 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 563
+      ID: 575
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1033568
       GoKind: 22
-      Pointee: 564 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 576 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 631
+      ID: 643
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1196512
       GoKind: 22
-      Pointee: 632 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1033440
       GoKind: 22
-      Pointee: 527 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 539 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1196000
       GoKind: 22
-      Pointee: 624 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 636 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1195872
       GoKind: 22
-      Pointee: 622 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 634 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 629
+      ID: 641
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1196384
       GoKind: 22
-      Pointee: 630 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 642 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1196256
       GoKind: 22
-      Pointee: 628 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 640 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 635
+      ID: 647
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1196896
       GoKind: 22
-      Pointee: 636 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1033824
       GoKind: 22
-      Pointee: 568 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1033696
       GoKind: 22
-      Pointee: 566 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 578 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 633
+      ID: 645
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1196768
       GoKind: 22
-      Pointee: 634 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 938336
       GoKind: 22
-      Pointee: 310 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 322 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 312
+      ID: 324
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 323 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 672
+      ID: 684
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1649408
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 685 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 589
+      ID: 601
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1074016
       GoKind: 22
-      Pointee: 590 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 602 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 507
+      ID: 519
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 940352
       GoKind: 22
-      Pointee: 313 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 325 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 643
+      ID: 655
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1249376
       GoKind: 22
-      Pointee: 644 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 656 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 940640
       GoKind: 22
-      Pointee: 511 StructureType golang.org/x/net/http2.connError
+      Pointee: 523 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 509
+      ID: 521
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940544
       GoKind: 22
-      Pointee: 317 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 329 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 319
+      ID: 331
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 318 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 330 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 940832
       GoKind: 22
-      Pointee: 323 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 335 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 325
+      ID: 337
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 324 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 336 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 940736
       GoKind: 22
-      Pointee: 320 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 332 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 322
+      ID: 334
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 321 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 333 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 940448
       GoKind: 22
-      Pointee: 314 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 326 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 316
+      ID: 328
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 315 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 327 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 514
+      ID: 526
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 940928
       GoKind: 22
-      Pointee: 515 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 527 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 941024
       GoKind: 22
-      Pointee: 326 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 338 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 489
+      ID: 501
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 932384
       GoKind: 22
-      Pointee: 490 StructureType google.golang.org/grpc.dropError
+      Pointee: 502 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 641
+      ID: 653
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1246176
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 654 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1431040
       GoKind: 22
-      Pointee: 662 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 674 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 936608
       GoKind: 22
-      Pointee: 501 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 513 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1793824
       GoKind: 22
-      Pointee: 907 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 914 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1068256
       GoKind: 22
-      Pointee: 588 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 600 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1551744
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 898 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 472 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 484 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 581
+      ID: 593
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1047008
       GoKind: 22
-      Pointee: 582 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 594 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 639
+      ID: 651
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1212384
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 652 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 637
+      ID: 649
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1212128
       GoKind: 22
-      Pointee: 638 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 650 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 904352
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 392 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 721
+      ID: 728
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1539904
       GoKind: 22
-      Pointee: 722 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 729 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 173
+      ID: 139
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1194080
       GoKind: 22
-      Pointee: 174 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Pointee: 140 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1882208
       GoKind: 22
-      Pointee: 913 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 920 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1784416
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+      Pointee: 912 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 152
+      ID: 146
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoRuntimeType: 2289216
       GoKind: 22
-      Pointee: 153 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 116 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 178
+      ID: 144
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext'
       ByteSize: 8
       GoRuntimeType: 1959456
       GoKind: 22
-      Pointee: 179 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+      Pointee: 145 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
     - __kind: PointerType
-      ID: 176
+      ID: 142
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1181024
       GoKind: 22
-      Pointee: 177 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Pointee: 143 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 719
+      ID: 726
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1181664
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 727 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 251
+      ID: 254
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1181792
       GoKind: 22
-      Pointee: 252 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 255 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 180
+      ID: 147
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2203872
       GoKind: 22
-      Pointee: 181 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+      Pointee: 148 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2154656
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
+      Pointee: 789 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 993
+      ID: 157
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1409600
       GoKind: 22
-      Pointee: 994 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
+      Pointee: 158 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2135648
       GoKind: 22
-      Pointee: 780 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
+      Pointee: 787 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1040480
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
+      Pointee: 871 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 431 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 443 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 924992
       GoKind: 22
-      Pointee: 474 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 486 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 475
+      ID: 487
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 925088
       GoKind: 22
-      Pointee: 476 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 488 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 933920
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 511 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 941792
       GoKind: 22
-      Pointee: 518 UnresolvedPointeeType html/template.Error
+      Pointee: 530 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -1566,321 +1566,321 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 409
+      ID: 421
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 410 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 422 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 910016
       GoKind: 22
-      Pointee: 408 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 420 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 617
+      ID: 629
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1189600
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 630 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2350048
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType internal/poll.FD
+      Pointee: 953 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 615
+      ID: 627
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1189472
       GoKind: 22
-      Pointee: 616 StructureType internal/poll.errNetClosing
+      Pointee: 628 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 897728
       GoKind: 22
-      Pointee: 356 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 368 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 910
+      ID: 917
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1823808
       GoKind: 22
-      Pointee: 911 UnresolvedPointeeType io.PipeReader
+      Pointee: 918 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1536544
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType io.SectionReader
+      Pointee: 922 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1021280
       GoKind: 22
-      Pointee: 862 StructureType io.nopCloser
+      Pointee: 869 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1184224
       GoKind: 22
-      Pointee: 880 StructureType io.nopCloserWriterTo
+      Pointee: 887 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 613
+      ID: 625
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1188704
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType io/fs.PathError
+      Pointee: 626 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 136
+      ID: 179
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 137 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 180 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 774 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 781 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 234
+      ID: 223
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 235 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 224 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 954 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 961 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 813 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 820 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 168
+      ID: 134
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 169 GoSwissMapHeaderType map<string,float64>
+      Pointee: 135 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 668 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 680 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 163
+      ID: 129
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 164 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 158
+      ID: 124
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<string,string>
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 913280
       GoKind: 22
-      Pointee: 429 StructureType math/big.ErrNaN
+      Pointee: 441 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902912
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 975 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 833 StructureType mime/multipart.Form
+      Pointee: 840 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1615040
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 900 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1615232
       GoKind: 22
-      Pointee: 895 StructureType mime/multipart.sectionReadCloser
+      Pointee: 902 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 599
+      ID: 611
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1174880
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType net.AddrError
+      Pointee: 612 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1399360
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType net.DNSError
+      Pointee: 661 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2207904
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType net.IPConn
+      Pointee: 929 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 646
+      ID: 658
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1399040
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType net.OpError
+      Pointee: 659 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1175008
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType net.ParseError
+      Pointee: 614 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2239168
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType net.TCPConn
+      Pointee: 937 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2281920
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net.UDPConn
+      Pointee: 941 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2238656
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType net.UnixConn
+      Pointee: 935 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 598
+      ID: 610
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1174112
       GoKind: 22
-      Pointee: 593 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 605 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 595
+      ID: 607
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 594 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 606 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1011552
       GoKind: 22
-      Pointee: 533 StructureType net.canceledError
+      Pointee: 545 StructureType net.canceledError
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1995456
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType net.conn
+      Pointee: 927 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 690
+      ID: 702
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1817760
       GoKind: 22
-      Pointee: 691 StructureType net.dialResult·1
+      Pointee: 703 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2284960
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType net.netFD
+      Pointee: 943 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 327
+      ID: 339
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 890336
       GoKind: 22
-      Pointee: 328 UnresolvedPointeeType net.notFoundError
+      Pointee: 340 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 991
+      ID: 155
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1399200
       GoKind: 22
-      Pointee: 992 StructureType net.onlyValuesCtx
+      Pointee: 156 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 329
+      ID: 341
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 891008
       GoKind: 22
-      Pointee: 330 StructureType net.result·2
+      Pointee: 342 StructureType net.result·2
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2224704
       GoKind: 22
-      Pointee: 926 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 933 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2224224
       GoKind: 22
-      Pointee: 924 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 931 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1175648
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType net.temporaryError
+      Pointee: 616 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1399680
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType net.timeoutError
+      Pointee: 663 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 335
+      ID: 347
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 893600
       GoKind: 22
-      Pointee: 336 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 348 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 534
+      ID: 546
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1015008
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 547 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -1889,559 +1889,559 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1706048
       GoKind: 22
-      Pointee: 838 StructureType net/http.Response
+      Pointee: 845 StructureType net/http.Response
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1783520
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType net/http.body
+      Pointee: 910 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1178208
       GoKind: 22
-      Pointee: 874 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 881 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1014880
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 861 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1881184
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType net/http.conn
+      Pointee: 812 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1013600
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 851 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1017184
       GoKind: 22
-      Pointee: 858 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 865 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 893792
       GoKind: 22
-      Pointee: 255 BaseType net/http.http2ConnectionError
+      Pointee: 267 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 893888
       GoKind: 22
-      Pointee: 339 StructureType net/http.http2GoAwayError
+      Pointee: 351 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 652
+      ID: 664
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1400640
       GoKind: 22
-      Pointee: 653 StructureType net/http.http2StreamError
+      Pointee: 665 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 1996896
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 895 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 344
+      ID: 356
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 894944
       GoKind: 22
-      Pointee: 345 StructureType net/http.http2connError
+      Pointee: 357 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 894368
       GoKind: 22
-      Pointee: 259 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 271 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 261
+      ID: 273
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 260 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 272 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 342
+      ID: 354
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 894464
       GoKind: 22
-      Pointee: 343 StructureType net/http.http2goAwayFlowError
+      Pointee: 355 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1014624
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 859 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 895136
       GoKind: 22
-      Pointee: 265 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 277 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 267
+      ID: 279
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 266 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 278 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 895040
       GoKind: 22
-      Pointee: 262 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 274 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 264
+      ID: 276
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 263 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 275 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 607
+      ID: 619
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1179616
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 620 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 847
+      ID: 854
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1014368
       GoKind: 22
-      Pointee: 848 StructureType net/http.http2missingBody
+      Pointee: 855 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1017440
       GoKind: 22
-      Pointee: 860 StructureType net/http.http2noBodyReader
+      Pointee: 867 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 540
+      ID: 552
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1017312
       GoKind: 22
-      Pointee: 541 StructureType net/http.http2noCachedConnError
+      Pointee: 553 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 894272
       GoKind: 22
-      Pointee: 256 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 268 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 258
+      ID: 270
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 257 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 269 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1015520
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 863 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1996320
       GoKind: 22
-      Pointee: 759 StructureType net/http.http2responseWriter
+      Pointee: 766 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1599872
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 810 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1014496
       GoKind: 22
-      Pointee: 850 StructureType net/http.http2transportResponseBody
+      Pointee: 857 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 845
+      ID: 852
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1013856
       GoKind: 22
-      Pointee: 846 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 853 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1178464
       GoKind: 22
-      Pointee: 878 StructureType net/http.noBody
+      Pointee: 885 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 536
+      ID: 548
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1016928
       GoKind: 22
-      Pointee: 537 StructureType net/http.nothingWrittenError
+      Pointee: 549 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1597952
       GoKind: 22
-      Pointee: 840 StructureType net/http.pattern
+      Pointee: 847 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1013216
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 849 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 875
+      ID: 882
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1178336
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 883 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 895328
       GoKind: 22
-      Pointee: 349 StructureType net/http.requestBodyReadError
+      Pointee: 361 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2189984
       GoKind: 22
-      Pointee: 761 StructureType net/http.response
+      Pointee: 768 StructureType net/http.response
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388640
       GoKind: 22
-      Pointee: 987 StructureType net/http.segment
+      Pointee: 994 StructureType net/http.segment
     - __kind: PointerType
-      ID: 333
+      ID: 345
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 893504
       GoKind: 22
-      Pointee: 334 StructureType net/http.statusError
+      Pointee: 346 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 654
+      ID: 666
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1402080
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 667 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 605
+      ID: 617
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1179488
       GoKind: 22
-      Pointee: 606 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 618 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 538
+      ID: 550
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1017056
       GoKind: 22
-      Pointee: 539 StructureType net/http.transportReadFromServerError
+      Pointee: 551 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1819328
       GoKind: 22
-      Pointee: 909 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 916 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 331
+      ID: 343
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 892736
       GoKind: 22
-      Pointee: 332 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 344 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 869
+      ID: 876
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1075296
       GoKind: 22
-      Pointee: 870 StructureType net/http/httputil.failureToReadBody
+      Pointee: 877 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 361
+      ID: 373
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 900128
       GoKind: 22
-      Pointee: 362 StructureType net/netip.parseAddrError
+      Pointee: 374 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 359
+      ID: 371
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 900032
       GoKind: 22
-      Pointee: 360 StructureType net/netip.parsePrefixError
+      Pointee: 372 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 903392
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType net/textproto.Error
+      Pointee: 387 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 373
+      ID: 385
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 903296
       GoKind: 22
-      Pointee: 279 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 291 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 281
+      ID: 293
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 280 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 292 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1406720
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType net/url.Error
+      Pointee: 672 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 902240
       GoKind: 22
-      Pointee: 273 GoStringHeaderType net/url.EscapeError
+      Pointee: 285 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 275
+      ID: 287
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType net/url.EscapeError.str
+      Pointee: 286 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 902336
       GoKind: 22
-      Pointee: 276 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 288 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 278
+      ID: 290
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 289 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 828
+      ID: 835
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2100096
       GoKind: 22
-      Pointee: 829 StructureType net/url.URL
+      Pointee: 836 StructureType net/url.URL
     - __kind: PointerType
-      ID: 949
+      ID: 956
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1192160
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 957 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 191
+      ID: 234
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 192 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 235 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 803 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 247
+      ID: 250
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 251 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 960 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 967 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 823 StructureType noalg.map.group[string][]string
+      Pointee: 830 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 225
+      ID: 214
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 226 StructureType noalg.map.group[string]float64
+      Pointee: 215 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 698
+      ID: 710
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 711 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 217
+      ID: 206
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 218 StructureType noalg.map.group[string]interface {}
+      Pointee: 207 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 209
+      ID: 198
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 210 StructureType noalg.map.group[string]string
+      Pointee: 199 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2325760
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType os.File
+      Pointee: 949 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 542
+      ID: 554
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1019232
       GoKind: 22
-      Pointee: 543 UnresolvedPointeeType os.LinkError
+      Pointee: 555 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 149
+      ID: 172
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 391456
       GoKind: 22
-      Pointee: 150 GoInterfaceType os.Signal
+      Pointee: 173 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 609
+      ID: 621
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1180128
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType os.SyscallError
+      Pointee: 622 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2321344
       GoKind: 22
-      Pointee: 940 StructureType os.fileWithoutReadFrom
+      Pointee: 947 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2320608
       GoKind: 22
-      Pointee: 938 StructureType os.fileWithoutWriteTo
+      Pointee: 945 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 573
+      ID: 585
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1040736
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType os/exec.Error
+      Pointee: 586 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 694
+      ID: 706
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2075136
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 707 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1040864
       GoKind: 22
-      Pointee: 576 StructureType os/exec.wrappedError
+      Pointee: 588 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 126
+      ID: 168
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1602560
       GoKind: 22
-      Pointee: 127 StructureType os/signal.signalCtx
+      Pointee: 169 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 929216
       GoKind: 22
-      Pointee: 304 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 316 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 306
+      ID: 318
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 305 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 317 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 929120
       GoKind: 22
-      Pointee: 303 BaseType os/user.UnknownUserIdError
+      Pointee: 315 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 357
+      ID: 369
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 898496
       GoKind: 22
-      Pointee: 358 UnresolvedPointeeType reflect.ValueError
+      Pointee: 370 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 433 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 445 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 550
+      ID: 562
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1023840
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 563 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 554
+      ID: 566
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1025632
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 567 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2457,12 +2457,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 552
+      ID: 564
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1023968
       GoKind: 22
-      Pointee: 553 StructureType runtime.boundsError
+      Pointee: 565 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -2478,24 +2478,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 611
+      ID: 623
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1188064
       GoKind: 22
-      Pointee: 612 StructureType runtime.errorAddressString
+      Pointee: 624 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 548
+      ID: 560
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1023456
       GoKind: 22
-      Pointee: 519 GoStringHeaderType runtime.errorString
+      Pointee: 531 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 520 GoStringDataType runtime.errorString.str
+      Pointee: 532 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2511,17 +2511,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1023584
       GoKind: 22
-      Pointee: 522 GoStringHeaderType runtime.plainError
+      Pointee: 534 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 523 GoStringDataType runtime.plainError.str
+      Pointee: 535 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2551,12 +2551,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 546
+      ID: 558
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1023072
       GoKind: 22
-      Pointee: 547 UnresolvedPointeeType strconv.NumError
+      Pointee: 559 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -2565,235 +2565,235 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 184
+      ID: 191
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 183 GoStringDataType string.str
+      Pointee: 190 GoStringDataType string.str
     - __kind: PointerType
-      ID: 727
+      ID: 734
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1677056
       GoKind: 22
-      Pointee: 728 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 735 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1729472
       GoKind: 22
-      Pointee: 742 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 749 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 723
+      ID: 730
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1676672
       GoKind: 22
-      Pointee: 724 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 731 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 733
+      ID: 740
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1728704
       GoKind: 22
-      Pointee: 734 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 741 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1800096
       GoKind: 22
-      Pointee: 748 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 755 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1728896
       GoKind: 22
-      Pointee: 736 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 743 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1728512
       GoKind: 22
-      Pointee: 732 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 739 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1799648
       GoKind: 22
-      Pointee: 744 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 751 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1869504
       GoKind: 22
-      Pointee: 752 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 759 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 745
+      ID: 752
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1799872
       GoKind: 22
-      Pointee: 746 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 753 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 729
+      ID: 736
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1677248
       GoKind: 22
-      Pointee: 730 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 737 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 725
+      ID: 732
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1676864
       GoKind: 22
-      Pointee: 726 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 733 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1729088
       GoKind: 22
-      Pointee: 738 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 745 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1800320
       GoKind: 22
-      Pointee: 750 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 757 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1729280
       GoKind: 22
-      Pointee: 740 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 747 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1082432
       GoKind: 22
-      Pointee: 872 StructureType struct { io.Reader; io.Closer }
+      Pointee: 879 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 656
+      ID: 668
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1405600
       GoKind: 22
-      Pointee: 645 BaseType syscall.Errno
+      Pointee: 657 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 717
+      ID: 724
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1026144
       GoKind: 22
-      Pointee: 716 BaseType syscall.Signal
+      Pointee: 723 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 139
+      ID: 182
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 189 StructureType table<context.canceler,struct {}>
+      Pointee: 232 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 793 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 800 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 237
+      ID: 226
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 245 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 248 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 957 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 964 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 820 StructureType table<string,[]string>
+      Pointee: 827 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 171
+      ID: 137
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 223 StructureType table<string,float64>
+      Pointee: 212 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 670
+      ID: 682
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 696 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 708 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 166
+      ID: 132
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 215 StructureType table<string,interface {}>
+      Pointee: 204 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 161
+      ID: 127
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 207 StructureType table<string,string>
+      Pointee: 196 StructureType table<string,string>
     - __kind: PointerType
-      ID: 591
+      ID: 603
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1078496
       GoKind: 22
-      Pointee: 592 StructureType text/template.ExecError
+      Pointee: 604 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 144
+      ID: 188
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1602944
       GoKind: 22
-      Pointee: 145 StructureType time.Location
+      Pointee: 189 StructureType time.Location
     - __kind: PointerType
-      ID: 351
+      ID: 363
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 896192
       GoKind: 22
-      Pointee: 352 UnresolvedPointeeType time.ParseError
+      Pointee: 364 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 141
+      ID: 185
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1019744
       GoKind: 22
-      Pointee: 142 StructureType time.Timer
+      Pointee: 186 StructureType time.Timer
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 896096
       GoKind: 22
-      Pointee: 268 GoStringHeaderType time.fileSizeError
+      Pointee: 280 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 270
+      ID: 282
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 269 GoStringDataType time.fileSizeError.str
+      Pointee: 281 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 200
+      ID: 243
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391776
       GoKind: 22
-      Pointee: 201 StructureType time.zone
+      Pointee: 244 StructureType time.zone
     - __kind: PointerType
-      ID: 203
+      ID: 246
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391840
       GoKind: 22
-      Pointee: 204 StructureType time.zoneTrans
+      Pointee: 247 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -2837,47 +2837,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 900896
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 376 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 903584
       GoKind: 22
-      Pointee: 377 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 389 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 903680
       GoKind: 22
-      Pointee: 282 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 294 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1031008
       GoKind: 22
-      Pointee: 560 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 572 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 561
+      ID: 573
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1031136
       GoKind: 22
-      Pointee: 526 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 538 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 836
+      ID: 843
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
     - __kind: GoChannelType
-      ID: 710
+      ID: 722
       Name: <-chan time.Time
       GoRuntimeType: 596160
       GoKind: 18
@@ -2963,7 +2963,7 @@ Types:
       HasCount: true
       Element: 92 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 817
+      ID: 824
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 677568
@@ -2972,7 +2972,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 816
+      ID: 823
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 677472
@@ -3044,7 +3044,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 818
+      ID: 825
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 677664
@@ -3062,7 +3062,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 678
+      ID: 690
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 695744
@@ -3089,7 +3089,7 @@ Types:
       HasCount: true
       Element: 85 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 971
+      ID: 978
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498464
@@ -3097,22 +3097,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 972 PointerType **crypto/x509.Certificate
+          Type: 979 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 979 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 986 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 979
+      ID: 986
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 664 PointerType *crypto/x509.Certificate
+      Element: 676 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 711
+      ID: 262
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 24
       GoRuntimeType: 486816
@@ -3120,22 +3120,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 712 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 263 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 714 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Data: 265 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 265
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Element: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: GoSliceHeaderType
-      ID: 963
+      ID: 970
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483904
@@ -3143,76 +3143,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 964 PointerType **mime/multipart.FileHeader
+          Type: 971 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 969 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 976 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 969
+      ID: 976
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 965 PointerType *mime/multipart.FileHeader
+      Element: 972 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 240
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 139 PointerType *table<context.canceler,struct {}>
+      Element: 182 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 800
+      ID: 807
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 776 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 783 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 256
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 237 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 226 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 966
+      ID: 973
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 956 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 963 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 826
+      ID: 833
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 815 PointerType *table<string,[]string>
+      Element: 822 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 218
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 171 PointerType *table<string,float64>
+      Element: 137 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 702
+      ID: 714
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 670 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 682 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 210
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 166 PointerType *table<string,interface {}>
+      Element: 132 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 202
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 161 PointerType *table<string,string>
+      Element: 127 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 973
+      ID: 980
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498592
@@ -3220,22 +3220,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 974 PointerType *[]*crypto/x509.Certificate
+          Type: 981 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 981 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 988 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 981
+      ID: 988
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 971 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 978 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 975
+      ID: 982
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478688
@@ -3243,22 +3243,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 976 PointerType *[]uint8
+          Type: 983 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 983 GoSliceDataType [][]uint8.array
+      Data: 990 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 983
+      ID: 990
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 683
+      ID: 695
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 492576
@@ -3273,15 +3273,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 706 GoSliceDataType []float64.array
+      Data: 718 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 706
+      ID: 718
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 20 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 138
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 24
       GoRuntimeType: 486560
@@ -3289,22 +3289,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 139 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 231 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 220 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 220
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 174 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Element: 140 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 141
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 486752
@@ -3312,22 +3312,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 142 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 239 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 228 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 228
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 177 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Element: 143 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 985
+      ID: 992
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481280
@@ -3335,76 +3335,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 986 PointerType *net/http.segment
+          Type: 993 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 988 GoSliceDataType []net/http.segment.array
+      Data: 995 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 988
+      ID: 995
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 987 StructureType net/http.segment
+      Element: 994 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 241
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 192 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 235 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 801
+      ID: 808
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 803 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 257
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 251 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 967
+      ID: 974
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 960 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 967 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 827
+      ID: 834
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 823 StructureType noalg.map.group[string][]string
+      Element: 830 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 219
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 226 StructureType noalg.map.group[string]float64
+      Element: 215 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 703
+      ID: 715
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 711 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 211
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 218 StructureType noalg.map.group[string]interface {}
+      Element: 207 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 203
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 210 StructureType noalg.map.group[string]string
+      Element: 199 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 148
+      ID: 171
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 478496
@@ -3412,26 +3412,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 149 PointerType *os.Signal
+          Type: 172 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 205 GoSliceDataType []os.Signal.array
+      Data: 230 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 230
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 150 GoInterfaceType os.Signal
+      Element: 173 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 682
+      ID: 694
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -3446,15 +3446,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 704 GoSliceDataType []string.array
+      Data: 716 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 704
+      ID: 716
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 199
+      ID: 242
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -3462,22 +3462,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 200 PointerType *time.zone
+          Type: 243 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 241 GoSliceDataType []time.zone.array
+      Data: 258 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 258
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 201 StructureType time.zone
+      Element: 244 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 202
+      ID: 245
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 486016
@@ -3485,20 +3485,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 203 PointerType *time.zoneTrans
+          Type: 246 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 243 GoSliceDataType []time.zoneTrans.array
+      Data: 260 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 260
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 204 StructureType time.zoneTrans
+      Element: 247 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3515,9 +3515,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 185 GoSliceDataType []uint8.array
+      Data: 192 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 192
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3538,15 +3538,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 187 GoSliceDataType []uintptr.array
+      Data: 194 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 194
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 504
+      ID: 516
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 939200
@@ -3561,27 +3561,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 505 GoSliceDataType archive/tar.headerError.array
+      Data: 517 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 505
+      ID: 517
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 884
+      ID: 891
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 875
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 873
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3591,7 +3591,7 @@ Types:
       GoRuntimeType: 580672
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 816
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3599,12 +3599,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 819
+      ID: 826
       Name: chan bool
       GoRuntimeType: 592320
       GoKind: 18
     - __kind: GoChannelType
-      ID: 151
+      ID: 174
       Name: chan os.Signal
       GoRuntimeType: 598976
       GoKind: 18
@@ -3621,13 +3621,13 @@ Types:
       GoRuntimeType: 580416
       GoKind: 15
     - __kind: BaseType
-      ID: 298
+      ID: 310
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 832544
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 299
+      ID: 311
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -3635,26 +3635,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 301 PointerType *compress/flate.InternalError.str
+          Type: 313 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 300 GoStringDataType compress/flate.InternalError.str
+      Data: 312 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 300
+      ID: 312
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 897
+      ID: 904
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 147
+      ID: 170
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 671808
@@ -3673,19 +3673,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 165
       Name: context.backgroundCtx
       GoRuntimeType: 1781952
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 129 StructureType context.emptyCtx
+          Type: 151 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 117
+      ID: 176
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1952960
@@ -3696,13 +3696,13 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 130 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 133 StructureType sync/atomic.Value
+          Type: 177 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 135 GoMapType map[context.canceler]struct {}
+          Type: 178 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 15 GoInterfaceType error
@@ -3712,7 +3712,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 195
+      ID: 238
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1098848
@@ -3725,13 +3725,13 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: context.deadlineExceededError
       GoRuntimeType: 1448288
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 129
+      ID: 151
       Name: context.emptyCtx
       GoRuntimeType: 1580704
       GoKind: 25
@@ -3740,7 +3740,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 153
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1807488
@@ -3751,11 +3751,11 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 140 GoSubroutineType func() bool
+          Type: 154 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 184
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1596032
@@ -3763,29 +3763,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 117 StructureType context.cancelCtx
+          Type: 176 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 141 PointerType *time.Timer
+          Type: 185 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 143 GoTimeType time.Time
+          Type: 187 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 146
+      ID: 167
       Name: context.todoCtx
       GoRuntimeType: 1782176
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 129 StructureType context.emptyCtx
+          Type: 151 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 160
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1816192
@@ -3796,14 +3796,14 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 134 GoEmptyInterfaceType interface {}
+          Type: 161 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 134 GoEmptyInterfaceType interface {}
+          Type: 161 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 163
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1781728
@@ -3815,45 +3815,45 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 294
+      ID: 306
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 832160
       GoKind: 2
     - __kind: BaseType
-      ID: 295
+      ID: 307
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 832256
       GoKind: 2
     - __kind: BaseType
-      ID: 296
+      ID: 308
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 832352
       GoKind: 2
     - __kind: BaseType
-      ID: 297
+      ID: 309
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 832448
       GoKind: 2
     - __kind: BaseType
-      ID: 271
+      ID: 283
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 829856
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 570
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 955
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2232384
@@ -3882,13 +3882,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 971 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 978 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 973 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 980 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 975 GoSliceHeaderType [][]uint8
+          Type: 982 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -3900,25 +3900,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 977 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 984 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 978 BaseType crypto/tls.CurveID
+          Type: 985 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 978
+      ID: 985
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829664
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 368
+      ID: 380
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 366
+      ID: 378
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1710080
@@ -3929,26 +3929,26 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 678 ArrayType [5]uint8
+          Type: 690 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 679 GoInterfaceType net.Conn
+          Type: 691 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 525
+      ID: 537
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 979808
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 670
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 677
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 419
+      ID: 431
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1712192
@@ -3956,21 +3956,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 664 PointerType *crypto/x509.Certificate
+          Type: 676 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 688 BaseType crypto/x509.InvalidReason
+          Type: 700 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 413
+      ID: 425
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1105120
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 415
+      ID: 427
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1582784
@@ -3978,24 +3978,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 664 PointerType *crypto/x509.Certificate
+          Type: 676 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 293
+      ID: 305
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 831968
       GoKind: 2
     - __kind: BaseType
-      ID: 688
+      ID: 700
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 583424
       GoKind: 2
     - __kind: StructureType
-      ID: 572
+      ID: 584
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1543424
@@ -4005,13 +4005,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1105376
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 417
+      ID: 429
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1712000
@@ -4019,15 +4019,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 664 PointerType *crypto/x509.Certificate
+          Type: 676 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 664 PointerType *crypto/x509.Certificate
+          Type: 676 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 463
+      ID: 475
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1418880
@@ -4037,7 +4037,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 467
+      ID: 479
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1419040
@@ -4047,47 +4047,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 465
+      ID: 477
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 272
+      ID: 284
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 829952
       GoKind: 6
     - __kind: BaseType
-      ID: 292
+      ID: 304
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 831776
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 390
+      ID: 402
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 582
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 394
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 400
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 398
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 396
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 392
+      ID: 404
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1409760
@@ -4097,15 +4097,15 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 494
+      ID: 506
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 492
+      ID: 504
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 319
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 835232
@@ -4113,18 +4113,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *encoding/xml.UnmarshalError.str
+          Type: 321 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 320 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 320
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 497
+      ID: 509
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4141,11 +4141,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 366
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 557
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4161,11 +4161,11 @@ Types:
       GoRuntimeType: 580608
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 529
+      ID: 541
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 531
+      ID: 543
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4175,13 +4175,13 @@ Types:
       GoRuntimeType: 476896
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 830
+      ID: 837
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687968
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 140
+      ID: 154
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 591104
@@ -4193,23 +4193,23 @@ Types:
       GoRuntimeType: 849568
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 977
+      ID: 984
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 995552
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 415
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2040352
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 395
+      ID: 407
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1711232
@@ -4217,7 +4217,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 680 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 692 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4225,25 +4225,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 397
+      ID: 409
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 697
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 401
+      ID: 413
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1104224
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 699
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 286
+      ID: 298
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 831200
@@ -4251,18 +4251,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 288 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 300 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 287 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 299 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 287
+      ID: 299
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 680
+      ID: 692
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2198944
@@ -4270,13 +4270,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 681 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 693 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4285,7 +4285,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 683 GoSliceHeaderType []float64
+          Type: 695 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4294,13 +4294,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 684 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 696 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 686 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 698 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4311,13 +4311,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 681
+      ID: 693
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 582208
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 295
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 831104
@@ -4325,18 +4325,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 297 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 296 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 296
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 289
+      ID: 301
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 831296
@@ -4344,30 +4344,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 291 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 303 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 290 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 302 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 290
+      ID: 302
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 470
+      ID: 482
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1107936
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 302
+      ID: 314
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 833792
       GoKind: 2
     - __kind: StructureType
-      ID: 437
+      ID: 449
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1583584
@@ -4380,7 +4380,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 441
+      ID: 453
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1713920
@@ -4396,7 +4396,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 439
+      ID: 451
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1417440
@@ -4406,7 +4406,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1417120
@@ -4416,14 +4416,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 666
+      ID: 678
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1489568
       GoKind: 21
-      HeaderType: 668 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 680 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 689
+      ID: 701
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1041760
@@ -4438,15 +4438,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 708 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 720 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 708
+      ID: 720
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 449
+      ID: 461
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1583904
@@ -4454,12 +4454,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 666 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 678 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 666 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 678 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 443
+      ID: 455
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1417600
@@ -4469,7 +4469,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 447
+      ID: 459
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1714112
@@ -4480,12 +4480,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 701 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 701 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 445
+      ID: 457
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1583744
@@ -4498,7 +4498,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 451
+      ID: 463
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1417760
@@ -4506,9 +4506,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 143 GoTimeType time.Time
+          Type: 187 GoTimeType time.Time
     - __kind: StructureType
-      ID: 457
+      ID: 469
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1584224
@@ -4521,7 +4521,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 459
+      ID: 471
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1418080
@@ -4531,7 +4531,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 455
+      ID: 467
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1584064
@@ -4544,7 +4544,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 453
+      ID: 465
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1417920
@@ -4554,7 +4554,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 461
+      ID: 473
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1584384
@@ -4567,29 +4567,29 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 799
+      ID: 806
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 834656
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 799
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 786
+      ID: 793
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 788
+      ID: 795
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 797
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 480
+      ID: 492
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1424000
@@ -4599,11 +4599,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 778
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 482
+      ID: 494
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1424160
@@ -4611,17 +4611,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 480 StructureType github.com/cihub/seelog.baseError
+          Type: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 770
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 772
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 769
+      ID: 776
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1810624
@@ -4629,12 +4629,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 764 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 771 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 772 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 779 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 486
+      ID: 498
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1424480
@@ -4642,9 +4642,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 480 StructureType github.com/cihub/seelog.baseError
+          Type: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 767
+      ID: 774
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1791360
@@ -4652,13 +4652,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 764 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 771 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 791
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 484
+      ID: 496
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1424320
@@ -4666,9 +4666,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 480 StructureType github.com/cihub/seelog.baseError
+          Type: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 488
+      ID: 500
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1424640
@@ -4676,9 +4676,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 480 StructureType github.com/cihub/seelog.baseError
+          Type: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 898
+      ID: 905
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1112800
@@ -4691,7 +4691,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 882
+      ID: 889
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1657088
@@ -4699,36 +4699,36 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 898 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 905 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 908
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 584
+      ID: 596
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 598
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 578
+      ID: 590
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 406
+      ID: 418
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1411040
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 580
+      ID: 592
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 626
+      ID: 638
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1830752
@@ -4744,11 +4744,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 632
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 564
+      ID: 576
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1684832
@@ -4761,7 +4761,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 632
+      ID: 644
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1831200
@@ -4777,13 +4777,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 527
+      ID: 539
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 980960
       GoKind: 8
     - __kind: StructureType
-      ID: 624
+      ID: 636
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1830528
@@ -4799,13 +4799,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 692
+      ID: 704
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 830720
       GoKind: 8
     - __kind: StructureType
-      ID: 622
+      ID: 634
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1830304
@@ -4813,15 +4813,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 692 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 704 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 692 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 704 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 630
+      ID: 642
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1745760
@@ -4834,7 +4834,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 628
+      ID: 640
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1830976
@@ -4850,7 +4850,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 636
+      ID: 648
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1619456
@@ -4860,19 +4860,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 568
+      ID: 580
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1270432
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 566
+      ID: 578
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1270304
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 634
+      ID: 646
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1745952
@@ -4885,7 +4885,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 322
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835904
@@ -4893,22 +4893,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 324 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 311 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 323 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 323
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 685
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 602
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1433760
@@ -4918,19 +4918,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 313
+      ID: 325
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 836480
       GoKind: 10
     - __kind: BaseType
-      ID: 671
+      ID: 683
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 992576
       GoKind: 10
     - __kind: StructureType
-      ID: 644
+      ID: 656
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1863904
@@ -4941,12 +4941,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 671 BaseType golang.org/x/net/http2.ErrCode
+          Type: 683 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 511
+      ID: 523
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1591104
@@ -4954,12 +4954,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 671 BaseType golang.org/x/net/http2.ErrCode
+          Type: 683 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 317
+      ID: 329
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836672
@@ -4967,18 +4967,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 319 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 331 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 318 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 330 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 318
+      ID: 330
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 323
+      ID: 335
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836864
@@ -4986,18 +4986,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 325 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 337 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 324 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 336 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 324
+      ID: 336
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 320
+      ID: 332
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -5005,18 +5005,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 322 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 334 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 321 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 333 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 321
+      ID: 333
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 314
+      ID: 326
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836576
@@ -5024,18 +5024,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 316 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 328 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 315 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 327 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 315
+      ID: 327
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 515
+      ID: 527
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1435040
@@ -5045,13 +5045,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 326
+      ID: 338
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836960
       GoKind: 2
     - __kind: StructureType
-      ID: 490
+      ID: 502
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1429440
@@ -5061,11 +5061,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 654
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 662
+      ID: 674
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1890656
@@ -5081,7 +5081,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1590144
@@ -5094,11 +5094,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 907
+      ID: 914
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 588
+      ID: 600
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1550944
@@ -5108,33 +5108,33 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 898
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 472
+      ID: 484
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 582
+      ID: 594
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 652
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 650
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1497728
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 392
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 753
+      ID: 760
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1408320
@@ -5147,7 +5147,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 722
+      ID: 729
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1582304
@@ -5173,7 +5173,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 174
+      ID: 140
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
       ByteSize: 56
       GoRuntimeType: 1901568
@@ -5190,7 +5190,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -5198,7 +5198,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 913
+      ID: 920
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1953472
@@ -5206,29 +5206,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 904 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+          Type: 911 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 916 BaseType time.Duration
+          Type: 923 BaseType time.Duration
     - __kind: GoMapType
-      ID: 162
+      ID: 128
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1268896
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 912
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 713
+      ID: 264
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 579456
       GoKind: 10
     - __kind: DDTraceSpanType
-      ID: 153
+      ID: 116
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
       ByteSize: 288
       GoRuntimeType: 2317792
@@ -5236,7 +5236,7 @@ Types:
       RawFields:
         - Name: RWMutex
           Offset: 0
-          Type: 154 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: Name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -5257,13 +5257,13 @@ Types:
           Type: 14 BaseType int64
         - Name: Meta
           Offset: 104
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: MetaStruct
           Offset: 112
-          Type: 162 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
+          Type: 128 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
         - Name: Metrics
           Offset: 120
-          Type: 167 GoMapType map[string]float64
+          Type: 133 GoMapType map[string]float64
         - Name: SpanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -5278,10 +5278,10 @@ Types:
           Type: 12 BaseType int32
         - Name: SpanLinks
           Offset: 160
-          Type: 172 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 138 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: SpanEvents
           Offset: 184
-          Type: 175 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 141 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -5293,7 +5293,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 178 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+          Type: 144 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -5316,7 +5316,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 179
+      ID: 145
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
       ByteSize: 160
       GoRuntimeType: 2170848
@@ -5327,10 +5327,10 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 180 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+          Type: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: errors
           Offset: 24
           Type: 12 BaseType int32
@@ -5342,16 +5342,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 182 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
+          Type: 149 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 154 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -5360,9 +5360,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 172 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 138 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: StructureType
-      ID: 177
+      ID: 143
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1737312
@@ -5376,16 +5376,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 233 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 222 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 238 GoMapType map[string]interface {}
+          Type: 227 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 727
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 252
+      ID: 255
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1897472
@@ -5393,7 +5393,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 718 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
+          Type: 725 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -5408,15 +5408,15 @@ Types:
           Type: 20 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 719 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+          Type: 726 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 718
+      ID: 725
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 977312
       GoKind: 5
     - __kind: StructureType
-      ID: 181
+      ID: 148
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2088832
@@ -5424,16 +5424,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 154 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 711 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 262 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: tags
           Offset: 48
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -5448,12 +5448,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 713 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
+          Type: 264 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: ArrayType
-      ID: 182
+      ID: 149
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 896960
@@ -5462,11 +5462,11 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 789
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 994
+    - __kind: GoContextImplementationType
+      ID: 158
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1620032
@@ -5475,20 +5475,22 @@ Types:
         - Name: Context
           Offset: 0
           Type: 115 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 780
+      ID: 787
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 871
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 431
+      ID: 443
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 474
+      ID: 486
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1421280
@@ -5498,7 +5500,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 476
+      ID: 488
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1421440
@@ -5508,137 +5510,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 511
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 190
+      ID: 233
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 191 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 234 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 192 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 198 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 235 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 241 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 794
+      ID: 801
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 795 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 802 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 801 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 803 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 808 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 246
+      ID: 249
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 247 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 250 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 251 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 958
+      ID: 965
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 959 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 966 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 960 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 967 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 967 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 974 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 821
+      ID: 828
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 822 PointerType *noalg.map.group[string][]string
+          Type: 829 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 823 StructureType noalg.map.group[string][]string
-      GroupSliceType: 827 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 830 StructureType noalg.map.group[string][]string
+      GroupSliceType: 834 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 224
+      ID: 213
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 225 PointerType *noalg.map.group[string]float64
+          Type: 214 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 226 StructureType noalg.map.group[string]float64
-      GroupSliceType: 230 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 215 StructureType noalg.map.group[string]float64
+      GroupSliceType: 219 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 697
+      ID: 709
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 698 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 710 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 703 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 711 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 715 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 216
+      ID: 205
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 217 PointerType *noalg.map.group[string]interface {}
+          Type: 206 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 218 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 207 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 211 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 208
+      ID: 197
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 209 PointerType *noalg.map.group[string]string
+          Type: 198 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 210 StructureType noalg.map.group[string]string
-      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 199 StructureType noalg.map.group[string]string
+      GroupSliceType: 203 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 518
+      ID: 530
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5672,7 +5674,7 @@ Types:
       GoRuntimeType: 579712
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 134
+      ID: 161
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 849280
@@ -5685,7 +5687,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 410
+      ID: 422
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5711,25 +5713,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 408
+      ID: 420
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 630
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 953
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 616
+      ID: 628
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1465088
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 356
+      ID: 368
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5810,7 +5812,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 132
+      ID: 120
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1478848
@@ -5823,7 +5825,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 899
+      ID: 906
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1021792
@@ -5836,11 +5838,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 911
+      ID: 918
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 806
+      ID: 813
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1101280
@@ -5853,7 +5855,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 889
+      ID: 896
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1021152
@@ -5866,11 +5868,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 922
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 862
+      ID: 869
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1536384
@@ -5878,9 +5880,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 889 GoInterfaceType io.Reader
+          Type: 896 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 880
+      ID: 887
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1604480
@@ -5888,13 +5890,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 889 GoInterfaceType io.Reader
+          Type: 896 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 626
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 137
+      ID: 180
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -5907,7 +5909,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 138 PointerType **table<context.canceler,struct {}>
+          Type: 181 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5923,10 +5925,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 197 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 192 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 240 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 235 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 774
+      ID: 781
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -5939,7 +5941,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 775 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 782 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5955,10 +5957,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 800 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 807 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 803 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 235
+      ID: 224
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -5971,7 +5973,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 236 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 225 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5987,10 +5989,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 256 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 251 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 954
+      ID: 961
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6003,7 +6005,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 955 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 962 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6019,10 +6021,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 966 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 960 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 973 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 967 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 813
+      ID: 820
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6035,7 +6037,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 814 PointerType **table<string,[]string>
+          Type: 821 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6051,10 +6053,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 826 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 823 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 833 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 830 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 169
+      ID: 135
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6067,7 +6069,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 170 PointerType **table<string,float64>
+          Type: 136 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6083,10 +6085,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 229 GoSliceDataType []*table<string,float64>.array
-      GroupType: 226 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 218 GoSliceDataType []*table<string,float64>.array
+      GroupType: 215 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 668
+      ID: 680
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6099,7 +6101,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 669 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 681 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6115,10 +6117,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 702 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 714 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 711 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 164
+      ID: 130
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6131,7 +6133,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 165 PointerType **table<string,interface {}>
+          Type: 131 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6147,10 +6149,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 221 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 218 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 210 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 207 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 159
+      ID: 125
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6163,7 +6165,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 160 PointerType **table<string,string>
+          Type: 126 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6179,66 +6181,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 210 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 202 GoSliceDataType []*table<string,string>.array
+      GroupType: 199 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 135
+      ID: 178
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1117664
       GoKind: 21
-      HeaderType: 137 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 180 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 772
+      ID: 779
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1148192
       GoKind: 21
-      HeaderType: 774 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 781 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 233
+      ID: 222
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1124288
       GoKind: 21
-      HeaderType: 235 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 224 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 952
+      ID: 959
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1123296
       GoKind: 21
-      HeaderType: 954 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 961 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 951
+      ID: 958
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1118688
       GoKind: 21
-      HeaderType: 813 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 820 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 167
+      ID: 133
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1124160
       GoKind: 21
-      HeaderType: 169 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 135 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 238
+      ID: 227
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1117280
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 157
+      ID: 123
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1119712
       GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<string,string>
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 429
+      ID: 441
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1414240
@@ -6248,11 +6250,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 975
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 833
+      ID: 840
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1467968
@@ -6260,16 +6262,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 951 GoMapType map[string][]string
+          Type: 958 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 952 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 959 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 900
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1900544
@@ -6277,16 +6279,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 914 PointerType *io.SectionReader
+          Type: 921 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 899 GoInterfaceType io.Closer
+          Type: 906 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 612
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 679
+      ID: 691
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1580864
@@ -6299,35 +6301,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 661
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 659
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 614
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 937
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 941
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 593
+      ID: 605
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1099104
@@ -6335,28 +6337,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 595 PointerType *net.UnknownNetworkError.str
+          Type: 607 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 594 GoStringDataType net.UnknownNetworkError.str
+      Data: 606 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 594
+      ID: 606
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 533
+      ID: 545
       Name: net.canceledError
       GoRuntimeType: 1267872
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 691
+      ID: 703
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2087776
@@ -6364,7 +6366,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 679 GoInterfaceType net.Conn
+          Type: 691 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -6375,27 +6377,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 932
+      ID: 939
       Name: net.noReadFrom
       GoRuntimeType: 1099360
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 931
+      ID: 938
       Name: net.noWriteTo
       GoRuntimeType: 1099232
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 328
+      ID: 340
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 992
+    - __kind: GoContextImplementationType
+      ID: 156
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1731552
@@ -6407,8 +6409,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 115 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 330
+      ID: 342
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1705472
@@ -6416,7 +6420,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 674 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 686 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6424,7 +6428,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 926
+      ID: 933
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2266496
@@ -6432,12 +6436,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 932 StructureType net.noReadFrom
+          Type: 939 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 929 PointerType *net.TCPConn
+          Type: 936 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 924
+      ID: 931
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2265952
@@ -6445,20 +6449,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 931 StructureType net.noWriteTo
+          Type: 938 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 929 PointerType *net.TCPConn
+          Type: 936 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 616
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 663
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 756
+      ID: 763
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1019104
@@ -6471,7 +6475,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 754
+      ID: 761
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1017696
@@ -6484,14 +6488,14 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 811
+      ID: 818
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2088128
       GoKind: 21
-      HeaderType: 813 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 820 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 757
+      ID: 764
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1017824
@@ -6504,15 +6508,15 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 336
+      ID: 348
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 547
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 755
+      ID: 762
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1018080
@@ -6536,7 +6540,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 828 PointerType *net/url.URL
+          Type: 835 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6548,19 +6552,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 806 GoInterfaceType io.ReadCloser
+          Type: 813 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 830 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 837 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6569,16 +6573,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 831 GoMapType net/url.Values
+          Type: 838 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 831 GoMapType net/url.Values
+          Type: 838 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 832 PointerType *mime/multipart.Form
+          Type: 839 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6587,13 +6591,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 834 PointerType *crypto/tls.ConnectionState
+          Type: 841 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 836 GoChannelType <-chan struct {}
+          Type: 843 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 837 PointerType *net/http.Response
+          Type: 844 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6602,15 +6606,15 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 839 PointerType *net/http.pattern
+          Type: 846 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
     - __kind: StructureType
-      ID: 838
+      ID: 845
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2195808
@@ -6633,16 +6637,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 806 GoInterfaceType io.ReadCloser
+          Type: 813 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6651,13 +6655,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 110 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 834 PointerType *crypto/tls.ConnectionState
+          Type: 841 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 109
       Name: net/http.ResponseWriter
@@ -6672,19 +6676,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 874
+      ID: 881
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 861
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1733088
@@ -6692,10 +6696,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 760 PointerType *net/http.response
+          Type: 767 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6703,31 +6707,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 851
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 858
+      ID: 865
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 255
+      ID: 267
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 827744
       GoKind: 10
     - __kind: BaseType
-      ID: 663
+      ID: 675
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 977120
       GoKind: 10
     - __kind: StructureType
-      ID: 339
+      ID: 351
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1707200
@@ -6738,12 +6742,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 663 BaseType net/http.http2ErrCode
+          Type: 675 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 653
+      ID: 665
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1881440
@@ -6754,16 +6758,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 663 BaseType net/http.http2ErrCode
+          Type: 675 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 345
+      ID: 357
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1581344
@@ -6771,12 +6775,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 663 BaseType net/http.http2ErrCode
+          Type: 675 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 259
+      ID: 271
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 827936
@@ -6784,28 +6788,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 261 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 273 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 260 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 272 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 260
+      ID: 272
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 343
+      ID: 355
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1100384
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 859
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 265
+      ID: 277
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 828128
@@ -6813,18 +6817,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 267 PointerType *net/http.http2headerFieldNameError.str
+          Type: 279 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 266 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 278 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 266
+      ID: 278
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 262
+      ID: 274
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 828032
@@ -6832,40 +6836,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 264 PointerType *net/http.http2headerFieldValueError.str
+          Type: 276 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 263 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 275 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 263
+      ID: 275
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 620
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 848
+      ID: 855
       Name: net/http.http2missingBody
       GoRuntimeType: 1268128
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 860
+      ID: 867
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1268640
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 541
+      ID: 553
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1268512
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 256
+      ID: 268
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 827840
@@ -6873,22 +6877,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 258 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 270 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 257 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 269 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 257
+      ID: 269
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1177568
@@ -6896,13 +6900,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 802 PointerType *net/http.http2responseWriterState
+          Type: 809 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 857
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1533664
@@ -6910,19 +6914,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 887 PointerType *net/http.http2clientStream
+          Type: 894 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 846
+      ID: 853
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 878
+      ID: 885
       Name: net/http.noBody
       GoRuntimeType: 1451328
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 537
+      ID: 549
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1534944
@@ -6932,7 +6936,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1818656
@@ -6949,20 +6953,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 985 GoSliceHeaderType []net/http.segment
+          Type: 992 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 849
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 883
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 349
+      ID: 361
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1402880
@@ -6972,7 +6976,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: net/http.response
       ByteSize: 224
       GoRuntimeType: 2323552
@@ -6980,16 +6984,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 804 PointerType *net/http.conn
+          Type: 811 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 110 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 806 GoInterfaceType io.ReadCloser
+          Type: 813 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 147 GoSubroutineType context.CancelFunc
+          Type: 170 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7001,19 +7005,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 130 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 807 StructureType sync/atomic.Bool
+          Type: 814 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 808 PointerType *bufio.Writer
+          Type: 815 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 810 StructureType net/http.chunkWriter
+          Type: 817 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7037,27 +7041,27 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 807 StructureType sync/atomic.Bool
+          Type: 814 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 816 ArrayType [29]uint8
+          Type: 823 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 817 ArrayType [10]uint8
+          Type: 824 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 818 ArrayType [3]uint8
+          Type: 825 ArrayType [3]uint8
         - Name: closeNotifyCh
           Offset: 208
-          Type: 819 GoChannelType chan bool
+          Type: 826 GoChannelType chan bool
         - Name: didCloseNotify
           Offset: 216
-          Type: 807 StructureType sync/atomic.Bool
+          Type: 814 StructureType sync/atomic.Bool
     - __kind: StructureType
-      ID: 987
+      ID: 994
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1597760
@@ -7073,7 +7077,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 334
+      ID: 346
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1581184
@@ -7086,17 +7090,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 667
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 606
+      ID: 618
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1452928
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 539
+      ID: 551
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1535104
@@ -7106,7 +7110,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 909
+      ID: 916
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2012736
@@ -7114,22 +7118,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 679 GoInterfaceType net.Conn
+          Type: 691 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 679 GoInterfaceType net.Conn
+          Type: 691 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 332
+      ID: 344
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 870
+      ID: 877
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1277344
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 362
+      ID: 374
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1709696
@@ -7145,7 +7149,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 360
+      ID: 372
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1581824
@@ -7158,11 +7162,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 387
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 279
+      ID: 291
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 830240
@@ -7170,22 +7174,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 281 PointerType *net/textproto.ProtocolError.str
+          Type: 293 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 280 GoStringDataType net/textproto.ProtocolError.str
+      Data: 292 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 280
+      ID: 292
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 672
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 285
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 830048
@@ -7193,18 +7197,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *net/url.EscapeError.str
+          Type: 287 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType net/url.EscapeError.str
+      Data: 286 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 286
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 288
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 830144
@@ -7212,18 +7216,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *net/url.InvalidHostError.str
+          Type: 290 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType net/url.InvalidHostError.str
+      Data: 289 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 289
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 829
+      ID: 836
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2113024
@@ -7237,7 +7241,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 949 PointerType *net/url.Userinfo
+          Type: 956 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7263,99 +7267,99 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 957
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 831
+      ID: 838
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1871296
       GoKind: 21
-      HeaderType: 813 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 820 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 193
+      ID: 236
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 679392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 237 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 797
+      ID: 804
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 776608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 798 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 805 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 249
+      ID: 252
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 698624
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 250 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 253 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 961
+      ID: 968
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 694016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 962 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 969 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 824
+      ID: 831
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 825 StructureType noalg.struct { key string; elem []string }
+      Element: 832 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 227
+      ID: 216
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 698528
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 228 StructureType noalg.struct { key string; elem float64 }
+      Element: 217 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 700
+      ID: 712
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 754080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 701 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 713 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 219
+      ID: 208
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 675840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 220 StructureType noalg.struct { key string; elem interface {} }
+      Element: 209 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 211
+      ID: 200
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 212 StructureType noalg.struct { key string; elem string }
+      Element: 201 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 192
+      ID: 235
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1279648
@@ -7366,9 +7370,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 236 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 796
+      ID: 803
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1356960
@@ -7379,9 +7383,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 797 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 804 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 248
+      ID: 251
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1297056
@@ -7392,9 +7396,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 249 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 252 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 960
+      ID: 967
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1290528
@@ -7405,9 +7409,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 961 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 968 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 823
+      ID: 830
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1281056
@@ -7418,9 +7422,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 824 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 831 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 226
+      ID: 215
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1296800
@@ -7431,9 +7435,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 227 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 216 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 699
+      ID: 711
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1338528
@@ -7444,9 +7448,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 700 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 712 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 218
+      ID: 207
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1278496
@@ -7457,9 +7461,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 219 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 208 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 210
+      ID: 199
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1283360
@@ -7470,9 +7474,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 211 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 200 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 194
+      ID: 237
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1279520
@@ -7480,12 +7484,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 GoInterfaceType context.canceler
+          Type: 238 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 196 StructureType struct {}
+          Type: 239 StructureType struct {}
     - __kind: StructureType
-      ID: 798
+      ID: 805
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1356832
@@ -7493,12 +7497,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 799 BaseType github.com/cihub/seelog.LogLevel
+          Type: 806 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 250
+      ID: 253
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1296928
@@ -7509,9 +7513,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 251 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 254 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 962
+      ID: 969
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1290400
@@ -7522,9 +7526,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 963 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 970 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 825
+      ID: 832
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1280928
@@ -7535,9 +7539,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 228
+      ID: 217
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1296672
@@ -7550,7 +7554,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 701
+      ID: 713
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1338400
@@ -7561,9 +7565,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 701 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 220
+      ID: 209
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1278368
@@ -7574,9 +7578,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 134 GoEmptyInterfaceType interface {}
+          Type: 161 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 212
+      ID: 201
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1283232
@@ -7589,15 +7593,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 949
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 543
+      ID: 555
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 173
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1101024
@@ -7610,11 +7614,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 622
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 940
+      ID: 947
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2334208
@@ -7622,12 +7626,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 944 StructureType os.noReadFrom
+          Type: 951 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 941 PointerType *os.File
+          Type: 948 PointerType *os.File
     - __kind: StructureType
-      ID: 938
+      ID: 945
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2333408
@@ -7635,32 +7639,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 943 StructureType os.noWriteTo
+          Type: 950 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 941 PointerType *os.File
+          Type: 948 PointerType *os.File
     - __kind: StructureType
-      ID: 944
+      ID: 951
       Name: os.noReadFrom
       GoRuntimeType: 1100896
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 943
+      ID: 950
       Name: os.noWriteTo
       GoRuntimeType: 1100768
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 586
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 707
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 576
+      ID: 588
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1685024
@@ -7673,7 +7677,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 127
+      ID: 169
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1953216
@@ -7684,17 +7688,17 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 147 GoSubroutineType context.CancelFunc
+          Type: 170 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 148 GoSliceHeaderType []os.Signal
+          Type: 171 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 151 GoChannelType chan os.Signal
+          Type: 174 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 304
+      ID: 316
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 834560
@@ -7702,36 +7706,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 306 PointerType *os/user.UnknownGroupIdError.str
+          Type: 318 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 305 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 317 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 305
+      ID: 317
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 303
+      ID: 315
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 834464
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 358
+      ID: 370
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 433
+      ID: 445
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 563
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 567
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7743,7 +7747,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 553
+      ID: 565
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1870848
@@ -7760,9 +7764,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 693 BaseType runtime.boundsErrorCode
+          Type: 705 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 693
+      ID: 705
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 580800
@@ -7782,7 +7786,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 612
+      ID: 624
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1740192
@@ -7795,7 +7799,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 519
+      ID: 531
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 978368
@@ -7803,13 +7807,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 521 PointerType *runtime.errorString.str
+          Type: 533 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 520 GoStringDataType runtime.errorString.str
+      Data: 532 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 520
+      ID: 532
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8465,7 +8469,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 522
+      ID: 534
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 978464
@@ -8473,13 +8477,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 524 PointerType *runtime.plainError.str
+          Type: 536 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 523 GoStringDataType runtime.plainError.str
+      Data: 535 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 523
+      ID: 535
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8565,7 +8569,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 547
+      ID: 559
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8577,18 +8581,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 184 PointerType *string.str
+          Type: 191 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 183 GoStringDataType string.str
+      Data: 190 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 183
+      ID: 190
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 728
+      ID: 735
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1932800
@@ -8596,12 +8600,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 742
+      ID: 749
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2010432
@@ -8609,15 +8613,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 724
+      ID: 731
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1932288
@@ -8625,12 +8629,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 734
+      ID: 741
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2009280
@@ -8638,15 +8642,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 748
+      ID: 755
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2071712
@@ -8654,18 +8658,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 736
+      ID: 743
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2009568
@@ -8673,15 +8677,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 732
+      ID: 739
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2008992
@@ -8689,15 +8693,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 744
+      ID: 751
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2071072
@@ -8705,18 +8709,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 752
+      ID: 759
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2131456
@@ -8724,21 +8728,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 746
+      ID: 753
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2071392
@@ -8746,18 +8750,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 730
+      ID: 737
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1933056
@@ -8765,12 +8769,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 726
+      ID: 733
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1932544
@@ -8778,12 +8782,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 738
+      ID: 745
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2009856
@@ -8791,15 +8795,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 750
+      ID: 757
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2072032
@@ -8807,18 +8811,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 740
+      ID: 747
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2010144
@@ -8826,15 +8830,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 872
+      ID: 879
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1690016
@@ -8842,18 +8846,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 889 GoInterfaceType io.Reader
+          Type: 896 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 899 GoInterfaceType io.Closer
+          Type: 906 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 196
+      ID: 239
       Name: struct {}
       GoRuntimeType: 840800
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 130
+      ID: 118
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1456128
@@ -8861,12 +8865,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 131 StructureType sync.noCopy
+          Type: 119 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 132 StructureType internal/sync.Mutex
+          Type: 120 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 154
+      ID: 117
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1824256
@@ -8874,7 +8878,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 130 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -8883,18 +8887,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 155 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 155 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 131
+      ID: 119
       Name: sync.noCopy
       GoRuntimeType: 977984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 807
+      ID: 814
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1457248
@@ -8902,12 +8906,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 122 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 155
+      ID: 121
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1457408
@@ -8915,12 +8919,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 122 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 133
+      ID: 177
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1185504
@@ -8928,27 +8932,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 134 GoEmptyInterfaceType interface {}
+          Type: 161 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 156
+      ID: 122
       Name: sync/atomic.noCopy
       GoRuntimeType: 978080
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 645
+      ID: 657
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1269408
       GoKind: 12
     - __kind: BaseType
-      ID: 716
+      ID: 723
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 979328
       GoKind: 2
     - __kind: StructureType
-      ID: 189
+      ID: 232
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -8970,9 +8974,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 190 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 233 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 793
+      ID: 800
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -8994,9 +8998,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 794 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 801 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 245
+      ID: 248
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9018,9 +9022,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 246 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 249 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 957
+      ID: 964
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9042,9 +9046,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 958 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 965 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 820
+      ID: 827
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9066,9 +9070,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 821 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 828 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 223
+      ID: 212
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9090,9 +9094,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 224 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 213 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 696
+      ID: 708
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9114,9 +9118,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 697 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 709 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 215
+      ID: 204
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9138,9 +9142,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 216 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 205 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 207
+      ID: 196
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9162,9 +9166,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 208 GoSwissMapGroupsType groupReference<string,string>
+          Type: 197 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 592
+      ID: 604
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1689248
@@ -9177,13 +9181,13 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 916
+      ID: 923
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1897216
       GoKind: 6
     - __kind: StructureType
-      ID: 145
+      ID: 189
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1958592
@@ -9194,10 +9198,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 199 GoSliceHeaderType []time.zone
+          Type: 242 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 202 GoSliceHeaderType []time.zoneTrans
+          Type: 245 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9209,13 +9213,13 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 200 PointerType *time.zone
+          Type: 243 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 352
+      ID: 364
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 143
+      ID: 187
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2349088
@@ -9229,7 +9233,7 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 144 PointerType *time.Location
+          Type: 188 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9239,7 +9243,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 142
+      ID: 186
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1453728
@@ -9247,12 +9251,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 710 GoChannelType <-chan time.Time
+          Type: 722 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 268
+      ID: 280
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 828224
@@ -9260,18 +9264,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 270 PointerType *time.fileSizeError.str
+          Type: 282 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 269 GoStringDataType time.fileSizeError.str
+      Data: 281 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 269
+      ID: 281
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 201
+      ID: 244
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1602752
@@ -9287,7 +9291,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 204
+      ID: 247
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1737120
@@ -9348,7 +9352,7 @@ Types:
       GoRuntimeType: 580736
       GoKind: 26
     - __kind: StructureType
-      ID: 674
+      ID: 686
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2045152
@@ -9359,10 +9363,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 675 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 687 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 676 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 688 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9377,18 +9381,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 677 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 689 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 677
+      ID: 689
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 979424
       GoKind: 9
     - __kind: StructureType
-      ID: 675
+      ID: 687
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1899776
@@ -9413,17 +9417,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 376
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 676
+      ID: 688
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 581632
       GoKind: 8
     - __kind: StructureType
-      ID: 377
+      ID: 389
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1407840
@@ -9433,13 +9437,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 282
+      ID: 294
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 830336
       GoKind: 2
     - __kind: StructureType
-      ID: 560
+      ID: 572
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1684448
@@ -9452,7 +9456,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 526
+      ID: 538
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 980288

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -137,23 +137,23 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 685 PointerType *crypto/x509.Certificate
+      Pointee: 697 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 733
+      ID: 268
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 148 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 986 PointerType *mime/multipart.FileHeader
+      Pointee: 993 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
       ID: 65
       Name: '**runtime.p'
@@ -161,111 +161,111 @@ Types:
       GoKind: 22
       Pointee: 66 PointerType *runtime.p
     - __kind: PointerType
-      ID: 140
+      ID: 183
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 141 PointerType *table<context.canceler,struct {}>
+      Pointee: 184 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 797 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 804 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 241
+      ID: 230
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 242 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 231 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 977 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 984 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 836 PointerType *table<string,[]string>
+      Pointee: 843 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 172
+      ID: 138
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 173 PointerType *table<string,float64>
+      Pointee: 139 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 690
+      ID: 702
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 703 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 167
+      ID: 133
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<string,interface {}>
+      Pointee: 134 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 162
+      ID: 128
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 163 PointerType *table<string,string>
+      Pointee: 129 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 993 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 1000 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 1002
+      ID: 1009
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 1001 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1008 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 736
+      ID: 271
       Name: '*[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       ByteSize: 8
-      Pointee: 735 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Pointee: 270 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 990 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 997 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 193
+      ID: 200
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []*runtime.p.array
-    - __kind: PointerType
-      ID: 1004
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 1003 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 1006
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 1005 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 728
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 727 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 237
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
-      ByteSize: 8
-      Pointee: 236 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
-    - __kind: PointerType
-      ID: 245
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 244 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 199 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 1011
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1010 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1013
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1012 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 740
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 739 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 226
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
+      ByteSize: 8
+      Pointee: 225 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+    - __kind: PointerType
+      ID: 234
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1018
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1010 GoSliceDataType []net/http.segment.array
+      Pointee: 1017 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 211
+      ID: 236
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []os.Signal.array
+      Pointee: 235 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -274,77 +274,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 726
+      ID: 738
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 725 GoSliceDataType []string.array
+      Pointee: 737 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 247
+      ID: 264
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []time.zone.array
+      Pointee: 263 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 249
+      ID: 266
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []time.zoneTrans.array
+      Pointee: 265 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481600
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 188
+      ID: 195
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []uint8.array
+      Pointee: 194 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 190
+      ID: 197
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []uintptr.array
+      Pointee: 196 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 946176
       GoKind: 22
-      Pointee: 519 GoSliceHeaderType archive/tar.headerError
+      Pointee: 531 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 520 GoSliceDataType archive/tar.headerError.array
+      Pointee: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1256704
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 910 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1083744
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 896 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1444032
       GoKind: 22
-      Pointee: 907 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 914 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1083488
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 894 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -353,12 +353,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1952544
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType bufio.Writer
+      Pointee: 837 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 114
       Name: '*bytes.Buffer'
@@ -367,372 +367,372 @@ Types:
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 439
+      ID: 451
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 919488
       GoKind: 22
-      Pointee: 306 BaseType compress/flate.CorruptInputError
+      Pointee: 318 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 919584
       GoKind: 22
-      Pointee: 307 GoStringHeaderType compress/flate.InternalError
+      Pointee: 319 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 309
+      ID: 321
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType compress/flate.InternalError.str
+      Pointee: 320 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 1983328
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 946 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1626848
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 925 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 1017
+      ID: 166
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1542848
       GoKind: 22
-      Pointee: 130 StructureType context.backgroundCtx
+      Pointee: 167 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 118
+      ID: 177
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1717280
       GoKind: 22
-      Pointee: 119 StructureType context.cancelCtx
+      Pointee: 178 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 615
+      ID: 627
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1182464
       GoKind: 22
-      Pointee: 616 StructureType context.deadlineExceededError
+      Pointee: 628 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1012
+      ID: 152
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1407552
       GoKind: 22
-      Pointee: 131 StructureType context.emptyCtx
+      Pointee: 153 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 120
+      ID: 154
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1407712
       GoKind: 22
-      Pointee: 121 StructureType context.stopCtx
+      Pointee: 155 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 122
+      ID: 185
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1717472
       GoKind: 22
-      Pointee: 123 StructureType context.timerCtx
+      Pointee: 186 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1018
+      ID: 168
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1543008
       GoKind: 22
-      Pointee: 148 StructureType context.todoCtx
+      Pointee: 169 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 124
+      ID: 161
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1542528
       GoKind: 22
-      Pointee: 125 StructureType context.valueCtx
+      Pointee: 162 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 126
+      ID: 164
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1542688
       GoKind: 22
-      Pointee: 127 StructureType context.withoutCancelCtx
+      Pointee: 165 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 435
+      ID: 447
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918240
       GoKind: 22
-      Pointee: 302 BaseType crypto/aes.KeySizeError
+      Pointee: 314 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918432
       GoKind: 22
-      Pointee: 303 BaseType crypto/des.KeySizeError
+      Pointee: 315 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 437
+      ID: 449
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918720
       GoKind: 22
-      Pointee: 304 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 316 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1053664
       GoKind: 22
-      Pointee: 597 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 609 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 305 BaseType crypto/rc4.KeySizeError
+      Pointee: 317 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 909024
       GoKind: 22
-      Pointee: 276 BaseType crypto/tls.AlertError
+      Pointee: 288 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1037920
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 585 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2370912
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 976 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 856 StructureType crypto/tls.ConnectionState
+      Pointee: 863 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 377
+      ID: 389
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 378 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 390 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 375
+      ID: 387
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 376 StructureType crypto/tls.RecordHeaderError
+      Pointee: 388 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 571
+      ID: 583
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1036256
       GoKind: 22
-      Pointee: 540 BaseType crypto/tls.alert
+      Pointee: 552 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 908832
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 392 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 676
+      ID: 688
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1416032
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 689 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 685
+      ID: 697
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2043968
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 698 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 431
+      ID: 443
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 918048
       GoKind: 22
-      Pointee: 432 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 444 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 917568
       GoKind: 22
-      Pointee: 426 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 438 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 917664
       GoKind: 22
-      Pointee: 428 StructureType crypto/x509.HostnameError
+      Pointee: 440 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 301 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 313 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1046496
       GoKind: 22
-      Pointee: 589 StructureType crypto/x509.SystemRootsError
+      Pointee: 601 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 433
+      ID: 445
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 918144
       GoKind: 22
-      Pointee: 434 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 446 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 429
+      ID: 441
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 917952
       GoKind: 22
-      Pointee: 430 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 442 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 475
+      ID: 487
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 928416
       GoKind: 22
-      Pointee: 476 StructureType encoding/asn1.StructuralError
+      Pointee: 488 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 479
+      ID: 491
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 928608
       GoKind: 22
-      Pointee: 480 StructureType encoding/asn1.SyntaxError
+      Pointee: 492 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 928512
       GoKind: 22
-      Pointee: 478 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 490 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 382
+      ID: 394
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 909120
       GoKind: 22
-      Pointee: 277 BaseType encoding/base64.CorruptInputError
+      Pointee: 289 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 916224
       GoKind: 22
-      Pointee: 297 BaseType encoding/hex.InvalidByteError
+      Pointee: 309 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 401
+      ID: 413
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 912672
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 414 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 584
+      ID: 596
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1042912
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 597 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 393
+      ID: 405
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 912288
       GoKind: 22
-      Pointee: 394 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 406 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 412 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 912480
       GoKind: 22
-      Pointee: 398 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 395
+      ID: 407
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 912384
       GoKind: 22
-      Pointee: 396 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 408 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 913056
       GoKind: 22
-      Pointee: 404 StructureType encoding/json.jsonError
+      Pointee: 416 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 940032
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 521 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 939936
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 519 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 940128
       GoKind: 22
-      Pointee: 315 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 327 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 317
+      ID: 329
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 316 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 328 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 940224
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 524 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -741,19 +741,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 361
+      ID: 373
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 903936
       GoKind: 22
-      Pointee: 362 UnresolvedPointeeType errors.errorString
+      Pointee: 374 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1029216
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType errors.joinError
+      Pointee: 572 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -769,799 +769,799 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 543
+      ID: 555
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1018848
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType fmt.wrapError
+      Pointee: 556 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 545
+      ID: 557
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1018976
       GoKind: 22
-      Pointee: 546 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 558 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915744
       GoKind: 22
-      Pointee: 415 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 427 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2013824
       GoKind: 22
-      Pointee: 799 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 806 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 406
+      ID: 418
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 419 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 914496
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 421 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 705
+      ID: 717
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 914208
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 718 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 914784
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 425 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 707
+      ID: 719
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 720 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 410
+      ID: 422
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 914592
       GoKind: 22
-      Pointee: 291 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 303 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 293
+      ID: 305
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 292 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 304 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 914112
       GoKind: 22
-      Pointee: 288 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 300 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 290
+      ID: 302
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 301 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 914688
       GoKind: 22
-      Pointee: 294 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 306 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 296
+      ID: 308
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 929280
       GoKind: 22
-      Pointee: 485 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 497 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 929088
       GoKind: 22
-      Pointee: 310 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 322 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 482
+      ID: 494
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 929184
       GoKind: 22
-      Pointee: 483 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
+      Pointee: 495 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 449
+      ID: 461
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 925248
       GoKind: 22
-      Pointee: 450 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 462 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 454 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 466 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 451
+      ID: 463
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 925344
       GoKind: 22
-      Pointee: 452 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 464 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 447
+      ID: 459
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 925152
       GoKind: 22
-      Pointee: 448 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 460 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 730
+      ID: 742
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 741 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 461
+      ID: 473
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 925824
       GoKind: 22
-      Pointee: 462 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 474 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 925536
       GoKind: 22
-      Pointee: 456 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 468 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 925728
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 472 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 925632
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 470 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 463
+      ID: 475
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 925920
       GoKind: 22
-      Pointee: 464 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 476 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 470 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 926304
       GoKind: 22
-      Pointee: 472 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 926112
       GoKind: 22
-      Pointee: 468 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 465
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 926016
       GoKind: 22
-      Pointee: 466 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 474 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2313568
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 820 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2299136
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 814 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2306528
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2307168
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 818 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 494
+      ID: 506
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 937248
       GoKind: 22
-      Pointee: 495 StructureType github.com/cihub/seelog.baseError
+      Pointee: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1804416
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 799 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 937344
       GoKind: 22
-      Pointee: 497 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 509 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1434752
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 791 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1661408
       GoKind: 22
-      Pointee: 786 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 793 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1662176
       GoKind: 22
-      Pointee: 790 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 797 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 937536
       GoKind: 22
-      Pointee: 501 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 513 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1661600
       GoKind: 22
-      Pointee: 788 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 795 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2278624
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 812 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 937440
       GoKind: 22
-      Pointee: 499 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 511 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 937632
       GoKind: 22
-      Pointee: 503 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 515 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1248512
       GoKind: 22
-      Pointee: 901 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 908 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1736288
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 929 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 602
+      ID: 614
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1066080
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 615 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 604
+      ID: 616
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1066208
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 617 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 594
+      ID: 606
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1050848
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 607 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 417
+      ID: 429
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 916416
       GoKind: 22
-      Pointee: 418 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 430 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 598
+      ID: 610
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1054432
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 611 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 644
+      ID: 656
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1204736
       GoKind: 22
-      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 638
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1204352
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 651 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1042016
       GoKind: 22
-      Pointee: 579 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1205120
       GoKind: 22
-      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1041888
       GoKind: 22
-      Pointee: 542 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 554 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 642
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1204608
       GoKind: 22
-      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 640
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1204480
       GoKind: 22
-      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1204992
       GoKind: 22
-      Pointee: 649 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 646
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1204864
       GoKind: 22
-      Pointee: 647 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 654
+      ID: 666
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1205504
       GoKind: 22
-      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1042272
       GoKind: 22
-      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 580
+      ID: 592
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1042144
       GoKind: 22
-      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 652
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1205376
       GoKind: 22
-      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 945408
       GoKind: 22
-      Pointee: 318 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 330 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 320
+      ID: 332
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 331 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 693
+      ID: 705
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1660448
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 706 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 608
+      ID: 620
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1082848
       GoKind: 22
-      Pointee: 609 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 621 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 522
+      ID: 534
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 947424
       GoKind: 22
-      Pointee: 321 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 333 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 662
+      ID: 674
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1258368
       GoKind: 22
-      Pointee: 663 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 675 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 525
+      ID: 537
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 947712
       GoKind: 22
-      Pointee: 526 StructureType golang.org/x/net/http2.connError
+      Pointee: 538 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 947616
       GoKind: 22
-      Pointee: 325 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 337 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 327
+      ID: 339
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 338 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 947904
       GoKind: 22
-      Pointee: 331 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 343 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 333
+      ID: 345
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 344 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 947808
       GoKind: 22
-      Pointee: 328 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 340 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 330
+      ID: 342
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 341 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 947520
       GoKind: 22
-      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 334 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 324
+      ID: 336
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 335 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 529
+      ID: 541
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 948000
       GoKind: 22
-      Pointee: 530 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 542 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 531
+      ID: 543
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 948096
       GoKind: 22
-      Pointee: 334 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 346 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 939456
       GoKind: 22
-      Pointee: 505 StructureType google.golang.org/grpc.dropError
+      Pointee: 517 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 660
+      ID: 672
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1255168
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 673 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 680
+      ID: 692
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1440512
       GoKind: 22
-      Pointee: 681 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 693 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 943680
       GoKind: 22
-      Pointee: 516 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 528 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1807104
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 935 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 606
+      ID: 618
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1077088
       GoKind: 22
-      Pointee: 607 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 619 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1562368
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 919 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 486
+      ID: 498
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 931488
       GoKind: 22
-      Pointee: 487 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 499 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 600
+      ID: 612
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1055840
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 613 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 658
+      ID: 670
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1221376
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 671 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 656
+      ID: 668
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1221120
       GoKind: 22
-      Pointee: 657 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 669 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 911328
       GoKind: 22
-      Pointee: 392 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 404 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 742
+      ID: 749
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1550528
       GoKind: 22
-      Pointee: 743 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 750 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 175
+      ID: 141
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1202688
       GoKind: 22
-      Pointee: 176 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Pointee: 142 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1895616
       GoKind: 22
-      Pointee: 934 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 941 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1798144
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+      Pointee: 933 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 154
+      ID: 148
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoRuntimeType: 2304608
       GoKind: 22
-      Pointee: 155 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 118 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 180
+      ID: 146
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext'
       ByteSize: 8
       GoRuntimeType: 1974400
       GoKind: 22
-      Pointee: 181 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+      Pointee: 147 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
     - __kind: PointerType
-      ID: 178
+      ID: 144
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1189632
       GoKind: 22
-      Pointee: 179 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Pointee: 145 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 740
+      ID: 747
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1190272
       GoKind: 22
-      Pointee: 741 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 748 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 256
+      ID: 259
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1190400
       GoKind: 22
-      Pointee: 257 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 260 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 182
+      ID: 149
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2218720
       GoKind: 22
-      Pointee: 183 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+      Pointee: 150 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2169920
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
+      Pointee: 810 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1015
+      ID: 159
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1419232
       GoKind: 22
-      Pointee: 1016 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
+      Pointee: 160 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2150560
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
+      Pointee: 808 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1049184
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
+      Pointee: 892 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 443
+      ID: 455
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 444 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 456 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932064
       GoKind: 22
-      Pointee: 489 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 501 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 490
+      ID: 502
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 932160
       GoKind: 22
-      Pointee: 491 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 503 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 940992
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 526 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 948864
       GoKind: 22
-      Pointee: 533 UnresolvedPointeeType html/template.Error
+      Pointee: 545 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -1598,347 +1598,347 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType int8
     - __kind: PointerType
-      ID: 682
+      ID: 694
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2205728
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType internal/abi.Type
+      Pointee: 695 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 917088
       GoKind: 22
-      Pointee: 423 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 435 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 916992
       GoKind: 22
-      Pointee: 421 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 433 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1198208
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 649 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2365664
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType internal/poll.FD
+      Pointee: 974 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 634
+      ID: 646
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1198080
       GoKind: 22
-      Pointee: 635 StructureType internal/poll.errNetClosing
+      Pointee: 647 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 904320
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 376 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 419
+      ID: 431
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 916896
       GoKind: 22
-      Pointee: 298 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 310 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 300
+      ID: 312
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 299 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 311 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 586
+      ID: 598
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1045472
       GoKind: 22
-      Pointee: 587 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 599 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1838784
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType io.PipeReader
+      Pointee: 939 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1547168
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType io.SectionReader
+      Pointee: 943 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1029728
       GoKind: 22
-      Pointee: 883 StructureType io.nopCloser
+      Pointee: 890 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1192832
       GoKind: 22
-      Pointee: 899 StructureType io.nopCloserWriterTo
+      Pointee: 906 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 632
+      ID: 644
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1197056
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType io/fs.PathError
+      Pointee: 645 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 138
+      ID: 181
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 139 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 182 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 795 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 802 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 239
+      ID: 228
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 240 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 229 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 975 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 982 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 834 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 841 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 170
+      ID: 136
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 171 GoSwissMapHeaderType map<string,float64>
+      Pointee: 137 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 688
+      ID: 700
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 701 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 165
+      ID: 131
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 160
+      ID: 126
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 161 GoSwissMapHeaderType map<string,string>
+      Pointee: 127 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 920256
       GoKind: 22
-      Pointee: 442 StructureType math/big.ErrNaN
+      Pointee: 454 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 996 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 854 StructureType mime/multipart.Form
+      Pointee: 861 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1625888
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 921 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1626080
       GoKind: 22
-      Pointee: 916 StructureType mime/multipart.sectionReadCloser
+      Pointee: 923 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1183616
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType net.AddrError
+      Pointee: 631 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1408352
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType net.DNSError
+      Pointee: 680 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2222304
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType net.IPConn
+      Pointee: 950 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1408032
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType net.OpError
+      Pointee: 678 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1183744
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType net.ParseError
+      Pointee: 633 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2254048
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType net.TCPConn
+      Pointee: 958 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2297312
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType net.UDPConn
+      Pointee: 962 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2253536
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType net.UnixConn
+      Pointee: 956 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 617
+      ID: 629
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1182848
       GoKind: 22
-      Pointee: 612 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 624 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 613 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 625 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 547
+      ID: 559
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1019872
       GoKind: 22
-      Pointee: 548 StructureType net.canceledError
+      Pointee: 560 StructureType net.canceledError
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2009504
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType net.conn
+      Pointee: 948 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 711
+      ID: 723
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1832736
       GoKind: 22
-      Pointee: 712 StructureType net.dialResult·1
+      Pointee: 724 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2300352
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType net.netFD
+      Pointee: 964 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 335
+      ID: 347
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 896928
       GoKind: 22
-      Pointee: 336 UnresolvedPointeeType net.notFoundError
+      Pointee: 348 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1013
+      ID: 157
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1408192
       GoKind: 22
-      Pointee: 1014 StructureType net.onlyValuesCtx
+      Pointee: 158 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 897600
       GoKind: 22
-      Pointee: 338 StructureType net.result·2
+      Pointee: 350 StructureType net.result·2
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2239584
       GoKind: 22
-      Pointee: 947 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 954 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2239104
       GoKind: 22
-      Pointee: 945 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 952 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 622
+      ID: 634
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1184384
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net.temporaryError
+      Pointee: 635 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1408672
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType net.timeoutError
+      Pointee: 682 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 343
+      ID: 355
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 900192
       GoKind: 22
-      Pointee: 344 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 356 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1023328
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 562 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 112
       Name: '*net/http.Request'
@@ -1947,559 +1947,559 @@ Types:
       GoKind: 22
       Pointee: 113 StructureType net/http.Request
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1718816
       GoKind: 22
-      Pointee: 859 StructureType net/http.Response
+      Pointee: 866 StructureType net/http.Response
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1797248
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/http.body
+      Pointee: 931 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1186944
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 902 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1023200
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 882 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1894592
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType net/http.conn
+      Pointee: 833 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1021920
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 872 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1025504
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 886 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 900384
       GoKind: 22
-      Pointee: 260 BaseType net/http.http2ConnectionError
+      Pointee: 272 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 900480
       GoKind: 22
-      Pointee: 347 StructureType net/http.http2GoAwayError
+      Pointee: 359 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 671
+      ID: 683
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1409632
       GoKind: 22
-      Pointee: 672 StructureType net/http.http2StreamError
+      Pointee: 684 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2010944
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 916 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 352
+      ID: 364
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 901536
       GoKind: 22
-      Pointee: 353 StructureType net/http.http2connError
+      Pointee: 365 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900960
       GoKind: 22
-      Pointee: 264 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 276 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 266
+      ID: 278
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 277 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 901056
       GoKind: 22
-      Pointee: 351 StructureType net/http.http2goAwayFlowError
+      Pointee: 363 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1022944
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 880 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 270 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 282 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 272
+      ID: 284
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 283 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 901632
       GoKind: 22
-      Pointee: 267 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 279 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 269
+      ID: 281
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 280 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 626
+      ID: 638
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1188224
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 639 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1022688
       GoKind: 22
-      Pointee: 869 StructureType net/http.http2missingBody
+      Pointee: 876 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1025760
       GoKind: 22
-      Pointee: 881 StructureType net/http.http2noBodyReader
+      Pointee: 888 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 555
+      ID: 567
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1025632
       GoKind: 22
-      Pointee: 556 StructureType net/http.http2noCachedConnError
+      Pointee: 568 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 261 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 273 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 263
+      ID: 275
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 274 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1023840
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 884 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2010368
       GoKind: 22
-      Pointee: 780 StructureType net/http.http2responseWriter
+      Pointee: 787 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1610528
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 831 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1022816
       GoKind: 22
-      Pointee: 871 StructureType net/http.http2transportResponseBody
+      Pointee: 878 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1022176
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 874 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1187072
       GoKind: 22
-      Pointee: 897 StructureType net/http.noBody
+      Pointee: 904 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 551
+      ID: 563
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1025248
       GoKind: 22
-      Pointee: 552 StructureType net/http.nothingWrittenError
+      Pointee: 564 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1608608
       GoKind: 22
-      Pointee: 861 StructureType net/http.pattern
+      Pointee: 868 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1021536
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 870 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1409952
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 912 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 901920
       GoKind: 22
-      Pointee: 357 StructureType net/http.requestBodyReadError
+      Pointee: 369 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2218272
       GoKind: 22
-      Pointee: 782 StructureType net/http.response
+      Pointee: 789 StructureType net/http.response
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391808
       GoKind: 22
-      Pointee: 1009 StructureType net/http.segment
+      Pointee: 1016 StructureType net/http.segment
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 900096
       GoKind: 22
-      Pointee: 342 StructureType net/http.statusError
+      Pointee: 354 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 673
+      ID: 685
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1411232
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 686 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 624
+      ID: 636
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1188096
       GoKind: 22
-      Pointee: 625 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 637 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 553
+      ID: 565
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1025376
       GoKind: 22
-      Pointee: 554 StructureType net/http.transportReadFromServerError
+      Pointee: 566 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1834304
       GoKind: 22
-      Pointee: 930 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 937 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 339
+      ID: 351
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 899328
       GoKind: 22
-      Pointee: 340 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 352 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1084128
       GoKind: 22
-      Pointee: 891 StructureType net/http/httputil.failureToReadBody
+      Pointee: 898 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 372 StructureType net/netip.parseAddrError
+      Pointee: 384 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 906912
       GoKind: 22
-      Pointee: 370 StructureType net/netip.parsePrefixError
+      Pointee: 382 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 386
+      ID: 398
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 910368
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType net/textproto.Error
+      Pointee: 399 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 910272
       GoKind: 22
-      Pointee: 284 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 296 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 286
+      ID: 298
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 297 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 678
+      ID: 690
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1416352
       GoKind: 22
-      Pointee: 679 UnresolvedPointeeType net/url.Error
+      Pointee: 691 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 909216
       GoKind: 22
-      Pointee: 278 GoStringHeaderType net/url.EscapeError
+      Pointee: 290 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 280
+      ID: 292
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 279 GoStringDataType net/url.EscapeError.str
+      Pointee: 291 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 909312
       GoKind: 22
-      Pointee: 281 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 293 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 283
+      ID: 295
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 282 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 294 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2113600
       GoKind: 22
-      Pointee: 850 StructureType net/url.URL
+      Pointee: 857 StructureType net/url.URL
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1200768
       GoKind: 22
-      Pointee: 971 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 978 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 196
+      ID: 239
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 240 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 816
+      ID: 823
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 824 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 252
+      ID: 255
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 256 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 981 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 988 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 844 StructureType noalg.map.group[string][]string
+      Pointee: 851 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 230
+      ID: 219
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 231 StructureType noalg.map.group[string]float64
+      Pointee: 220 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 719
+      ID: 731
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 732 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 222
+      ID: 211
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 223 StructureType noalg.map.group[string]interface {}
+      Pointee: 212 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 214
+      ID: 203
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 215 StructureType noalg.map.group[string]string
+      Pointee: 204 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2342016
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType os.File
+      Pointee: 970 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 557
+      ID: 569
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1027680
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType os.LinkError
+      Pointee: 570 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 151
+      ID: 174
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 394624
       GoKind: 22
-      Pointee: 152 GoInterfaceType os.Signal
+      Pointee: 175 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1188608
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType os.SyscallError
+      Pointee: 641 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2339776
       GoKind: 22
-      Pointee: 961 StructureType os.fileWithoutReadFrom
+      Pointee: 968 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2339040
       GoKind: 22
-      Pointee: 959 StructureType os.fileWithoutWriteTo
+      Pointee: 966 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 590
+      ID: 602
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1049440
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType os/exec.Error
+      Pointee: 603 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 715
+      ID: 727
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2089344
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 728 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 592
+      ID: 604
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1049568
       GoKind: 22
-      Pointee: 593 StructureType os/exec.wrappedError
+      Pointee: 605 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 128
+      ID: 170
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1613216
       GoKind: 22
-      Pointee: 129 StructureType os/signal.signalCtx
+      Pointee: 171 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 493
+      ID: 505
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 936288
       GoKind: 22
-      Pointee: 312 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 324 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 314
+      ID: 326
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 313 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 325 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 492
+      ID: 504
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 936192
       GoKind: 22
-      Pointee: 311 BaseType os/user.UnknownUserIdError
+      Pointee: 323 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 366 UnresolvedPointeeType reflect.ValueError
+      Pointee: 378 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 445
+      ID: 457
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 446 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 458 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1032288
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 578 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 569
+      ID: 581
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1034080
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 582 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2515,12 +2515,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1032416
       GoKind: 22
-      Pointee: 568 StructureType runtime.boundsError
+      Pointee: 580 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -2536,24 +2536,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1196544
       GoKind: 22
-      Pointee: 631 StructureType runtime.errorAddressString
+      Pointee: 643 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 563
+      ID: 575
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1031904
       GoKind: 22
-      Pointee: 534 GoStringHeaderType runtime.errorString
+      Pointee: 546 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 536
+      ID: 548
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 535 GoStringDataType runtime.errorString.str
+      Pointee: 547 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2574,19 +2574,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1033440
       GoKind: 22
-      Pointee: 191 UnresolvedPointeeType runtime.p
+      Pointee: 198 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1032032
       GoKind: 22
-      Pointee: 537 GoStringHeaderType runtime.plainError
+      Pointee: 549 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 538 GoStringDataType runtime.plainError.str
+      Pointee: 550 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2602,12 +2602,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 367
+      ID: 379
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 368 StructureType runtime.synctestDeadlockError
+      Pointee: 380 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -2623,12 +2623,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 561
+      ID: 573
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1031520
       GoKind: 22
-      Pointee: 562 UnresolvedPointeeType strconv.NumError
+      Pointee: 574 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -2637,235 +2637,235 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 186
+      ID: 193
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 185 GoStringDataType string.str
+      Pointee: 192 GoStringDataType string.str
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1688480
       GoKind: 22
-      Pointee: 749 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 756 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1742240
       GoKind: 22
-      Pointee: 763 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 770 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1688096
       GoKind: 22
-      Pointee: 745 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 752 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1741472
       GoKind: 22
-      Pointee: 755 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 762 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1814048
       GoKind: 22
-      Pointee: 769 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 776 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1741664
       GoKind: 22
-      Pointee: 757 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 764 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1741280
       GoKind: 22
-      Pointee: 753 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 760 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1813600
       GoKind: 22
-      Pointee: 765 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 772 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1882912
       GoKind: 22
-      Pointee: 773 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 780 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1813824
       GoKind: 22
-      Pointee: 767 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 774 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1688672
       GoKind: 22
-      Pointee: 751 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 758 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1688288
       GoKind: 22
-      Pointee: 747 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 754 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1741856
       GoKind: 22
-      Pointee: 759 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 766 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1814272
       GoKind: 22
-      Pointee: 771 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 778 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1742048
       GoKind: 22
-      Pointee: 761 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 768 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1091264
       GoKind: 22
-      Pointee: 893 StructureType struct { io.Reader; io.Closer }
+      Pointee: 900 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 675
+      ID: 687
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1415232
       GoKind: 22
-      Pointee: 664 BaseType syscall.Errno
+      Pointee: 676 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1034592
       GoKind: 22
-      Pointee: 737 BaseType syscall.Signal
+      Pointee: 744 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 141
+      ID: 184
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 194 StructureType table<context.canceler,struct {}>
+      Pointee: 237 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 814 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 821 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 242
+      ID: 231
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 250 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 253 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 978 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 985 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 841 StructureType table<string,[]string>
+      Pointee: 848 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 173
+      ID: 139
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 228 StructureType table<string,float64>
+      Pointee: 217 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 691
+      ID: 703
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 717 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 729 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 168
+      ID: 134
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 220 StructureType table<string,interface {}>
+      Pointee: 209 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 163
+      ID: 129
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 212 StructureType table<string,string>
+      Pointee: 201 StructureType table<string,string>
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1087328
       GoKind: 22
-      Pointee: 611 StructureType text/template.ExecError
+      Pointee: 623 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 146
+      ID: 190
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1613600
       GoKind: 22
-      Pointee: 147 StructureType time.Location
+      Pointee: 191 StructureType time.Location
     - __kind: PointerType
-      ID: 359
+      ID: 371
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902784
       GoKind: 22
-      Pointee: 360 UnresolvedPointeeType time.ParseError
+      Pointee: 372 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 143
+      ID: 187
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1028192
       GoKind: 22
-      Pointee: 144 StructureType time.Timer
+      Pointee: 188 StructureType time.Timer
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 273 GoStringHeaderType time.fileSizeError
+      Pointee: 285 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 275
+      ID: 287
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType time.fileSizeError.str
+      Pointee: 286 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 205
+      ID: 248
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394880
       GoKind: 22
-      Pointee: 206 StructureType time.zone
+      Pointee: 249 StructureType time.zone
     - __kind: PointerType
-      ID: 208
+      ID: 251
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394944
       GoKind: 22
-      Pointee: 209 StructureType time.zoneTrans
+      Pointee: 252 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -2909,47 +2909,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 373
+      ID: 385
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 907776
       GoKind: 22
-      Pointee: 374 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 386 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 910560
       GoKind: 22
-      Pointee: 389 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 401 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 910656
       GoKind: 22
-      Pointee: 287 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 299 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1039456
       GoKind: 22
-      Pointee: 575 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 587 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 576
+      ID: 588
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1039584
       GoKind: 22
-      Pointee: 541 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 553 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 857
+      ID: 864
       Name: <-chan struct {}
       GoRuntimeType: 597696
       GoKind: 18
     - __kind: GoChannelType
-      ID: 731
+      ID: 743
       Name: <-chan time.Time
       GoRuntimeType: 600960
       GoKind: 18
@@ -3028,7 +3028,7 @@ Types:
       HasCount: true
       Element: 95 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 838
+      ID: 845
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 683040
@@ -3037,7 +3037,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 837
+      ID: 844
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 682944
@@ -3109,7 +3109,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 839
+      ID: 846
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 683136
@@ -3127,7 +3127,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 699
+      ID: 711
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 700928
@@ -3154,7 +3154,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 993
+      ID: 1000
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502496
@@ -3162,22 +3162,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 994 PointerType **crypto/x509.Certificate
+          Type: 1001 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1001 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1008 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1001
+      ID: 1008
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 685 PointerType *crypto/x509.Certificate
+      Element: 697 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 732
+      ID: 267
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 24
       GoRuntimeType: 490368
@@ -3185,22 +3185,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 733 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 268 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 735 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Data: 270 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: GoSliceDataType
-      ID: 735
+      ID: 270
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Element: 148 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: GoSliceHeaderType
-      ID: 984
+      ID: 991
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487328
@@ -3208,20 +3208,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 985 PointerType **mime/multipart.FileHeader
+          Type: 992 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 990 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 997 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 990
+      ID: 997
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 986 PointerType *mime/multipart.FileHeader
+      Element: 993 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 64
       Name: '[]*runtime.p'
@@ -3238,69 +3238,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType []*runtime.p.array
+      Data: 199 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 199
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 66 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 245
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 141 PointerType *table<context.canceler,struct {}>
+      Element: 184 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 821
+      ID: 828
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 797 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 804 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 261
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 242 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 231 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 987
+      ID: 994
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 977 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 984 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 847
+      ID: 854
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 836 PointerType *table<string,[]string>
+      Element: 843 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 223
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 173 PointerType *table<string,float64>
+      Element: 139 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 723
+      ID: 735
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 703 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 215
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<string,interface {}>
+      Element: 134 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 207
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 163 PointerType *table<string,string>
+      Element: 129 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 995
+      ID: 1002
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502560
@@ -3308,22 +3308,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 996 PointerType *[]*crypto/x509.Certificate
+          Type: 1003 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1003 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1010 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1003
+      ID: 1010
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 993 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 1000 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 997
+      ID: 1004
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481920
@@ -3331,22 +3331,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 998 PointerType *[]uint8
+          Type: 1005 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1005 GoSliceDataType [][]uint8.array
+      Data: 1012 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 1005
+      ID: 1012
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 704
+      ID: 716
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 496192
@@ -3361,15 +3361,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 727 GoSliceDataType []float64.array
+      Data: 739 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 727
+      ID: 739
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 140
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 24
       GoRuntimeType: 490112
@@ -3377,22 +3377,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 175 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 236 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 225 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 225
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 176 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Element: 142 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 177
+      ID: 143
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 490304
@@ -3400,22 +3400,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 178 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 144 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 244 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 233 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 233
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 179 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Element: 145 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1007
+      ID: 1014
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484640
@@ -3423,76 +3423,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1008 PointerType *net/http.segment
+          Type: 1015 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1010 GoSliceDataType []net/http.segment.array
+      Data: 1017 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1010
+      ID: 1017
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1009 StructureType net/http.segment
+      Element: 1016 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 246
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 197 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 240 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 822
+      ID: 829
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 824 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 262
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 256 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 988
+      ID: 995
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 981 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 988 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 848
+      ID: 855
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 844 StructureType noalg.map.group[string][]string
+      Element: 851 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 224
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 231 StructureType noalg.map.group[string]float64
+      Element: 220 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 724
+      ID: 736
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 732 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 216
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 223 StructureType noalg.map.group[string]interface {}
+      Element: 212 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 208
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 215 StructureType noalg.map.group[string]string
+      Element: 204 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 150
+      ID: 173
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 481792
@@ -3500,26 +3500,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 151 PointerType *os.Signal
+          Type: 174 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 210 GoSliceDataType []os.Signal.array
+      Data: 235 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 235
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 152 GoInterfaceType os.Signal
+      Element: 175 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 703
+      ID: 715
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496448
@@ -3534,15 +3534,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 725 GoSliceDataType []string.array
+      Data: 737 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 725
+      ID: 737
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 204
+      ID: 247
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489504
@@ -3550,22 +3550,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *time.zone
+          Type: 248 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 246 GoSliceDataType []time.zone.array
+      Data: 263 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 263
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 206 StructureType time.zone
+      Element: 249 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 207
+      ID: 250
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489568
@@ -3573,20 +3573,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 208 PointerType *time.zoneTrans
+          Type: 251 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 248 GoSliceDataType []time.zoneTrans.array
+      Data: 265 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 265
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 209 StructureType time.zoneTrans
+      Element: 252 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3603,9 +3603,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 187 GoSliceDataType []uint8.array
+      Data: 194 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 194
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3626,15 +3626,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 189 GoSliceDataType []uintptr.array
+      Data: 196 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 196
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 519
+      ID: 531
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 946272
@@ -3649,27 +3649,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 520 GoSliceDataType archive/tar.headerError.array
+      Data: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 532
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 896
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 907
+      ID: 914
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 894
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3679,7 +3679,7 @@ Types:
       GoRuntimeType: 585472
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3687,12 +3687,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 840
+      ID: 847
       Name: chan bool
       GoRuntimeType: 597120
       GoKind: 18
     - __kind: GoChannelType
-      ID: 153
+      ID: 176
       Name: chan os.Signal
       GoRuntimeType: 604032
       GoKind: 18
@@ -3709,13 +3709,13 @@ Types:
       GoRuntimeType: 585216
       GoKind: 15
     - __kind: BaseType
-      ID: 306
+      ID: 318
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 838112
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 319
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 838208
@@ -3723,26 +3723,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *compress/flate.InternalError.str
+          Type: 321 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType compress/flate.InternalError.str
+      Data: 320 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 320
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 149
+      ID: 172
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 677184
@@ -3761,19 +3761,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 167
       Name: context.backgroundCtx
       GoRuntimeType: 1795680
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 131 StructureType context.emptyCtx
+          Type: 153 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 178
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1967648
@@ -3784,23 +3784,23 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 132 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 135 StructureType sync/atomic.Value
+          Type: 179 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 137 GoMapType map[context.canceler]struct {}
+          Type: 180 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 135 StructureType sync/atomic.Value
+          Type: 179 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 15 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 200
+      ID: 243
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1108032
@@ -3813,13 +3813,13 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 616
+      ID: 628
       Name: context.deadlineExceededError
       GoRuntimeType: 1457792
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 131
+      ID: 153
       Name: context.emptyCtx
       GoRuntimeType: 1590720
       GoKind: 25
@@ -3828,7 +3828,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 155
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1822240
@@ -3839,11 +3839,11 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 142 GoSubroutineType func() bool
+          Type: 156 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 186
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1606688
@@ -3851,29 +3851,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 119 StructureType context.cancelCtx
+          Type: 178 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 143 PointerType *time.Timer
+          Type: 187 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 145 GoTimeType time.Time
+          Type: 189 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 148
+      ID: 169
       Name: context.todoCtx
       GoRuntimeType: 1795904
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 131 StructureType context.emptyCtx
+          Type: 153 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 162
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1831168
@@ -3884,14 +3884,14 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 163 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 163 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 127
+      ID: 165
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1795456
@@ -3903,51 +3903,51 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 302
+      ID: 314
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837728
       GoKind: 2
     - __kind: BaseType
-      ID: 303
+      ID: 315
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837824
       GoKind: 2
     - __kind: BaseType
-      ID: 304
+      ID: 316
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837920
       GoKind: 2
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1283264
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 305
+      ID: 317
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838016
       GoKind: 2
     - __kind: BaseType
-      ID: 276
+      ID: 288
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835328
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 585
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 976
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 856
+      ID: 863
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2262752
@@ -3967,7 +3967,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 992 BaseType crypto/tls.CurveID
+          Type: 999 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -3979,13 +3979,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 993 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 1000 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 995 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 1002 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 997 GoSliceHeaderType [][]uint8
+          Type: 1004 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -3997,25 +3997,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 999 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 1006 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 1000 BaseType crypto/tls.SignatureScheme
+          Type: 1007 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 992
+      ID: 999
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 835040
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 378
+      ID: 390
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 376
+      ID: 388
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1722848
@@ -4026,36 +4026,36 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 699 ArrayType [5]uint8
+          Type: 711 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 700 GoInterfaceType net.Conn
+          Type: 712 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 1000
+      ID: 1007
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 835136
       GoKind: 9
     - __kind: BaseType
-      ID: 540
+      ID: 552
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 987552
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 392
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 689
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 698
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 432
+      ID: 444
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1724960
@@ -4063,21 +4063,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 697 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 709 BaseType crypto/x509.InvalidReason
+          Type: 721 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 426
+      ID: 438
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1114304
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 428
+      ID: 440
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1593280
@@ -4085,24 +4085,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 697 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 301
+      ID: 313
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 837536
       GoKind: 2
     - __kind: BaseType
-      ID: 709
+      ID: 721
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 588224
       GoKind: 2
     - __kind: StructureType
-      ID: 589
+      ID: 601
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1554208
@@ -4112,13 +4112,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 434
+      ID: 446
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1114560
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 430
+      ID: 442
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1724768
@@ -4126,15 +4126,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 697 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 697 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 476
+      ID: 488
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1428352
@@ -4144,7 +4144,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 480
+      ID: 492
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1428512
@@ -4154,47 +4154,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 478
+      ID: 490
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 277
+      ID: 289
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835424
       GoKind: 6
     - __kind: BaseType
-      ID: 297
+      ID: 309
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 837248
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 414
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 597
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 394
+      ID: 406
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 412
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 398
+      ID: 410
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 396
+      ID: 408
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 404
+      ID: 416
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1419392
@@ -4204,15 +4204,15 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 521
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 519
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 315
+      ID: 327
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 840800
@@ -4220,18 +4220,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 317 PointerType *encoding/xml.UnmarshalError.str
+          Type: 329 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 316 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 328 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 316
+      ID: 328
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 524
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4248,11 +4248,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 362
+      ID: 374
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 572
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4268,11 +4268,11 @@ Types:
       GoRuntimeType: 585408
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 556
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 546
+      ID: 558
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4282,13 +4282,13 @@ Types:
       GoRuntimeType: 480064
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 851
+      ID: 858
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693344
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 142
+      ID: 156
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 595904
@@ -4300,23 +4300,23 @@ Types:
       GoRuntimeType: 855136
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 999
+      ID: 1006
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1003296
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 415
+      ID: 427
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 806
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2053248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 407
+      ID: 419
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1724000
@@ -4324,7 +4324,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 701 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 713 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4332,25 +4332,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 421
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 718
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 413
+      ID: 425
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1113408
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 720
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 291
+      ID: 303
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 836672
@@ -4358,18 +4358,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 293 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 305 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 292 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 304 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 292
+      ID: 304
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 701
+      ID: 713
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2212896
@@ -4377,13 +4377,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 702 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 714 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4392,7 +4392,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 704 GoSliceHeaderType []float64
+          Type: 716 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4401,13 +4401,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 705 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 717 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 707 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 719 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4418,13 +4418,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 702
+      ID: 714
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 587008
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 300
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 836576
@@ -4432,18 +4432,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 302 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 301 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 301
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 294
+      ID: 306
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -4451,36 +4451,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 296 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 308 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 295
+      ID: 307
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 485
+      ID: 497
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1117248
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 310
+      ID: 322
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 839360
       GoKind: 2
     - __kind: StructureType
-      ID: 483
+      ID: 495
       Name: github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
       GoRuntimeType: 1117120
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 450
+      ID: 462
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1594080
@@ -4493,7 +4493,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 454
+      ID: 466
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1726688
@@ -4509,7 +4509,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 452
+      ID: 464
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1426912
@@ -4519,7 +4519,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 448
+      ID: 460
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1426592
@@ -4529,14 +4529,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 687
+      ID: 699
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1499872
       GoKind: 21
-      HeaderType: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 701 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 710
+      ID: 722
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1050464
@@ -4551,15 +4551,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 741 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 729
+      ID: 741
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 462
+      ID: 474
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1594400
@@ -4567,12 +4567,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 699 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 699 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 456
+      ID: 468
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1427072
@@ -4582,7 +4582,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 460
+      ID: 472
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1726880
@@ -4593,12 +4593,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 722 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 722 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 458
+      ID: 470
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1594240
@@ -4611,7 +4611,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 464
+      ID: 476
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1427232
@@ -4619,9 +4619,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 145 GoTimeType time.Time
+          Type: 189 GoTimeType time.Time
     - __kind: StructureType
-      ID: 470
+      ID: 482
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1594720
@@ -4634,7 +4634,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 472
+      ID: 484
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1427552
@@ -4644,7 +4644,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 468
+      ID: 480
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1594560
@@ -4657,7 +4657,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 466
+      ID: 478
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1427392
@@ -4667,7 +4667,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 474
+      ID: 486
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1594880
@@ -4680,29 +4680,29 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 820
+      ID: 827
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 840224
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 814
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 816
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 818
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 495
+      ID: 507
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1433472
@@ -4712,11 +4712,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 799
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 497
+      ID: 509
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1433632
@@ -4724,17 +4724,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 495 StructureType github.com/cihub/seelog.baseError
+          Type: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 791
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 786
+      ID: 793
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1825376
@@ -4742,12 +4742,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 785 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 792 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 793 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 800 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1433952
@@ -4755,9 +4755,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 495 StructureType github.com/cihub/seelog.baseError
+          Type: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 788
+      ID: 795
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1804640
@@ -4765,13 +4765,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 785 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 792 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 499
+      ID: 511
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1433792
@@ -4779,9 +4779,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 495 StructureType github.com/cihub/seelog.baseError
+          Type: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 503
+      ID: 515
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1434112
@@ -4789,9 +4789,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 495 StructureType github.com/cihub/seelog.baseError
+          Type: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 919
+      ID: 926
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1122112
@@ -4804,7 +4804,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 901
+      ID: 908
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1668128
@@ -4812,36 +4812,36 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 919 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 926 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 615
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 617
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 607
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 418
+      ID: 430
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1420672
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 611
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 657
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1845280
@@ -4857,11 +4857,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 579
+      ID: 591
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1696256
@@ -4874,7 +4874,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 651
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1845728
@@ -4890,13 +4890,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 542
+      ID: 554
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 988704
       GoKind: 8
     - __kind: StructureType
-      ID: 643
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1845056
@@ -4912,13 +4912,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 713
+      ID: 725
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 836192
       GoKind: 8
     - __kind: StructureType
-      ID: 641
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1844832
@@ -4926,15 +4926,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 725 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 725 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 649
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1759488
@@ -4947,7 +4947,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 647
+      ID: 659
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1845504
@@ -4963,7 +4963,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 655
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1630304
@@ -4973,19 +4973,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 595
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1279808
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 581
+      ID: 593
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1279680
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 653
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1759680
@@ -4998,7 +4998,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 318
+      ID: 330
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 841472
@@ -5006,22 +5006,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 320 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 332 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 331 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 319
+      ID: 331
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 706
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 609
+      ID: 621
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1443232
@@ -5031,19 +5031,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 321
+      ID: 333
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 842048
       GoKind: 10
     - __kind: BaseType
-      ID: 692
+      ID: 704
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1000320
       GoKind: 10
     - __kind: StructureType
-      ID: 663
+      ID: 675
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1877760
@@ -5054,12 +5054,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 692 BaseType golang.org/x/net/http2.ErrCode
+          Type: 704 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 526
+      ID: 538
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1601600
@@ -5067,12 +5067,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 692 BaseType golang.org/x/net/http2.ErrCode
+          Type: 704 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 337
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 842240
@@ -5080,18 +5080,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 339 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 338 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 338
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 343
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 842432
@@ -5099,18 +5099,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 345 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 344 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 344
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 340
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 842336
@@ -5118,18 +5118,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 342 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 341 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 341
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 334
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 842144
@@ -5137,18 +5137,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 336 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 335 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 335
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 530
+      ID: 542
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1444512
@@ -5158,13 +5158,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 334
+      ID: 346
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 842528
       GoKind: 2
     - __kind: StructureType
-      ID: 505
+      ID: 517
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1438912
@@ -5174,11 +5174,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 673
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 681
+      ID: 693
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1904832
@@ -5194,7 +5194,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 516
+      ID: 528
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1600640
@@ -5207,11 +5207,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 607
+      ID: 619
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1561568
@@ -5221,33 +5221,33 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 919
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 487
+      ID: 499
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 613
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 671
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 669
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1508032
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 392
+      ID: 404
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 774
+      ID: 781
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1417952
@@ -5260,7 +5260,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 743
+      ID: 750
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1592800
@@ -5286,7 +5286,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 176
+      ID: 142
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
       ByteSize: 56
       GoRuntimeType: 1916736
@@ -5303,7 +5303,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -5311,7 +5311,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 934
+      ID: 941
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1968160
@@ -5319,29 +5319,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 925 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+          Type: 932 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 937 BaseType time.Duration
+          Type: 944 BaseType time.Duration
     - __kind: GoMapType
-      ID: 164
+      ID: 130
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1278272
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 933
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 734
+      ID: 269
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 584256
       GoKind: 10
     - __kind: DDTraceSpanType
-      ID: 155
+      ID: 118
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
       ByteSize: 288
       GoRuntimeType: 2332544
@@ -5349,7 +5349,7 @@ Types:
       RawFields:
         - Name: RWMutex
           Offset: 0
-          Type: 156 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: Name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -5370,13 +5370,13 @@ Types:
           Type: 14 BaseType int64
         - Name: Meta
           Offset: 104
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: MetaStruct
           Offset: 112
-          Type: 164 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
+          Type: 130 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
         - Name: Metrics
           Offset: 120
-          Type: 169 GoMapType map[string]float64
+          Type: 135 GoMapType map[string]float64
         - Name: SpanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -5391,10 +5391,10 @@ Types:
           Type: 12 BaseType int32
         - Name: SpanLinks
           Offset: 160
-          Type: 174 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 140 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: SpanEvents
           Offset: 184
-          Type: 177 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 143 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -5406,7 +5406,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 180 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+          Type: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -5429,7 +5429,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 181
+      ID: 147
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
       ByteSize: 160
       GoRuntimeType: 2186112
@@ -5440,10 +5440,10 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 182 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+          Type: 149 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 148 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: errors
           Offset: 24
           Type: 12 BaseType int32
@@ -5455,16 +5455,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 184 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
+          Type: 151 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 156 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -5473,9 +5473,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 174 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 140 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: StructureType
-      ID: 179
+      ID: 145
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1751040
@@ -5489,16 +5489,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 238 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 227 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 243 GoMapType map[string]interface {}
+          Type: 232 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 741
+      ID: 748
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 257
+      ID: 260
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1912128
@@ -5506,7 +5506,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 739 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
+          Type: 746 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -5521,15 +5521,15 @@ Types:
           Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 740 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+          Type: 747 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 739
+      ID: 746
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 984960
       GoKind: 5
     - __kind: StructureType
-      ID: 183
+      ID: 150
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2102336
@@ -5537,16 +5537,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 156 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 732 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 267 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: tags
           Offset: 48
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -5561,12 +5561,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 734 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
+          Type: 269 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 148 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: ArrayType
-      ID: 184
+      ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 903552
@@ -5575,11 +5575,11 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1016
+    - __kind: GoContextImplementationType
+      ID: 160
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1630880
@@ -5588,20 +5588,22 @@ Types:
         - Name: Context
           Offset: 0
           Type: 117 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 892
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 444
+      ID: 456
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 489
+      ID: 501
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1430752
@@ -5611,7 +5613,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 491
+      ID: 503
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1430912
@@ -5621,137 +5623,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 526
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 238
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 239 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 203 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 240 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 246 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 815
+      ID: 822
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 816 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 823 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 822 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 824 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 829 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 251
+      ID: 254
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 252 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 255 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 256 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 262 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 979
+      ID: 986
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 980 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 987 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 981 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 988 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 988 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 995 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 842
+      ID: 849
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 843 PointerType *noalg.map.group[string][]string
+          Type: 850 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 844 StructureType noalg.map.group[string][]string
-      GroupSliceType: 848 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 851 StructureType noalg.map.group[string][]string
+      GroupSliceType: 855 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 229
+      ID: 218
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 230 PointerType *noalg.map.group[string]float64
+          Type: 219 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 231 StructureType noalg.map.group[string]float64
-      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 220 StructureType noalg.map.group[string]float64
+      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 718
+      ID: 730
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 719 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 731 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 724 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 732 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 736 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 221
+      ID: 210
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 222 PointerType *noalg.map.group[string]interface {}
+          Type: 211 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 223 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 227 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 212 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 213
+      ID: 202
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 214 PointerType *noalg.map.group[string]string
+          Type: 203 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 215 StructureType noalg.map.group[string]string
-      GroupSliceType: 219 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 204 StructureType noalg.map.group[string]string
+      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 533
+      ID: 545
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5785,7 +5787,7 @@ Types:
       GoRuntimeType: 584512
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 136
+      ID: 163
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854848
@@ -5798,11 +5800,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 695
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 423
+      ID: 435
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5828,25 +5830,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 421
+      ID: 433
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 649
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 974
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 635
+      ID: 647
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1475392
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 376
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5927,7 +5929,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 298
+      ID: 310
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 837440
@@ -5935,18 +5937,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 300 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 312 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 299 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 311 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 299
+      ID: 311
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 587
+      ID: 599
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1553248
@@ -5954,9 +5956,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 682 PointerType *internal/abi.Type
+          Type: 694 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 134
+      ID: 122
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1488992
@@ -5969,7 +5971,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 920
+      ID: 927
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1030240
@@ -5982,11 +5984,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 827
+      ID: 834
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1110464
@@ -5999,7 +6001,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 910
+      ID: 917
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1029600
@@ -6012,11 +6014,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 883
+      ID: 890
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1547008
@@ -6024,9 +6026,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 910 GoInterfaceType io.Reader
+          Type: 917 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1615136
@@ -6034,13 +6036,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 910 GoInterfaceType io.Reader
+          Type: 917 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 645
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 139
+      ID: 182
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -6053,7 +6055,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 140 PointerType **table<context.canceler,struct {}>
+          Type: 183 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6072,10 +6074,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 202 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 197 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 245 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 240 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 795
+      ID: 802
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6088,7 +6090,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 796 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 803 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6107,10 +6109,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 821 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 828 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 824 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 240
+      ID: 229
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6123,7 +6125,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 241 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 230 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6142,10 +6144,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 261 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 256 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 975
+      ID: 982
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6158,7 +6160,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 976 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 983 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6177,10 +6179,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 987 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 981 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 994 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 988 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 834
+      ID: 841
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6193,7 +6195,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 835 PointerType **table<string,[]string>
+          Type: 842 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6212,10 +6214,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 847 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 844 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 854 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 851 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 171
+      ID: 137
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6228,7 +6230,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 172 PointerType **table<string,float64>
+          Type: 138 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6247,10 +6249,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 234 GoSliceDataType []*table<string,float64>.array
-      GroupType: 231 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 223 GoSliceDataType []*table<string,float64>.array
+      GroupType: 220 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 689
+      ID: 701
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6263,7 +6265,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 690 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 702 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6282,10 +6284,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 723 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 735 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 732 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 132
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6298,7 +6300,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<string,interface {}>
+          Type: 133 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6317,10 +6319,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 226 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 223 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 215 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 212 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 161
+      ID: 127
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6333,7 +6335,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 162 PointerType **table<string,string>
+          Type: 128 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6352,66 +6354,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 218 GoSliceDataType []*table<string,string>.array
-      GroupType: 215 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 207 GoSliceDataType []*table<string,string>.array
+      GroupType: 204 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 137
+      ID: 180
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1126976
       GoKind: 21
-      HeaderType: 139 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 182 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 793
+      ID: 800
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1157024
       GoKind: 21
-      HeaderType: 795 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 802 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 238
+      ID: 227
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1133344
       GoKind: 21
-      HeaderType: 240 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 229 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 973
+      ID: 980
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1132352
       GoKind: 21
-      HeaderType: 975 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 982 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 972
+      ID: 979
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1128000
       GoKind: 21
-      HeaderType: 834 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 841 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 169
+      ID: 135
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1133216
       GoKind: 21
-      HeaderType: 171 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 137 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 243
+      ID: 232
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1126592
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 159
+      ID: 125
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1129024
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,string>
+      HeaderType: 127 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 442
+      ID: 454
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1423552
@@ -6421,11 +6423,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 996
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1478112
@@ -6433,16 +6435,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 972 GoMapType map[string][]string
+          Type: 979 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 973 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 980 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 921
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 923
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1915712
@@ -6450,16 +6452,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 935 PointerType *io.SectionReader
+          Type: 942 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 920 GoInterfaceType io.Closer
+          Type: 927 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 631
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 700
+      ID: 712
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1590880
@@ -6472,35 +6474,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 680
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 950
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 678
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 633
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 612
+      ID: 624
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1108288
@@ -6508,28 +6510,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 614 PointerType *net.UnknownNetworkError.str
+          Type: 626 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 613 GoStringDataType net.UnknownNetworkError.str
+      Data: 625 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 613
+      ID: 625
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 548
+      ID: 560
       Name: net.canceledError
       GoRuntimeType: 1277248
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 948
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 712
+      ID: 724
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2101280
@@ -6537,7 +6539,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 700 GoInterfaceType net.Conn
+          Type: 712 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -6548,27 +6550,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 964
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: net.noReadFrom
       GoRuntimeType: 1108544
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 952
+      ID: 959
       Name: net.noWriteTo
       GoRuntimeType: 1108416
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 336
+      ID: 348
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1014
+    - __kind: GoContextImplementationType
+      ID: 158
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1745280
@@ -6580,8 +6582,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 117 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 338
+      ID: 350
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1718240
@@ -6589,7 +6593,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 695 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 707 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6597,7 +6601,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 947
+      ID: 954
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2281888
@@ -6605,12 +6609,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 953 StructureType net.noReadFrom
+          Type: 960 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 950 PointerType *net.TCPConn
+          Type: 957 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 945
+      ID: 952
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2281344
@@ -6618,20 +6622,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 952 StructureType net.noWriteTo
+          Type: 959 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 950 PointerType *net.TCPConn
+          Type: 957 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 635
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 682
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 777
+      ID: 784
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1027552
@@ -6644,7 +6648,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 775
+      ID: 782
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1026016
@@ -6657,14 +6661,14 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 832
+      ID: 839
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2101632
       GoKind: 21
-      HeaderType: 834 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 841 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 778
+      ID: 785
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1026144
@@ -6677,15 +6681,15 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 344
+      ID: 356
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 562
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 776
+      ID: 783
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1026400
@@ -6709,7 +6713,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 849 PointerType *net/url.URL
+          Type: 856 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6721,19 +6725,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 827 GoInterfaceType io.ReadCloser
+          Type: 834 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 851 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 858 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6742,16 +6746,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 852 GoMapType net/url.Values
+          Type: 859 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 852 GoMapType net/url.Values
+          Type: 859 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 853 PointerType *mime/multipart.Form
+          Type: 860 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6760,13 +6764,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 855 PointerType *crypto/tls.ConnectionState
+          Type: 862 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 857 GoChannelType <-chan struct {}
+          Type: 864 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 858 PointerType *net/http.Response
+          Type: 865 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6775,15 +6779,15 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 860 PointerType *net/http.pattern
+          Type: 867 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
     - __kind: StructureType
-      ID: 859
+      ID: 866
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2210656
@@ -6806,16 +6810,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 827 GoInterfaceType io.ReadCloser
+          Type: 834 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6824,13 +6828,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 112 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 855 PointerType *crypto/tls.ConnectionState
+          Type: 862 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 111
       Name: net/http.ResponseWriter
@@ -6845,19 +6849,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 931
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 902
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 831
+      ID: 838
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1746816
@@ -6865,10 +6869,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 781 PointerType *net/http.response
+          Type: 788 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6876,31 +6880,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 872
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 260
+      ID: 272
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 833312
       GoKind: 10
     - __kind: BaseType
-      ID: 684
+      ID: 696
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 984768
       GoKind: 10
     - __kind: StructureType
-      ID: 347
+      ID: 359
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1719968
@@ -6911,12 +6915,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 696 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 672
+      ID: 684
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1894848
@@ -6927,16 +6931,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 696 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 916
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 353
+      ID: 365
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1591360
@@ -6944,12 +6948,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 696 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 264
+      ID: 276
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833504
@@ -6957,28 +6961,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 266 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 278 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 277 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 265
+      ID: 277
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 351
+      ID: 363
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1109568
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 282
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833696
@@ -6986,18 +6990,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *net/http.http2headerFieldNameError.str
+          Type: 284 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 271 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 283 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 283
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 279
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 833600
@@ -7005,40 +7009,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *net/http.http2headerFieldValueError.str
+          Type: 281 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 280 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 280
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 639
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: net/http.http2missingBody
       GoRuntimeType: 1277504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 881
+      ID: 888
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1278016
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 556
+      ID: 568
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1277888
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 273
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833408
@@ -7046,22 +7050,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 275 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 262 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 274 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 274
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1186304
@@ -7069,13 +7073,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 823 PointerType *net/http.http2responseWriterState
+          Type: 830 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1544288
@@ -7083,19 +7087,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 908 PointerType *net/http.http2clientStream
+          Type: 915 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: net/http.noBody
       GoRuntimeType: 1460832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 552
+      ID: 564
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1545568
@@ -7105,7 +7109,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 861
+      ID: 868
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1833632
@@ -7122,20 +7126,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1007 GoSliceHeaderType []net/http.segment
+          Type: 1014 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 870
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 912
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 357
+      ID: 369
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1412032
@@ -7145,7 +7149,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: net/http.response
       ByteSize: 232
       GoRuntimeType: 2341248
@@ -7153,16 +7157,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 825 PointerType *net/http.conn
+          Type: 832 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 112 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 827 GoInterfaceType io.ReadCloser
+          Type: 834 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 149 GoSubroutineType context.CancelFunc
+          Type: 172 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7174,19 +7178,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 132 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 828 StructureType sync/atomic.Bool
+          Type: 835 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 829 PointerType *bufio.Writer
+          Type: 836 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 831 StructureType net/http.chunkWriter
+          Type: 838 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7210,30 +7214,30 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 828 StructureType sync/atomic.Bool
+          Type: 835 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 837 ArrayType [29]uint8
+          Type: 844 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 838 ArrayType [10]uint8
+          Type: 845 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 839 ArrayType [3]uint8
+          Type: 846 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 132 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
-          Type: 840 GoChannelType chan bool
+          Type: 847 GoChannelType chan bool
         - Name: closeNotifyTriggered
           Offset: 224
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1009
+      ID: 1016
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1608416
@@ -7249,7 +7253,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 342
+      ID: 354
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1591200
@@ -7262,17 +7266,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 686
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 625
+      ID: 637
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1462432
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 554
+      ID: 566
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1545728
@@ -7282,7 +7286,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 930
+      ID: 937
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2026208
@@ -7290,22 +7294,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 700 GoInterfaceType net.Conn
+          Type: 712 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 700 GoInterfaceType net.Conn
+          Type: 712 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 340
+      ID: 352
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1286720
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 372
+      ID: 384
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1722464
@@ -7321,7 +7325,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 370
+      ID: 382
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1592320
@@ -7334,11 +7338,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 399
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 296
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835712
@@ -7346,22 +7350,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *net/textproto.ProtocolError.str
+          Type: 298 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 285 GoStringDataType net/textproto.ProtocolError.str
+      Data: 297 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 297
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 679
+      ID: 691
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 278
+      ID: 290
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 835520
@@ -7369,18 +7373,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 280 PointerType *net/url.EscapeError.str
+          Type: 292 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 279 GoStringDataType net/url.EscapeError.str
+      Data: 291 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 279
+      ID: 291
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 281
+      ID: 293
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 835616
@@ -7388,18 +7392,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 283 PointerType *net/url.InvalidHostError.str
+          Type: 295 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 282 GoStringDataType net/url.InvalidHostError.str
+      Data: 294 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 282
+      ID: 294
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 850
+      ID: 857
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2127584
@@ -7413,7 +7417,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 970 PointerType *net/url.Userinfo
+          Type: 977 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7439,99 +7443,99 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 971
+      ID: 978
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 852
+      ID: 859
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1885152
       GoKind: 21
-      HeaderType: 834 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 841 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 198
+      ID: 241
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 684864
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 199 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 242 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 818
+      ID: 825
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 783552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 819 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 826 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 254
+      ID: 257
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 703616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 255 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 258 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 982
+      ID: 989
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 983 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 990 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 845
+      ID: 852
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 846 StructureType noalg.struct { key string; elem []string }
+      Element: 853 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 232
+      ID: 221
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 703520
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 233 StructureType noalg.struct { key string; elem float64 }
+      Element: 222 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 721
+      ID: 733
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 760672
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 722 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 734 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 224
+      ID: 213
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 681216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 225 StructureType noalg.struct { key string; elem interface {} }
+      Element: 214 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 216
+      ID: 205
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key string; elem string }
+      Element: 206 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 197
+      ID: 240
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1289024
@@ -7542,9 +7546,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 198 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 241 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 817
+      ID: 824
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1365952
@@ -7555,9 +7559,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 818 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 825 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 253
+      ID: 256
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1306048
@@ -7568,9 +7572,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 254 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 257 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 981
+      ID: 988
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1299520
@@ -7581,9 +7585,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 982 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 989 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 844
+      ID: 851
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1290432
@@ -7594,9 +7598,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 845 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 852 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 231
+      ID: 220
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1305792
@@ -7607,9 +7611,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 232 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 720
+      ID: 732
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1347648
@@ -7620,9 +7624,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 721 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 733 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 223
+      ID: 212
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1287872
@@ -7633,9 +7637,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 224 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 213 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 215
+      ID: 204
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1292864
@@ -7646,9 +7650,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 205 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 199
+      ID: 242
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1288896
@@ -7656,12 +7660,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 200 GoInterfaceType context.canceler
+          Type: 243 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 201 StructureType struct {}
+          Type: 244 StructureType struct {}
     - __kind: StructureType
-      ID: 819
+      ID: 826
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1365824
@@ -7669,12 +7673,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 820 BaseType github.com/cihub/seelog.LogLevel
+          Type: 827 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 255
+      ID: 258
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1305920
@@ -7685,9 +7689,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 256 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 259 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 983
+      ID: 990
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1299392
@@ -7698,9 +7702,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 984 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 991 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 846
+      ID: 853
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1290304
@@ -7711,9 +7715,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 233
+      ID: 222
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1305664
@@ -7726,7 +7730,7 @@ Types:
           Offset: 16
           Type: 17 BaseType float64
     - __kind: StructureType
-      ID: 722
+      ID: 734
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1347520
@@ -7737,9 +7741,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 722 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 225
+      ID: 214
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1287744
@@ -7750,9 +7754,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 163 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 217
+      ID: 206
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1292736
@@ -7765,15 +7769,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 970
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 570
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 175
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1110208
@@ -7786,11 +7790,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 641
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 961
+      ID: 968
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2351392
@@ -7798,12 +7802,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 965 StructureType os.noReadFrom
+          Type: 972 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 962 PointerType *os.File
+          Type: 969 PointerType *os.File
     - __kind: StructureType
-      ID: 959
+      ID: 966
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2350592
@@ -7811,32 +7815,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 964 StructureType os.noWriteTo
+          Type: 971 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 962 PointerType *os.File
+          Type: 969 PointerType *os.File
     - __kind: StructureType
-      ID: 965
+      ID: 972
       Name: os.noReadFrom
       GoRuntimeType: 1110080
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 964
+      ID: 971
       Name: os.noWriteTo
       GoRuntimeType: 1109952
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 603
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 728
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 593
+      ID: 605
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1696448
@@ -7849,7 +7853,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 129
+      ID: 171
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1967904
@@ -7860,17 +7864,17 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 149 GoSubroutineType context.CancelFunc
+          Type: 172 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 150 GoSliceHeaderType []os.Signal
+          Type: 173 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 153 GoChannelType chan os.Signal
+          Type: 176 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 312
+      ID: 324
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 840128
@@ -7878,36 +7882,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 314 PointerType *os/user.UnknownGroupIdError.str
+          Type: 326 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 313 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 325 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 313
+      ID: 325
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 311
+      ID: 323
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 840032
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 366
+      ID: 378
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 446
+      ID: 458
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 578
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 582
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7919,7 +7923,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 568
+      ID: 580
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1884704
@@ -7936,9 +7940,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 714 BaseType runtime.boundsErrorCode
+          Type: 726 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 714
+      ID: 726
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585600
@@ -7958,7 +7962,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 631
+      ID: 643
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1754112
@@ -7971,7 +7975,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 534
+      ID: 546
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 986016
@@ -7979,13 +7983,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 536 PointerType *runtime.errorString.str
+          Type: 548 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 535 GoStringDataType runtime.errorString.str
+      Data: 547 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 535
+      ID: 547
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8612,7 +8616,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 191
+      ID: 198
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -8648,7 +8652,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 537
+      ID: 549
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 986112
@@ -8656,13 +8660,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 539 PointerType *runtime.plainError.str
+          Type: 551 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 538 GoStringDataType runtime.plainError.str
+      Data: 550 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 538
+      ID: 550
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8703,7 +8707,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 368
+      ID: 380
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1592000
@@ -8761,7 +8765,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 562
+      ID: 574
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8773,18 +8777,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 186 PointerType *string.str
+          Type: 193 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 185 GoStringDataType string.str
+      Data: 192 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 185
+      ID: 192
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 749
+      ID: 756
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1947456
@@ -8792,12 +8796,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 763
+      ID: 770
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2023616
@@ -8805,15 +8809,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 745
+      ID: 752
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1946944
@@ -8821,12 +8825,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 755
+      ID: 762
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2022464
@@ -8834,15 +8838,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 769
+      ID: 776
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2085568
@@ -8850,18 +8854,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 757
+      ID: 764
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2022752
@@ -8869,15 +8873,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 753
+      ID: 760
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2022176
@@ -8885,15 +8889,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 765
+      ID: 772
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2084928
@@ -8901,18 +8905,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 773
+      ID: 780
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2146400
@@ -8920,21 +8924,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 767
+      ID: 774
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2085248
@@ -8942,18 +8946,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 751
+      ID: 758
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1947712
@@ -8961,12 +8965,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 747
+      ID: 754
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1947200
@@ -8974,12 +8978,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2023040
@@ -8987,15 +8991,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 771
+      ID: 778
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2085888
@@ -9003,18 +9007,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2023328
@@ -9022,15 +9026,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1701632
@@ -9038,18 +9042,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 910 GoInterfaceType io.Reader
+          Type: 917 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 920 GoInterfaceType io.Closer
+          Type: 927 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 201
+      ID: 244
       Name: struct {}
       GoRuntimeType: 846368
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 132
+      ID: 120
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1465792
@@ -9057,12 +9061,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 133 StructureType sync.noCopy
+          Type: 121 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 134 StructureType internal/sync.Mutex
+          Type: 122 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 156
+      ID: 119
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1839232
@@ -9070,7 +9074,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 132 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -9079,18 +9083,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 157 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 157 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 133
+      ID: 121
       Name: sync.noCopy
       GoRuntimeType: 985632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 828
+      ID: 835
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1466912
@@ -9098,12 +9102,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 158 StructureType sync/atomic.noCopy
+          Type: 124 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 157
+      ID: 123
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1467072
@@ -9111,12 +9115,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 158 StructureType sync/atomic.noCopy
+          Type: 124 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 135
+      ID: 179
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1193984
@@ -9124,27 +9128,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 163 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 158
+      ID: 124
       Name: sync/atomic.noCopy
       GoRuntimeType: 985728
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 664
+      ID: 676
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1278784
       GoKind: 12
     - __kind: BaseType
-      ID: 737
+      ID: 744
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 987072
       GoKind: 2
     - __kind: StructureType
-      ID: 194
+      ID: 237
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9166,9 +9170,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 238 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 814
+      ID: 821
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9190,9 +9194,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 815 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 822 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 250
+      ID: 253
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9214,9 +9218,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 251 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 254 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9238,9 +9242,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 979 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 986 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9262,9 +9266,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 842 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 849 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 228
+      ID: 217
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9286,9 +9290,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 229 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 218 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 717
+      ID: 729
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9310,9 +9314,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 718 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 730 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 220
+      ID: 209
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9334,9 +9338,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 221 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 210 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 212
+      ID: 201
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9358,9 +9362,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 213 GoSwissMapGroupsType groupReference<string,string>
+          Type: 202 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 611
+      ID: 623
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1700672
@@ -9373,13 +9377,13 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 937
+      ID: 944
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1911872
       GoKind: 6
     - __kind: StructureType
-      ID: 147
+      ID: 191
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1973536
@@ -9390,10 +9394,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 204 GoSliceHeaderType []time.zone
+          Type: 247 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 207 GoSliceHeaderType []time.zoneTrans
+          Type: 250 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9405,13 +9409,13 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 205 PointerType *time.zone
+          Type: 248 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 360
+      ID: 372
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 145
+      ID: 189
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2364704
@@ -9425,7 +9429,7 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 146 PointerType *time.Location
+          Type: 190 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9435,7 +9439,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 144
+      ID: 188
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1463392
@@ -9443,12 +9447,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 731 GoChannelType <-chan time.Time
+          Type: 743 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 285
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 833792
@@ -9456,18 +9460,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *time.fileSizeError.str
+          Type: 287 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType time.fileSizeError.str
+      Data: 286 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 286
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 206
+      ID: 249
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1613408
@@ -9483,7 +9487,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 209
+      ID: 252
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1750848
@@ -9544,7 +9548,7 @@ Types:
       GoRuntimeType: 585536
       GoKind: 26
     - __kind: StructureType
-      ID: 695
+      ID: 707
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2058368
@@ -9555,10 +9559,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 696 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 708 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 697 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 709 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9573,18 +9577,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 698 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 710 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 698
+      ID: 710
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 987168
       GoKind: 9
     - __kind: StructureType
-      ID: 696
+      ID: 708
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1914944
@@ -9609,17 +9613,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 374
+      ID: 386
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 697
+      ID: 709
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 586432
       GoKind: 8
     - __kind: StructureType
-      ID: 389
+      ID: 401
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1417472
@@ -9629,13 +9633,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 287
+      ID: 299
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835808
       GoKind: 2
     - __kind: StructureType
-      ID: 575
+      ID: 587
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1695872
@@ -9648,7 +9652,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 541
+      ID: 553
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 988032

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.26rc1.yaml
@@ -137,23 +137,23 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1004
+      ID: 1011
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 695 PointerType *crypto/x509.Certificate
+      Pointee: 707 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 743
+      ID: 278
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 165 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 995
+      ID: 1002
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 996 PointerType *mime/multipart.FileHeader
+      Pointee: 1003 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
       ID: 69
       Name: '**runtime.p'
@@ -161,111 +161,111 @@ Types:
       GoKind: 22
       Pointee: 70 PointerType *runtime.p
     - __kind: PointerType
-      ID: 146
+      ID: 189
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 147 PointerType *table<context.canceler,struct {}>
+      Pointee: 190 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 807 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 814 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 251
+      ID: 240
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 252 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 241 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 987 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 994 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 845
+      ID: 852
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 846 PointerType *table<string,[]string>
+      Pointee: 853 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 144
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 183 PointerType *table<string,float64>
+      Pointee: 145 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 700
+      ID: 712
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 701 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 713 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 177
+      ID: 139
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 178 PointerType *table<string,interface {}>
+      Pointee: 140 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 172
+      ID: 134
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 173 PointerType *table<string,string>
+      Pointee: 135 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 1006
+      ID: 1013
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1003 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 1010 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 1012
+      ID: 1019
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 1011 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1018 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 746
+      ID: 281
       Name: '*[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       ByteSize: 8
-      Pointee: 745 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Pointee: 280 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 1000 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 1007 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 203
+      ID: 210
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []*runtime.p.array
-    - __kind: PointerType
-      ID: 1014
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 1013 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 1016
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 1015 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 738
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 737 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 247
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
-      ByteSize: 8
-      Pointee: 246 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 209 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 1021
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1020 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1023
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1022 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 750
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 749 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 236
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
+      ByteSize: 8
+      Pointee: 235 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+    - __kind: PointerType
+      ID: 244
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1028
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1020 GoSliceDataType []net/http.segment.array
+      Pointee: 1027 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 221
+      ID: 246
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType []os.Signal.array
+      Pointee: 245 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -274,77 +274,77 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 736
+      ID: 748
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 735 GoSliceDataType []string.array
+      Pointee: 747 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 257
+      ID: 274
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []time.zone.array
+      Pointee: 273 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 259
+      ID: 276
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []time.zoneTrans.array
+      Pointee: 275 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 487360
       GoKind: 22
       Pointee: 41 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 198
+      ID: 205
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []uint8.array
+      Pointee: 204 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 200
+      ID: 207
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []uintptr.array
+      Pointee: 206 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 955616
       GoKind: 22
-      Pointee: 529 GoSliceHeaderType archive/tar.headerError
+      Pointee: 541 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 531
+      ID: 543
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 530 GoSliceDataType archive/tar.headerError.array
+      Pointee: 542 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1266432
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 916 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1092576
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 902 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1455264
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 920 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1092320
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 900 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -353,12 +353,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1972960
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType bufio.Writer
+      Pointee: 847 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 120
       Name: '*bytes.Buffer'
@@ -374,353 +374,353 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 919520
       GoKind: 22
-      Pointee: 301 BaseType compress/flate.CorruptInputError
+      Pointee: 313 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 404
+      ID: 416
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 919616
       GoKind: 22
-      Pointee: 302 GoStringHeaderType compress/flate.InternalError
+      Pointee: 314 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 304
+      ID: 316
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 303 GoStringDataType compress/flate.InternalError.str
+      Pointee: 315 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 2000256
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 956 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1642912
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 935 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 124
+      ID: 198
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 1734688
       GoKind: 22
-      Pointee: 125 StructureType context.afterFuncCtx
+      Pointee: 199 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 1027
+      ID: 172
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1556160
       GoKind: 22
-      Pointee: 151 StructureType context.backgroundCtx
+      Pointee: 173 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 126
+      ID: 183
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1734112
       GoKind: 22
-      Pointee: 127 StructureType context.cancelCtx
+      Pointee: 184 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1190656
       GoKind: 22
-      Pointee: 626 StructureType context.deadlineExceededError
+      Pointee: 638 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1022
+      ID: 158
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1418304
       GoKind: 22
-      Pointee: 152 StructureType context.emptyCtx
+      Pointee: 159 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 128
+      ID: 160
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1418464
       GoKind: 22
-      Pointee: 129 StructureType context.stopCtx
+      Pointee: 161 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 130
+      ID: 191
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1734304
       GoKind: 22
-      Pointee: 131 StructureType context.timerCtx
+      Pointee: 192 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1028
+      ID: 174
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1556320
       GoKind: 22
-      Pointee: 159 StructureType context.todoCtx
+      Pointee: 175 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 132
+      ID: 167
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1555840
       GoKind: 22
-      Pointee: 133 StructureType context.valueCtx
+      Pointee: 168 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 134
+      ID: 170
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1556000
       GoKind: 22
-      Pointee: 135 StructureType context.withoutCancelCtx
+      Pointee: 171 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 452
+      ID: 464
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928256
       GoKind: 22
-      Pointee: 320 BaseType crypto/aes.KeySizeError
+      Pointee: 332 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928448
       GoKind: 22
-      Pointee: 321 BaseType crypto/des.KeySizeError
+      Pointee: 333 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 454
+      ID: 466
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928736
       GoKind: 22
-      Pointee: 322 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 334 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 606
+      ID: 618
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1063008
       GoKind: 22
-      Pointee: 607 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 619 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929024
       GoKind: 22
-      Pointee: 323 BaseType crypto/rc4.KeySizeError
+      Pointee: 335 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 290 BaseType crypto/tls.AlertError
+      Pointee: 302 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1047392
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 595 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 978
+      ID: 985
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2393728
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 986 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 917216
       GoKind: 22
-      Pointee: 866 StructureType crypto/tls.ConnectionState
+      Pointee: 873 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 393
+      ID: 405
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 917696
       GoKind: 22
-      Pointee: 394 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 406 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 391 StructureType crypto/tls.RecordHeaderError
+      Pointee: 403 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 581
+      ID: 593
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1045728
       GoKind: 22
-      Pointee: 550 BaseType crypto/tls.alert
+      Pointee: 562 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 395
+      ID: 407
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 917792
       GoKind: 22
-      Pointee: 396 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 408 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 686
+      ID: 698
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1426304
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 699 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 695
+      ID: 707
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2034784
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 708 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 927872
       GoKind: 22
-      Pointee: 449 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 461 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 443 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 455 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 927392
       GoKind: 22
-      Pointee: 445 StructureType crypto/x509.HostnameError
+      Pointee: 457 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 926816
       GoKind: 22
-      Pointee: 319 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 331 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 598
+      ID: 610
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1056096
       GoKind: 22
-      Pointee: 599 StructureType crypto/x509.SystemRootsError
+      Pointee: 611 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 450
+      ID: 462
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 927968
       GoKind: 22
-      Pointee: 451 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 463 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 447 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 459 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 490
+      ID: 502
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 937952
       GoKind: 22
-      Pointee: 491 StructureType encoding/asn1.StructuralError
+      Pointee: 503 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 494
+      ID: 506
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 938144
       GoKind: 22
-      Pointee: 495 StructureType encoding/asn1.SyntaxError
+      Pointee: 507 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 492
+      ID: 504
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 938048
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 505 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 917984
       GoKind: 22
-      Pointee: 291 BaseType encoding/base64.CorruptInputError
+      Pointee: 303 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 433
+      ID: 445
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 315 BaseType encoding/hex.InvalidByteError
+      Pointee: 327 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 922016
       GoKind: 22
-      Pointee: 419 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 431 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 594
+      ID: 606
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1052384
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 607 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 410
+      ID: 422
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 921632
       GoKind: 22
-      Pointee: 411 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 423 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 921920
       GoKind: 22
-      Pointee: 417 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 429 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 921824
       GoKind: 22
-      Pointee: 415 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 427 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 921728
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 425 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 922400
       GoKind: 22
-      Pointee: 421 StructureType encoding/json.jsonError
+      Pointee: 433 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 949664
       GoKind: 22
-      Pointee: 522 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 534 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -729,19 +729,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 375
+      ID: 387
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 912512
       GoKind: 22
-      Pointee: 376 UnresolvedPointeeType errors.errorString
+      Pointee: 388 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 569
+      ID: 581
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1038560
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType errors.joinError
+      Pointee: 582 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -757,799 +757,799 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 553
+      ID: 565
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1027936
       GoKind: 22
-      Pointee: 554 UnresolvedPointeeType fmt.wrapError
+      Pointee: 566 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 555
+      ID: 567
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1028064
       GoKind: 22
-      Pointee: 556 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 568 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 431
+      ID: 443
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 925088
       GoKind: 22
-      Pointee: 432 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 444 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2035936
       GoKind: 22
-      Pointee: 809 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 816 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 423
+      ID: 435
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 923744
       GoKind: 22
-      Pointee: 424 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 436 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 923840
       GoKind: 22
-      Pointee: 426 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 438 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 715
+      ID: 727
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 923552
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 728 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 429
+      ID: 441
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 924128
       GoKind: 22
-      Pointee: 430 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 442 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 717
+      ID: 729
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 923648
       GoKind: 22
-      Pointee: 718 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 730 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 923936
       GoKind: 22
-      Pointee: 309 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 321 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 311
+      ID: 323
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 310 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 322 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 306 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 318 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 319 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 312 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 324 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 314
+      ID: 326
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 313 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 325 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 499
+      ID: 511
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 939104
       GoKind: 22
-      Pointee: 500 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 512 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 938912
       GoKind: 22
-      Pointee: 324 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 336 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 497
+      ID: 509
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 939008
       GoKind: 22
-      Pointee: 498 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
+      Pointee: 510 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 464
+      ID: 476
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 934784
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 477 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 468
+      ID: 480
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 934976
       GoKind: 22
-      Pointee: 469 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 481 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 466
+      ID: 478
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 934880
       GoKind: 22
-      Pointee: 467 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 479 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 934688
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 475 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 740
+      ID: 752
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 739 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 751 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 935360
       GoKind: 22
-      Pointee: 477 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 489 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 470
+      ID: 482
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 935072
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 483 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 935264
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 487 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 472
+      ID: 484
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 935168
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 485 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 935456
       GoKind: 22
-      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 491 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 485 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 497 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 486
+      ID: 498
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 935840
       GoKind: 22
-      Pointee: 487 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 499 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 482
+      ID: 494
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 935648
       GoKind: 22
-      Pointee: 483 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 495 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 935552
       GoKind: 22
-      Pointee: 481 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 493 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 936032
       GoKind: 22
-      Pointee: 489 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 501 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2334400
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 830 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 816
+      ID: 823
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2320608
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 824 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2328000
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 826 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 820
+      ID: 827
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2328640
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 828 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 509
+      ID: 521
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 947072
       GoKind: 22
-      Pointee: 510 StructureType github.com/cihub/seelog.baseError
+      Pointee: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1823168
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 809 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 947168
       GoKind: 22
-      Pointee: 512 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 524 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 793
+      ID: 800
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1445984
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 801 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1678816
       GoKind: 22
-      Pointee: 796 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1679584
       GoKind: 22
-      Pointee: 800 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 807 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 947360
       GoKind: 22
-      Pointee: 516 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 528 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1679008
       GoKind: 22
-      Pointee: 798 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 805 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2299488
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 822 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 947264
       GoKind: 22
-      Pointee: 514 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 526 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 947456
       GoKind: 22
-      Pointee: 518 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 530 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1258240
       GoKind: 22
-      Pointee: 907 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 914 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1754272
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 939 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 612
+      ID: 624
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1075424
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 625 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1075552
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 627 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 604
+      ID: 616
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1060192
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 617 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 925760
       GoKind: 22
-      Pointee: 435 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 447 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 608
+      ID: 620
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1063776
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 621 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 654
+      ID: 666
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1213952
       GoKind: 22
-      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1213568
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 661 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1051488
       GoKind: 22
-      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 660
+      ID: 672
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1214336
       GoKind: 22
-      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 673 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1051360
       GoKind: 22
-      Pointee: 552 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 564 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 652
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1213824
       GoKind: 22
-      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1213696
       GoKind: 22
-      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 658
+      ID: 670
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1214208
       GoKind: 22
-      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 671 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 656
+      ID: 668
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1214080
       GoKind: 22
-      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 669 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 664
+      ID: 676
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1214720
       GoKind: 22
-      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 677 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 592
+      ID: 604
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1051744
       GoKind: 22
-      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 590
+      ID: 602
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1051616
       GoKind: 22
-      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 603 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 662
+      ID: 674
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1214592
       GoKind: 22
-      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 675 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 954848
       GoKind: 22
-      Pointee: 329 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 341 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 331
+      ID: 343
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 342 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 703
+      ID: 715
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1677856
       GoKind: 22
-      Pointee: 704 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 716 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1091680
       GoKind: 22
-      Pointee: 619 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 631 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 956864
       GoKind: 22
-      Pointee: 332 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 344 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 672
+      ID: 684
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1268096
       GoKind: 22
-      Pointee: 673 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 685 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 535
+      ID: 547
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 957152
       GoKind: 22
-      Pointee: 536 StructureType golang.org/x/net/http2.connError
+      Pointee: 548 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 534
+      ID: 546
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 957056
       GoKind: 22
-      Pointee: 336 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 348 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 349 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 538
+      ID: 550
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 957344
       GoKind: 22
-      Pointee: 342 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 354 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 344
+      ID: 356
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 355 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 537
+      ID: 549
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 957248
       GoKind: 22
-      Pointee: 339 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 351 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 352 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 956960
       GoKind: 22
-      Pointee: 333 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 345 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 335
+      ID: 347
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 346 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 957440
       GoKind: 22
-      Pointee: 540 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 552 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 541
+      ID: 553
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 957536
       GoKind: 22
-      Pointee: 345 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 357 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 519
+      ID: 531
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 949280
       GoKind: 22
-      Pointee: 520 StructureType google.golang.org/grpc.dropError
+      Pointee: 532 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 670
+      ID: 682
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1264896
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 683 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 690
+      ID: 702
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1451744
       GoKind: 22
-      Pointee: 691 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 703 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 525
+      ID: 537
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 953120
       GoKind: 22
-      Pointee: 526 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 538 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1825856
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 945 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 616
+      ID: 628
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1085920
       GoKind: 22
-      Pointee: 617 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 629 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1577120
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 929 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 501
+      ID: 513
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 941312
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 514 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1065184
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 623 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 668
+      ID: 680
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1231488
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 681 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 666
+      ID: 678
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1231232
       GoKind: 22
-      Pointee: 667 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 679 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 920672
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 421 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1564960
       GoKind: 22
-      Pointee: 753 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 760 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 185
+      ID: 147
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1211904
       GoKind: 22
-      Pointee: 186 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Pointee: 148 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1914496
       GoKind: 22
-      Pointee: 944 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 951 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1816448
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+      Pointee: 943 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 165
+      ID: 154
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoRuntimeType: 2326080
       GoKind: 22
-      Pointee: 166 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 124 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 190
+      ID: 152
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext'
       ByteSize: 8
       GoRuntimeType: 1995360
       GoKind: 22
-      Pointee: 191 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+      Pointee: 153 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
     - __kind: PointerType
-      ID: 188
+      ID: 150
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1197568
       GoKind: 22
-      Pointee: 189 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Pointee: 151 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1198208
       GoKind: 22
-      Pointee: 751 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 758 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 266
+      ID: 269
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1198336
       GoKind: 22
-      Pointee: 267 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 270 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 192
+      ID: 155
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2241600
       GoKind: 22
-      Pointee: 193 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+      Pointee: 156 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2192448
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
+      Pointee: 820 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1025
+      ID: 165
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1430144
       GoKind: 22
-      Pointee: 1026 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
+      Pointee: 166 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2172704
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
+      Pointee: 818 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1058528
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
+      Pointee: 898 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 458
+      ID: 470
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 933056
       GoKind: 22
-      Pointee: 459 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 471 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 503
+      ID: 515
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 941888
       GoKind: 22
-      Pointee: 504 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 516 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 505
+      ID: 517
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 941984
       GoKind: 22
-      Pointee: 506 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 518 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 950432
       GoKind: 22
-      Pointee: 524 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 536 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 542
+      ID: 554
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 958304
       GoKind: 22
-      Pointee: 543 UnresolvedPointeeType html/template.Error
+      Pointee: 555 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 106
       Name: '*int'
@@ -1586,54 +1586,54 @@ Types:
       GoKind: 22
       Pointee: 22 BaseType int8
     - __kind: PointerType
-      ID: 692
+      ID: 704
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2215712
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType internal/abi.Type
+      Pointee: 705 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 439
+      ID: 451
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 926432
       GoKind: 22
-      Pointee: 440 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 452 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 437
+      ID: 449
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 926336
       GoKind: 22
-      Pointee: 438 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 450 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 646
+      ID: 658
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1206528
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 659 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2388416
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType internal/poll.FD
+      Pointee: 984 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 644
+      ID: 656
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1206400
       GoKind: 22
-      Pointee: 645 StructureType internal/poll.errNetClosing
+      Pointee: 657 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 377
+      ID: 389
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 912896
       GoKind: 22
-      Pointee: 378 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 390 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -1642,305 +1642,305 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 926240
       GoKind: 22
-      Pointee: 316 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 328 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 318
+      ID: 330
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 329 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1054944
       GoKind: 22
-      Pointee: 597 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 609 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 289 BaseType internal/strconv.Error
+      Pointee: 301 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1857536
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType io.PipeReader
+      Pointee: 949 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1561280
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType io.SectionReader
+      Pointee: 953 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1039072
       GoKind: 22
-      Pointee: 889 StructureType io.nopCloser
+      Pointee: 896 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1200768
       GoKind: 22
-      Pointee: 905 StructureType io.nopCloserWriterTo
+      Pointee: 912 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 642
+      ID: 654
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1205376
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType io/fs.PathError
+      Pointee: 655 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 144
+      ID: 187
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 145 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 188 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 805 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 812 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 249
+      ID: 238
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 250 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 239 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 984
+      ID: 991
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 985 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 992 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 844 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 851 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 180
+      ID: 142
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 181 GoSwissMapHeaderType map<string,float64>
+      Pointee: 143 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 698
+      ID: 710
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 699 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 711 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 175
+      ID: 137
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 170
+      ID: 132
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 171 GoSwissMapHeaderType map<string,string>
+      Pointee: 133 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 456
+      ID: 468
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 929792
       GoKind: 22
-      Pointee: 457 StructureType math/big.ErrNaN
+      Pointee: 469 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 918752
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 1006 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 864 StructureType mime/multipart.Form
+      Pointee: 871 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1641760
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 931 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1641952
       GoKind: 22
-      Pointee: 926 StructureType mime/multipart.sectionReadCloser
+      Pointee: 933 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1191808
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType net.AddrError
+      Pointee: 641 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 677
+      ID: 689
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1419104
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType net.DNSError
+      Pointee: 690 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2245632
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType net.IPConn
+      Pointee: 960 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 675
+      ID: 687
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1418784
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType net.OpError
+      Pointee: 688 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1191936
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType net.ParseError
+      Pointee: 643 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2275936
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType net.TCPConn
+      Pointee: 968 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2318176
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net.UDPConn
+      Pointee: 972 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2275424
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType net.UnixConn
+      Pointee: 966 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1191040
       GoKind: 22
-      Pointee: 622 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 634 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 624
+      ID: 636
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 623 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 635 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 557
+      ID: 569
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1028960
       GoKind: 22
-      Pointee: 558 StructureType net.canceledError
+      Pointee: 570 StructureType net.canceledError
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2030752
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType net.conn
+      Pointee: 958 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 721
+      ID: 733
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1851264
       GoKind: 22
-      Pointee: 722 StructureType net.dialResult·1
+      Pointee: 734 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2321824
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType net.netFD
+      Pointee: 974 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 905312
       GoKind: 22
-      Pointee: 347 UnresolvedPointeeType net.notFoundError
+      Pointee: 359 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1023
+      ID: 163
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1418944
       GoKind: 22
-      Pointee: 1024 StructureType net.onlyValuesCtx
+      Pointee: 164 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 905984
       GoKind: 22
-      Pointee: 349 StructureType net.result·2
+      Pointee: 361 StructureType net.result·2
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2262912
       GoKind: 22
-      Pointee: 957 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 964 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2262432
       GoKind: 22
-      Pointee: 955 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 962 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 632
+      ID: 644
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1192576
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType net.temporaryError
+      Pointee: 645 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 679
+      ID: 691
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1419424
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType net.timeoutError
+      Pointee: 692 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 908576
       GoKind: 22
-      Pointee: 355 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 367 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1032672
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 572 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 118
       Name: '*net/http.Request'
@@ -1949,571 +1949,571 @@ Types:
       GoKind: 22
       Pointee: 119 StructureType net/http.Request
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1735840
       GoKind: 22
-      Pointee: 869 StructureType net/http.Response
+      Pointee: 876 StructureType net/http.Response
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1815552
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net/http.body
+      Pointee: 941 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1194880
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 908 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1032544
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 890 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1912704
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType net/http.conn
+      Pointee: 843 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1031264
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 882 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 918
+      ID: 925
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1559840
       GoKind: 22
-      Pointee: 919 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 926 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 908768
       GoKind: 22
-      Pointee: 270 BaseType net/http.http2ConnectionError
+      Pointee: 282 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 357
+      ID: 369
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 908864
       GoKind: 22
-      Pointee: 358 StructureType net/http.http2GoAwayError
+      Pointee: 370 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 681
+      ID: 693
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1420224
       GoKind: 22
-      Pointee: 682 StructureType net/http.http2StreamError
+      Pointee: 694 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2032480
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 922 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 909920
       GoKind: 22
-      Pointee: 364 StructureType net/http.http2connError
+      Pointee: 376 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 909344
       GoKind: 22
-      Pointee: 274 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 286 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 276
+      ID: 288
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 275 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 287 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 361
+      ID: 373
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 909440
       GoKind: 22
-      Pointee: 362 StructureType net/http.http2goAwayFlowError
+      Pointee: 374 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 916
+      ID: 923
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1558240
       GoKind: 22
-      Pointee: 917 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 924 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 280 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 292 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 282
+      ID: 294
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 293 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 910016
       GoKind: 22
-      Pointee: 277 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 289 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 279
+      ID: 291
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 290 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1196160
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 649 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1032160
       GoKind: 22
-      Pointee: 879 StructureType net/http.http2missingBody
+      Pointee: 886 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1034976
       GoKind: 22
-      Pointee: 887 StructureType net/http.http2noBodyReader
+      Pointee: 894 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1034848
       GoKind: 22
-      Pointee: 566 StructureType net/http.http2noCachedConnError
+      Pointee: 578 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 359
+      ID: 371
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 909248
       GoKind: 22
-      Pointee: 271 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 283 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 273
+      ID: 285
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 284 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1033184
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 892 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2031904
       GoKind: 22
-      Pointee: 790 StructureType net/http.http2responseWriter
+      Pointee: 797 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1626400
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 841 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1032288
       GoKind: 22
-      Pointee: 881 StructureType net/http.http2transportResponseBody
+      Pointee: 888 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1031520
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 884 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1195008
       GoKind: 22
-      Pointee: 903 StructureType net/http.noBody
+      Pointee: 910 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 561
+      ID: 573
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1034592
       GoKind: 22
-      Pointee: 562 StructureType net/http.nothingWrittenError
+      Pointee: 574 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1624672
       GoKind: 22
-      Pointee: 871 StructureType net/http.pattern
+      Pointee: 878 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1030880
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 880 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 910
+      ID: 917
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1420544
       GoKind: 22
-      Pointee: 911 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 918 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 367
+      ID: 379
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 910304
       GoKind: 22
-      Pointee: 368 StructureType net/http.requestBodyReadError
+      Pointee: 380 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2241152
       GoKind: 22
-      Pointee: 792 StructureType net/http.response
+      Pointee: 799 StructureType net/http.response
     - __kind: PointerType
-      ID: 1018
+      ID: 1025
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396864
       GoKind: 22
-      Pointee: 1019 StructureType net/http.segment
+      Pointee: 1026 StructureType net/http.segment
     - __kind: PointerType
-      ID: 352
+      ID: 364
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 908480
       GoKind: 22
-      Pointee: 353 StructureType net/http.statusError
+      Pointee: 365 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 683
+      ID: 695
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1421664
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 696 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 634
+      ID: 646
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1196032
       GoKind: 22
-      Pointee: 635 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 647 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 563
+      ID: 575
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1034720
       GoKind: 22
-      Pointee: 564 StructureType net/http.transportReadFromServerError
+      Pointee: 576 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1852608
       GoKind: 22
-      Pointee: 940 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 947 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 907712
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 363 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1092960
       GoKind: 22
-      Pointee: 897 StructureType net/http/httputil.failureToReadBody
+      Pointee: 904 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 915776
       GoKind: 22
-      Pointee: 386 StructureType net/netip.parseAddrError
+      Pointee: 398 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 915680
       GoKind: 22
-      Pointee: 384 StructureType net/netip.parsePrefixError
+      Pointee: 396 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 401
+      ID: 413
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 919232
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType net/textproto.Error
+      Pointee: 414 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 919136
       GoKind: 22
-      Pointee: 298 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 310 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 300
+      ID: 312
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 299 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 311 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 688
+      ID: 700
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1426624
       GoKind: 22
-      Pointee: 689 UnresolvedPointeeType net/url.Error
+      Pointee: 701 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 292 GoStringHeaderType net/url.EscapeError
+      Pointee: 304 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 294
+      ID: 306
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 293 GoStringDataType net/url.EscapeError.str
+      Pointee: 305 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 918176
       GoKind: 22
-      Pointee: 295 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 307 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 297
+      ID: 309
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 296 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 308 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2149344
       GoKind: 22
-      Pointee: 860 StructureType net/url.URL
+      Pointee: 867 StructureType net/url.URL
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1209472
       GoKind: 22
-      Pointee: 981 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 988 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 206
+      ID: 249
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 207 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 250 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 826
+      ID: 833
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 834 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 262
+      ID: 265
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 266 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 990
+      ID: 997
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 991 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 998 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 854 StructureType noalg.map.group[string][]string
+      Pointee: 861 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 240
+      ID: 229
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 241 StructureType noalg.map.group[string]float64
+      Pointee: 230 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 729
+      ID: 741
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 742 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 232
+      ID: 221
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 233 StructureType noalg.map.group[string]interface {}
+      Pointee: 222 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 224
+      ID: 213
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[string]string
+      Pointee: 214 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 972
+      ID: 979
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2362880
       GoKind: 22
-      Pointee: 973 UnresolvedPointeeType os.File
+      Pointee: 980 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1037024
       GoKind: 22
-      Pointee: 568 UnresolvedPointeeType os.LinkError
+      Pointee: 580 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 162
+      ID: 180
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 399808
       GoKind: 22
-      Pointee: 163 GoInterfaceType os.Signal
+      Pointee: 181 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 638
+      ID: 650
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1196544
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType os.SyscallError
+      Pointee: 651 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2360608
       GoKind: 22
-      Pointee: 971 StructureType os.fileWithoutReadFrom
+      Pointee: 978 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2359872
       GoKind: 22
-      Pointee: 969 StructureType os.fileWithoutWriteTo
+      Pointee: 976 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 600
+      ID: 612
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1058784
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType os/exec.Error
+      Pointee: 613 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 725
+      ID: 737
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2111072
       GoKind: 22
-      Pointee: 726 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 738 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 602
+      ID: 614
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1058912
       GoKind: 22
-      Pointee: 603 StructureType os/exec.wrappedError
+      Pointee: 615 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 136
+      ID: 176
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1628704
       GoKind: 22
-      Pointee: 137 StructureType os/signal.signalCtx
+      Pointee: 177 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*os/signal.signalError'
       ByteSize: 8
       GoRuntimeType: 911072
       GoKind: 22
-      Pointee: 283 GoStringHeaderType os/signal.signalError
+      Pointee: 295 GoStringHeaderType os/signal.signalError
     - __kind: PointerType
-      ID: 285
+      ID: 297
       Name: '*os/signal.signalError.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType os/signal.signalError.str
+      Pointee: 296 GoStringDataType os/signal.signalError.str
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 946112
       GoKind: 22
-      Pointee: 326 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 338 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 328
+      ID: 340
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 327 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 339 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 507
+      ID: 519
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 946016
       GoKind: 22
-      Pointee: 325 BaseType os/user.UnknownUserIdError
+      Pointee: 337 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 913664
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType reflect.ValueError
+      Pointee: 392 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 934016
       GoKind: 22
-      Pointee: 461 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 473 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1042912
       GoKind: 22
-      Pointee: 576 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 588 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 579
+      ID: 591
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1043552
       GoKind: 22
-      Pointee: 580 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 592 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -2529,12 +2529,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1043040
       GoKind: 22
-      Pointee: 578 StructureType runtime.boundsError
+      Pointee: 590 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -2550,24 +2550,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 640
+      ID: 652
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1204864
       GoKind: 22
-      Pointee: 641 StructureType runtime.errorAddressString
+      Pointee: 653 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 573
+      ID: 585
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1041248
       GoKind: 22
-      Pointee: 544 GoStringHeaderType runtime.errorString
+      Pointee: 556 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 546
+      ID: 558
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 545 GoStringDataType runtime.errorString.str
+      Pointee: 557 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -2588,19 +2588,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1042656
       GoKind: 22
-      Pointee: 201 UnresolvedPointeeType runtime.p
+      Pointee: 208 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1041376
       GoKind: 22
-      Pointee: 547 GoStringHeaderType runtime.plainError
+      Pointee: 559 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 548 GoStringDataType runtime.plainError.str
+      Pointee: 560 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -2616,12 +2616,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 915392
       GoKind: 22
-      Pointee: 382 StructureType runtime.synctestDeadlockError
+      Pointee: 394 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -2644,12 +2644,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 571
+      ID: 583
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1040864
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType strconv.NumError
+      Pointee: 584 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -2658,242 +2658,242 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 196
+      ID: 203
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 195 GoStringDataType string.str
+      Pointee: 202 GoStringDataType string.str
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1705504
       GoKind: 22
-      Pointee: 759 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 766 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1760224
       GoKind: 22
-      Pointee: 773 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 780 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1705120
       GoKind: 22
-      Pointee: 755 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 762 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1759456
       GoKind: 22
-      Pointee: 765 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 772 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 778
+      ID: 785
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1832352
       GoKind: 22
-      Pointee: 779 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 786 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1759648
       GoKind: 22
-      Pointee: 767 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 774 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1759264
       GoKind: 22
-      Pointee: 763 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 770 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 774
+      ID: 781
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1831904
       GoKind: 22
-      Pointee: 775 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 782 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 782
+      ID: 789
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1901216
       GoKind: 22
-      Pointee: 783 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 790 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1832128
       GoKind: 22
-      Pointee: 777 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 784 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1705696
       GoKind: 22
-      Pointee: 761 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 768 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1705312
       GoKind: 22
-      Pointee: 757 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 764 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1759840
       GoKind: 22
-      Pointee: 769 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 776 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1832576
       GoKind: 22
-      Pointee: 781 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 788 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1760032
       GoKind: 22
-      Pointee: 771 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 778 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1099872
       GoKind: 22
-      Pointee: 899 StructureType struct { io.Reader; io.Closer }
+      Pointee: 906 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 685
+      ID: 697
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1425504
       GoKind: 22
-      Pointee: 674 BaseType syscall.Errno
+      Pointee: 686 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1044064
       GoKind: 22
-      Pointee: 747 BaseType syscall.Signal
+      Pointee: 754 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 147
+      ID: 190
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 204 StructureType table<context.canceler,struct {}>
+      Pointee: 247 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 824 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 831 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 252
+      ID: 241
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 260 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 263 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 988 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 995 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 851 StructureType table<string,[]string>
+      Pointee: 858 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 183
+      ID: 145
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 238 StructureType table<string,float64>
+      Pointee: 227 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 701
+      ID: 713
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 727 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 739 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 178
+      ID: 140
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 230 StructureType table<string,interface {}>
+      Pointee: 219 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 173
+      ID: 135
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 222 StructureType table<string,string>
+      Pointee: 211 StructureType table<string,string>
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1096160
       GoKind: 22
-      Pointee: 621 StructureType text/template.ExecError
+      Pointee: 633 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 157
+      ID: 196
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1629088
       GoKind: 22
-      Pointee: 158 StructureType time.Location
+      Pointee: 197 StructureType time.Location
     - __kind: PointerType
-      ID: 373
+      ID: 385
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 911360
       GoKind: 22
-      Pointee: 374 UnresolvedPointeeType time.ParseError
+      Pointee: 386 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 154
+      ID: 193
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1037536
       GoKind: 22
-      Pointee: 155 StructureType time.Timer
+      Pointee: 194 StructureType time.Timer
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 911168
       GoKind: 22
-      Pointee: 286 GoStringHeaderType time.fileSizeError
+      Pointee: 298 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 288
+      ID: 300
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 287 GoStringDataType time.fileSizeError.str
+      Pointee: 299 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 911264
       GoKind: 22
-      Pointee: 372 UnresolvedPointeeType time.parseDurationError
+      Pointee: 384 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 215
+      ID: 258
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 400064
       GoKind: 22
-      Pointee: 216 StructureType time.zone
+      Pointee: 259 StructureType time.zone
     - __kind: PointerType
-      ID: 218
+      ID: 261
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 400128
       GoKind: 22
-      Pointee: 219 StructureType time.zoneTrans
+      Pointee: 262 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -2937,47 +2937,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 916640
       GoKind: 22
-      Pointee: 389 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 401 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 406 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 418 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 305 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 317 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 584
+      ID: 596
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1048928
       GoKind: 22
-      Pointee: 585 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 597 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 586
+      ID: 598
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1049056
       GoKind: 22
-      Pointee: 551 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 563 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 867
+      ID: 874
       Name: <-chan struct {}
       GoRuntimeType: 604000
       GoKind: 18
     - __kind: GoChannelType
-      ID: 741
+      ID: 753
       Name: <-chan time.Time
       GoRuntimeType: 609696
       GoKind: 18
@@ -3056,7 +3056,7 @@ Types:
       HasCount: true
       Element: 98 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 848
+      ID: 855
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 690368
@@ -3065,7 +3065,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 847
+      ID: 854
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 690272
@@ -3137,7 +3137,7 @@ Types:
       HasCount: true
       Element: 35 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 849
+      ID: 856
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 690464
@@ -3155,7 +3155,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 709
+      ID: 721
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 708032
@@ -3182,7 +3182,7 @@ Types:
       HasCount: true
       Element: 91 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1003
+      ID: 1010
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 508384
@@ -3190,22 +3190,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1004 PointerType **crypto/x509.Certificate
+          Type: 1011 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1011 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1018 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1011
+      ID: 1018
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 695 PointerType *crypto/x509.Certificate
+      Element: 707 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 742
+      ID: 277
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 24
       GoRuntimeType: 496320
@@ -3213,22 +3213,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 743 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 278 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 745 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Data: 280 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: GoSliceDataType
-      ID: 745
+      ID: 280
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 165 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Element: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: GoSliceHeaderType
-      ID: 994
+      ID: 1001
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 493344
@@ -3236,20 +3236,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 995 PointerType **mime/multipart.FileHeader
+          Type: 1002 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1000 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 1007 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 1000
+      ID: 1007
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 996 PointerType *mime/multipart.FileHeader
+      Element: 1003 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 68
       Name: '[]*runtime.p'
@@ -3266,69 +3266,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 202 GoSliceDataType []*runtime.p.array
+      Data: 209 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 209
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 70 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 255
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 147 PointerType *table<context.canceler,struct {}>
+      Element: 190 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 831
+      ID: 838
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 807 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 814 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 271
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 252 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 241 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 997
+      ID: 1004
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 987 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 994 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 857
+      ID: 864
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 846 PointerType *table<string,[]string>
+      Element: 853 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 233
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 183 PointerType *table<string,float64>
+      Element: 145 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 733
+      ID: 745
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 701 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 713 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 225
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 178 PointerType *table<string,interface {}>
+      Element: 140 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 217
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 173 PointerType *table<string,string>
+      Element: 135 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 1005
+      ID: 1012
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 508448
@@ -3336,22 +3336,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1006 PointerType *[]*crypto/x509.Certificate
+          Type: 1013 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1013 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1020 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1013
+      ID: 1020
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1003 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 1010 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 1007
+      ID: 1014
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 487680
@@ -3359,22 +3359,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1008 PointerType *[]uint8
+          Type: 1015 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1015 GoSliceDataType [][]uint8.array
+      Data: 1022 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 1015
+      ID: 1022
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 41 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 714
+      ID: 726
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 502208
@@ -3389,15 +3389,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 737 GoSliceDataType []float64.array
+      Data: 749 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 737
+      ID: 749
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 15 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 184
+      ID: 146
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 24
       GoRuntimeType: 496064
@@ -3405,22 +3405,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 185 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 246 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 235 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 235
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 186 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Element: 148 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 187
+      ID: 149
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 496256
@@ -3428,22 +3428,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 188 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 150 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 254 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 243 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 243
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 189 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Element: 151 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1017
+      ID: 1024
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 490592
@@ -3451,76 +3451,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1018 PointerType *net/http.segment
+          Type: 1025 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1020 GoSliceDataType []net/http.segment.array
+      Data: 1027 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1020
+      ID: 1027
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1019 StructureType net/http.segment
+      Element: 1026 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 256
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 207 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 250 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 832
+      ID: 839
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 834 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 272
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 266 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 998
+      ID: 1005
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 991 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 998 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 858
+      ID: 865
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 854 StructureType noalg.map.group[string][]string
+      Element: 861 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 234
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 241 StructureType noalg.map.group[string]float64
+      Element: 230 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 734
+      ID: 746
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 742 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 226
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 233 StructureType noalg.map.group[string]interface {}
+      Element: 222 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 218
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 225 StructureType noalg.map.group[string]string
+      Element: 214 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 179
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 487552
@@ -3528,26 +3528,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *os.Signal
+          Type: 180 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 220 GoSliceDataType []os.Signal.array
+      Data: 245 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 245
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 163 GoInterfaceType os.Signal
+      Element: 181 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 43
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 713
+      ID: 725
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 502464
@@ -3562,15 +3562,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 735 GoSliceDataType []string.array
+      Data: 747 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 735
+      ID: 747
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 214
+      ID: 257
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 495456
@@ -3578,22 +3578,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 215 PointerType *time.zone
+          Type: 258 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 256 GoSliceDataType []time.zone.array
+      Data: 273 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 273
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 216 StructureType time.zone
+      Element: 259 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 260
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 495520
@@ -3601,20 +3601,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *time.zoneTrans
+          Type: 261 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 258 GoSliceDataType []time.zoneTrans.array
+      Data: 275 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 275
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 219 StructureType time.zoneTrans
+      Element: 262 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 41
       Name: '[]uint8'
@@ -3631,9 +3631,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 197 GoSliceDataType []uint8.array
+      Data: 204 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 204
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3654,15 +3654,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 199 GoSliceDataType []uintptr.array
+      Data: 206 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 206
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 529
+      ID: 541
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 955712
@@ -3677,27 +3677,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 530 GoSliceDataType archive/tar.headerError.array
+      Data: 542 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 542
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 916
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 902
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 920
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 900
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3707,7 +3707,7 @@ Types:
       GoRuntimeType: 591328
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 847
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3715,12 +3715,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 850
+      ID: 857
       Name: chan bool
       GoRuntimeType: 603488
       GoKind: 18
     - __kind: GoChannelType
-      ID: 164
+      ID: 182
       Name: chan os.Signal
       GoRuntimeType: 610400
       GoKind: 18
@@ -3737,13 +3737,13 @@ Types:
       GoRuntimeType: 591072
       GoKind: 15
     - __kind: BaseType
-      ID: 301
+      ID: 313
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 842816
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 302
+      ID: 314
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 842912
@@ -3751,32 +3751,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 304 PointerType *compress/flate.InternalError.str
+          Type: 316 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 303 GoStringDataType compress/flate.InternalError.str
+      Data: 315 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 303
+      ID: 315
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 160
+      ID: 178
       Name: context.CancelCauseFunc
       ByteSize: 8
       GoRuntimeType: 839360
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 838
+      ID: 845
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 683552
@@ -3795,7 +3795,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 199
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 1734496
@@ -3803,29 +3803,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 127 StructureType context.cancelCtx
+          Type: 184 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 148 StructureType sync.Once
+          Type: 200 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 151
+      ID: 173
       Name: context.backgroundCtx
       GoRuntimeType: 1814208
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 152 StructureType context.emptyCtx
+          Type: 159 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 127
+      ID: 184
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1988320
@@ -3836,23 +3836,23 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 141 StructureType sync/atomic.Value
+          Type: 185 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 143 GoMapType map[context.canceler]struct {}
+          Type: 186 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 141 StructureType sync/atomic.Value
+          Type: 185 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 17 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 210
+      ID: 253
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1116672
@@ -3865,13 +3865,13 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 626
+      ID: 638
       Name: context.deadlineExceededError
       GoRuntimeType: 1469184
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 152
+      ID: 159
       Name: context.emptyCtx
       GoRuntimeType: 1605952
       GoKind: 25
@@ -3880,7 +3880,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 129
+      ID: 161
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1840992
@@ -3891,11 +3891,11 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 153 GoSubroutineType func() bool
+          Type: 162 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 131
+      ID: 192
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1622560
@@ -3903,29 +3903,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 127 StructureType context.cancelCtx
+          Type: 184 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 154 PointerType *time.Timer
+          Type: 193 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 156 GoTimeType time.Time
+          Type: 195 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 159
+      ID: 175
       Name: context.todoCtx
       GoRuntimeType: 1814432
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 152 StructureType context.emptyCtx
+          Type: 159 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 133
+      ID: 168
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1849696
@@ -3936,14 +3936,14 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 142 GoEmptyInterfaceType interface {}
+          Type: 169 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 142 GoEmptyInterfaceType interface {}
+          Type: 169 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 135
+      ID: 171
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1813984
@@ -3955,51 +3955,51 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 320
+      ID: 332
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845024
       GoKind: 2
     - __kind: BaseType
-      ID: 321
+      ID: 333
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845120
       GoKind: 2
     - __kind: BaseType
-      ID: 322
+      ID: 334
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845216
       GoKind: 2
     - __kind: StructureType
-      ID: 607
+      ID: 619
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1293888
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 323
+      ID: 335
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 845312
       GoKind: 2
     - __kind: BaseType
-      ID: 290
+      ID: 302
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 842336
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 595
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 986
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 873
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2283616
@@ -4019,7 +4019,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 1002 BaseType crypto/tls.CurveID
+          Type: 1009 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4031,13 +4031,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 1003 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 1010 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 1005 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 1012 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 1007 GoSliceHeaderType [][]uint8
+          Type: 1014 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 41 GoSliceHeaderType []uint8
@@ -4052,22 +4052,22 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 1009 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 1016 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 184
-          Type: 1010 BaseType crypto/tls.SignatureScheme
+          Type: 1017 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 1002
+      ID: 1009
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 842048
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 394
+      ID: 406
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 391
+      ID: 403
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1740448
@@ -4078,36 +4078,36 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 709 ArrayType [5]uint8
+          Type: 721 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 710 GoInterfaceType net.Conn
+          Type: 722 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 1010
+      ID: 1017
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 842144
       GoKind: 9
     - __kind: BaseType
-      ID: 550
+      ID: 562
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 996832
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 396
+      ID: 408
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 699
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 708
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 449
+      ID: 461
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1742560
@@ -4115,21 +4115,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 695 PointerType *crypto/x509.Certificate
+          Type: 707 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 719 BaseType crypto/x509.InvalidReason
+          Type: 731 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 443
+      ID: 455
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1123328
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 445
+      ID: 457
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1608832
@@ -4137,24 +4137,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 695 PointerType *crypto/x509.Certificate
+          Type: 707 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 319
+      ID: 331
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 844736
       GoKind: 2
     - __kind: BaseType
-      ID: 719
+      ID: 731
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 594016
       GoKind: 2
     - __kind: StructureType
-      ID: 599
+      ID: 611
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1568640
@@ -4164,13 +4164,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 451
+      ID: 463
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1123584
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 447
+      ID: 459
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1742368
@@ -4178,15 +4178,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 695 PointerType *crypto/x509.Certificate
+          Type: 707 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 695 PointerType *crypto/x509.Certificate
+          Type: 707 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 491
+      ID: 503
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1439584
@@ -4196,7 +4196,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 495
+      ID: 507
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1439744
@@ -4206,47 +4206,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 505
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 291
+      ID: 303
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 842432
       GoKind: 6
     - __kind: BaseType
-      ID: 315
+      ID: 327
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 844448
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 419
+      ID: 431
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 607
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 411
+      ID: 423
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 417
+      ID: 429
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 415
+      ID: 427
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 425
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1430304
@@ -4256,7 +4256,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 522
+      ID: 534
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4273,11 +4273,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 376
+      ID: 388
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 582
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4293,11 +4293,11 @@ Types:
       GoRuntimeType: 591264
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 554
+      ID: 566
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 556
+      ID: 568
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4307,13 +4307,13 @@ Types:
       GoRuntimeType: 485760
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 861
+      ID: 868
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 700736
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 153
+      ID: 162
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 601632
@@ -4325,23 +4325,23 @@ Types:
       GoRuntimeType: 859168
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 1009
+      ID: 1016
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1012672
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 432
+      ID: 444
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 816
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2075008
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 424
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1741600
@@ -4349,7 +4349,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 711 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 723 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4357,25 +4357,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 426
+      ID: 438
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 728
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 430
+      ID: 442
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1122304
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 718
+      ID: 730
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 309
+      ID: 321
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 843872
@@ -4383,18 +4383,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 311 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 323 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 310 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 322 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 310
+      ID: 322
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 711
+      ID: 723
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2235776
@@ -4402,13 +4402,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 712 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 724 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4417,7 +4417,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 714 GoSliceHeaderType []float64
+          Type: 726 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -4426,13 +4426,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 715 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 727 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 717 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 729 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4443,13 +4443,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 712
+      ID: 724
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 592800
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 318
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 843776
@@ -4457,18 +4457,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 320 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 319 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 319
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 312
+      ID: 324
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 843968
@@ -4476,36 +4476,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 314 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 326 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 313 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 325 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 313
+      ID: 325
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 500
+      ID: 512
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1126016
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 324
+      ID: 336
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 846464
       GoKind: 2
     - __kind: StructureType
-      ID: 498
+      ID: 510
       Name: github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
       GoRuntimeType: 1125888
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 465
+      ID: 477
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1609952
@@ -4518,7 +4518,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 469
+      ID: 481
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1744672
@@ -4534,7 +4534,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 467
+      ID: 479
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1438144
@@ -4544,7 +4544,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 463
+      ID: 475
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1437824
@@ -4554,14 +4554,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 697
+      ID: 709
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1513504
       GoKind: 21
-      HeaderType: 699 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 711 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 720
+      ID: 732
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1059808
@@ -4576,15 +4576,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 739 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 751 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 739
+      ID: 751
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 477
+      ID: 489
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1610272
@@ -4592,12 +4592,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 697 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 709 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 697 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 709 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 471
+      ID: 483
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1438304
@@ -4607,7 +4607,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 475
+      ID: 487
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1744864
@@ -4618,12 +4618,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 732 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 732 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 473
+      ID: 485
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1610112
@@ -4636,7 +4636,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 479
+      ID: 491
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1438464
@@ -4644,9 +4644,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 156 GoTimeType time.Time
+          Type: 195 GoTimeType time.Time
     - __kind: StructureType
-      ID: 485
+      ID: 497
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1610592
@@ -4659,7 +4659,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 487
+      ID: 499
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1438784
@@ -4669,7 +4669,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 483
+      ID: 495
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1610432
@@ -4682,7 +4682,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 481
+      ID: 493
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1438624
@@ -4692,7 +4692,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 489
+      ID: 501
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1610752
@@ -4705,29 +4705,29 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 830
+      ID: 837
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 847328
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 830
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 824
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 826
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 828
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 510
+      ID: 522
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1444704
@@ -4737,11 +4737,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 809
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 512
+      ID: 524
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1444864
@@ -4749,17 +4749,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 510 StructureType github.com/cihub/seelog.baseError
+          Type: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 801
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 796
+      ID: 803
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 800
+      ID: 807
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1843904
@@ -4767,12 +4767,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 795 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 802 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 803 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 810 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 516
+      ID: 528
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1445184
@@ -4780,9 +4780,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 510 StructureType github.com/cihub/seelog.baseError
+          Type: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 798
+      ID: 805
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1823392
@@ -4790,13 +4790,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 795 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 802 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 822
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 514
+      ID: 526
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1445024
@@ -4804,9 +4804,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 510 StructureType github.com/cihub/seelog.baseError
+          Type: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 518
+      ID: 530
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1445344
@@ -4814,9 +4814,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 510 StructureType github.com/cihub/seelog.baseError
+          Type: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 929
+      ID: 936
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1130880
@@ -4829,7 +4829,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 907
+      ID: 914
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1685344
@@ -4837,36 +4837,36 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 929 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 936 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 625
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 627
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 617
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1431584
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 621
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1864032
@@ -4882,11 +4882,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 589
+      ID: 601
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1713856
@@ -4899,7 +4899,7 @@ Types:
           Offset: 1
           Type: 22 BaseType int8
     - __kind: StructureType
-      ID: 661
+      ID: 673
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1864480
@@ -4915,13 +4915,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 552
+      ID: 564
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 997984
       GoKind: 8
     - __kind: StructureType
-      ID: 653
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1863808
@@ -4937,13 +4937,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 723
+      ID: 735
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 843392
       GoKind: 8
     - __kind: StructureType
-      ID: 651
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1863584
@@ -4951,15 +4951,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 723 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 735 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 723 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 735 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 659
+      ID: 671
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1778208
@@ -4972,7 +4972,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 657
+      ID: 669
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1864256
@@ -4988,7 +4988,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 665
+      ID: 677
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1646176
@@ -4998,19 +4998,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 593
+      ID: 605
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1290176
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 591
+      ID: 603
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1290048
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 663
+      ID: 675
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1778400
@@ -5023,7 +5023,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 329
+      ID: 341
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 848480
@@ -5031,22 +5031,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 331 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 343 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 342 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 330
+      ID: 342
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 704
+      ID: 716
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 619
+      ID: 631
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1454464
@@ -5056,19 +5056,19 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 332
+      ID: 344
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 849056
       GoKind: 10
     - __kind: BaseType
-      ID: 702
+      ID: 714
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1009696
       GoKind: 10
     - __kind: StructureType
-      ID: 673
+      ID: 685
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1896064
@@ -5079,12 +5079,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 702 BaseType golang.org/x/net/http2.ErrCode
+          Type: 714 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 536
+      ID: 548
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1617472
@@ -5092,12 +5092,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 702 BaseType golang.org/x/net/http2.ErrCode
+          Type: 714 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 336
+      ID: 348
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 849248
@@ -5105,18 +5105,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 338 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 350 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 349 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 337
+      ID: 349
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 342
+      ID: 354
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 849440
@@ -5124,18 +5124,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 344 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 356 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 355 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 343
+      ID: 355
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 339
+      ID: 351
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 849344
@@ -5143,18 +5143,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 341 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 353 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 352 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 340
+      ID: 352
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 333
+      ID: 345
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 849152
@@ -5162,18 +5162,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 335 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 347 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 346 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 334
+      ID: 346
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 540
+      ID: 552
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1455744
@@ -5183,13 +5183,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 345
+      ID: 357
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 849536
       GoKind: 2
     - __kind: StructureType
-      ID: 520
+      ID: 532
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1450144
@@ -5199,11 +5199,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 683
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 691
+      ID: 703
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1924224
@@ -5219,7 +5219,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 526
+      ID: 538
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1616512
@@ -5232,11 +5232,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 945
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 617
+      ID: 629
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1576320
@@ -5246,33 +5246,33 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 514
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 623
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 681
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 679
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1521984
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 421
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 784
+      ID: 791
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1428864
@@ -5285,7 +5285,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 753
+      ID: 760
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1608192
@@ -5311,7 +5311,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 186
+      ID: 148
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
       ByteSize: 56
       GoRuntimeType: 1936384
@@ -5328,7 +5328,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -5336,7 +5336,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 944
+      ID: 951
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1988832
@@ -5344,29 +5344,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 935 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+          Type: 942 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 947 BaseType time.Duration
+          Type: 954 BaseType time.Duration
     - __kind: GoMapType
-      ID: 174
+      ID: 136
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1288768
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 744
+      ID: 279
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 590112
       GoKind: 10
     - __kind: DDTraceSpanType
-      ID: 166
+      ID: 124
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
       ByteSize: 288
       GoRuntimeType: 2352640
@@ -5374,7 +5374,7 @@ Types:
       RawFields:
         - Name: RWMutex
           Offset: 0
-          Type: 167 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: Name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -5395,13 +5395,13 @@ Types:
           Type: 14 BaseType int64
         - Name: Meta
           Offset: 104
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: MetaStruct
           Offset: 112
-          Type: 174 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
+          Type: 136 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
         - Name: Metrics
           Offset: 120
-          Type: 179 GoMapType map[string]float64
+          Type: 141 GoMapType map[string]float64
         - Name: SpanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -5416,10 +5416,10 @@ Types:
           Type: 12 BaseType int32
         - Name: SpanLinks
           Offset: 160
-          Type: 184 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 146 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: SpanEvents
           Offset: 184
-          Type: 187 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 149 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -5431,7 +5431,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 190 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+          Type: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -5454,7 +5454,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 191
+      ID: 153
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
       ByteSize: 160
       GoRuntimeType: 2209888
@@ -5465,10 +5465,10 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 192 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+          Type: 155 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 165 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: errors
           Offset: 24
           Type: 12 BaseType int32
@@ -5480,16 +5480,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 194 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
+          Type: 157 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 167 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -5498,9 +5498,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 184 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 146 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: StructureType
-      ID: 189
+      ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1769184
@@ -5514,16 +5514,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 248 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 237 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 253 GoMapType map[string]interface {}
+          Type: 242 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 751
+      ID: 758
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 267
+      ID: 270
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1931264
@@ -5531,7 +5531,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 749 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
+          Type: 756 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -5546,15 +5546,15 @@ Types:
           Type: 15 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 750 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+          Type: 757 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 749
+      ID: 756
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
     - __kind: StructureType
-      ID: 193
+      ID: 156
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2124064
@@ -5562,16 +5562,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 167 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 742 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 277 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: tags
           Offset: 48
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -5586,12 +5586,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 744 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
+          Type: 279 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 165 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: ArrayType
-      ID: 194
+      ID: 157
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 912128
@@ -5600,11 +5600,11 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1026
+    - __kind: GoContextImplementationType
+      ID: 166
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1646752
@@ -5613,20 +5613,22 @@ Types:
         - Name: Context
           Offset: 0
           Type: 123 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 818
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 898
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 459
+      ID: 471
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 504
+      ID: 516
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1441984
@@ -5636,7 +5638,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 506
+      ID: 518
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1442144
@@ -5646,137 +5648,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 524
+      ID: 536
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 205
+      ID: 248
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 206 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 249 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 207 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 250 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 256 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 825
+      ID: 832
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 826 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 833 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 832 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 834 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 839 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 261
+      ID: 264
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 262 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 265 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 266 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 272 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 989
+      ID: 996
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 990 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 997 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 991 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 998 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 998 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 1005 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 852
+      ID: 859
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 853 PointerType *noalg.map.group[string][]string
+          Type: 860 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 854 StructureType noalg.map.group[string][]string
-      GroupSliceType: 858 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 861 StructureType noalg.map.group[string][]string
+      GroupSliceType: 865 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 239
+      ID: 228
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 240 PointerType *noalg.map.group[string]float64
+          Type: 229 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 241 StructureType noalg.map.group[string]float64
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 230 StructureType noalg.map.group[string]float64
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 728
+      ID: 740
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 729 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 734 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 742 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 746 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 231
+      ID: 220
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 232 PointerType *noalg.map.group[string]interface {}
+          Type: 221 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 233 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 222 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 226 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 212
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[string]string
+          Type: 213 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[string]string
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 214 StructureType noalg.map.group[string]string
+      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 543
+      ID: 555
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5810,7 +5812,7 @@ Types:
       GoRuntimeType: 590368
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 142
+      ID: 169
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 862912
@@ -5823,17 +5825,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 724
+      ID: 736
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 593440
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 705
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 440
+      ID: 452
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5859,25 +5861,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 438
+      ID: 450
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 659
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 984
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 657
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1487584
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 378
+      ID: 390
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5949,7 +5951,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 328
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 844640
@@ -5957,18 +5959,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 330 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 329 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 329
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1567680
@@ -5976,15 +5978,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 692 PointerType *internal/abi.Type
+          Type: 704 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 289
+      ID: 301
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 841856
       GoKind: 2
     - __kind: StructureType
-      ID: 140
+      ID: 128
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1502144
@@ -5997,7 +5999,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 930
+      ID: 937
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1039584
@@ -6010,11 +6012,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 949
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 837
+      ID: 844
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1119104
@@ -6027,7 +6029,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 920
+      ID: 927
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1038944
@@ -6040,11 +6042,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 953
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 889
+      ID: 896
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1561120
@@ -6052,9 +6054,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 920 GoInterfaceType io.Reader
+          Type: 927 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 905
+      ID: 912
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1630624
@@ -6062,13 +6064,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 920 GoInterfaceType io.Reader
+          Type: 927 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 655
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 145
+      ID: 188
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -6081,7 +6083,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 146 PointerType **table<context.canceler,struct {}>
+          Type: 189 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6100,10 +6102,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 207 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 255 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 250 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 805
+      ID: 812
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6116,7 +6118,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 806 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 813 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6135,10 +6137,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 831 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 838 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 834 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 250
+      ID: 239
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6151,7 +6153,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 251 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 240 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6170,10 +6172,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 271 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 266 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 985
+      ID: 992
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6186,7 +6188,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 986 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 993 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6205,10 +6207,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 997 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 991 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 1004 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 998 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 844
+      ID: 851
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6221,7 +6223,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 845 PointerType **table<string,[]string>
+          Type: 852 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6240,10 +6242,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 857 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 854 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 864 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 861 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 181
+      ID: 143
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6256,7 +6258,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 182 PointerType **table<string,float64>
+          Type: 144 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6275,10 +6277,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,float64>.array
-      GroupType: 241 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 233 GoSliceDataType []*table<string,float64>.array
+      GroupType: 230 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 699
+      ID: 711
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6291,7 +6293,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 700 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 712 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6310,10 +6312,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 733 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 745 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 742 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 176
+      ID: 138
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6326,7 +6328,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 177 PointerType **table<string,interface {}>
+          Type: 139 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6345,10 +6347,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 233 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 225 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 222 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 171
+      ID: 133
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6361,7 +6363,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 172 PointerType **table<string,string>
+          Type: 134 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6380,66 +6382,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<string,string>.array
-      GroupType: 225 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 217 GoSliceDataType []*table<string,string>.array
+      GroupType: 214 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 143
+      ID: 186
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1135744
       GoKind: 21
-      HeaderType: 145 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 188 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 803
+      ID: 810
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1165440
       GoKind: 21
-      HeaderType: 805 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 812 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 248
+      ID: 237
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1142112
       GoKind: 21
-      HeaderType: 250 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 239 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 983
+      ID: 990
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1141120
       GoKind: 21
-      HeaderType: 985 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 992 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 982
+      ID: 989
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1136768
       GoKind: 21
-      HeaderType: 844 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 851 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 179
+      ID: 141
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1141984
       GoKind: 21
-      HeaderType: 181 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 143 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 253
+      ID: 242
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1135360
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 169
+      ID: 131
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1137792
       GoKind: 21
-      HeaderType: 171 GoSwissMapHeaderType map<string,string>
+      HeaderType: 133 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 457
+      ID: 469
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1434784
@@ -6449,11 +6451,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1006
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 871
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1490624
@@ -6461,16 +6463,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 982 GoMapType map[string][]string
+          Type: 989 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 983 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 990 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 931
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 926
+      ID: 933
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1935104
@@ -6478,16 +6480,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 945 PointerType *io.SectionReader
+          Type: 952 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 930 GoInterfaceType io.Closer
+          Type: 937 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 641
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 710
+      ID: 722
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1606112
@@ -6500,35 +6502,35 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 690
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 960
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 688
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 643
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 968
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 972
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 966
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 622
+      ID: 634
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1116928
@@ -6536,28 +6538,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 624 PointerType *net.UnknownNetworkError.str
+          Type: 636 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 623 GoStringDataType net.UnknownNetworkError.str
+      Data: 635 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 623
+      ID: 635
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 558
+      ID: 570
       Name: net.canceledError
       GoRuntimeType: 1287488
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 734
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2123008
@@ -6565,7 +6567,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 710 GoInterfaceType net.Conn
+          Type: 722 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -6576,27 +6578,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 974
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 963
+      ID: 970
       Name: net.noReadFrom
       GoRuntimeType: 1117184
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 962
+      ID: 969
       Name: net.noWriteTo
       GoRuntimeType: 1117056
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 347
+      ID: 359
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1024
+    - __kind: GoContextImplementationType
+      ID: 164
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1763424
@@ -6608,8 +6610,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 123 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 349
+      ID: 361
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1735456
@@ -6617,7 +6621,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 717 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6625,7 +6629,7 @@ Types:
           Offset: 96
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 957
+      ID: 964
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2302752
@@ -6633,12 +6637,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 963 StructureType net.noReadFrom
+          Type: 970 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 960 PointerType *net.TCPConn
+          Type: 967 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 955
+      ID: 962
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2302208
@@ -6646,20 +6650,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 962 StructureType net.noWriteTo
+          Type: 969 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 960 PointerType *net.TCPConn
+          Type: 967 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 645
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 692
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 787
+      ID: 794
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1036896
@@ -6672,7 +6676,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 785
+      ID: 792
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1035232
@@ -6685,14 +6689,14 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 842
+      ID: 849
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2123360
       GoKind: 21
-      HeaderType: 844 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 851 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 788
+      ID: 795
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1035360
@@ -6705,15 +6709,15 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 355
+      ID: 367
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 572
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 786
+      ID: 793
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1035616
@@ -6737,7 +6741,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 859 PointerType *net/url.URL
+          Type: 866 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6749,19 +6753,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 837 GoInterfaceType io.ReadCloser
+          Type: 844 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 861 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 868 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6770,16 +6774,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 862 GoMapType net/url.Values
+          Type: 869 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 862 GoMapType net/url.Values
+          Type: 869 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 863 PointerType *mime/multipart.Form
+          Type: 870 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6788,13 +6792,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 865 PointerType *crypto/tls.ConnectionState
+          Type: 872 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 867 GoChannelType <-chan struct {}
+          Type: 874 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 868 PointerType *net/http.Response
+          Type: 875 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6803,15 +6807,15 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 870 PointerType *net/http.pattern
+          Type: 877 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2233536
@@ -6834,16 +6838,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 837 GoInterfaceType io.ReadCloser
+          Type: 844 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6852,13 +6856,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 118 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 865 PointerType *crypto/tls.ConnectionState
+          Type: 872 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 117
       Name: net/http.ResponseWriter
@@ -6873,19 +6877,19 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 941
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 908
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 890
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1764960
@@ -6893,10 +6897,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 791 PointerType *net/http.response
+          Type: 798 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6904,31 +6908,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 843
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 919
+      ID: 926
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 270
+      ID: 282
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 840128
       GoKind: 10
     - __kind: BaseType
-      ID: 694
+      ID: 706
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 994048
       GoKind: 10
     - __kind: StructureType
-      ID: 358
+      ID: 370
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1737184
@@ -6939,12 +6943,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 694 BaseType net/http.http2ErrCode
+          Type: 706 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 682
+      ID: 694
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1912960
@@ -6955,16 +6959,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 694 BaseType net/http.http2ErrCode
+          Type: 706 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 922
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 364
+      ID: 376
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1606592
@@ -6972,12 +6976,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 694 BaseType net/http.http2ErrCode
+          Type: 706 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 274
+      ID: 286
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840320
@@ -6985,28 +6989,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 276 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 288 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 275 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 287 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 275
+      ID: 287
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 362
+      ID: 374
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1118208
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 917
+      ID: 924
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 292
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840512
@@ -7014,18 +7018,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *net/http.http2headerFieldNameError.str
+          Type: 294 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 281 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 293 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 293
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 289
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840416
@@ -7033,40 +7037,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *net/http.http2headerFieldValueError.str
+          Type: 291 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 278 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 290 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 290
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 649
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 879
+      ID: 886
       Name: net/http.http2missingBody
       GoRuntimeType: 1288000
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 887
+      ID: 894
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1288512
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 566
+      ID: 578
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1288384
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 283
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840224
@@ -7074,22 +7078,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 285 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 272 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 284 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 284
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 892
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1194240
@@ -7097,13 +7101,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 833 PointerType *net/http.http2responseWriterState
+          Type: 840 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 841
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 881
+      ID: 888
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1558080
@@ -7111,19 +7115,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 914 PointerType *net/http.http2clientStream
+          Type: 921 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 903
+      ID: 910
       Name: net/http.noBody
       GoRuntimeType: 1472224
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 562
+      ID: 574
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1559520
@@ -7133,7 +7137,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1852160
@@ -7150,20 +7154,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1017 GoSliceHeaderType []net/http.segment
+          Type: 1024 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 911
+      ID: 918
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 368
+      ID: 380
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1422464
@@ -7173,7 +7177,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 792
+      ID: 799
       Name: net/http.response
       ByteSize: 232
       GoRuntimeType: 2361344
@@ -7181,16 +7185,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 835 PointerType *net/http.conn
+          Type: 842 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 118 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 837 GoInterfaceType io.ReadCloser
+          Type: 844 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 838 GoSubroutineType context.CancelFunc
+          Type: 845 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7202,19 +7206,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 149 StructureType sync/atomic.Bool
+          Type: 201 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 839 PointerType *bufio.Writer
+          Type: 846 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 841 StructureType net/http.chunkWriter
+          Type: 848 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7238,30 +7242,30 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 149 StructureType sync/atomic.Bool
+          Type: 201 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 847 ArrayType [29]uint8
+          Type: 854 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 848 ArrayType [10]uint8
+          Type: 855 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 849 ArrayType [3]uint8
+          Type: 856 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
-          Type: 850 GoChannelType chan bool
+          Type: 857 GoChannelType chan bool
         - Name: closeNotifyTriggered
           Offset: 224
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1019
+      ID: 1026
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1624480
@@ -7277,7 +7281,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 353
+      ID: 365
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1606432
@@ -7290,17 +7294,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 696
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 635
+      ID: 647
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1473664
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 564
+      ID: 576
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1559680
@@ -7310,7 +7314,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 940
+      ID: 947
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2048320
@@ -7318,22 +7322,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 710 GoInterfaceType net.Conn
+          Type: 722 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 710 GoInterfaceType net.Conn
+          Type: 722 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 363
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1297344
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 386
+      ID: 398
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1740064
@@ -7349,7 +7353,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 384
+      ID: 396
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1607712
@@ -7362,11 +7366,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 414
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 298
+      ID: 310
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 842720
@@ -7374,22 +7378,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 300 PointerType *net/textproto.ProtocolError.str
+          Type: 312 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 299 GoStringDataType net/textproto.ProtocolError.str
+      Data: 311 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 299
+      ID: 311
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 689
+      ID: 701
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 292
+      ID: 304
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 842528
@@ -7397,18 +7401,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 294 PointerType *net/url.EscapeError.str
+          Type: 306 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 293 GoStringDataType net/url.EscapeError.str
+      Data: 305 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 293
+      ID: 305
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 295
+      ID: 307
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 842624
@@ -7416,18 +7420,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 297 PointerType *net/url.InvalidHostError.str
+          Type: 309 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 296 GoStringDataType net/url.InvalidHostError.str
+      Data: 308 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 296
+      ID: 308
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 860
+      ID: 867
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2149728
@@ -7441,7 +7445,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 980 PointerType *net/url.Userinfo
+          Type: 987 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7467,99 +7471,99 @@ Types:
           Offset: 137
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 981
+      ID: 988
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 862
+      ID: 869
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1903456
       GoKind: 21
-      HeaderType: 844 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 851 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 208
+      ID: 251
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 692192
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 209 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 252 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 828
+      ID: 835
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 790944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 829 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 836 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 264
+      ID: 267
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711104
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 265 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 268 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 992
+      ID: 999
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 706400
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 993 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 1000 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 855
+      ID: 862
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 696704
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 856 StructureType noalg.struct { key string; elem []string }
+      Element: 863 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 242
+      ID: 231
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 243 StructureType noalg.struct { key string; elem float64 }
+      Element: 232 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 731
+      ID: 743
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 767680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 732 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 744 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 234
+      ID: 223
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 687584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key string; elem interface {} }
+      Element: 224 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 226
+      ID: 215
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 700928
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key string; elem string }
+      Element: 216 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 207
+      ID: 250
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1299648
@@ -7570,9 +7574,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 208 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 251 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 827
+      ID: 834
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1376576
@@ -7583,9 +7587,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 828 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 835 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 263
+      ID: 266
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1317056
@@ -7596,9 +7600,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 264 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 267 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 991
+      ID: 998
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1310272
@@ -7609,9 +7613,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 992 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 999 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1301184
@@ -7622,9 +7626,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 855 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 862 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 241
+      ID: 230
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1316800
@@ -7635,9 +7639,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 242 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 231 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 730
+      ID: 742
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1358272
@@ -7648,9 +7652,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 731 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 743 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 233
+      ID: 222
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1298496
@@ -7661,9 +7665,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 223 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 225
+      ID: 214
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1303616
@@ -7674,9 +7678,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 215 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 209
+      ID: 252
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1299520
@@ -7684,12 +7688,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 210 GoInterfaceType context.canceler
+          Type: 253 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 211 StructureType struct {}
+          Type: 254 StructureType struct {}
     - __kind: StructureType
-      ID: 829
+      ID: 836
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1376448
@@ -7697,12 +7701,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 830 BaseType github.com/cihub/seelog.LogLevel
+          Type: 837 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 265
+      ID: 268
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1316928
@@ -7713,9 +7717,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 266 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 269 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 993
+      ID: 1000
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1310144
@@ -7726,9 +7730,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 994 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 1001 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 856
+      ID: 863
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1301056
@@ -7739,9 +7743,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 243
+      ID: 232
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1316672
@@ -7754,7 +7758,7 @@ Types:
           Offset: 16
           Type: 15 BaseType float64
     - __kind: StructureType
-      ID: 732
+      ID: 744
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1358144
@@ -7765,9 +7769,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 732 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 235
+      ID: 224
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1298368
@@ -7778,9 +7782,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 142 GoEmptyInterfaceType interface {}
+          Type: 169 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 227
+      ID: 216
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1303488
@@ -7793,15 +7797,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 973
+      ID: 980
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 568
+      ID: 580
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 163
+      ID: 181
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1118848
@@ -7814,11 +7818,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 651
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 971
+      ID: 978
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2372288
@@ -7826,12 +7830,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 975 StructureType os.noReadFrom
+          Type: 982 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 972 PointerType *os.File
+          Type: 979 PointerType *os.File
     - __kind: StructureType
-      ID: 969
+      ID: 976
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2371488
@@ -7839,32 +7843,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 974 StructureType os.noWriteTo
+          Type: 981 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 972 PointerType *os.File
+          Type: 979 PointerType *os.File
     - __kind: StructureType
-      ID: 975
+      ID: 982
       Name: os.noReadFrom
       GoRuntimeType: 1118720
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 974
+      ID: 981
       Name: os.noWriteTo
       GoRuntimeType: 1118592
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 613
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 726
+      ID: 738
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 603
+      ID: 615
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1714048
@@ -7877,7 +7881,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 137
+      ID: 177
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1988576
@@ -7888,17 +7892,17 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 160 GoSubroutineType context.CancelCauseFunc
+          Type: 178 GoSubroutineType context.CancelCauseFunc
         - Name: signals
           Offset: 24
-          Type: 161 GoSliceHeaderType []os.Signal
+          Type: 179 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 164 GoChannelType chan os.Signal
+          Type: 182 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 295
       Name: os/signal.signalError
       ByteSize: 16
       GoRuntimeType: 840608
@@ -7906,18 +7910,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *os/signal.signalError.str
+          Type: 297 PointerType *os/signal.signalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 284 GoStringDataType os/signal.signalError.str
+      Data: 296 GoStringDataType os/signal.signalError.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 296
       Name: os/signal.signalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 326
+      ID: 338
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 847232
@@ -7925,36 +7929,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 328 PointerType *os/user.UnknownGroupIdError.str
+          Type: 340 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 327 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 339 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 327
+      ID: 339
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 325
+      ID: 337
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 847136
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 392
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 461
+      ID: 473
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 576
+      ID: 588
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 580
+      ID: 592
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7966,7 +7970,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 578
+      ID: 590
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1903008
@@ -7983,7 +7987,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 724 BaseType internal/abi.BoundsErrorCode
+          Type: 736 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -7999,7 +8003,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 641
+      ID: 653
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1772256
@@ -8012,7 +8016,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 544
+      ID: 556
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 995296
@@ -8020,13 +8024,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 546 PointerType *runtime.errorString.str
+          Type: 558 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 545 GoStringDataType runtime.errorString.str
+      Data: 557 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 545
+      ID: 557
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8675,7 +8679,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 201
+      ID: 208
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -8711,7 +8715,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 547
+      ID: 559
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 995392
@@ -8719,13 +8723,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 549 PointerType *runtime.plainError.str
+          Type: 561 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 548 GoStringDataType runtime.plainError.str
+      Data: 560 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 548
+      ID: 560
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8766,7 +8770,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 382
+      ID: 394
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1607392
@@ -8838,7 +8842,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 584
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8850,18 +8854,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 196 PointerType *string.str
+          Type: 203 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 195 GoStringDataType string.str
+      Data: 202 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 195
+      ID: 202
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1967872
@@ -8869,12 +8873,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 773
+      ID: 780
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2046016
@@ -8882,15 +8886,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 755
+      ID: 762
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1967360
@@ -8898,12 +8902,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 765
+      ID: 772
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2044864
@@ -8911,15 +8915,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 779
+      ID: 786
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2107648
@@ -8927,18 +8931,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 767
+      ID: 774
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2045152
@@ -8946,15 +8950,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 763
+      ID: 770
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2044576
@@ -8962,15 +8966,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 775
+      ID: 782
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2107008
@@ -8978,18 +8982,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 783
+      ID: 790
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2168544
@@ -8997,21 +9001,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 777
+      ID: 784
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2107328
@@ -9019,18 +9023,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1968128
@@ -9038,12 +9042,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 757
+      ID: 764
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1967616
@@ -9051,12 +9055,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 769
+      ID: 776
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2045440
@@ -9064,15 +9068,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 781
+      ID: 788
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2107968
@@ -9080,18 +9084,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 771
+      ID: 778
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2045728
@@ -9099,15 +9103,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1719232
@@ -9115,18 +9119,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 920 GoInterfaceType io.Reader
+          Type: 927 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 930 GoInterfaceType io.Closer
+          Type: 937 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 211
+      ID: 254
       Name: struct {}
       GoRuntimeType: 854048
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 138
+      ID: 126
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1477184
@@ -9134,12 +9138,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 139 StructureType sync.noCopy
+          Type: 127 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 140 StructureType internal/sync.Mutex
+          Type: 128 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 148
+      ID: 200
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1631968
@@ -9147,15 +9151,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 139 StructureType sync.noCopy
+          Type: 127 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 149 StructureType sync/atomic.Bool
+          Type: 201 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 167
+      ID: 125
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1857984
@@ -9163,7 +9167,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -9172,18 +9176,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 168 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 168 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 139
+      ID: 127
       Name: sync.noCopy
       GoRuntimeType: 994912
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 149
+      ID: 201
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1478304
@@ -9191,12 +9195,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 130 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 168
+      ID: 129
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1478464
@@ -9204,12 +9208,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 130 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 141
+      ID: 185
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1201920
@@ -9217,27 +9221,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 142 GoEmptyInterfaceType interface {}
+          Type: 169 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 150
+      ID: 130
       Name: sync/atomic.noCopy
       GoRuntimeType: 995008
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 674
+      ID: 686
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1289152
       GoKind: 12
     - __kind: BaseType
-      ID: 747
+      ID: 754
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 996352
       GoKind: 2
     - __kind: StructureType
-      ID: 204
+      ID: 247
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9259,9 +9263,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 205 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 248 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 824
+      ID: 831
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9283,9 +9287,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 825 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 832 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 260
+      ID: 263
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9307,9 +9311,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 261 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 264 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 988
+      ID: 995
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9331,9 +9335,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 989 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 996 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 851
+      ID: 858
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9355,9 +9359,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 852 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 859 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 238
+      ID: 227
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9379,9 +9383,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 239 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 228 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 727
+      ID: 739
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9403,9 +9407,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 728 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 740 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 230
+      ID: 219
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9427,9 +9431,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 231 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 220 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 222
+      ID: 211
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9451,9 +9455,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<string,string>
+          Type: 212 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 621
+      ID: 633
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1718272
@@ -9466,13 +9470,13 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 947
+      ID: 954
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1931008
       GoKind: 6
     - __kind: StructureType
-      ID: 158
+      ID: 197
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1994496
@@ -9483,10 +9487,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 214 GoSliceHeaderType []time.zone
+          Type: 257 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 217 GoSliceHeaderType []time.zoneTrans
+          Type: 260 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9498,13 +9502,13 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 215 PointerType *time.zone
+          Type: 258 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 374
+      ID: 386
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 156
+      ID: 195
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2386432
@@ -9518,7 +9522,7 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 157 PointerType *time.Location
+          Type: 196 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9528,7 +9532,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 155
+      ID: 194
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1474784
@@ -9536,12 +9540,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 741 GoChannelType <-chan time.Time
+          Type: 753 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 286
+      ID: 298
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 840704
@@ -9549,22 +9553,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 288 PointerType *time.fileSizeError.str
+          Type: 300 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 287 GoStringDataType time.fileSizeError.str
+      Data: 299 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 287
+      ID: 299
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 372
+      ID: 384
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 216
+      ID: 259
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1628896
@@ -9580,7 +9584,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 219
+      ID: 262
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1768992
@@ -9641,7 +9645,7 @@ Types:
       GoRuntimeType: 591392
       GoKind: 26
     - __kind: StructureType
-      ID: 705
+      ID: 717
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2079808
@@ -9652,10 +9656,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 706 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 718 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 719 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9670,18 +9674,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 708 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 720 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 708
+      ID: 720
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 996448
       GoKind: 9
     - __kind: StructureType
-      ID: 706
+      ID: 718
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1934080
@@ -9706,17 +9710,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 389
+      ID: 401
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 707
+      ID: 719
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 592224
       GoKind: 8
     - __kind: StructureType
-      ID: 406
+      ID: 418
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1428384
@@ -9726,13 +9730,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 305
+      ID: 317
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 843008
       GoKind: 2
     - __kind: StructureType
-      ID: 585
+      ID: 597
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1713472
@@ -9745,7 +9749,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 551
+      ID: 563
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 997312

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -137,78 +137,78 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 628 PointerType *crypto/x509.Certificate
+      Pointee: 640 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 670
+      ID: 231
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 905 PointerType *mime/multipart.FileHeader
+      Pointee: 912 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 910 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 917 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 918 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 925 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 673
+      ID: 234
       Name: '*[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       ByteSize: 8
-      Pointee: 672 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Pointee: 233 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 908 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 921
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 920 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 923
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 922 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 665
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 664 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 206
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
-      ByteSize: 8
-      Pointee: 205 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
-    - __kind: PointerType
-      ID: 214
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 213 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 915 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 928
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 927 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 930
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 929 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 677
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 676 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 200
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
+      ByteSize: 8
+      Pointee: 199 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+    - __kind: PointerType
+      ID: 208
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 207 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 935
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 927 GoSliceDataType []net/http.segment.array
+      Pointee: 934 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 197
+      ID: 210
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []os.Signal.array
+      Pointee: 209 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -217,77 +217,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 663
+      ID: 675
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 662 GoSliceDataType []string.array
+      Pointee: 674 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 216
+      ID: 227
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []time.zone.array
+      Pointee: 226 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 218
+      ID: 229
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []time.zoneTrans.array
+      Pointee: 228 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452640
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 181
+      ID: 188
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []uint8.array
+      Pointee: 187 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 183
+      ID: 190
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []uintptr.array
+      Pointee: 189 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 872512
       GoKind: 22
-      Pointee: 468 GoSliceHeaderType archive/tar.headerError
+      Pointee: 480 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 470
+      ID: 482
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 469 GoSliceDataType archive/tar.headerError.array
+      Pointee: 481 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 830
+      ID: 837
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1168544
       GoKind: 22
-      Pointee: 831 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 838 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1040768
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 822 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1261280
       GoKind: 22
-      Pointee: 833 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 840 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1040512
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 820 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -296,57 +296,57 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 131
+      ID: 176
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 132 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 177 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 733
+      ID: 740
       Name: '*bucket<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 741 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 210
+      ID: 204
       Name: '*bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 901 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 908 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 768 GoHMapBucketType bucket<string,[]string>
+      Pointee: 775 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 165
+      ID: 131
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 166 GoHMapBucketType bucket<string,float64>
+      Pointee: 132 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 633
+      ID: 645
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 646 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 160
+      ID: 126
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 161 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 127 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
-      ID: 155
+      ID: 119
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 156 GoHMapBucketType bucket<string,string>
+      Pointee: 120 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1815264
       GoKind: 22
-      Pointee: 762 UnresolvedPointeeType bufio.Writer
+      Pointee: 769 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 107
       Name: '*bytes.Buffer'
@@ -355,351 +355,351 @@ Types:
       GoKind: 22
       Pointee: 108 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 846880
       GoKind: 22
-      Pointee: 265 BaseType compress/flate.CorruptInputError
+      Pointee: 277 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 846976
       GoKind: 22
-      Pointee: 266 GoStringHeaderType compress/flate.InternalError
+      Pointee: 278 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 268
+      ID: 280
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 267 GoStringDataType compress/flate.InternalError.str
+      Pointee: 279 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 1843744
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 870 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1434816
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 851 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 934
+      ID: 159
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1354656
       GoKind: 22
-      Pointee: 123 StructureType context.backgroundCtx
+      Pointee: 160 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 111
+      ID: 170
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1589920
       GoKind: 22
-      Pointee: 112 StructureType context.cancelCtx
+      Pointee: 171 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 560
+      ID: 572
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1095072
       GoKind: 22
-      Pointee: 561 StructureType context.deadlineExceededError
+      Pointee: 573 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 929
+      ID: 145
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1226080
       GoKind: 22
-      Pointee: 124 StructureType context.emptyCtx
+      Pointee: 146 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 113
+      ID: 147
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1226240
       GoKind: 22
-      Pointee: 114 StructureType context.stopCtx
+      Pointee: 148 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 115
+      ID: 178
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1590112
       GoKind: 22
-      Pointee: 116 StructureType context.timerCtx
+      Pointee: 179 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 935
+      ID: 161
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1354816
       GoKind: 22
-      Pointee: 141 StructureType context.todoCtx
+      Pointee: 162 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 117
+      ID: 154
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1354336
       GoKind: 22
-      Pointee: 118 StructureType context.valueCtx
+      Pointee: 155 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 119
+      ID: 157
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1354496
       GoKind: 22
-      Pointee: 120 StructureType context.withoutCancelCtx
+      Pointee: 158 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 845920
       GoKind: 22
-      Pointee: 262 BaseType crypto/aes.KeySizeError
+      Pointee: 274 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 846112
       GoKind: 22
-      Pointee: 263 BaseType crypto/des.KeySizeError
+      Pointee: 275 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 389
+      ID: 401
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 846400
       GoKind: 22
-      Pointee: 264 BaseType crypto/rc4.KeySizeError
+      Pointee: 276 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 336
+      ID: 348
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 836608
       GoKind: 22
-      Pointee: 239 BaseType crypto/tls.AlertError
+      Pointee: 251 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 993792
       GoKind: 22
-      Pointee: 522 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 534 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2222752
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 900 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 782 StructureType crypto/tls.ConnectionState
+      Pointee: 789 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 334
+      ID: 346
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 836416
       GoKind: 22
-      Pointee: 335 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 347 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 332
+      ID: 344
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 836320
       GoKind: 22
-      Pointee: 333 StructureType crypto/tls.RecordHeaderError
+      Pointee: 345 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 520
+      ID: 532
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 992128
       GoKind: 22
-      Pointee: 489 BaseType crypto/tls.alert
+      Pointee: 501 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1233760
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 634 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1905824
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 641 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 845728
       GoKind: 22
-      Pointee: 384 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 396 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 377
+      ID: 389
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 845248
       GoKind: 22
-      Pointee: 378 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 390 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 845344
       GoKind: 22
-      Pointee: 380 StructureType crypto/x509.HostnameError
+      Pointee: 392 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 845152
       GoKind: 22
-      Pointee: 261 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 273 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 535
+      ID: 547
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1002752
       GoKind: 22
-      Pointee: 536 StructureType crypto/x509.SystemRootsError
+      Pointee: 548 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 845824
       GoKind: 22
-      Pointee: 386 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 398 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 845632
       GoKind: 22
-      Pointee: 382 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 394 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 855136
       GoKind: 22
-      Pointee: 427 StructureType encoding/asn1.StructuralError
+      Pointee: 439 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 855328
       GoKind: 22
-      Pointee: 431 StructureType encoding/asn1.SyntaxError
+      Pointee: 443 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 855232
       GoKind: 22
-      Pointee: 429 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 441 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 836704
       GoKind: 22
-      Pointee: 240 BaseType encoding/base64.CorruptInputError
+      Pointee: 252 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 844096
       GoKind: 22
-      Pointee: 260 BaseType encoding/hex.InvalidByteError
+      Pointee: 272 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 840448
       GoKind: 22
-      Pointee: 357 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 369 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 998784
       GoKind: 22
-      Pointee: 534 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 546 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 840064
       GoKind: 22
-      Pointee: 349 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 361 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 840352
       GoKind: 22
-      Pointee: 355 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 367 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 352
+      ID: 364
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 840256
       GoKind: 22
-      Pointee: 353 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 365 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 840160
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 363 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 840832
       GoKind: 22
-      Pointee: 359 StructureType encoding/json.jsonError
+      Pointee: 371 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 866368
       GoKind: 22
-      Pointee: 458 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 470 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 866272
       GoKind: 22
-      Pointee: 456 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 468 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 866464
       GoKind: 22
-      Pointee: 274 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 286 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 276
+      ID: 288
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 275 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 287 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 866560
       GoKind: 22
-      Pointee: 461 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 473 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -708,19 +708,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 320
+      ID: 332
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 831808
       GoKind: 22
-      Pointee: 321 UnresolvedPointeeType errors.errorString
+      Pointee: 333 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 985088
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType errors.joinError
+      Pointee: 521 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -736,837 +736,837 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 492
+      ID: 504
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 975104
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType fmt.wrapError
+      Pointee: 505 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 494
+      ID: 506
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 975232
       GoKind: 22
-      Pointee: 495 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 507 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 843616
       GoKind: 22
-      Pointee: 370 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 382 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 1875424
       GoKind: 22
-      Pointee: 736 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 743 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 361
+      ID: 373
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 842176
       GoKind: 22
-      Pointee: 362 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 374 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 842272
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 376 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 841984
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 661 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 367
+      ID: 379
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 842560
       GoKind: 22
-      Pointee: 368 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 380 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 842080
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 663 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 842368
       GoKind: 22
-      Pointee: 254 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 266 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 256
+      ID: 268
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 255 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 267 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 841888
       GoKind: 22
-      Pointee: 251 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 263 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 253
+      ID: 265
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 252 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 264 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 842464
       GoKind: 22
-      Pointee: 257 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 269 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 259
+      ID: 271
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 258 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 270 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 433
+      ID: 445
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 855808
       GoKind: 22
-      Pointee: 434 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 446 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 855712
       GoKind: 22
-      Pointee: 269 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 281 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 852544
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 413 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 404
+      ID: 416
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 852736
       GoKind: 22
-      Pointee: 405 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 417 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 402
+      ID: 414
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 852640
       GoKind: 22
-      Pointee: 403 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 415 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 852448
       GoKind: 22
-      Pointee: 399 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 411 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 666 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 678 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 853120
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 425 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 406
+      ID: 418
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 852832
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 419 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 410
+      ID: 422
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 853024
       GoKind: 22
-      Pointee: 411 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 423 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 852928
       GoKind: 22
-      Pointee: 409 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 421 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 853216
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 427 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 853504
       GoKind: 22
-      Pointee: 421 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 433 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 853600
       GoKind: 22
-      Pointee: 423 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 435 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 853408
       GoKind: 22
-      Pointee: 419 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 431 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 853312
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 429 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 853792
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 437 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2167296
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 757 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2152896
       GoKind: 22
-      Pointee: 744 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 751 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 745
+      ID: 752
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2160256
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 753 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2160896
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 755 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 443
+      ID: 455
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 863584
       GoKind: 22
-      Pointee: 444 StructureType github.com/cihub/seelog.baseError
+      Pointee: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1676928
       GoKind: 22
-      Pointee: 729 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 736 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 445
+      ID: 457
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 863680
       GoKind: 22
-      Pointee: 446 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 458 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1252000
       GoKind: 22
-      Pointee: 721 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 728 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1469568
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 730 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1470336
       GoKind: 22
-      Pointee: 727 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 734 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 449
+      ID: 461
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 863872
       GoKind: 22
-      Pointee: 450 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 462 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 724
+      ID: 731
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1469760
       GoKind: 22
-      Pointee: 725 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 732 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2132960
       GoKind: 22
-      Pointee: 742 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 749 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 447
+      ID: 459
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 863776
       GoKind: 22
-      Pointee: 448 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 460 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 451
+      ID: 463
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 863968
       GoKind: 22
-      Pointee: 452 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 464 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 828
+      ID: 835
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1160224
       GoKind: 22
-      Pointee: 829 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 836 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 847
+      ID: 854
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1610272
       GoKind: 22
-      Pointee: 848 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 855 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 547
+      ID: 559
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1022976
       GoKind: 22
-      Pointee: 548 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 560 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1023104
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 562 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 541
+      ID: 553
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1007744
       GoKind: 22
-      Pointee: 542 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 554 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 844288
       GoKind: 22
-      Pointee: 373 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 385 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 543
+      ID: 555
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1010688
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 556 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 589
+      ID: 601
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1118112
       GoKind: 22
-      Pointee: 590 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 602 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 583
+      ID: 595
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1117728
       GoKind: 22
-      Pointee: 584 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 596 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 997760
       GoKind: 22
-      Pointee: 528 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 540 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 595
+      ID: 607
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1118496
       GoKind: 22
-      Pointee: 596 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 608 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 526
+      ID: 538
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 997632
       GoKind: 22
-      Pointee: 491 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 503 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1117984
       GoKind: 22
-      Pointee: 588 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 600 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 585
+      ID: 597
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1117856
       GoKind: 22
-      Pointee: 586 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 598 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 593
+      ID: 605
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1118368
       GoKind: 22
-      Pointee: 594 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 606 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 591
+      ID: 603
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1118240
       GoKind: 22
-      Pointee: 592 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 604 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 599
+      ID: 611
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1118880
       GoKind: 22
-      Pointee: 600 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 612 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 531
+      ID: 543
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 998016
       GoKind: 22
-      Pointee: 532 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 544 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 529
+      ID: 541
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 997888
       GoKind: 22
-      Pointee: 530 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 542 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 597
+      ID: 609
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1118752
       GoKind: 22
-      Pointee: 598 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 610 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 466
+      ID: 478
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871744
       GoKind: 22
-      Pointee: 277 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 289 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 279
+      ID: 291
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 290 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1468608
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 649 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 553
+      ID: 565
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1039872
       GoKind: 22
-      Pointee: 554 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 566 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 873760
       GoKind: 22
-      Pointee: 280 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 292 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 607
+      ID: 619
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1170208
       GoKind: 22
-      Pointee: 608 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 620 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 22
-      Pointee: 475 StructureType golang.org/x/net/http2.connError
+      Pointee: 487 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 22
-      Pointee: 284 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 296 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 286
+      ID: 298
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 297 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 22
-      Pointee: 290 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 302 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 292
+      ID: 304
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 291 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 303 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 22
-      Pointee: 287 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 299 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 289
+      ID: 301
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 288 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 300 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 472
+      ID: 484
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 873856
       GoKind: 22
-      Pointee: 281 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 293 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 283
+      ID: 295
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 282 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 294 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 22
-      Pointee: 479 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 491 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 874432
       GoKind: 22
-      Pointee: 293 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 305 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 865792
       GoKind: 22
-      Pointee: 454 StructureType google.golang.org/grpc.dropError
+      Pointee: 466 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 605
+      ID: 617
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1166880
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 618 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1257760
       GoKind: 22
-      Pointee: 626 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 638 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 464
+      ID: 476
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 870016
       GoKind: 22
-      Pointee: 465 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 477 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1679616
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 861 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 551
+      ID: 563
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1034112
       GoKind: 22
-      Pointee: 552 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 564 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1372896
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 845 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 435
+      ID: 447
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 858016
       GoKind: 22
-      Pointee: 436 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 448 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 545
+      ID: 557
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1012224
       GoKind: 22
-      Pointee: 546 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 558 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1133344
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 616 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1133088
       GoKind: 22
-      Pointee: 602 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 614 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 839104
       GoKind: 22
-      Pointee: 347 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 359 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1362016
       GoKind: 22
-      Pointee: 680 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 687 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 168
+      ID: 134
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1116064
       GoKind: 22
-      Pointee: 169 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Pointee: 135 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1761376
       GoKind: 22
-      Pointee: 858 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 865 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1669760
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+      Pointee: 859 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 147
+      ID: 141
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoRuntimeType: 2158976
       GoKind: 22
-      Pointee: 148 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 111 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 173
+      ID: 139
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext'
       ByteSize: 8
       GoRuntimeType: 1835392
       GoKind: 22
-      Pointee: 174 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+      Pointee: 140 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
     - __kind: PointerType
-      ID: 171
+      ID: 137
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1102624
       GoKind: 22
-      Pointee: 172 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Pointee: 138 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 677
+      ID: 684
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1103264
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 685 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 220
+      ID: 223
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1103392
       GoKind: 22
-      Pointee: 221 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 224 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 175
+      ID: 142
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2072992
       GoKind: 22
-      Pointee: 176 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+      Pointee: 143 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2024608
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
+      Pointee: 747 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 932
+      ID: 152
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1237120
       GoKind: 22
-      Pointee: 933 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
+      Pointee: 153 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2008320
       GoKind: 22
-      Pointee: 738 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
+      Pointee: 745 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1005824
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
+      Pointee: 818 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 850816
       GoKind: 22
-      Pointee: 395 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 407 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 437
+      ID: 449
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 858592
       GoKind: 22
-      Pointee: 438 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 450 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 439
+      ID: 451
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 858688
       GoKind: 22
-      Pointee: 440 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 452 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 867328
       GoKind: 22
-      Pointee: 463 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 475 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 129
+      ID: 174
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 130 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 175 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*hash<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 732 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 739 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 208
+      ID: 202
       Name: '*hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 209 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 203 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 899 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 906 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 766 GoHMapHeaderType hash<string,[]string>
+      Pointee: 773 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 163
+      ID: 129
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 164 GoHMapHeaderType hash<string,float64>
+      Pointee: 130 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 631
+      ID: 643
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 632 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 644 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 158
+      ID: 124
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 159 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 153
+      ID: 117
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 154 GoHMapHeaderType hash<string,string>
+      Pointee: 118 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 875200
       GoKind: 22
-      Pointee: 482 UnresolvedPointeeType html/template.Error
+      Pointee: 494 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 96
       Name: '*int'
@@ -1603,269 +1603,269 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 844672
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 387 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 581
+      ID: 593
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1111840
       GoKind: 22
-      Pointee: 582 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 594 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2217600
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType internal/poll.FD
+      Pointee: 898 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 579
+      ID: 591
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1111712
       GoKind: 22
-      Pointee: 580 StructureType internal/poll.errNetClosing
+      Pointee: 592 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 322
+      ID: 334
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 832192
       GoKind: 22
-      Pointee: 323 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 335 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1707040
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType io.PipeReader
+      Pointee: 863 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1358816
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType io.SectionReader
+      Pointee: 867 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 985600
       GoKind: 22
-      Pointee: 809 StructureType io.nopCloser
+      Pointee: 816 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 826
+      ID: 833
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1105824
       GoKind: 22
-      Pointee: 827 StructureType io.nopCloserWriterTo
+      Pointee: 834 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1110944
       GoKind: 22
-      Pointee: 578 UnresolvedPointeeType io/fs.PathError
+      Pointee: 590 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 847552
       GoKind: 22
-      Pointee: 393 StructureType math/big.ErrNaN
+      Pointee: 405 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 907 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 914 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 780 StructureType mime/multipart.Form
+      Pointee: 787 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1434048
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 847 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1434240
       GoKind: 22
-      Pointee: 842 StructureType mime/multipart.sectionReadCloser
+      Pointee: 849 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 563
+      ID: 575
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1096224
       GoKind: 22
-      Pointee: 564 UnresolvedPointeeType net.AddrError
+      Pointee: 576 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 612
+      ID: 624
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1226880
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType net.DNSError
+      Pointee: 625 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2077024
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType net.IPConn
+      Pointee: 874 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1226560
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType net.OpError
+      Pointee: 623 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1096352
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType net.ParseError
+      Pointee: 578 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2107328
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType net.TCPConn
+      Pointee: 882 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2151072
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType net.UDPConn
+      Pointee: 886 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2106816
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net.UnixConn
+      Pointee: 880 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1095456
       GoKind: 22
-      Pointee: 557 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 569 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 558 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 570 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 976128
       GoKind: 22
-      Pointee: 497 StructureType net.canceledError
+      Pointee: 509 StructureType net.canceledError
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1870816
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType net.conn
+      Pointee: 872 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 654
+      ID: 666
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1701216
       GoKind: 22
-      Pointee: 655 StructureType net.dialResult·1
+      Pointee: 667 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2154112
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType net.netFD
+      Pointee: 888 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 294
+      ID: 306
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 824992
       GoKind: 22
-      Pointee: 295 UnresolvedPointeeType net.notFoundError
+      Pointee: 307 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 930
+      ID: 150
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1226720
       GoKind: 22
-      Pointee: 931 StructureType net.onlyValuesCtx
+      Pointee: 151 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 296
+      ID: 308
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 825664
       GoKind: 22
-      Pointee: 297 StructureType net.result·2
+      Pointee: 309 StructureType net.result·2
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2092384
       GoKind: 22
-      Pointee: 871 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 878 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2091904
       GoKind: 22
-      Pointee: 869 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 876 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1096992
       GoKind: 22
-      Pointee: 568 UnresolvedPointeeType net.temporaryError
+      Pointee: 580 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1227200
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType net.timeoutError
+      Pointee: 627 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 302
+      ID: 314
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 828256
       GoKind: 22
-      Pointee: 303 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 315 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 979456
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 511 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 105
       Name: '*net/http.Request'
@@ -1874,507 +1874,507 @@ Types:
       GoKind: 22
       Pointee: 106 StructureType net/http.Request
     - __kind: PointerType
-      ID: 784
+      ID: 791
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1591456
       GoKind: 22
-      Pointee: 785 StructureType net/http.Response
+      Pointee: 792 StructureType net/http.Response
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1669088
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType net/http.body
+      Pointee: 857 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 820
+      ID: 827
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1099680
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 828 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 979328
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 808 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1702336
       GoKind: 22
-      Pointee: 758 UnresolvedPointeeType net/http.conn
+      Pointee: 765 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 978176
       GoKind: 22
-      Pointee: 791 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 798 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 981376
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 812 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 304
+      ID: 316
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 828448
       GoKind: 22
-      Pointee: 223 BaseType net/http.http2ConnectionError
+      Pointee: 235 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 305
+      ID: 317
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 828544
       GoKind: 22
-      Pointee: 306 StructureType net/http.http2GoAwayError
+      Pointee: 318 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 616
+      ID: 628
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1228160
       GoKind: 22
-      Pointee: 617 StructureType net/http.http2StreamError
+      Pointee: 629 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 1871968
       GoKind: 22
-      Pointee: 835 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 842 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 311
+      ID: 323
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 829408
       GoKind: 22
-      Pointee: 312 StructureType net/http.http2connError
+      Pointee: 324 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 828928
       GoKind: 22
-      Pointee: 227 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 239 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 229
+      ID: 241
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 228 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 240 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 309
+      ID: 321
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 829024
       GoKind: 22
-      Pointee: 310 StructureType net/http.http2goAwayFlowError
+      Pointee: 322 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 979072
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 806 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 314
+      ID: 326
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 829600
       GoKind: 22
-      Pointee: 233 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 245 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 235
+      ID: 247
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 234 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 246 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 313
+      ID: 325
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 829504
       GoKind: 22
-      Pointee: 230 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 242 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 232
+      ID: 244
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 231 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 243 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 571
+      ID: 583
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1101216
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 584 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 978816
       GoKind: 22
-      Pointee: 795 StructureType net/http.http2missingBody
+      Pointee: 802 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 981632
       GoKind: 22
-      Pointee: 807 StructureType net/http.http2noBodyReader
+      Pointee: 814 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 981504
       GoKind: 22
-      Pointee: 505 StructureType net/http.http2noCachedConnError
+      Pointee: 517 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 307
+      ID: 319
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 828832
       GoKind: 22
-      Pointee: 224 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 236 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 226
+      ID: 238
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 225 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 237 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 979968
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 810 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1833376
       GoKind: 22
-      Pointee: 717 StructureType net/http.http2responseWriter
+      Pointee: 724 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1418496
       GoKind: 22
-      Pointee: 756 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 763 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 978944
       GoKind: 22
-      Pointee: 797 StructureType net/http.http2transportResponseBody
+      Pointee: 804 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 978304
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 800 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 824
+      ID: 831
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1099936
       GoKind: 22
-      Pointee: 825 StructureType net/http.noBody
+      Pointee: 832 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 981120
       GoKind: 22
-      Pointee: 501 StructureType net/http.nothingWrittenError
+      Pointee: 513 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1416576
       GoKind: 22
-      Pointee: 787 StructureType net/http.pattern
+      Pointee: 794 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 977664
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 796 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1099808
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 830 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 315
+      ID: 327
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 829792
       GoKind: 22
-      Pointee: 316 StructureType net/http.requestBodyReadError
+      Pointee: 328 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2059552
       GoKind: 22
-      Pointee: 719 StructureType net/http.response
+      Pointee: 726 StructureType net/http.response
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364064
       GoKind: 22
-      Pointee: 926 StructureType net/http.segment
+      Pointee: 933 StructureType net/http.segment
     - __kind: PointerType
-      ID: 300
+      ID: 312
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 828160
       GoKind: 22
-      Pointee: 301 StructureType net/http.statusError
+      Pointee: 313 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1229600
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 631 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 569
+      ID: 581
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1101088
       GoKind: 22
-      Pointee: 570 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 582 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 981248
       GoKind: 22
-      Pointee: 503 StructureType net/http.transportReadFromServerError
+      Pointee: 515 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 298
+      ID: 310
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 827392
       GoKind: 22
-      Pointee: 299 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 311 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 816
+      ID: 823
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1041152
       GoKind: 22
-      Pointee: 817 StructureType net/http/httputil.failureToReadBody
+      Pointee: 824 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 328
+      ID: 340
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 834688
       GoKind: 22
-      Pointee: 329 StructureType net/netip.parseAddrError
+      Pointee: 341 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 326
+      ID: 338
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 834592
       GoKind: 22
-      Pointee: 327 StructureType net/netip.parsePrefixError
+      Pointee: 339 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 837952
       GoKind: 22
-      Pointee: 342 UnresolvedPointeeType net/textproto.Error
+      Pointee: 354 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 837856
       GoKind: 22
-      Pointee: 247 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 259 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 249
+      ID: 261
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 248 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 260 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1234240
       GoKind: 22
-      Pointee: 624 UnresolvedPointeeType net/url.Error
+      Pointee: 636 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836800
       GoKind: 22
-      Pointee: 241 GoStringHeaderType net/url.EscapeError
+      Pointee: 253 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 243
+      ID: 255
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 242 GoStringDataType net/url.EscapeError.str
+      Pointee: 254 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 339
+      ID: 351
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 22
-      Pointee: 244 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 256 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 246
+      ID: 258
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 245 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 257 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1949760
       GoKind: 22
-      Pointee: 776 StructureType net/url.URL
+      Pointee: 783 StructureType net/url.URL
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1114400
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 902 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2193472
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType os.File
+      Pointee: 894 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 983424
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType os.LinkError
+      Pointee: 519 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 144
+      ID: 167
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 366816
       GoKind: 22
-      Pointee: 145 GoInterfaceType os.Signal
+      Pointee: 168 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 573
+      ID: 585
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1101728
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType os.SyscallError
+      Pointee: 586 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2189792
       GoKind: 22
-      Pointee: 885 StructureType os.fileWithoutReadFrom
+      Pointee: 892 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2189056
       GoKind: 22
-      Pointee: 883 StructureType os.fileWithoutWriteTo
+      Pointee: 890 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 537
+      ID: 549
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1006080
       GoKind: 22
-      Pointee: 538 UnresolvedPointeeType os/exec.Error
+      Pointee: 550 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 658
+      ID: 670
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1951872
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 671 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1006208
       GoKind: 22
-      Pointee: 540 StructureType os/exec.wrappedError
+      Pointee: 552 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 121
+      ID: 163
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1421184
       GoKind: 22
-      Pointee: 122 StructureType os/signal.signalCtx
+      Pointee: 164 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 862624
       GoKind: 22
-      Pointee: 271 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 283 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 273
+      ID: 285
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 284 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 862528
       GoKind: 22
-      Pointee: 270 BaseType os/user.UnknownUserIdError
+      Pointee: 282 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 324
+      ID: 336
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 833056
       GoKind: 22
-      Pointee: 325 UnresolvedPointeeType reflect.ValueError
+      Pointee: 337 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 851776
       GoKind: 22
-      Pointee: 397 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 409 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 988032
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 526 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 989952
       GoKind: 22
-      Pointee: 519 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 531 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2390,12 +2390,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 988160
       GoKind: 22
-      Pointee: 516 StructureType runtime.boundsError
+      Pointee: 528 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -2411,24 +2411,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1109792
       GoKind: 22
-      Pointee: 576 StructureType runtime.errorAddressString
+      Pointee: 588 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 987776
       GoKind: 22
-      Pointee: 483 GoStringHeaderType runtime.errorString
+      Pointee: 495 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 485
+      ID: 497
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 484 GoStringDataType runtime.errorString.str
+      Pointee: 496 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -2444,24 +2444,24 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 133
+      ID: 121
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375584
       GoKind: 22
-      Pointee: 134 UnresolvedPointeeType runtime.mapextra
+      Pointee: 122 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 989696
       GoKind: 22
-      Pointee: 486 GoStringHeaderType runtime.plainError
+      Pointee: 498 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 487 GoStringDataType runtime.plainError.str
+      Pointee: 499 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2484,12 +2484,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 987392
       GoKind: 22
-      Pointee: 511 UnresolvedPointeeType strconv.NumError
+      Pointee: 523 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -2498,190 +2498,190 @@ Types:
       GoKind: 22
       Pointee: 13 GoStringHeaderType string
     - __kind: PointerType
-      ID: 179
+      ID: 186
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 178 GoStringDataType string.str
+      Pointee: 185 GoStringDataType string.str
     - __kind: PointerType
-      ID: 685
+      ID: 692
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1496256
       GoKind: 22
-      Pointee: 686 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 693 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 699
+      ID: 706
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1616224
       GoKind: 22
-      Pointee: 700 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 707 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 681
+      ID: 688
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1495872
       GoKind: 22
-      Pointee: 682 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 689 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 691
+      ID: 698
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1615456
       GoKind: 22
-      Pointee: 692 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 699 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 705
+      ID: 712
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1685440
       GoKind: 22
-      Pointee: 706 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 713 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 693
+      ID: 700
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1615648
       GoKind: 22
-      Pointee: 694 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 701 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1615264
       GoKind: 22
-      Pointee: 690 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 697 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 701
+      ID: 708
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1684992
       GoKind: 22
-      Pointee: 702 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 709 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 709
+      ID: 716
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1750720
       GoKind: 22
-      Pointee: 710 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 717 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 703
+      ID: 710
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1685216
       GoKind: 22
-      Pointee: 704 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 711 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1496448
       GoKind: 22
-      Pointee: 688 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 695 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1496064
       GoKind: 22
-      Pointee: 684 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 691 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 695
+      ID: 702
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1615840
       GoKind: 22
-      Pointee: 696 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 703 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 707
+      ID: 714
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1685664
       GoKind: 22
-      Pointee: 708 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 715 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 697
+      ID: 704
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1616032
       GoKind: 22
-      Pointee: 698 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 705 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1048416
       GoKind: 22
-      Pointee: 819 StructureType struct { io.Reader; io.Closer }
+      Pointee: 826 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1233120
       GoKind: 22
-      Pointee: 609 BaseType syscall.Errno
+      Pointee: 621 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 675
+      ID: 682
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 990464
       GoKind: 22
-      Pointee: 674 BaseType syscall.Signal
+      Pointee: 681 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 555
+      ID: 567
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1044352
       GoKind: 22
-      Pointee: 556 StructureType text/template.ExecError
+      Pointee: 568 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 139
+      ID: 183
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1421568
       GoKind: 22
-      Pointee: 140 StructureType time.Location
+      Pointee: 184 StructureType time.Location
     - __kind: PointerType
-      ID: 318
+      ID: 330
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 830656
       GoKind: 22
-      Pointee: 319 UnresolvedPointeeType time.ParseError
+      Pointee: 331 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 136
+      ID: 180
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 983936
       GoKind: 22
-      Pointee: 137 StructureType time.Timer
+      Pointee: 181 StructureType time.Timer
     - __kind: PointerType
-      ID: 317
+      ID: 329
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 830560
       GoKind: 22
-      Pointee: 236 GoStringHeaderType time.fileSizeError
+      Pointee: 248 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 238
+      ID: 250
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 237 GoStringDataType time.fileSizeError.str
+      Pointee: 249 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 191
+      ID: 217
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 192 StructureType time.zone
+      Pointee: 218 StructureType time.zone
     - __kind: PointerType
-      ID: 194
+      ID: 220
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367200
       GoKind: 22
-      Pointee: 195 StructureType time.zoneTrans
+      Pointee: 221 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -2725,47 +2725,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 330
+      ID: 342
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 835456
       GoKind: 22
-      Pointee: 331 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 343 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 343
+      ID: 355
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 838336
       GoKind: 22
-      Pointee: 344 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 356 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 838432
       GoKind: 22
-      Pointee: 250 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 262 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 995200
       GoKind: 22
-      Pointee: 524 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 536 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 525
+      ID: 537
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 995328
       GoKind: 22
-      Pointee: 490 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 502 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 783
+      ID: 790
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
     - __kind: GoChannelType
-      ID: 668
+      ID: 680
       Name: <-chan time.Time
       GoRuntimeType: 550144
       GoKind: 18
@@ -2844,7 +2844,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 770
+      ID: 777
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 624512
@@ -2853,7 +2853,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 769
+      ID: 776
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 624416
@@ -2916,7 +2916,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 771
+      ID: 778
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 624608
@@ -2934,7 +2934,7 @@ Types:
       HasCount: true
       Element: 12 BaseType uint64
     - __kind: ArrayType
-      ID: 642
+      ID: 654
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 642080
@@ -2961,7 +2961,7 @@ Types:
       HasCount: true
       Element: 81 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 184
+      ID: 191
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
@@ -2970,7 +2970,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 910
+      ID: 917
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -2978,22 +2978,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 911 PointerType **crypto/x509.Certificate
+          Type: 918 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 918 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 925 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 918
+      ID: 925
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 628 PointerType *crypto/x509.Certificate
+      Element: 640 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 669
+      ID: 230
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 24
       GoRuntimeType: 459904
@@ -3001,22 +3001,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 670 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 231 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 672 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Data: 233 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: GoSliceDataType
-      ID: 672
+      ID: 233
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Element: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: GoSliceHeaderType
-      ID: 903
+      ID: 910
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457504
@@ -3024,22 +3024,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 904 PointerType **mime/multipart.FileHeader
+          Type: 911 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 908 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 915 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 908
+      ID: 915
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 905 PointerType *mime/multipart.FileHeader
+      Element: 912 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 912
+      ID: 919
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469792
@@ -3047,22 +3047,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 913 PointerType *[]*crypto/x509.Certificate
+          Type: 920 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 920 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 927 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 920
+      ID: 927
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 910 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 917 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 914
+      ID: 921
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452960
@@ -3070,76 +3070,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 915 PointerType *[]uint8
+          Type: 922 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 922 GoSliceDataType [][]uint8.array
+      Data: 929 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 922
+      ID: 929
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 215
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 132 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 177 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 754
+      ID: 761
       Name: '[]bucket<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
-      Element: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      Element: 741 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 225
       Name: '[]bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 906
+      ID: 913
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 901 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 908 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 774
+      ID: 781
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 768 GoHMapBucketType bucket<string,[]string>
+      Element: 775 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 198
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 166 GoHMapBucketType bucket<string,float64>
+      Element: 132 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 661
+      ID: 673
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 646 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 196
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 161 GoHMapBucketType bucket<string,interface {}>
+      Element: 127 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 194
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 156 GoHMapBucketType bucket<string,string>
+      Element: 120 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceHeaderType
-      ID: 647
+      ID: 659
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 464512
@@ -3154,15 +3154,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 664 GoSliceDataType []float64.array
+      Data: 676 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 664
+      ID: 676
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 19 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 133
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 24
       GoRuntimeType: 459648
@@ -3170,22 +3170,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 134 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 205 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 199 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 199
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 169 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Element: 135 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 170
+      ID: 136
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 459840
@@ -3193,43 +3193,43 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 171 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 137 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 213 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 207 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 207
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 172 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Element: 138 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 185
+      ID: 211
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 186 GoInterfaceType context.canceler
+      Element: 212 GoInterfaceType context.canceler
     - __kind: ArrayType
-      ID: 751
+      ID: 758
       Name: '[]key<github.com/cihub/seelog.LogLevel>'
       ByteSize: 8
       Count: 8
       HasCount: true
-      Element: 752 BaseType github.com/cihub/seelog.LogLevel
+      Element: 759 BaseType github.com/cihub/seelog.LogLevel
     - __kind: ArrayType
-      ID: 198
+      ID: 192
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 924
+      ID: 931
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454944
@@ -3237,22 +3237,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 925 PointerType *net/http.segment
+          Type: 932 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 927 GoSliceDataType []net/http.segment.array
+      Data: 934 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 927
+      ID: 934
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 926 StructureType net/http.segment
+      Element: 933 StructureType net/http.segment
     - __kind: GoSliceHeaderType
-      ID: 143
+      ID: 166
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 452832
@@ -3260,26 +3260,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 144 PointerType *os.Signal
+          Type: 167 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 196 GoSliceDataType []os.Signal.array
+      Data: 209 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 209
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 145 GoInterfaceType os.Signal
+      Element: 168 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 646
+      ID: 658
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -3294,15 +3294,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 662 GoSliceDataType []string.array
+      Data: 674 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 662
+      ID: 674
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 190
+      ID: 216
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -3310,22 +3310,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 191 PointerType *time.zone
+          Type: 217 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 215 GoSliceDataType []time.zone.array
+      Data: 226 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 226
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 192 StructureType time.zone
+      Element: 218 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 193
+      ID: 219
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459232
@@ -3333,20 +3333,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 194 PointerType *time.zoneTrans
+          Type: 220 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 217 GoSliceDataType []time.zoneTrans.array
+      Data: 228 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 228
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 195 StructureType time.zoneTrans
+      Element: 221 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3363,9 +3363,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 180 GoSliceDataType []uint8.array
+      Data: 187 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 187
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3386,77 +3386,77 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 182 GoSliceDataType []uintptr.array
+      Data: 189 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 189
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 219
+      ID: 222
       Name: '[]val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 220 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 223 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 902
+      ID: 909
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 903 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 910 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 773
+      ID: 780
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 646 GoSliceHeaderType []string
+      Element: 658 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 753
+      ID: 760
       Name: '[]val<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 203
+      ID: 197
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 660
+      ID: 672
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 665 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 201
+      ID: 195
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 127 GoEmptyInterfaceType interface {}
+      Element: 156 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 199
+      ID: 193
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 187
+      ID: 213
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
-      Element: 188 StructureType struct {}
+      Element: 214 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 468
+      ID: 480
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 872608
@@ -3471,27 +3471,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 469 GoSliceDataType archive/tar.headerError.array
+      Data: 481 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 481
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 831
+      ID: 838
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 822
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 833
+      ID: 840
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3501,178 +3501,178 @@ Types:
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 132
+      ID: 177
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 185 ArrayType []key<context.canceler>
+          Type: 211 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 187 ArrayType []val<struct {}>
+          Type: 213 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 131 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 186 GoInterfaceType context.canceler
-      ValueType: 188 StructureType struct {}
+          Type: 176 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 212 GoInterfaceType context.canceler
+      ValueType: 214 StructureType struct {}
     - __kind: GoHMapBucketType
-      ID: 734
+      ID: 741
       Name: bucket<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 751 ArrayType []key<github.com/cihub/seelog.LogLevel>
+          Type: 758 ArrayType []key<github.com/cihub/seelog.LogLevel>
         - Name: values
           Offset: 16
-          Type: 753 ArrayType []val<bool>
+          Type: 760 ArrayType []val<bool>
         - Name: overflow
           Offset: 24
-          Type: 733 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
-      KeyType: 752 BaseType github.com/cihub/seelog.LogLevel
+          Type: 740 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+      KeyType: 759 BaseType github.com/cihub/seelog.LogLevel
       ValueType: 6 BaseType bool
     - __kind: GoHMapBucketType
-      ID: 211
+      ID: 205
       Name: bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 219 ArrayType []val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 222 ArrayType []val<*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 220 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      ValueType: 223 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
-      ID: 901
+      ID: 908
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 902 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 909 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 900 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 907 PointerType *bucket<string,[]*mime/multipart.FileHeader>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 903 GoSliceHeaderType []*mime/multipart.FileHeader
+      ValueType: 910 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoHMapBucketType
-      ID: 768
+      ID: 775
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 773 ArrayType []val<[]string>
+          Type: 780 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 767 PointerType *bucket<string,[]string>
+          Type: 774 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 646 GoSliceHeaderType []string
+      ValueType: 658 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 166
+      ID: 132
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 203 ArrayType []val<float64>
+          Type: 197 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 165 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 634
+      ID: 646
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 660 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 672 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 645 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 665 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
-      ID: 161
+      ID: 127
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 201 ArrayType []val<interface {}>
+          Type: 195 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 160 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 127 GoEmptyInterfaceType interface {}
+      ValueType: 156 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
-      ID: 156
+      ID: 120
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 184 ArrayType [8]uint8
+          Type: 191 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 198 ArrayType []key<string>
+          Type: 192 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 199 ArrayType []val<string>
+          Type: 193 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 155 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 762
+      ID: 769
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3680,12 +3680,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 772
+      ID: 779
       Name: chan bool
       GoRuntimeType: 546368
       GoKind: 18
     - __kind: GoChannelType
-      ID: 146
+      ID: 169
       Name: chan os.Signal
       GoRuntimeType: 552896
       GoKind: 18
@@ -3702,13 +3702,13 @@ Types:
       GoRuntimeType: 534528
       GoKind: 15
     - __kind: BaseType
-      ID: 265
+      ID: 277
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 768928
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 266
+      ID: 278
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 769024
@@ -3716,26 +3716,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 268 PointerType *compress/flate.InternalError.str
+          Type: 280 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 267 GoStringDataType compress/flate.InternalError.str
+      Data: 279 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 267
+      ID: 279
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 870
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 851
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 142
+      ID: 165
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 618368
@@ -3754,19 +3754,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 160
       Name: context.backgroundCtx
       GoRuntimeType: 1667744
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 124 StructureType context.emptyCtx
+          Type: 146 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 112
+      ID: 171
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1828320
@@ -3777,13 +3777,13 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 125 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 126 StructureType sync/atomic.Value
+          Type: 172 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 128 GoMapType map[context.canceler]struct {}
+          Type: 173 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -3793,7 +3793,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 186
+      ID: 212
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1064896
@@ -3806,13 +3806,13 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 561
+      ID: 573
       Name: context.deadlineExceededError
       GoRuntimeType: 1275008
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 124
+      ID: 146
       Name: context.emptyCtx
       GoRuntimeType: 1399808
       GoKind: 25
@@ -3821,7 +3821,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 114
+      ID: 148
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1691392
@@ -3832,11 +3832,11 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 135 GoSubroutineType func() bool
+          Type: 149 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 116
+      ID: 179
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1414656
@@ -3844,29 +3844,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 112 StructureType context.cancelCtx
+          Type: 171 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 136 PointerType *time.Timer
+          Type: 180 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 138 GoTimeType time.Time
+          Type: 182 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 141
+      ID: 162
       Name: context.todoCtx
       GoRuntimeType: 1667968
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 124 StructureType context.emptyCtx
+          Type: 146 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 118
+      ID: 155
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1699648
@@ -3877,14 +3877,14 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 120
+      ID: 158
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1667520
@@ -3896,39 +3896,39 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 262
+      ID: 274
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768640
       GoKind: 2
     - __kind: BaseType
-      ID: 263
+      ID: 275
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768736
       GoKind: 2
     - __kind: BaseType
-      ID: 264
+      ID: 276
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 768832
       GoKind: 2
     - __kind: BaseType
-      ID: 239
+      ID: 251
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 766336
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 522
+      ID: 534
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 900
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2100544
@@ -3957,13 +3957,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 910 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 917 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 912 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 919 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 914 GoSliceHeaderType [][]uint8
+          Type: 921 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -3975,25 +3975,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 916 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 923 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 917 BaseType crypto/tls.CurveID
+          Type: 924 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 917
+      ID: 924
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766144
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 335
+      ID: 347
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 333
+      ID: 345
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1596064
@@ -4004,26 +4004,26 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 642 ArrayType [5]uint8
+          Type: 654 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 643 GoInterfaceType net.Conn
+          Type: 655 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 489
+      ID: 501
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 945088
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 634
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 641
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 384
+      ID: 396
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1598944
@@ -4031,21 +4031,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 628 PointerType *crypto/x509.Certificate
+          Type: 640 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 652 BaseType crypto/x509.InvalidReason
+          Type: 664 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 378
+      ID: 390
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1071040
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 380
+      ID: 392
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1401728
@@ -4053,24 +4053,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 628 PointerType *crypto/x509.Certificate
+          Type: 640 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 261
+      ID: 273
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
     - __kind: BaseType
-      ID: 652
+      ID: 664
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537536
       GoKind: 2
     - __kind: StructureType
-      ID: 536
+      ID: 548
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1365216
@@ -4080,13 +4080,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 386
+      ID: 398
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1071296
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 382
+      ID: 394
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1598752
@@ -4094,15 +4094,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 628 PointerType *crypto/x509.Certificate
+          Type: 640 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 628 PointerType *crypto/x509.Certificate
+          Type: 640 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 427
+      ID: 439
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1245600
@@ -4112,7 +4112,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 431
+      ID: 443
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1245760
@@ -4122,47 +4122,47 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 429
+      ID: 441
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 240
+      ID: 252
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 766432
       GoKind: 6
     - __kind: BaseType
-      ID: 260
+      ID: 272
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 768256
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 357
+      ID: 369
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 534
+      ID: 546
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 349
+      ID: 361
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 355
+      ID: 367
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 353
+      ID: 365
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 363
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 359
+      ID: 371
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1237280
@@ -4172,15 +4172,15 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 458
+      ID: 470
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 456
+      ID: 468
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 274
+      ID: 286
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 771616
@@ -4188,18 +4188,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 276 PointerType *encoding/xml.UnmarshalError.str
+          Type: 288 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 275 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 287 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 275
+      ID: 287
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 461
+      ID: 473
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4216,11 +4216,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 321
+      ID: 333
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 521
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4236,11 +4236,11 @@ Types:
       GoRuntimeType: 534720
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 505
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 495
+      ID: 507
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4250,13 +4250,13 @@ Types:
       GoRuntimeType: 451296
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 777
+      ID: 784
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634400
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 135
+      ID: 149
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 545152
@@ -4268,23 +4268,23 @@ Types:
       GoRuntimeType: 785760
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 916
+      ID: 923
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960448
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 370
+      ID: 382
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 736
+      ID: 743
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 1915744
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 362
+      ID: 374
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1597408
@@ -4292,7 +4292,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 644 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 656 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -4300,25 +4300,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 376
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 661
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 368
+      ID: 380
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1070016
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 663
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 254
+      ID: 266
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 767680
@@ -4326,18 +4326,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 256 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 268 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 255 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 267 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 255
+      ID: 267
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 644
+      ID: 656
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2068064
@@ -4345,13 +4345,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 645 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 657 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 13 GoStringHeaderType string
@@ -4360,7 +4360,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 647 GoSliceHeaderType []float64
+          Type: 659 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 16 BaseType int64
@@ -4369,13 +4369,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 648 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 660 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 650 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 662 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 13 GoStringHeaderType string
@@ -4386,13 +4386,13 @@ Types:
           Offset: 184
           Type: 16 BaseType int64
     - __kind: BaseType
-      ID: 645
+      ID: 657
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 536320
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 251
+      ID: 263
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 767584
@@ -4400,18 +4400,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 253 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 265 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 252 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 264 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 252
+      ID: 264
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 257
+      ID: 269
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 767776
@@ -4419,30 +4419,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 259 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 271 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 258 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 270 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 258
+      ID: 270
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 434
+      ID: 446
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1073856
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 269
+      ID: 281
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 770176
       GoKind: 2
     - __kind: StructureType
-      ID: 401
+      ID: 413
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1402688
@@ -4455,7 +4455,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 405
+      ID: 417
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1600672
@@ -4471,7 +4471,7 @@ Types:
           Offset: 24
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 403
+      ID: 415
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1244160
@@ -4481,7 +4481,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 399
+      ID: 411
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1243840
@@ -4491,14 +4491,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 630
+      ID: 642
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1129760
       GoKind: 21
-      HeaderType: 632 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 644 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 653
+      ID: 665
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1007104
@@ -4513,15 +4513,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 666 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 678 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 666
+      ID: 678
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 413
+      ID: 425
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1403008
@@ -4529,12 +4529,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 630 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 642 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 630 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 642 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 407
+      ID: 419
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1244320
@@ -4544,7 +4544,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 411
+      ID: 423
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1600864
@@ -4555,12 +4555,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 665 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 653 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 665 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 409
+      ID: 421
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1402848
@@ -4573,7 +4573,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 415
+      ID: 427
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1244480
@@ -4581,9 +4581,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 138 GoTimeType time.Time
+          Type: 182 GoTimeType time.Time
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1403328
@@ -4596,7 +4596,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 423
+      ID: 435
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1244800
@@ -4606,7 +4606,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 419
+      ID: 431
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1403168
@@ -4619,7 +4619,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 417
+      ID: 429
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1244640
@@ -4629,7 +4629,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 425
+      ID: 437
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1403488
@@ -4642,29 +4642,29 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: BaseType
-      ID: 752
+      ID: 759
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 771040
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 757
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 744
+      ID: 751
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 753
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 755
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 444
+      ID: 456
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1250720
@@ -4674,11 +4674,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 729
+      ID: 736
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 446
+      ID: 458
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1250880
@@ -4686,17 +4686,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 444 StructureType github.com/cihub/seelog.baseError
+          Type: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 721
+      ID: 728
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 730
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 727
+      ID: 734
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1694080
@@ -4704,12 +4704,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 722 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 729 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 730 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 737 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 450
+      ID: 462
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1251200
@@ -4717,9 +4717,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 444 StructureType github.com/cihub/seelog.baseError
+          Type: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 725
+      ID: 732
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1677152
@@ -4727,13 +4727,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 722 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 729 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 742
+      ID: 749
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 448
+      ID: 460
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1251040
@@ -4741,9 +4741,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 444 StructureType github.com/cihub/seelog.baseError
+          Type: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 452
+      ID: 464
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1251360
@@ -4751,9 +4751,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 444 StructureType github.com/cihub/seelog.baseError
+          Type: 456 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 845
+      ID: 852
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1078720
@@ -4766,7 +4766,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 829
+      ID: 836
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1476288
@@ -4774,36 +4774,36 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 845 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 852 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 848
+      ID: 855
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 548
+      ID: 560
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 562
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 542
+      ID: 554
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 373
+      ID: 385
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1238560
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 556
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 602
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1713312
@@ -4819,11 +4819,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 584
+      ID: 596
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 528
+      ID: 540
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1503648
@@ -4836,7 +4836,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 596
+      ID: 608
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1713760
@@ -4852,13 +4852,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 491
+      ID: 503
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 946240
       GoKind: 8
     - __kind: StructureType
-      ID: 588
+      ID: 600
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1713088
@@ -4874,13 +4874,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 656
+      ID: 668
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 767200
       GoKind: 8
     - __kind: StructureType
-      ID: 586
+      ID: 598
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1712864
@@ -4888,15 +4888,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 656 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 668 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 656 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 668 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 594
+      ID: 606
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1632896
@@ -4909,7 +4909,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 592
+      ID: 604
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1713536
@@ -4925,7 +4925,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 600
+      ID: 612
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1438464
@@ -4935,19 +4935,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 532
+      ID: 544
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1189984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 530
+      ID: 542
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1189856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 598
+      ID: 610
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1633088
@@ -4960,7 +4960,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 289
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 772288
@@ -4968,22 +4968,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 291 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 278 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 290 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 290
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 649
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 554
+      ID: 566
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1260480
@@ -4993,19 +4993,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 280
+      ID: 292
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 772864
       GoKind: 10
     - __kind: BaseType
-      ID: 635
+      ID: 647
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 957760
       GoKind: 10
     - __kind: StructureType
-      ID: 608
+      ID: 620
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1746016
@@ -5016,12 +5016,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 635 BaseType golang.org/x/net/http2.ErrCode
+          Type: 647 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 475
+      ID: 487
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1410208
@@ -5029,12 +5029,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 635 BaseType golang.org/x/net/http2.ErrCode
+          Type: 647 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 296
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 773056
@@ -5042,18 +5042,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 298 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 285 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 297 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 297
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 290
+      ID: 302
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 773248
@@ -5061,18 +5061,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 292 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 304 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 291 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 303 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 291
+      ID: 303
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 287
+      ID: 299
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 773152
@@ -5080,18 +5080,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 289 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 301 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 288 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 300 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 288
+      ID: 300
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 281
+      ID: 293
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 772960
@@ -5099,18 +5099,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 283 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 295 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 282 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 294 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 282
+      ID: 294
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 479
+      ID: 491
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1261760
@@ -5120,13 +5120,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 293
+      ID: 305
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 773344
       GoKind: 2
     - __kind: StructureType
-      ID: 454
+      ID: 466
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1256160
@@ -5136,11 +5136,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 618
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 626
+      ID: 638
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1770592
@@ -5156,7 +5156,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 465
+      ID: 477
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1409248
@@ -5169,11 +5169,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 861
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 552
+      ID: 564
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1372096
@@ -5183,33 +5183,33 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 845
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 436
+      ID: 448
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 546
+      ID: 558
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 616
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 602
+      ID: 614
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1321248
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 347
+      ID: 359
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 711
+      ID: 718
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1235840
@@ -5222,7 +5222,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 680
+      ID: 687
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1401248
@@ -5248,7 +5248,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 169
+      ID: 135
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
       ByteSize: 56
       GoRuntimeType: 1781760
@@ -5265,7 +5265,7 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -5273,7 +5273,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 858
+      ID: 865
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1828832
@@ -5281,29 +5281,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 851 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+          Type: 858 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 861 BaseType time.Duration
+          Type: 868 BaseType time.Duration
     - __kind: GoMapType
-      ID: 157
+      ID: 123
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 984064
       GoKind: 21
-      HeaderType: 159 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 859
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 671
+      ID: 232
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 533568
       GoKind: 10
     - __kind: DDTraceSpanType
-      ID: 148
+      ID: 111
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
       ByteSize: 288
       GoRuntimeType: 2186240
@@ -5311,7 +5311,7 @@ Types:
       RawFields:
         - Name: RWMutex
           Offset: 0
-          Type: 149 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: Name
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -5332,13 +5332,13 @@ Types:
           Type: 16 BaseType int64
         - Name: Meta
           Offset: 104
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: MetaStruct
           Offset: 112
-          Type: 157 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
+          Type: 123 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
         - Name: Metrics
           Offset: 120
-          Type: 162 GoMapType map[string]float64
+          Type: 128 GoMapType map[string]float64
         - Name: SpanID
           Offset: 128
           Type: 12 BaseType uint64
@@ -5353,10 +5353,10 @@ Types:
           Type: 15 BaseType int32
         - Name: SpanLinks
           Offset: 160
-          Type: 167 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 133 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: SpanEvents
           Offset: 184
-          Type: 170 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 136 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -5368,7 +5368,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 173 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+          Type: 139 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
         - Name: integration
           Offset: 224
           Type: 13 GoStringHeaderType string
@@ -5391,7 +5391,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 174
+      ID: 140
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
       ByteSize: 160
       GoRuntimeType: 2040832
@@ -5402,10 +5402,10 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 175 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+          Type: 142 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: errors
           Offset: 24
           Type: 15 BaseType int32
@@ -5417,16 +5417,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 177 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
+          Type: 144 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 12 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 149 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -5435,9 +5435,9 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 167 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 133 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: StructureType
-      ID: 172
+      ID: 138
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1624064
@@ -5451,16 +5451,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 207 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 201 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 212 GoMapType map[string]interface {}
+          Type: 206 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 685
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 221
+      ID: 224
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1777408
@@ -5468,7 +5468,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 676 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
+          Type: 683 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -5483,15 +5483,15 @@ Types:
           Type: 19 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 677 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+          Type: 684 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 676
+      ID: 683
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 942592
       GoKind: 5
     - __kind: StructureType
-      ID: 176
+      ID: 143
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 1963456
@@ -5499,16 +5499,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 149 StructureType sync.RWMutex
+          Type: 112 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 669 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 230 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: tags
           Offset: 48
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 11 BaseType int
@@ -5523,12 +5523,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 671 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
+          Type: 232 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: ArrayType
-      ID: 177
+      ID: 144
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 831424
@@ -5537,11 +5537,11 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 747
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 933
+    - __kind: GoContextImplementationType
+      ID: 153
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1439040
@@ -5550,20 +5550,22 @@ Types:
         - Name: Context
           Offset: 0
           Type: 110 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 738
+      ID: 745
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 818
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 395
+      ID: 407
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 438
+      ID: 450
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1248000
@@ -5573,7 +5575,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 440
+      ID: 452
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1248160
@@ -5583,11 +5585,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 463
+      ID: 475
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 130
+      ID: 175
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -5608,20 +5610,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 131 PointerType *bucket<context.canceler,struct {}>
+          Type: 176 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 131 PointerType *bucket<context.canceler,struct {}>
+          Type: 176 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 132 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 189 GoSliceDataType []bucket<context.canceler,struct {}>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 177 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 215 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
-      ID: 732
+      ID: 739
       Name: hash<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       RawFields:
@@ -5642,20 +5644,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 733 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+          Type: 740 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
         - Name: oldbuckets
           Offset: 24
-          Type: 733 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
+          Type: 740 PointerType *bucket<github.com/cihub/seelog.LogLevel,bool>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 734 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
-      BucketsType: 754 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 741 GoHMapBucketType bucket<github.com/cihub/seelog.LogLevel,bool>
+      BucketsType: 761 GoSliceDataType []bucket<github.com/cihub/seelog.LogLevel,bool>.array
     - __kind: GoHMapHeaderType
-      ID: 209
+      ID: 203
       Name: hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -5676,20 +5678,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 210 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 204 PointerType *bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 211 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 222 GoSliceDataType []bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 205 GoHMapBucketType bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 225 GoSliceDataType []bucket<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
-      ID: 899
+      ID: 906
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
@@ -5710,20 +5712,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 900 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 907 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 900 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 907 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 901 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 906 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 908 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 913 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: GoHMapHeaderType
-      ID: 766
+      ID: 773
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -5744,20 +5746,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 767 PointerType *bucket<string,[]string>
+          Type: 774 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 767 PointerType *bucket<string,[]string>
+          Type: 774 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 768 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 774 GoSliceDataType []bucket<string,[]string>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 775 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 781 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 164
+      ID: 130
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -5778,20 +5780,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 165 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 165 PointerType *bucket<string,float64>
+          Type: 131 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 166 GoHMapBucketType bucket<string,float64>
-      BucketsType: 204 GoSliceDataType []bucket<string,float64>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 132 GoHMapBucketType bucket<string,float64>
+      BucketsType: 198 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 632
+      ID: 644
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -5812,20 +5814,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 645 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 633 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 645 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 634 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 661 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 646 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 673 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
-      ID: 159
+      ID: 125
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -5846,20 +5848,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 160 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 160 PointerType *bucket<string,interface {}>
+          Type: 126 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 161 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 202 GoSliceDataType []bucket<string,interface {}>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 127 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 196 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
-      ID: 154
+      ID: 118
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -5880,20 +5882,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 155 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 155 PointerType *bucket<string,string>
+          Type: 119 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 133 PointerType *runtime.mapextra
-      BucketType: 156 GoHMapBucketType bucket<string,string>
-      BucketsType: 200 GoSliceDataType []bucket<string,string>.array
+          Type: 121 PointerType *runtime.mapextra
+      BucketType: 120 GoHMapBucketType bucket<string,string>
+      BucketsType: 194 GoSliceDataType []bucket<string,string>.array
     - __kind: UnresolvedPointeeType
-      ID: 482
+      ID: 494
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5927,7 +5929,7 @@ Types:
       GoRuntimeType: 533824
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 127
+      ID: 156
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785472
@@ -5940,7 +5942,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 387
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5966,21 +5968,21 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 582
+      ID: 594
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 898
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 580
+      ID: 592
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1291808
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 323
+      ID: 335
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -6061,7 +6063,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 846
+      ID: 853
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 986112
@@ -6074,11 +6076,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 759
+      ID: 766
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1067328
@@ -6091,7 +6093,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 836
+      ID: 843
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 985472
@@ -6104,11 +6106,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 816
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1358656
@@ -6116,9 +6118,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 836 GoInterfaceType io.Reader
+          Type: 843 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 827
+      ID: 834
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1423104
@@ -6126,69 +6128,69 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 836 GoInterfaceType io.Reader
+          Type: 843 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 578
+      ID: 590
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoMapType
-      ID: 128
+      ID: 173
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 880672
       GoKind: 21
-      HeaderType: 130 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 175 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 730
+      ID: 737
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 918240
       GoKind: 21
-      HeaderType: 732 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 739 GoHMapHeaderType hash<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 207
+      ID: 201
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 888448
       GoKind: 21
-      HeaderType: 209 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 203 GoHMapHeaderType hash<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 897
+      ID: 904
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887392
       GoKind: 21
-      HeaderType: 899 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 906 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 896
+      ID: 903
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882592
       GoKind: 21
-      HeaderType: 766 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 773 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 162
+      ID: 128
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 888352
       GoKind: 21
-      HeaderType: 164 GoHMapHeaderType hash<string,float64>
+      HeaderType: 130 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
-      ID: 212
+      ID: 206
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 880192
       GoKind: 21
-      HeaderType: 159 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 125 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
-      ID: 152
+      ID: 116
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
-      HeaderType: 154 GoHMapHeaderType hash<string,string>
+      HeaderType: 118 GoHMapHeaderType hash<string,string>
     - __kind: StructureType
-      ID: 393
+      ID: 405
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1240960
@@ -6198,11 +6200,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 907
+      ID: 914
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1294528
@@ -6210,16 +6212,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 896 GoMapType map[string][]string
+          Type: 903 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 897 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 904 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 847
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 849
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1780736
@@ -6227,16 +6229,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 859 PointerType *io.SectionReader
+          Type: 866 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 846 GoInterfaceType io.Closer
+          Type: 853 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 564
+      ID: 576
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 643
+      ID: 655
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1399968
@@ -6249,35 +6251,35 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 625
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 623
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 578
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 557
+      ID: 569
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1065152
@@ -6285,28 +6287,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 559 PointerType *net.UnknownNetworkError.str
+          Type: 571 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 558 GoStringDataType net.UnknownNetworkError.str
+      Data: 570 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 558
+      ID: 570
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 497
+      ID: 509
       Name: net.canceledError
       GoRuntimeType: 1187552
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 872
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 667
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1962752
@@ -6314,7 +6316,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 643 GoInterfaceType net.Conn
+          Type: 655 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -6325,27 +6327,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 888
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 884
       Name: net.noReadFrom
       GoRuntimeType: 1065408
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 876
+      ID: 883
       Name: net.noWriteTo
       GoRuntimeType: 1065280
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 295
+      ID: 307
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 931
+    - __kind: GoContextImplementationType
+      ID: 151
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1618496
@@ -6357,8 +6359,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 110 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 297
+      ID: 309
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1590880
@@ -6366,7 +6370,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 638 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 650 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -6374,7 +6378,7 @@ Types:
           Offset: 96
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2136224
@@ -6382,12 +6386,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 877 StructureType net.noReadFrom
+          Type: 884 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 874 PointerType *net.TCPConn
+          Type: 881 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2135680
@@ -6395,20 +6399,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 876 StructureType net.noWriteTo
+          Type: 883 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 874 PointerType *net.TCPConn
+          Type: 881 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 568
+      ID: 580
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 627
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 714
+      ID: 721
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 983296
@@ -6421,7 +6425,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 712
+      ID: 719
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 981888
@@ -6434,14 +6438,14 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 764
+      ID: 771
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1917984
       GoKind: 21
-      HeaderType: 766 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 773 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 715
+      ID: 722
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 982016
@@ -6454,15 +6458,15 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 303
+      ID: 315
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 511
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 713
+      ID: 720
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 982272
@@ -6486,7 +6490,7 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 775 PointerType *net/url.URL
+          Type: 782 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -6498,19 +6502,19 @@ Types:
           Type: 11 BaseType int
         - Name: Header
           Offset: 56
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 759 GoInterfaceType io.ReadCloser
+          Type: 766 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 777 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 784 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 16 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6519,16 +6523,16 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 778 GoMapType net/url.Values
+          Type: 785 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 778 GoMapType net/url.Values
+          Type: 785 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 779 PointerType *mime/multipart.Form
+          Type: 786 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 13 GoStringHeaderType string
@@ -6537,13 +6541,13 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 781 PointerType *crypto/tls.ConnectionState
+          Type: 788 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 783 GoChannelType <-chan struct {}
+          Type: 790 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 784 PointerType *net/http.Response
+          Type: 791 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 13 GoStringHeaderType string
@@ -6552,15 +6556,15 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 786 PointerType *net/http.pattern
+          Type: 793 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 152 GoMapType map[string]string
+          Type: 116 GoMapType map[string]string
     - __kind: StructureType
-      ID: 785
+      ID: 792
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2065376
@@ -6583,16 +6587,16 @@ Types:
           Type: 11 BaseType int
         - Name: Header
           Offset: 56
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 759 GoInterfaceType io.ReadCloser
+          Type: 766 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 16 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6601,13 +6605,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 105 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 781 PointerType *crypto/tls.ConnectionState
+          Type: 788 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 104
       Name: net/http.ResponseWriter
@@ -6622,19 +6626,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 857
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 828
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 763
+      ID: 770
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1620032
@@ -6642,10 +6646,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 718 PointerType *net/http.response
+          Type: 725 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6653,31 +6657,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 758
+      ID: 765
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 791
+      ID: 798
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 223
+      ID: 235
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 764224
       GoKind: 10
     - __kind: BaseType
-      ID: 627
+      ID: 639
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 942400
       GoKind: 10
     - __kind: StructureType
-      ID: 306
+      ID: 318
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1592416
@@ -6688,12 +6692,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 627 BaseType net/http.http2ErrCode
+          Type: 639 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 617
+      ID: 629
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1760608
@@ -6704,16 +6708,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 627 BaseType net/http.http2ErrCode
+          Type: 639 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 835
+      ID: 842
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 312
+      ID: 324
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1400448
@@ -6721,12 +6725,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 627 BaseType net/http.http2ErrCode
+          Type: 639 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 227
+      ID: 239
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 764416
@@ -6734,28 +6738,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 229 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 241 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 228 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 240 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 228
+      ID: 240
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 310
+      ID: 322
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1066432
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 806
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 233
+      ID: 245
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 764608
@@ -6763,18 +6767,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 235 PointerType *net/http.http2headerFieldNameError.str
+          Type: 247 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 234 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 246 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 234
+      ID: 246
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 230
+      ID: 242
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 764512
@@ -6782,40 +6786,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 232 PointerType *net/http.http2headerFieldValueError.str
+          Type: 244 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 231 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 243 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 231
+      ID: 243
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 584
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 795
+      ID: 802
       Name: net/http.http2missingBody
       GoRuntimeType: 1187808
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 807
+      ID: 814
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1188320
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 505
+      ID: 517
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1188192
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 224
+      ID: 236
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 764320
@@ -6823,22 +6827,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 226 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 238 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 225 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 237 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 225
+      ID: 237
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 717
+      ID: 724
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1099040
@@ -6846,13 +6850,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 755 PointerType *net/http.http2responseWriterState
+          Type: 762 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 756
+      ID: 763
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 797
+      ID: 804
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1356096
@@ -6860,19 +6864,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 834 PointerType *net/http.http2clientStream
+          Type: 841 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 832
       Name: net/http.noBody
       GoRuntimeType: 1278048
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1357216
@@ -6882,7 +6886,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 787
+      ID: 794
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1702112
@@ -6899,20 +6903,20 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 924 GoSliceHeaderType []net/http.segment
+          Type: 931 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 796
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 830
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 316
+      ID: 328
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1230400
@@ -6922,7 +6926,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: net/http.response
       ByteSize: 224
       GoRuntimeType: 2191264
@@ -6930,16 +6934,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 757 PointerType *net/http.conn
+          Type: 764 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 105 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 759 GoInterfaceType io.ReadCloser
+          Type: 766 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 165 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -6951,19 +6955,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 125 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 760 StructureType sync/atomic.Bool
+          Type: 767 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 761 PointerType *bufio.Writer
+          Type: 768 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 763 StructureType net/http.chunkWriter
+          Type: 770 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 764 GoMapType net/http.Header
+          Type: 771 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -6987,27 +6991,27 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 646 GoSliceHeaderType []string
+          Type: 658 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 760 StructureType sync/atomic.Bool
+          Type: 767 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 769 ArrayType [29]uint8
+          Type: 776 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 770 ArrayType [10]uint8
+          Type: 777 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 771 ArrayType [3]uint8
+          Type: 778 ArrayType [3]uint8
         - Name: closeNotifyCh
           Offset: 208
-          Type: 772 GoChannelType chan bool
+          Type: 779 GoChannelType chan bool
         - Name: didCloseNotify
           Offset: 216
-          Type: 760 StructureType sync/atomic.Bool
+          Type: 767 StructureType sync/atomic.Bool
     - __kind: StructureType
-      ID: 926
+      ID: 933
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1416384
@@ -7023,7 +7027,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 301
+      ID: 313
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1400288
@@ -7036,17 +7040,17 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 631
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 570
+      ID: 582
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1279488
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 503
+      ID: 515
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1357376
@@ -7056,17 +7060,17 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 299
+      ID: 311
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 817
+      ID: 824
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1194720
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 329
+      ID: 341
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1595488
@@ -7082,7 +7086,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 327
+      ID: 339
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1400768
@@ -7095,11 +7099,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 342
+      ID: 354
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 247
+      ID: 259
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 766720
@@ -7107,22 +7111,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 249 PointerType *net/textproto.ProtocolError.str
+          Type: 261 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 248 GoStringDataType net/textproto.ProtocolError.str
+      Data: 260 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 248
+      ID: 260
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 624
+      ID: 636
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 241
+      ID: 253
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 766528
@@ -7130,18 +7134,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 243 PointerType *net/url.EscapeError.str
+          Type: 255 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 242 GoStringDataType net/url.EscapeError.str
+      Data: 254 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 242
+      ID: 254
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 244
+      ID: 256
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 766624
@@ -7149,18 +7153,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 246 PointerType *net/url.InvalidHostError.str
+          Type: 258 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 245 GoStringDataType net/url.InvalidHostError.str
+      Data: 257 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 245
+      ID: 257
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 776
+      ID: 783
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1986816
@@ -7174,7 +7178,7 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 894 PointerType *net/url.Userinfo
+          Type: 901 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 13 GoStringHeaderType string
@@ -7200,26 +7204,26 @@ Types:
           Offset: 128
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 902
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 778
+      ID: 785
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1671328
       GoKind: 21
-      HeaderType: 766 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 773 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 894
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 519
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 145
+      ID: 168
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1067072
@@ -7232,11 +7236,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 586
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2203488
@@ -7244,12 +7248,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 889 StructureType os.noReadFrom
+          Type: 896 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 886 PointerType *os.File
+          Type: 893 PointerType *os.File
     - __kind: StructureType
-      ID: 883
+      ID: 890
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2202688
@@ -7257,32 +7261,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 888 StructureType os.noWriteTo
+          Type: 895 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 886 PointerType *os.File
+          Type: 893 PointerType *os.File
     - __kind: StructureType
-      ID: 889
+      ID: 896
       Name: os.noReadFrom
       GoRuntimeType: 1066944
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 888
+      ID: 895
       Name: os.noWriteTo
       GoRuntimeType: 1066816
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 538
+      ID: 550
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 671
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 540
+      ID: 552
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1503840
@@ -7295,7 +7299,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 122
+      ID: 164
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1828576
@@ -7306,17 +7310,17 @@ Types:
           Type: 110 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 142 GoSubroutineType context.CancelFunc
+          Type: 165 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 143 GoSliceHeaderType []os.Signal
+          Type: 166 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 146 GoChannelType chan os.Signal
+          Type: 169 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 283
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 770944
@@ -7324,36 +7328,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *os/user.UnknownGroupIdError.str
+          Type: 285 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 272 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 284 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 284
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 270
+      ID: 282
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 770848
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 325
+      ID: 337
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 397
+      ID: 409
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 526
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 519
+      ID: 531
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7365,7 +7369,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 516
+      ID: 528
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1751168
@@ -7382,9 +7386,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 657 BaseType runtime.boundsErrorCode
+          Type: 669 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 657
+      ID: 669
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 534912
@@ -7404,7 +7408,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 576
+      ID: 588
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1627136
@@ -7417,7 +7421,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 483
+      ID: 495
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 943648
@@ -7425,13 +7429,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 485 PointerType *runtime.errorString.str
+          Type: 497 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 484 GoStringDataType runtime.errorString.str
+      Data: 496 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 484
+      ID: 496
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8008,7 +8012,7 @@ Types:
           Offset: 24
           Type: 30 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 134
+      ID: 122
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -8057,7 +8061,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 486
+      ID: 498
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 944224
@@ -8065,13 +8069,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 488 PointerType *runtime.plainError.str
+          Type: 500 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 487 GoStringDataType runtime.plainError.str
+      Data: 499 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 487
+      ID: 499
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8153,7 +8157,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 511
+      ID: 523
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8165,18 +8169,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 179 PointerType *string.str
+          Type: 186 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 178 GoStringDataType string.str
+      Data: 185 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 178
+      ID: 185
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 686
+      ID: 693
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1810688
@@ -8184,12 +8188,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 700
+      ID: 707
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1885792
@@ -8197,15 +8201,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 682
+      ID: 689
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1810176
@@ -8213,12 +8217,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 692
+      ID: 699
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1884640
@@ -8226,15 +8230,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 706
+      ID: 713
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1947744
@@ -8242,18 +8246,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 694
+      ID: 701
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1884928
@@ -8261,15 +8265,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 690
+      ID: 697
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1884352
@@ -8277,15 +8281,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 702
+      ID: 709
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1947104
@@ -8293,18 +8297,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 710
+      ID: 717
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2005632
@@ -8312,21 +8316,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 704
+      ID: 711
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1947424
@@ -8334,18 +8338,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 712 GoInterfaceType net/http.Flusher
+          Type: 719 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 688
+      ID: 695
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1810944
@@ -8353,12 +8357,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 684
+      ID: 691
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1810432
@@ -8366,12 +8370,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 696
+      ID: 703
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1885216
@@ -8379,15 +8383,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 708
+      ID: 715
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1948064
@@ -8395,18 +8399,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 714 GoInterfaceType net/http.CloseNotifier
+          Type: 721 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 698
+      ID: 705
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1885504
@@ -8414,15 +8418,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 711 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 718 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 713 GoInterfaceType net/http.Pusher
+          Type: 720 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 715 GoInterfaceType net/http.Hijacker
+          Type: 722 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 819
+      ID: 826
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1515552
@@ -8430,18 +8434,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 836 GoInterfaceType io.Reader
+          Type: 843 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 846 GoInterfaceType io.Closer
+          Type: 853 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 188
+      ID: 214
       Name: struct {}
       GoRuntimeType: 777280
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 125
+      ID: 113
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1282688
@@ -8454,7 +8458,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 149
+      ID: 112
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1707488
@@ -8462,7 +8466,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 125 StructureType sync.Mutex
+          Type: 113 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -8471,12 +8475,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 150 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 150 StructureType sync/atomic.Int32
+          Type: 114 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 760
+      ID: 767
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1283968
@@ -8484,12 +8488,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 151 StructureType sync/atomic.noCopy
+          Type: 115 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 150
+      ID: 114
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1284128
@@ -8497,12 +8501,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 151 StructureType sync/atomic.noCopy
+          Type: 115 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 15 BaseType int32
     - __kind: StructureType
-      ID: 126
+      ID: 172
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1107104
@@ -8510,27 +8514,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 127 GoEmptyInterfaceType interface {}
+          Type: 156 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 151
+      ID: 115
       Name: sync/atomic.noCopy
       GoRuntimeType: 943360
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 609
+      ID: 621
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1188832
       GoKind: 12
     - __kind: BaseType
-      ID: 674
+      ID: 681
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 944416
       GoKind: 2
     - __kind: StructureType
-      ID: 556
+      ID: 568
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1508064
@@ -8543,13 +8547,13 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 861
+      ID: 868
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1777152
       GoKind: 6
     - __kind: StructureType
-      ID: 140
+      ID: 184
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1834528
@@ -8560,10 +8564,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 190 GoSliceHeaderType []time.zone
+          Type: 216 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 193 GoSliceHeaderType []time.zoneTrans
+          Type: 219 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -8575,13 +8579,13 @@ Types:
           Type: 16 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 191 PointerType *time.zone
+          Type: 217 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 319
+      ID: 331
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 138
+      ID: 182
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2215712
@@ -8595,7 +8599,7 @@ Types:
           Type: 16 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 139 PointerType *time.Location
+          Type: 183 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -8605,7 +8609,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 137
+      ID: 181
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1280288
@@ -8613,12 +8617,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 668 GoChannelType <-chan time.Time
+          Type: 680 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 236
+      ID: 248
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 764704
@@ -8626,18 +8630,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 238 PointerType *time.fileSizeError.str
+          Type: 250 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 237 GoStringDataType time.fileSizeError.str
+      Data: 249 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 237
+      ID: 249
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 192
+      ID: 218
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1421376
@@ -8653,7 +8657,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 195
+      ID: 221
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1623872
@@ -8714,7 +8718,7 @@ Types:
       GoRuntimeType: 534848
       GoKind: 26
     - __kind: StructureType
-      ID: 638
+      ID: 650
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1921504
@@ -8725,10 +8729,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 639 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 651 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 640 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 652 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -8743,18 +8747,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 641 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 653 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 641
+      ID: 653
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 944704
       GoKind: 9
     - __kind: StructureType
-      ID: 639
+      ID: 651
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1779968
@@ -8779,17 +8783,17 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 331
+      ID: 343
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 640
+      ID: 652
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 535744
       GoKind: 8
     - __kind: StructureType
-      ID: 344
+      ID: 356
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1235360
@@ -8799,13 +8803,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 250
+      ID: 262
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 766816
       GoKind: 2
     - __kind: StructureType
-      ID: 524
+      ID: 536
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1503264
@@ -8818,7 +8822,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 490
+      ID: 502
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 945568

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -137,124 +137,124 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 972
+      ID: 979
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 664 PointerType *crypto/x509.Certificate
+      Pointee: 676 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 712
+      ID: 263
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 965 PointerType *mime/multipart.FileHeader
+      Pointee: 972 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 138
+      ID: 181
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 139 PointerType *table<context.canceler,struct {}>
+      Pointee: 182 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 776 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 783 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 236
+      ID: 225
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 237 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 226 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 955
+      ID: 962
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 956 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 963 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 815 PointerType *table<string,[]string>
+      Pointee: 822 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 170
+      ID: 136
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 171 PointerType *table<string,float64>
+      Pointee: 137 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 670 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 682 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 165
+      ID: 131
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 166 PointerType *table<string,interface {}>
+      Pointee: 132 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 160
+      ID: 126
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 161 PointerType *table<string,string>
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 971 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 978 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 979 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 986 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 715
+      ID: 266
       Name: '*[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       ByteSize: 8
-      Pointee: 714 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Pointee: 265 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 969 GoSliceDataType []*mime/multipart.FileHeader.array
-    - __kind: PointerType
-      ID: 982
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 981 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 984
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 983 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 707
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 706 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 232
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
-      ByteSize: 8
-      Pointee: 231 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
-    - __kind: PointerType
-      ID: 240
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 239 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 976 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 989
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 988 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 991
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 990 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 719
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 718 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 221
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
+      ByteSize: 8
+      Pointee: 220 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+    - __kind: PointerType
+      ID: 229
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 228 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 996
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 988 GoSliceDataType []net/http.segment.array
+      Pointee: 995 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 206
+      ID: 231
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType []os.Signal.array
+      Pointee: 230 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -263,77 +263,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 705
+      ID: 717
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 704 GoSliceDataType []string.array
+      Pointee: 716 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 242
+      ID: 259
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []time.zone.array
+      Pointee: 258 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 244
+      ID: 261
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []time.zoneTrans.array
+      Pointee: 260 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478144
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 186
+      ID: 193
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []uint8.array
+      Pointee: 192 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 188
+      ID: 195
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []uintptr.array
+      Pointee: 194 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 503
+      ID: 515
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 938400
       GoKind: 22
-      Pointee: 504 GoSliceHeaderType archive/tar.headerError
+      Pointee: 516 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 505 GoSliceDataType archive/tar.headerError.array
+      Pointee: 517 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1247008
       GoKind: 22
-      Pointee: 884 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 891 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 867
+      ID: 874
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1074208
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 875 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1433856
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 893 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1073952
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 873 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -342,12 +342,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1936608
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType bufio.Writer
+      Pointee: 816 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 112
       Name: '*bytes.Buffer'
@@ -356,358 +356,358 @@ Types:
       GoKind: 22
       Pointee: 113 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 426
+      ID: 438
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 911904
       GoKind: 22
-      Pointee: 298 BaseType compress/flate.CorruptInputError
+      Pointee: 310 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 912000
       GoKind: 22
-      Pointee: 299 GoStringHeaderType compress/flate.InternalError
+      Pointee: 311 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 301
+      ID: 313
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 300 GoStringDataType compress/flate.InternalError.str
+      Pointee: 312 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 1967328
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 925 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1615456
       GoKind: 22
-      Pointee: 897 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 904 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 995
+      ID: 164
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1531680
       GoKind: 22
-      Pointee: 128 StructureType context.backgroundCtx
+      Pointee: 165 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 116
+      ID: 175
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1703968
       GoKind: 22
-      Pointee: 117 StructureType context.cancelCtx
+      Pointee: 176 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1173024
       GoKind: 22
-      Pointee: 597 StructureType context.deadlineExceededError
+      Pointee: 609 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 990
+      ID: 150
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1397856
       GoKind: 22
-      Pointee: 129 StructureType context.emptyCtx
+      Pointee: 151 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 118
+      ID: 152
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1398016
       GoKind: 22
-      Pointee: 119 StructureType context.stopCtx
+      Pointee: 153 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 120
+      ID: 183
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1704160
       GoKind: 22
-      Pointee: 121 StructureType context.timerCtx
+      Pointee: 184 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 996
+      ID: 166
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1531840
       GoKind: 22
-      Pointee: 146 StructureType context.todoCtx
+      Pointee: 167 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 122
+      ID: 159
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1531360
       GoKind: 22
-      Pointee: 123 StructureType context.valueCtx
+      Pointee: 160 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 124
+      ID: 162
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1531520
       GoKind: 22
-      Pointee: 125 StructureType context.withoutCancelCtx
+      Pointee: 163 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 910656
       GoKind: 22
-      Pointee: 294 BaseType crypto/aes.KeySizeError
+      Pointee: 306 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 423
+      ID: 435
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 910848
       GoKind: 22
-      Pointee: 295 BaseType crypto/des.KeySizeError
+      Pointee: 307 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911136
       GoKind: 22
-      Pointee: 296 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 308 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 911424
       GoKind: 22
-      Pointee: 297 BaseType crypto/rc4.KeySizeError
+      Pointee: 309 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 901440
       GoKind: 22
-      Pointee: 271 BaseType crypto/tls.AlertError
+      Pointee: 283 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 557
+      ID: 569
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1028768
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 570 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 947
+      ID: 954
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2355584
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 955 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 835 StructureType crypto/tls.ConnectionState
+      Pointee: 842 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 367
+      ID: 379
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 901248
       GoKind: 22
-      Pointee: 368 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 380 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 901152
       GoKind: 22
-      Pointee: 366 StructureType crypto/tls.RecordHeaderError
+      Pointee: 378 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 556
+      ID: 568
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1027104
       GoKind: 22
-      Pointee: 525 BaseType crypto/tls.alert
+      Pointee: 537 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 657
+      ID: 669
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1405536
       GoKind: 22
-      Pointee: 658 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 670 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 664
+      ID: 676
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2030304
       GoKind: 22
-      Pointee: 665 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 677 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 910464
       GoKind: 22
-      Pointee: 419 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 431 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 413 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 425 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 910080
       GoKind: 22
-      Pointee: 415 StructureType crypto/x509.HostnameError
+      Pointee: 427 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 293 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 305 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 571
+      ID: 583
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1037088
       GoKind: 22
-      Pointee: 572 StructureType crypto/x509.SystemRootsError
+      Pointee: 584 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 910560
       GoKind: 22
-      Pointee: 421 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 433 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 910368
       GoKind: 22
-      Pointee: 417 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 429 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 463 StructureType encoding/asn1.StructuralError
+      Pointee: 475 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 466
+      ID: 478
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 920928
       GoKind: 22
-      Pointee: 467 StructureType encoding/asn1.SyntaxError
+      Pointee: 479 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 464
+      ID: 476
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 920832
       GoKind: 22
-      Pointee: 465 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 477 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 901536
       GoKind: 22
-      Pointee: 272 BaseType encoding/base64.CorruptInputError
+      Pointee: 284 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 404
+      ID: 416
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 292 BaseType encoding/hex.InvalidByteError
+      Pointee: 304 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 389
+      ID: 401
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 390 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 402 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 569
+      ID: 581
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1033760
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 582 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 904704
       GoKind: 22
-      Pointee: 382 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 394 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 22
-      Pointee: 388 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 400 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 386 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 398 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 904800
       GoKind: 22
-      Pointee: 384 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 396 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 392 StructureType encoding/json.jsonError
+      Pointee: 404 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 493
+      ID: 505
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932256
       GoKind: 22
-      Pointee: 494 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 506 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 491
+      ID: 503
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 932160
       GoKind: 22
-      Pointee: 492 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 504 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 495
+      ID: 507
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 932352
       GoKind: 22
-      Pointee: 307 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 319 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 309
+      ID: 321
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 320 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 932448
       GoKind: 22
-      Pointee: 497 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 509 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -716,19 +716,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 353
+      ID: 365
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896736
       GoKind: 22
-      Pointee: 354 UnresolvedPointeeType errors.errorString
+      Pointee: 366 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 544
+      ID: 556
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1020064
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType errors.joinError
+      Pointee: 557 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -744,792 +744,792 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1009824
       GoKind: 22
-      Pointee: 529 UnresolvedPointeeType fmt.wrapError
+      Pointee: 541 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 530
+      ID: 542
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1009952
       GoKind: 22
-      Pointee: 531 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 543 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 402
+      ID: 414
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 403 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 415 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 1999584
       GoKind: 22
-      Pointee: 778 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 785 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 394
+      ID: 406
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 906816
       GoKind: 22
-      Pointee: 395 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 407 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 396
+      ID: 408
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 906912
       GoKind: 22
-      Pointee: 397 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 409 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 684
+      ID: 696
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 685 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 697 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 907200
       GoKind: 22
-      Pointee: 401 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 413 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 686
+      ID: 698
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 906720
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 699 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 286 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 298 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 288
+      ID: 300
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 287 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 299 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 393
+      ID: 405
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 906528
       GoKind: 22
-      Pointee: 283 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 295 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 285
+      ID: 297
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 296 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 907104
       GoKind: 22
-      Pointee: 289 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 301 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 291
+      ID: 303
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 290 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 302 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 921504
       GoKind: 22
-      Pointee: 470 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 482 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 468
+      ID: 480
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 921408
       GoKind: 22
-      Pointee: 302 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 314 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 917568
       GoKind: 22
-      Pointee: 437 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 449 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 917760
       GoKind: 22
-      Pointee: 441 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 453 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 917664
       GoKind: 22
-      Pointee: 439 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 451 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 435 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 447 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 709
+      ID: 721
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 708 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 720 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 918144
       GoKind: 22
-      Pointee: 449 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 461 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 917856
       GoKind: 22
-      Pointee: 443 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 455 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 918048
       GoKind: 22
-      Pointee: 447 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 459 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 917952
       GoKind: 22
-      Pointee: 445 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 457 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 450
+      ID: 462
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 918240
       GoKind: 22
-      Pointee: 451 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 463 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 456
+      ID: 468
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 918528
       GoKind: 22
-      Pointee: 457 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 469 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 458
+      ID: 470
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 918624
       GoKind: 22
-      Pointee: 459 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 471 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 454
+      ID: 466
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 918432
       GoKind: 22
-      Pointee: 455 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 467 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 452
+      ID: 464
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 918336
       GoKind: 22
-      Pointee: 453 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 465 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 918816
       GoKind: 22
-      Pointee: 461 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 473 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2298048
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 799 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2282976
       GoKind: 22
-      Pointee: 786 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 793 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2290368
       GoKind: 22
-      Pointee: 788 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 795 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2291008
       GoKind: 22
-      Pointee: 790 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 797 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 479
+      ID: 491
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 929472
       GoKind: 22
-      Pointee: 480 StructureType github.com/cihub/seelog.baseError
+      Pointee: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1790592
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 778 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 929568
       GoKind: 22
-      Pointee: 482 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 494 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1424576
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 770 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1649824
       GoKind: 22
-      Pointee: 765 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 772 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1650592
       GoKind: 22
-      Pointee: 769 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 776 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 485
+      ID: 497
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 929760
       GoKind: 22
-      Pointee: 486 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 498 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1650016
       GoKind: 22
-      Pointee: 767 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 774 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2262464
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 791 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 483
+      ID: 495
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 929664
       GoKind: 22
-      Pointee: 484 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 496 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 487
+      ID: 499
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 929856
       GoKind: 22
-      Pointee: 488 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 500 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1238816
       GoKind: 22
-      Pointee: 882 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 889 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1722976
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 908 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 583
+      ID: 595
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1056544
       GoKind: 22
-      Pointee: 584 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 596 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 585
+      ID: 597
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1056672
       GoKind: 22
-      Pointee: 586 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 598 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1041440
       GoKind: 22
-      Pointee: 578 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 590 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 908928
       GoKind: 22
-      Pointee: 406 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 418 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 579
+      ID: 591
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1044896
       GoKind: 22
-      Pointee: 580 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 592 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1195424
       GoKind: 22
-      Pointee: 626 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 638 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 619
+      ID: 631
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1195040
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 632 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 563
+      ID: 575
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1032864
       GoKind: 22
-      Pointee: 564 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 576 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 631
+      ID: 643
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1195808
       GoKind: 22
-      Pointee: 632 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 644 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 562
+      ID: 574
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1032736
       GoKind: 22
-      Pointee: 527 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 539 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 623
+      ID: 635
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1195296
       GoKind: 22
-      Pointee: 624 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 636 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 621
+      ID: 633
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1195168
       GoKind: 22
-      Pointee: 622 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 634 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 629
+      ID: 641
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1195680
       GoKind: 22
-      Pointee: 630 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 642 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1195552
       GoKind: 22
-      Pointee: 628 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 640 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 635
+      ID: 647
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1196192
       GoKind: 22
-      Pointee: 636 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 648 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1033120
       GoKind: 22
-      Pointee: 568 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 580 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1032992
       GoKind: 22
-      Pointee: 566 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 578 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 633
+      ID: 645
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1196064
       GoKind: 22
-      Pointee: 634 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 646 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 937632
       GoKind: 22
-      Pointee: 310 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 322 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 312
+      ID: 324
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 311 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 323 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 672
+      ID: 684
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1648864
       GoKind: 22
-      Pointee: 673 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 685 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 589
+      ID: 601
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1073312
       GoKind: 22
-      Pointee: 590 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 602 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 507
+      ID: 519
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 939648
       GoKind: 22
-      Pointee: 313 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 325 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 643
+      ID: 655
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1248672
       GoKind: 22
-      Pointee: 644 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 656 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 939936
       GoKind: 22
-      Pointee: 511 StructureType golang.org/x/net/http2.connError
+      Pointee: 523 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 509
+      ID: 521
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 939840
       GoKind: 22
-      Pointee: 317 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 329 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 319
+      ID: 331
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 318 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 330 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 940128
       GoKind: 22
-      Pointee: 323 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 335 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 325
+      ID: 337
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 324 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 336 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 512
+      ID: 524
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 940032
       GoKind: 22
-      Pointee: 320 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 332 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 322
+      ID: 334
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 321 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 333 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 939744
       GoKind: 22
-      Pointee: 314 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 326 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 316
+      ID: 328
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 315 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 327 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 514
+      ID: 526
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 940224
       GoKind: 22
-      Pointee: 515 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 527 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 516
+      ID: 528
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 940320
       GoKind: 22
-      Pointee: 326 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 338 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 489
+      ID: 501
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 931680
       GoKind: 22
-      Pointee: 490 StructureType google.golang.org/grpc.dropError
+      Pointee: 502 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 641
+      ID: 653
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1245472
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 654 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 661
+      ID: 673
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1430336
       GoKind: 22
-      Pointee: 662 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 674 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 935904
       GoKind: 22
-      Pointee: 501 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 513 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1793280
       GoKind: 22
-      Pointee: 907 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 914 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1067552
       GoKind: 22
-      Pointee: 588 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 600 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1551200
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 898 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 472 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 484 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 581
+      ID: 593
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1046304
       GoKind: 22
-      Pointee: 582 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 594 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 639
+      ID: 651
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1211680
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 652 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 637
+      ID: 649
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1211424
       GoKind: 22
-      Pointee: 638 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 650 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 903744
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 392 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 721
+      ID: 728
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1539360
       GoKind: 22
-      Pointee: 722 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 729 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 173
+      ID: 139
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1193376
       GoKind: 22
-      Pointee: 174 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Pointee: 140 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1881440
       GoKind: 22
-      Pointee: 913 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 920 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1783872
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+      Pointee: 912 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 152
+      ID: 146
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoRuntimeType: 2288448
       GoKind: 22
-      Pointee: 153 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 116 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 178
+      ID: 144
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext'
       ByteSize: 8
       GoRuntimeType: 1958688
       GoKind: 22
-      Pointee: 179 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+      Pointee: 145 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
     - __kind: PointerType
-      ID: 176
+      ID: 142
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1180320
       GoKind: 22
-      Pointee: 177 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Pointee: 143 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 719
+      ID: 726
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1180960
       GoKind: 22
-      Pointee: 720 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 727 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 251
+      ID: 254
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1181088
       GoKind: 22
-      Pointee: 252 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 255 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 180
+      ID: 147
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2203104
       GoKind: 22
-      Pointee: 181 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+      Pointee: 148 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2153888
       GoKind: 22
-      Pointee: 782 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
+      Pointee: 789 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 993
+      ID: 157
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1408896
       GoKind: 22
-      Pointee: 994 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
+      Pointee: 158 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2134880
       GoKind: 22
-      Pointee: 780 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
+      Pointee: 787 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1039776
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
+      Pointee: 871 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 430
+      ID: 442
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 915840
       GoKind: 22
-      Pointee: 431 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 443 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 924288
       GoKind: 22
-      Pointee: 474 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 486 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 475
+      ID: 487
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 924384
       GoKind: 22
-      Pointee: 476 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 488 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 933216
       GoKind: 22
-      Pointee: 499 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 511 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 941088
       GoKind: 22
-      Pointee: 518 UnresolvedPointeeType html/template.Error
+      Pointee: 530 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -1566,321 +1566,321 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType int8
     - __kind: PointerType
-      ID: 409
+      ID: 421
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 410 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 422 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 909408
       GoKind: 22
-      Pointee: 408 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 420 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 617
+      ID: 629
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1188896
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 630 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2349280
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType internal/poll.FD
+      Pointee: 953 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 615
+      ID: 627
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1188768
       GoKind: 22
-      Pointee: 616 StructureType internal/poll.errNetClosing
+      Pointee: 628 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 897120
       GoKind: 22
-      Pointee: 356 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 368 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 910
+      ID: 917
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1823264
       GoKind: 22
-      Pointee: 911 UnresolvedPointeeType io.PipeReader
+      Pointee: 918 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1536000
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType io.SectionReader
+      Pointee: 922 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1020576
       GoKind: 22
-      Pointee: 862 StructureType io.nopCloser
+      Pointee: 869 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1183520
       GoKind: 22
-      Pointee: 880 StructureType io.nopCloserWriterTo
+      Pointee: 887 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 613
+      ID: 625
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1188000
       GoKind: 22
-      Pointee: 614 UnresolvedPointeeType io/fs.PathError
+      Pointee: 626 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 136
+      ID: 179
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 137 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 180 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 774 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 781 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 234
+      ID: 223
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 235 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 224 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 954 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 961 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 813 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 820 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 168
+      ID: 134
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 169 GoSwissMapHeaderType map<string,float64>
+      Pointee: 135 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 668 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 680 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 163
+      ID: 129
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 164 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 158
+      ID: 124
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 159 GoSwissMapHeaderType map<string,string>
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 429 StructureType math/big.ErrNaN
+      Pointee: 441 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902304
       GoKind: 22
-      Pointee: 968 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 975 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 833 StructureType mime/multipart.Form
+      Pointee: 840 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1614496
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 900 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1614688
       GoKind: 22
-      Pointee: 895 StructureType mime/multipart.sectionReadCloser
+      Pointee: 902 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 599
+      ID: 611
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1174176
       GoKind: 22
-      Pointee: 600 UnresolvedPointeeType net.AddrError
+      Pointee: 612 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1398656
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType net.DNSError
+      Pointee: 661 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2207136
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType net.IPConn
+      Pointee: 929 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 646
+      ID: 658
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1398336
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType net.OpError
+      Pointee: 659 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 601
+      ID: 613
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1174304
       GoKind: 22
-      Pointee: 602 UnresolvedPointeeType net.ParseError
+      Pointee: 614 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2238400
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType net.TCPConn
+      Pointee: 937 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2281152
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net.UDPConn
+      Pointee: 941 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2237888
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType net.UnixConn
+      Pointee: 935 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 598
+      ID: 610
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1173408
       GoKind: 22
-      Pointee: 593 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 605 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 595
+      ID: 607
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 594 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 606 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1010848
       GoKind: 22
-      Pointee: 533 StructureType net.canceledError
+      Pointee: 545 StructureType net.canceledError
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1994688
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType net.conn
+      Pointee: 927 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 690
+      ID: 702
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1817216
       GoKind: 22
-      Pointee: 691 StructureType net.dialResult·1
+      Pointee: 703 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2284192
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType net.netFD
+      Pointee: 943 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 327
+      ID: 339
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 889728
       GoKind: 22
-      Pointee: 328 UnresolvedPointeeType net.notFoundError
+      Pointee: 340 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 991
+      ID: 155
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1398496
       GoKind: 22
-      Pointee: 992 StructureType net.onlyValuesCtx
+      Pointee: 156 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 329
+      ID: 341
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 890400
       GoKind: 22
-      Pointee: 330 StructureType net.result·2
+      Pointee: 342 StructureType net.result·2
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2223456
       GoKind: 22
-      Pointee: 926 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 933 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2222976
       GoKind: 22
-      Pointee: 924 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 931 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 603
+      ID: 615
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1174944
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType net.temporaryError
+      Pointee: 616 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1398976
       GoKind: 22
-      Pointee: 651 UnresolvedPointeeType net.timeoutError
+      Pointee: 663 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 335
+      ID: 347
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 892992
       GoKind: 22
-      Pointee: 336 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 348 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 534
+      ID: 546
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1014304
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 547 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -1889,559 +1889,559 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1705504
       GoKind: 22
-      Pointee: 838 StructureType net/http.Response
+      Pointee: 845 StructureType net/http.Response
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1782976
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType net/http.body
+      Pointee: 910 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1177504
       GoKind: 22
-      Pointee: 874 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 881 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1014176
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 861 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1880416
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType net/http.conn
+      Pointee: 812 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1012896
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 851 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1016480
       GoKind: 22
-      Pointee: 858 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 865 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 893184
       GoKind: 22
-      Pointee: 255 BaseType net/http.http2ConnectionError
+      Pointee: 267 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 893280
       GoKind: 22
-      Pointee: 339 StructureType net/http.http2GoAwayError
+      Pointee: 351 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 652
+      ID: 664
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1399936
       GoKind: 22
-      Pointee: 653 StructureType net/http.http2StreamError
+      Pointee: 665 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 1996128
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 895 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 344
+      ID: 356
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 894336
       GoKind: 22
-      Pointee: 345 StructureType net/http.http2connError
+      Pointee: 357 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 893760
       GoKind: 22
-      Pointee: 259 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 271 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 261
+      ID: 273
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 260 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 272 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 342
+      ID: 354
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 893856
       GoKind: 22
-      Pointee: 343 StructureType net/http.http2goAwayFlowError
+      Pointee: 355 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1013920
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 859 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 347
+      ID: 359
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 894528
       GoKind: 22
-      Pointee: 265 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 277 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 267
+      ID: 279
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 266 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 278 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 894432
       GoKind: 22
-      Pointee: 262 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 274 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 264
+      ID: 276
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 263 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 275 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 607
+      ID: 619
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1178912
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 620 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 847
+      ID: 854
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1013664
       GoKind: 22
-      Pointee: 848 StructureType net/http.http2missingBody
+      Pointee: 855 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1016736
       GoKind: 22
-      Pointee: 860 StructureType net/http.http2noBodyReader
+      Pointee: 867 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 540
+      ID: 552
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1016608
       GoKind: 22
-      Pointee: 541 StructureType net/http.http2noCachedConnError
+      Pointee: 553 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 340
+      ID: 352
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 893664
       GoKind: 22
-      Pointee: 256 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 268 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 258
+      ID: 270
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 257 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 269 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1014816
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 863 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1995552
       GoKind: 22
-      Pointee: 759 StructureType net/http.http2responseWriter
+      Pointee: 766 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1599328
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 810 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1013792
       GoKind: 22
-      Pointee: 850 StructureType net/http.http2transportResponseBody
+      Pointee: 857 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 845
+      ID: 852
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1013152
       GoKind: 22
-      Pointee: 846 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 853 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1177760
       GoKind: 22
-      Pointee: 878 StructureType net/http.noBody
+      Pointee: 885 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 536
+      ID: 548
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1016224
       GoKind: 22
-      Pointee: 537 StructureType net/http.nothingWrittenError
+      Pointee: 549 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1597408
       GoKind: 22
-      Pointee: 840 StructureType net/http.pattern
+      Pointee: 847 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1012512
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 849 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 875
+      ID: 882
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1177632
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 883 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 894720
       GoKind: 22
-      Pointee: 349 StructureType net/http.requestBodyReadError
+      Pointee: 361 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2189216
       GoKind: 22
-      Pointee: 761 StructureType net/http.response
+      Pointee: 768 StructureType net/http.response
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388544
       GoKind: 22
-      Pointee: 987 StructureType net/http.segment
+      Pointee: 994 StructureType net/http.segment
     - __kind: PointerType
-      ID: 333
+      ID: 345
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 892896
       GoKind: 22
-      Pointee: 334 StructureType net/http.statusError
+      Pointee: 346 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 654
+      ID: 666
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1401376
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 667 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 605
+      ID: 617
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1178784
       GoKind: 22
-      Pointee: 606 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 618 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 538
+      ID: 550
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1016352
       GoKind: 22
-      Pointee: 539 StructureType net/http.transportReadFromServerError
+      Pointee: 551 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1818784
       GoKind: 22
-      Pointee: 909 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 916 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 331
+      ID: 343
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 892128
       GoKind: 22
-      Pointee: 332 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 344 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 869
+      ID: 876
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1074592
       GoKind: 22
-      Pointee: 870 StructureType net/http/httputil.failureToReadBody
+      Pointee: 877 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 361
+      ID: 373
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 899520
       GoKind: 22
-      Pointee: 362 StructureType net/netip.parseAddrError
+      Pointee: 374 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 359
+      ID: 371
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 899424
       GoKind: 22
-      Pointee: 360 StructureType net/netip.parsePrefixError
+      Pointee: 372 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 374
+      ID: 386
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 902784
       GoKind: 22
-      Pointee: 375 UnresolvedPointeeType net/textproto.Error
+      Pointee: 387 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 373
+      ID: 385
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 279 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 291 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 281
+      ID: 293
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 280 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 292 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 659
+      ID: 671
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1406016
       GoKind: 22
-      Pointee: 660 UnresolvedPointeeType net/url.Error
+      Pointee: 672 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 901632
       GoKind: 22
-      Pointee: 273 GoStringHeaderType net/url.EscapeError
+      Pointee: 285 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 275
+      ID: 287
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType net/url.EscapeError.str
+      Pointee: 286 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 372
+      ID: 384
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 276 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 288 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 278
+      ID: 290
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 277 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 289 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 828
+      ID: 835
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2099328
       GoKind: 22
-      Pointee: 829 StructureType net/url.URL
+      Pointee: 836 StructureType net/url.URL
     - __kind: PointerType
-      ID: 949
+      ID: 956
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1191456
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 957 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 191
+      ID: 234
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 192 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 235 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 803 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 247
+      ID: 250
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 251 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 960 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 967 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 823 StructureType noalg.map.group[string][]string
+      Pointee: 830 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 225
+      ID: 214
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 226 StructureType noalg.map.group[string]float64
+      Pointee: 215 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 698
+      ID: 710
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 711 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 217
+      ID: 206
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 218 StructureType noalg.map.group[string]interface {}
+      Pointee: 207 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 209
+      ID: 198
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 210 StructureType noalg.map.group[string]string
+      Pointee: 199 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2324992
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType os.File
+      Pointee: 949 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 542
+      ID: 554
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1018528
       GoKind: 22
-      Pointee: 543 UnresolvedPointeeType os.LinkError
+      Pointee: 555 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 149
+      ID: 172
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 391360
       GoKind: 22
-      Pointee: 150 GoInterfaceType os.Signal
+      Pointee: 173 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 609
+      ID: 621
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1179424
       GoKind: 22
-      Pointee: 610 UnresolvedPointeeType os.SyscallError
+      Pointee: 622 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2320576
       GoKind: 22
-      Pointee: 940 StructureType os.fileWithoutReadFrom
+      Pointee: 947 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2319840
       GoKind: 22
-      Pointee: 938 StructureType os.fileWithoutWriteTo
+      Pointee: 945 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 573
+      ID: 585
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1040032
       GoKind: 22
-      Pointee: 574 UnresolvedPointeeType os/exec.Error
+      Pointee: 586 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 694
+      ID: 706
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2074368
       GoKind: 22
-      Pointee: 695 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 707 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1040160
       GoKind: 22
-      Pointee: 576 StructureType os/exec.wrappedError
+      Pointee: 588 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 126
+      ID: 168
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1602016
       GoKind: 22
-      Pointee: 127 StructureType os/signal.signalCtx
+      Pointee: 169 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 928512
       GoKind: 22
-      Pointee: 304 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 316 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 306
+      ID: 318
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 305 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 317 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 928416
       GoKind: 22
-      Pointee: 303 BaseType os/user.UnknownUserIdError
+      Pointee: 315 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 357
+      ID: 369
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 897888
       GoKind: 22
-      Pointee: 358 UnresolvedPointeeType reflect.ValueError
+      Pointee: 370 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 432
+      ID: 444
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 916800
       GoKind: 22
-      Pointee: 433 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 445 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 550
+      ID: 562
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1023136
       GoKind: 22
-      Pointee: 551 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 563 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 554
+      ID: 566
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1024928
       GoKind: 22
-      Pointee: 555 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 567 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2457,12 +2457,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 552
+      ID: 564
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1023264
       GoKind: 22
-      Pointee: 553 StructureType runtime.boundsError
+      Pointee: 565 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -2478,24 +2478,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 611
+      ID: 623
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1187360
       GoKind: 22
-      Pointee: 612 StructureType runtime.errorAddressString
+      Pointee: 624 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 548
+      ID: 560
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1022752
       GoKind: 22
-      Pointee: 519 GoStringHeaderType runtime.errorString
+      Pointee: 531 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 520 GoStringDataType runtime.errorString.str
+      Pointee: 532 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2511,17 +2511,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1022880
       GoKind: 22
-      Pointee: 522 GoStringHeaderType runtime.plainError
+      Pointee: 534 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 523 GoStringDataType runtime.plainError.str
+      Pointee: 535 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2551,12 +2551,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 546
+      ID: 558
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1022368
       GoKind: 22
-      Pointee: 547 UnresolvedPointeeType strconv.NumError
+      Pointee: 559 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -2565,235 +2565,235 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 184
+      ID: 191
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 183 GoStringDataType string.str
+      Pointee: 190 GoStringDataType string.str
     - __kind: PointerType
-      ID: 727
+      ID: 734
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1676512
       GoKind: 22
-      Pointee: 728 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 735 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1728928
       GoKind: 22
-      Pointee: 742 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 749 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 723
+      ID: 730
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1676128
       GoKind: 22
-      Pointee: 724 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 731 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 733
+      ID: 740
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1728160
       GoKind: 22
-      Pointee: 734 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 741 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1799552
       GoKind: 22
-      Pointee: 748 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 755 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1728352
       GoKind: 22
-      Pointee: 736 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 743 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1727968
       GoKind: 22
-      Pointee: 732 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 739 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1799104
       GoKind: 22
-      Pointee: 744 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 751 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1868736
       GoKind: 22
-      Pointee: 752 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 759 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 745
+      ID: 752
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1799328
       GoKind: 22
-      Pointee: 746 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 753 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 729
+      ID: 736
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1676704
       GoKind: 22
-      Pointee: 730 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 737 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 725
+      ID: 732
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1676320
       GoKind: 22
-      Pointee: 726 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 733 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1728544
       GoKind: 22
-      Pointee: 738 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 745 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1799776
       GoKind: 22
-      Pointee: 750 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 757 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1728736
       GoKind: 22
-      Pointee: 740 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 747 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1081728
       GoKind: 22
-      Pointee: 872 StructureType struct { io.Reader; io.Closer }
+      Pointee: 879 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 656
+      ID: 668
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1404896
       GoKind: 22
-      Pointee: 645 BaseType syscall.Errno
+      Pointee: 657 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 717
+      ID: 724
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1025440
       GoKind: 22
-      Pointee: 716 BaseType syscall.Signal
+      Pointee: 723 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 139
+      ID: 182
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 189 StructureType table<context.canceler,struct {}>
+      Pointee: 232 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 793 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 800 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 237
+      ID: 226
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 245 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 248 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 957 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 964 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 820 StructureType table<string,[]string>
+      Pointee: 827 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 171
+      ID: 137
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 223 StructureType table<string,float64>
+      Pointee: 212 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 670
+      ID: 682
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 696 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 708 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 166
+      ID: 132
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 215 StructureType table<string,interface {}>
+      Pointee: 204 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 161
+      ID: 127
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 207 StructureType table<string,string>
+      Pointee: 196 StructureType table<string,string>
     - __kind: PointerType
-      ID: 591
+      ID: 603
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1077792
       GoKind: 22
-      Pointee: 592 StructureType text/template.ExecError
+      Pointee: 604 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 144
+      ID: 188
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1602400
       GoKind: 22
-      Pointee: 145 StructureType time.Location
+      Pointee: 189 StructureType time.Location
     - __kind: PointerType
-      ID: 351
+      ID: 363
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 895584
       GoKind: 22
-      Pointee: 352 UnresolvedPointeeType time.ParseError
+      Pointee: 364 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 141
+      ID: 185
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1019040
       GoKind: 22
-      Pointee: 142 StructureType time.Timer
+      Pointee: 186 StructureType time.Timer
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 895488
       GoKind: 22
-      Pointee: 268 GoStringHeaderType time.fileSizeError
+      Pointee: 280 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 270
+      ID: 282
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 269 GoStringDataType time.fileSizeError.str
+      Pointee: 281 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 200
+      ID: 243
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391680
       GoKind: 22
-      Pointee: 201 StructureType time.zone
+      Pointee: 244 StructureType time.zone
     - __kind: PointerType
-      ID: 203
+      ID: 246
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391744
       GoKind: 22
-      Pointee: 204 StructureType time.zoneTrans
+      Pointee: 247 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -2837,47 +2837,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 900288
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 376 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 376
+      ID: 388
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 902976
       GoKind: 22
-      Pointee: 377 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 389 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 378
+      ID: 390
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 903072
       GoKind: 22
-      Pointee: 282 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 294 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1030304
       GoKind: 22
-      Pointee: 560 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 572 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 561
+      ID: 573
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1030432
       GoKind: 22
-      Pointee: 526 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 538 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 836
+      ID: 843
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
     - __kind: GoChannelType
-      ID: 710
+      ID: 722
       Name: <-chan time.Time
       GoRuntimeType: 595936
       GoKind: 18
@@ -2963,7 +2963,7 @@ Types:
       HasCount: true
       Element: 92 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 817
+      ID: 824
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 677440
@@ -2972,7 +2972,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 816
+      ID: 823
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 677344
@@ -3044,7 +3044,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 818
+      ID: 825
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 677536
@@ -3062,7 +3062,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 678
+      ID: 690
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 695616
@@ -3089,7 +3089,7 @@ Types:
       HasCount: true
       Element: 85 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 971
+      ID: 978
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498304
@@ -3097,22 +3097,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 972 PointerType **crypto/x509.Certificate
+          Type: 979 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 979 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 986 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 979
+      ID: 986
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 664 PointerType *crypto/x509.Certificate
+      Element: 676 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 711
+      ID: 262
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 24
       GoRuntimeType: 486656
@@ -3120,22 +3120,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 712 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 263 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 714 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Data: 265 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 265
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Element: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: GoSliceHeaderType
-      ID: 963
+      ID: 970
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483744
@@ -3143,76 +3143,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 964 PointerType **mime/multipart.FileHeader
+          Type: 971 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 969 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 976 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 969
+      ID: 976
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 965 PointerType *mime/multipart.FileHeader
+      Element: 972 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 240
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 139 PointerType *table<context.canceler,struct {}>
+      Element: 182 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 800
+      ID: 807
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 776 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 783 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 256
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 237 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 226 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 966
+      ID: 973
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 956 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 963 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 826
+      ID: 833
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 815 PointerType *table<string,[]string>
+      Element: 822 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 218
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 171 PointerType *table<string,float64>
+      Element: 137 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 702
+      ID: 714
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 670 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 682 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 210
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 166 PointerType *table<string,interface {}>
+      Element: 132 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 202
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 161 PointerType *table<string,string>
+      Element: 127 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 973
+      ID: 980
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498432
@@ -3220,22 +3220,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 974 PointerType *[]*crypto/x509.Certificate
+          Type: 981 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 981 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 988 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 981
+      ID: 988
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 971 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 978 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 975
+      ID: 982
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -3243,22 +3243,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 976 PointerType *[]uint8
+          Type: 983 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 983 GoSliceDataType [][]uint8.array
+      Data: 990 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 983
+      ID: 990
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 683
+      ID: 695
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 492416
@@ -3273,15 +3273,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 706 GoSliceDataType []float64.array
+      Data: 718 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 706
+      ID: 718
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 20 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 172
+      ID: 138
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 24
       GoRuntimeType: 486400
@@ -3289,22 +3289,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 139 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 231 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 220 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 220
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 174 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Element: 140 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 141
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 486592
@@ -3312,22 +3312,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 142 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 239 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 228 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 228
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 177 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Element: 143 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 985
+      ID: 992
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481120
@@ -3335,76 +3335,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 986 PointerType *net/http.segment
+          Type: 993 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 988 GoSliceDataType []net/http.segment.array
+      Data: 995 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 988
+      ID: 995
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 987 StructureType net/http.segment
+      Element: 994 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 241
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 192 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 235 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 801
+      ID: 808
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 803 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 257
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 251 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 967
+      ID: 974
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 960 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 967 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 827
+      ID: 834
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 823 StructureType noalg.map.group[string][]string
+      Element: 830 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 219
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 226 StructureType noalg.map.group[string]float64
+      Element: 215 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 703
+      ID: 715
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 711 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 211
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 218 StructureType noalg.map.group[string]interface {}
+      Element: 207 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 203
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 210 StructureType noalg.map.group[string]string
+      Element: 199 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 148
+      ID: 171
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 478336
@@ -3412,26 +3412,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 149 PointerType *os.Signal
+          Type: 172 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 205 GoSliceDataType []os.Signal.array
+      Data: 230 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 230
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 150 GoInterfaceType os.Signal
+      Element: 173 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 682
+      ID: 694
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -3446,15 +3446,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 704 GoSliceDataType []string.array
+      Data: 716 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 704
+      ID: 716
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 199
+      ID: 242
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -3462,22 +3462,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 200 PointerType *time.zone
+          Type: 243 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 241 GoSliceDataType []time.zone.array
+      Data: 258 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 258
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 201 StructureType time.zone
+      Element: 244 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 202
+      ID: 245
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 485856
@@ -3485,20 +3485,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 203 PointerType *time.zoneTrans
+          Type: 246 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 243 GoSliceDataType []time.zoneTrans.array
+      Data: 260 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 260
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 204 StructureType time.zoneTrans
+      Element: 247 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3515,9 +3515,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 185 GoSliceDataType []uint8.array
+      Data: 192 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 192
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3538,15 +3538,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 187 GoSliceDataType []uintptr.array
+      Data: 194 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 194
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 504
+      ID: 516
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 938496
@@ -3561,27 +3561,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 505 GoSliceDataType archive/tar.headerError.array
+      Data: 517 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 505
+      ID: 517
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 884
+      ID: 891
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 875
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 873
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3591,7 +3591,7 @@ Types:
       GoRuntimeType: 580448
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 816
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3599,12 +3599,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 819
+      ID: 826
       Name: chan bool
       GoRuntimeType: 592096
       GoKind: 18
     - __kind: GoChannelType
-      ID: 151
+      ID: 174
       Name: chan os.Signal
       GoRuntimeType: 598752
       GoKind: 18
@@ -3621,13 +3621,13 @@ Types:
       GoRuntimeType: 580192
       GoKind: 15
     - __kind: BaseType
-      ID: 298
+      ID: 310
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831936
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 299
+      ID: 311
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 832032
@@ -3635,26 +3635,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 301 PointerType *compress/flate.InternalError.str
+          Type: 313 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 300 GoStringDataType compress/flate.InternalError.str
+      Data: 312 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 300
+      ID: 312
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 897
+      ID: 904
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 147
+      ID: 170
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 671584
@@ -3673,19 +3673,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 128
+      ID: 165
       Name: context.backgroundCtx
       GoRuntimeType: 1781408
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 129 StructureType context.emptyCtx
+          Type: 151 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 117
+      ID: 176
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1952192
@@ -3696,13 +3696,13 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 130 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 133 StructureType sync/atomic.Value
+          Type: 177 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 135 GoMapType map[context.canceler]struct {}
+          Type: 178 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 16 GoInterfaceType error
@@ -3712,7 +3712,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 195
+      ID: 238
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1098144
@@ -3725,13 +3725,13 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: context.deadlineExceededError
       GoRuntimeType: 1447584
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 129
+      ID: 151
       Name: context.emptyCtx
       GoRuntimeType: 1580160
       GoKind: 25
@@ -3740,7 +3740,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 153
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1806944
@@ -3751,11 +3751,11 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 140 GoSubroutineType func() bool
+          Type: 154 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 184
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1595488
@@ -3763,29 +3763,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 117 StructureType context.cancelCtx
+          Type: 176 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 141 PointerType *time.Timer
+          Type: 185 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 143 GoTimeType time.Time
+          Type: 187 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 146
+      ID: 167
       Name: context.todoCtx
       GoRuntimeType: 1781632
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 129 StructureType context.emptyCtx
+          Type: 151 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 160
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1815648
@@ -3796,14 +3796,14 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 134 GoEmptyInterfaceType interface {}
+          Type: 161 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 134 GoEmptyInterfaceType interface {}
+          Type: 161 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 163
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1781184
@@ -3815,45 +3815,45 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 294
+      ID: 306
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 831552
       GoKind: 2
     - __kind: BaseType
-      ID: 295
+      ID: 307
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 831648
       GoKind: 2
     - __kind: BaseType
-      ID: 296
+      ID: 308
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 831744
       GoKind: 2
     - __kind: BaseType
-      ID: 297
+      ID: 309
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 831840
       GoKind: 2
     - __kind: BaseType
-      ID: 271
+      ID: 283
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 829248
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 570
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 955
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2231616
@@ -3882,13 +3882,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 971 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 978 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 973 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 980 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 975 GoSliceHeaderType [][]uint8
+          Type: 982 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -3900,25 +3900,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 977 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 984 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 978 BaseType crypto/tls.CurveID
+          Type: 985 BaseType crypto/tls.CurveID
     - __kind: BaseType
-      ID: 978
+      ID: 985
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829056
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 368
+      ID: 380
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 366
+      ID: 378
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1709536
@@ -3929,26 +3929,26 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 678 ArrayType [5]uint8
+          Type: 690 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 679 GoInterfaceType net.Conn
+          Type: 691 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 525
+      ID: 537
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 979104
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 658
+      ID: 670
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 665
+      ID: 677
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 419
+      ID: 431
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1711648
@@ -3956,21 +3956,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 664 PointerType *crypto/x509.Certificate
+          Type: 676 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 688 BaseType crypto/x509.InvalidReason
+          Type: 700 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 413
+      ID: 425
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1104416
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 415
+      ID: 427
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1582240
@@ -3978,24 +3978,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 664 PointerType *crypto/x509.Certificate
+          Type: 676 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 293
+      ID: 305
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 831360
       GoKind: 2
     - __kind: BaseType
-      ID: 688
+      ID: 700
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 583200
       GoKind: 2
     - __kind: StructureType
-      ID: 572
+      ID: 584
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1542880
@@ -4005,13 +4005,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1104672
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 417
+      ID: 429
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1711456
@@ -4019,15 +4019,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 664 PointerType *crypto/x509.Certificate
+          Type: 676 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 664 PointerType *crypto/x509.Certificate
+          Type: 676 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 463
+      ID: 475
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1418176
@@ -4037,7 +4037,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 467
+      ID: 479
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1418336
@@ -4047,47 +4047,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 465
+      ID: 477
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 272
+      ID: 284
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 829344
       GoKind: 6
     - __kind: BaseType
-      ID: 292
+      ID: 304
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 831168
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 390
+      ID: 402
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 582
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 382
+      ID: 394
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 388
+      ID: 400
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 386
+      ID: 398
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 384
+      ID: 396
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 392
+      ID: 404
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1409056
@@ -4097,15 +4097,15 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 494
+      ID: 506
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 492
+      ID: 504
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 319
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 834624
@@ -4113,18 +4113,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *encoding/xml.UnmarshalError.str
+          Type: 321 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 320 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 320
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 497
+      ID: 509
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4141,11 +4141,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 354
+      ID: 366
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 557
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4161,11 +4161,11 @@ Types:
       GoRuntimeType: 580384
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 529
+      ID: 541
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 531
+      ID: 543
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4175,13 +4175,13 @@ Types:
       GoRuntimeType: 476736
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 830
+      ID: 837
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687840
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 140
+      ID: 154
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 590880
@@ -4193,23 +4193,23 @@ Types:
       GoRuntimeType: 848960
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 977
+      ID: 984
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 994848
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 403
+      ID: 415
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2039584
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 395
+      ID: 407
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1710688
@@ -4217,7 +4217,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 680 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 692 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4225,25 +4225,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 397
+      ID: 409
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 685
+      ID: 697
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 401
+      ID: 413
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1103520
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 699
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 286
+      ID: 298
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 830592
@@ -4251,18 +4251,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 288 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 300 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 287 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 299 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 287
+      ID: 299
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 680
+      ID: 692
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2198176
@@ -4270,13 +4270,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 681 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 693 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4285,7 +4285,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 683 GoSliceHeaderType []float64
+          Type: 695 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4294,13 +4294,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 684 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 696 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 686 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 698 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4311,13 +4311,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 681
+      ID: 693
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 581984
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 295
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 830496
@@ -4325,18 +4325,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 297 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 284 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 296 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 296
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 289
+      ID: 301
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 830688
@@ -4344,30 +4344,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 291 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 303 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 290 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 302 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 290
+      ID: 302
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 470
+      ID: 482
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1107232
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 302
+      ID: 314
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 833184
       GoKind: 2
     - __kind: StructureType
-      ID: 437
+      ID: 449
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1583040
@@ -4380,7 +4380,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 441
+      ID: 453
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1713376
@@ -4396,7 +4396,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 439
+      ID: 451
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1416736
@@ -4406,7 +4406,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1416416
@@ -4416,14 +4416,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 666
+      ID: 678
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1489024
       GoKind: 21
-      HeaderType: 668 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 680 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 689
+      ID: 701
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1041056
@@ -4438,15 +4438,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 708 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 720 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 708
+      ID: 720
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 449
+      ID: 461
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1583360
@@ -4454,12 +4454,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 666 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 678 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 666 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 678 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 443
+      ID: 455
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1416896
@@ -4469,7 +4469,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 447
+      ID: 459
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1713568
@@ -4480,12 +4480,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 701 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 701 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 445
+      ID: 457
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1583200
@@ -4498,7 +4498,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 451
+      ID: 463
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1417056
@@ -4506,9 +4506,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 143 GoTimeType time.Time
+          Type: 187 GoTimeType time.Time
     - __kind: StructureType
-      ID: 457
+      ID: 469
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1583680
@@ -4521,7 +4521,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 459
+      ID: 471
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1417376
@@ -4531,7 +4531,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 455
+      ID: 467
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1583520
@@ -4544,7 +4544,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 453
+      ID: 465
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1417216
@@ -4554,7 +4554,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 461
+      ID: 473
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1583840
@@ -4567,29 +4567,29 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 799
+      ID: 806
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 834048
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 799
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 786
+      ID: 793
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 788
+      ID: 795
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 790
+      ID: 797
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 480
+      ID: 492
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1423296
@@ -4599,11 +4599,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 778
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 482
+      ID: 494
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1423456
@@ -4611,17 +4611,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 480 StructureType github.com/cihub/seelog.baseError
+          Type: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 770
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 765
+      ID: 772
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 769
+      ID: 776
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1810080
@@ -4629,12 +4629,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 764 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 771 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 772 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 779 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 486
+      ID: 498
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1423776
@@ -4642,9 +4642,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 480 StructureType github.com/cihub/seelog.baseError
+          Type: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 767
+      ID: 774
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1790816
@@ -4652,13 +4652,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 764 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 771 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 791
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 484
+      ID: 496
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1423616
@@ -4666,9 +4666,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 480 StructureType github.com/cihub/seelog.baseError
+          Type: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 488
+      ID: 500
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1423936
@@ -4676,9 +4676,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 480 StructureType github.com/cihub/seelog.baseError
+          Type: 492 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 898
+      ID: 905
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1112096
@@ -4691,7 +4691,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 882
+      ID: 889
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1656544
@@ -4699,36 +4699,36 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 898 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 905 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 908
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 584
+      ID: 596
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 586
+      ID: 598
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 578
+      ID: 590
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 406
+      ID: 418
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1410336
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 580
+      ID: 592
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 626
+      ID: 638
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1830208
@@ -4744,11 +4744,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 632
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 564
+      ID: 576
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1684288
@@ -4761,7 +4761,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 632
+      ID: 644
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1830656
@@ -4777,13 +4777,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 527
+      ID: 539
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 980256
       GoKind: 8
     - __kind: StructureType
-      ID: 624
+      ID: 636
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1829984
@@ -4799,13 +4799,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 692
+      ID: 704
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 830112
       GoKind: 8
     - __kind: StructureType
-      ID: 622
+      ID: 634
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1829760
@@ -4813,15 +4813,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 692 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 704 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 692 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 704 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 630
+      ID: 642
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1745216
@@ -4834,7 +4834,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 628
+      ID: 640
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1830432
@@ -4850,7 +4850,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 636
+      ID: 648
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1618912
@@ -4860,19 +4860,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 568
+      ID: 580
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1269728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 566
+      ID: 578
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1269600
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 634
+      ID: 646
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1745408
@@ -4885,7 +4885,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 310
+      ID: 322
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 835296
@@ -4893,22 +4893,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 312 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 324 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 311 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 323 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 311
+      ID: 323
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 673
+      ID: 685
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 590
+      ID: 602
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1433056
@@ -4918,19 +4918,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 313
+      ID: 325
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 835872
       GoKind: 10
     - __kind: BaseType
-      ID: 671
+      ID: 683
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 991872
       GoKind: 10
     - __kind: StructureType
-      ID: 644
+      ID: 656
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1863136
@@ -4941,12 +4941,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 671 BaseType golang.org/x/net/http2.ErrCode
+          Type: 683 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 511
+      ID: 523
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1590560
@@ -4954,12 +4954,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 671 BaseType golang.org/x/net/http2.ErrCode
+          Type: 683 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 317
+      ID: 329
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836064
@@ -4967,18 +4967,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 319 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 331 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 318 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 330 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 318
+      ID: 330
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 323
+      ID: 335
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836256
@@ -4986,18 +4986,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 325 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 337 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 324 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 336 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 324
+      ID: 336
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 320
+      ID: 332
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836160
@@ -5005,18 +5005,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 322 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 334 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 321 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 333 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 321
+      ID: 333
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 314
+      ID: 326
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 835968
@@ -5024,18 +5024,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 316 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 328 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 315 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 327 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 315
+      ID: 327
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 515
+      ID: 527
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1434336
@@ -5045,13 +5045,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 326
+      ID: 338
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836352
       GoKind: 2
     - __kind: StructureType
-      ID: 490
+      ID: 502
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1428736
@@ -5061,11 +5061,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 654
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 662
+      ID: 674
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1889888
@@ -5081,7 +5081,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1589600
@@ -5094,11 +5094,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 907
+      ID: 914
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 588
+      ID: 600
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1550400
@@ -5108,33 +5108,33 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 898
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 472
+      ID: 484
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 582
+      ID: 594
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 652
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 638
+      ID: 650
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1497184
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 392
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 753
+      ID: 760
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1407616
@@ -5147,7 +5147,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 722
+      ID: 729
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1581760
@@ -5173,7 +5173,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 174
+      ID: 140
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
       ByteSize: 56
       GoRuntimeType: 1900800
@@ -5190,7 +5190,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -5198,7 +5198,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 913
+      ID: 920
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1952704
@@ -5206,29 +5206,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 904 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+          Type: 911 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 916 BaseType time.Duration
+          Type: 923 BaseType time.Duration
     - __kind: GoMapType
-      ID: 162
+      ID: 128
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1268192
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 912
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 713
+      ID: 264
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 579232
       GoKind: 10
     - __kind: DDTraceSpanType
-      ID: 153
+      ID: 116
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
       ByteSize: 288
       GoRuntimeType: 2317024
@@ -5236,7 +5236,7 @@ Types:
       RawFields:
         - Name: RWMutex
           Offset: 0
-          Type: 154 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: Name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -5257,13 +5257,13 @@ Types:
           Type: 15 BaseType int64
         - Name: Meta
           Offset: 104
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: MetaStruct
           Offset: 112
-          Type: 162 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
+          Type: 128 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
         - Name: Metrics
           Offset: 120
-          Type: 167 GoMapType map[string]float64
+          Type: 133 GoMapType map[string]float64
         - Name: SpanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -5278,10 +5278,10 @@ Types:
           Type: 14 BaseType int32
         - Name: SpanLinks
           Offset: 160
-          Type: 172 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 138 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: SpanEvents
           Offset: 184
-          Type: 175 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 141 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -5293,7 +5293,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 178 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+          Type: 144 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -5316,7 +5316,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 179
+      ID: 145
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
       ByteSize: 160
       GoRuntimeType: 2170080
@@ -5327,10 +5327,10 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 180 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+          Type: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: errors
           Offset: 24
           Type: 14 BaseType int32
@@ -5342,16 +5342,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 182 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
+          Type: 149 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 154 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -5360,9 +5360,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 172 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 138 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: StructureType
-      ID: 177
+      ID: 143
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1736768
@@ -5376,16 +5376,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 233 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 222 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 238 GoMapType map[string]interface {}
+          Type: 227 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 720
+      ID: 727
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 252
+      ID: 255
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1896704
@@ -5393,7 +5393,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 718 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
+          Type: 725 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -5408,15 +5408,15 @@ Types:
           Type: 20 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 719 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+          Type: 726 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 718
+      ID: 725
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 976608
       GoKind: 5
     - __kind: StructureType
-      ID: 181
+      ID: 148
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2088064
@@ -5424,16 +5424,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 154 StructureType sync.RWMutex
+          Type: 117 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 711 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 262 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: tags
           Offset: 48
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -5448,12 +5448,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 713 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
+          Type: 264 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: ArrayType
-      ID: 182
+      ID: 149
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 896352
@@ -5462,11 +5462,11 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 782
+      ID: 789
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 994
+    - __kind: GoContextImplementationType
+      ID: 158
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1619488
@@ -5475,20 +5475,22 @@ Types:
         - Name: Context
           Offset: 0
           Type: 115 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 780
+      ID: 787
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 871
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 431
+      ID: 443
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 474
+      ID: 486
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1420576
@@ -5498,7 +5500,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 476
+      ID: 488
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1420736
@@ -5508,137 +5510,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 499
+      ID: 511
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 190
+      ID: 233
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 191 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 234 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 192 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 198 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 235 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 241 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 794
+      ID: 801
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 795 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 802 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 801 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 803 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 808 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 246
+      ID: 249
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 247 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 250 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 251 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 257 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 958
+      ID: 965
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 959 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 966 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 960 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 967 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 967 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 974 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 821
+      ID: 828
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 822 PointerType *noalg.map.group[string][]string
+          Type: 829 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 823 StructureType noalg.map.group[string][]string
-      GroupSliceType: 827 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 830 StructureType noalg.map.group[string][]string
+      GroupSliceType: 834 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 224
+      ID: 213
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 225 PointerType *noalg.map.group[string]float64
+          Type: 214 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 226 StructureType noalg.map.group[string]float64
-      GroupSliceType: 230 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 215 StructureType noalg.map.group[string]float64
+      GroupSliceType: 219 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 697
+      ID: 709
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 698 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 710 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 703 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 711 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 715 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 216
+      ID: 205
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 217 PointerType *noalg.map.group[string]interface {}
+          Type: 206 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 218 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 222 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 207 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 211 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 208
+      ID: 197
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 209 PointerType *noalg.map.group[string]string
+          Type: 198 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 210 StructureType noalg.map.group[string]string
-      GroupSliceType: 214 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 199 StructureType noalg.map.group[string]string
+      GroupSliceType: 203 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 518
+      ID: 530
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5672,7 +5674,7 @@ Types:
       GoRuntimeType: 579488
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 134
+      ID: 161
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 848672
@@ -5685,7 +5687,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 410
+      ID: 422
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5711,25 +5713,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 408
+      ID: 420
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 630
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 953
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 616
+      ID: 628
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1464384
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 356
+      ID: 368
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5810,7 +5812,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 132
+      ID: 120
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1478144
@@ -5823,7 +5825,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 899
+      ID: 906
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1021088
@@ -5836,11 +5838,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 911
+      ID: 918
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 806
+      ID: 813
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1100576
@@ -5853,7 +5855,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 889
+      ID: 896
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1020448
@@ -5866,11 +5868,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 922
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 862
+      ID: 869
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1535840
@@ -5878,9 +5880,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 889 GoInterfaceType io.Reader
+          Type: 896 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 880
+      ID: 887
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1603936
@@ -5888,13 +5890,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 889 GoInterfaceType io.Reader
+          Type: 896 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 614
+      ID: 626
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 137
+      ID: 180
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -5907,7 +5909,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 138 PointerType **table<context.canceler,struct {}>
+          Type: 181 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5923,10 +5925,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 197 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 192 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 240 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 235 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 774
+      ID: 781
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -5939,7 +5941,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 775 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 782 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5955,10 +5957,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 800 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 796 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 807 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 803 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 235
+      ID: 224
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -5971,7 +5973,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 236 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 225 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -5987,10 +5989,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 248 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 256 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 251 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 954
+      ID: 961
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6003,7 +6005,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 955 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 962 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6019,10 +6021,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 966 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 960 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 973 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 967 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 813
+      ID: 820
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6035,7 +6037,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 814 PointerType **table<string,[]string>
+          Type: 821 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6051,10 +6053,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 826 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 823 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 833 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 830 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 169
+      ID: 135
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6067,7 +6069,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 170 PointerType **table<string,float64>
+          Type: 136 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6083,10 +6085,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 229 GoSliceDataType []*table<string,float64>.array
-      GroupType: 226 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 218 GoSliceDataType []*table<string,float64>.array
+      GroupType: 215 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 668
+      ID: 680
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6099,7 +6101,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 669 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 681 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6115,10 +6117,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 702 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 699 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 714 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 711 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 164
+      ID: 130
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6131,7 +6133,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 165 PointerType **table<string,interface {}>
+          Type: 131 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6147,10 +6149,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 221 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 218 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 210 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 207 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 159
+      ID: 125
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6163,7 +6165,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 160 PointerType **table<string,string>
+          Type: 126 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6179,66 +6181,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 213 GoSliceDataType []*table<string,string>.array
-      GroupType: 210 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 202 GoSliceDataType []*table<string,string>.array
+      GroupType: 199 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 135
+      ID: 178
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1116960
       GoKind: 21
-      HeaderType: 137 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 180 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 772
+      ID: 779
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1147488
       GoKind: 21
-      HeaderType: 774 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 781 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 233
+      ID: 222
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1123584
       GoKind: 21
-      HeaderType: 235 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 224 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 952
+      ID: 959
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1122592
       GoKind: 21
-      HeaderType: 954 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 961 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 951
+      ID: 958
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1117984
       GoKind: 21
-      HeaderType: 813 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 820 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 167
+      ID: 133
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1123456
       GoKind: 21
-      HeaderType: 169 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 135 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 238
+      ID: 227
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1116576
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 130 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 157
+      ID: 123
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1119008
       GoKind: 21
-      HeaderType: 159 GoSwissMapHeaderType map<string,string>
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 429
+      ID: 441
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1413536
@@ -6248,11 +6250,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 968
+      ID: 975
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 833
+      ID: 840
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1467264
@@ -6260,16 +6262,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 951 GoMapType map[string][]string
+          Type: 958 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 952 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 959 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 900
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1899776
@@ -6277,16 +6279,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 914 PointerType *io.SectionReader
+          Type: 921 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 899 GoInterfaceType io.Closer
+          Type: 906 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 600
+      ID: 612
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 679
+      ID: 691
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1580320
@@ -6299,35 +6301,35 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 661
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 659
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 602
+      ID: 614
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 937
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 941
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 593
+      ID: 605
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1098400
@@ -6335,28 +6337,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 595 PointerType *net.UnknownNetworkError.str
+          Type: 607 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 594 GoStringDataType net.UnknownNetworkError.str
+      Data: 606 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 594
+      ID: 606
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 533
+      ID: 545
       Name: net.canceledError
       GoRuntimeType: 1267168
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 691
+      ID: 703
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2087008
@@ -6364,7 +6366,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 679 GoInterfaceType net.Conn
+          Type: 691 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -6375,27 +6377,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 932
+      ID: 939
       Name: net.noReadFrom
       GoRuntimeType: 1098656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 931
+      ID: 938
       Name: net.noWriteTo
       GoRuntimeType: 1098528
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 328
+      ID: 340
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 992
+    - __kind: GoContextImplementationType
+      ID: 156
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1731008
@@ -6407,8 +6409,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 115 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 330
+      ID: 342
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1704928
@@ -6416,7 +6420,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 674 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 686 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6424,7 +6428,7 @@ Types:
           Offset: 96
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 926
+      ID: 933
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2265728
@@ -6432,12 +6436,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 932 StructureType net.noReadFrom
+          Type: 939 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 929 PointerType *net.TCPConn
+          Type: 936 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 924
+      ID: 931
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2265184
@@ -6445,20 +6449,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 931 StructureType net.noWriteTo
+          Type: 938 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 929 PointerType *net.TCPConn
+          Type: 936 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 616
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 651
+      ID: 663
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 756
+      ID: 763
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1018400
@@ -6471,7 +6475,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 754
+      ID: 761
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1016992
@@ -6484,14 +6488,14 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 811
+      ID: 818
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2087360
       GoKind: 21
-      HeaderType: 813 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 820 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 757
+      ID: 764
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1017120
@@ -6504,15 +6508,15 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 336
+      ID: 348
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 547
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 755
+      ID: 762
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1017376
@@ -6536,7 +6540,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 828 PointerType *net/url.URL
+          Type: 835 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6548,19 +6552,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 806 GoInterfaceType io.ReadCloser
+          Type: 813 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 830 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 837 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6569,16 +6573,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 831 GoMapType net/url.Values
+          Type: 838 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 831 GoMapType net/url.Values
+          Type: 838 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 832 PointerType *mime/multipart.Form
+          Type: 839 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6587,13 +6591,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 834 PointerType *crypto/tls.ConnectionState
+          Type: 841 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 836 GoChannelType <-chan struct {}
+          Type: 843 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 837 PointerType *net/http.Response
+          Type: 844 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6602,15 +6606,15 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 839 PointerType *net/http.pattern
+          Type: 846 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 157 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
     - __kind: StructureType
-      ID: 838
+      ID: 845
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2195040
@@ -6633,16 +6637,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 806 GoInterfaceType io.ReadCloser
+          Type: 813 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6651,13 +6655,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 110 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 834 PointerType *crypto/tls.ConnectionState
+          Type: 841 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 109
       Name: net/http.ResponseWriter
@@ -6672,19 +6676,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 874
+      ID: 881
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 861
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1732544
@@ -6692,10 +6696,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 760 PointerType *net/http.response
+          Type: 767 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6703,31 +6707,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 851
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 858
+      ID: 865
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 255
+      ID: 267
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 827136
       GoKind: 10
     - __kind: BaseType
-      ID: 663
+      ID: 675
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 976416
       GoKind: 10
     - __kind: StructureType
-      ID: 339
+      ID: 351
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1706656
@@ -6738,12 +6742,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 663 BaseType net/http.http2ErrCode
+          Type: 675 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 653
+      ID: 665
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1880672
@@ -6754,16 +6758,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 663 BaseType net/http.http2ErrCode
+          Type: 675 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 345
+      ID: 357
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1580800
@@ -6771,12 +6775,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 663 BaseType net/http.http2ErrCode
+          Type: 675 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 259
+      ID: 271
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 827328
@@ -6784,28 +6788,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 261 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 273 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 260 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 272 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 260
+      ID: 272
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 343
+      ID: 355
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1099680
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 859
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 265
+      ID: 277
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 827520
@@ -6813,18 +6817,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 267 PointerType *net/http.http2headerFieldNameError.str
+          Type: 279 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 266 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 278 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 266
+      ID: 278
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 262
+      ID: 274
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 827424
@@ -6832,40 +6836,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 264 PointerType *net/http.http2headerFieldValueError.str
+          Type: 276 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 263 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 275 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 263
+      ID: 275
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 620
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 848
+      ID: 855
       Name: net/http.http2missingBody
       GoRuntimeType: 1267424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 860
+      ID: 867
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1267936
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 541
+      ID: 553
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1267808
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 256
+      ID: 268
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 827232
@@ -6873,22 +6877,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 258 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 270 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 257 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 269 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 257
+      ID: 269
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1176864
@@ -6896,13 +6900,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 802 PointerType *net/http.http2responseWriterState
+          Type: 809 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 850
+      ID: 857
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1533120
@@ -6910,19 +6914,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 887 PointerType *net/http.http2clientStream
+          Type: 894 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 846
+      ID: 853
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 878
+      ID: 885
       Name: net/http.noBody
       GoRuntimeType: 1450624
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 537
+      ID: 549
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1534400
@@ -6932,7 +6936,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1818112
@@ -6949,20 +6953,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 985 GoSliceHeaderType []net/http.segment
+          Type: 992 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 849
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 883
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 349
+      ID: 361
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1402176
@@ -6972,7 +6976,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: net/http.response
       ByteSize: 224
       GoRuntimeType: 2322784
@@ -6980,16 +6984,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 804 PointerType *net/http.conn
+          Type: 811 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 110 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 806 GoInterfaceType io.ReadCloser
+          Type: 813 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 147 GoSubroutineType context.CancelFunc
+          Type: 170 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7001,19 +7005,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 130 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 807 StructureType sync/atomic.Bool
+          Type: 814 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 808 PointerType *bufio.Writer
+          Type: 815 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 810 StructureType net/http.chunkWriter
+          Type: 817 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 811 GoMapType net/http.Header
+          Type: 818 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7037,27 +7041,27 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 807 StructureType sync/atomic.Bool
+          Type: 814 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 816 ArrayType [29]uint8
+          Type: 823 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 817 ArrayType [10]uint8
+          Type: 824 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 818 ArrayType [3]uint8
+          Type: 825 ArrayType [3]uint8
         - Name: closeNotifyCh
           Offset: 208
-          Type: 819 GoChannelType chan bool
+          Type: 826 GoChannelType chan bool
         - Name: didCloseNotify
           Offset: 216
-          Type: 807 StructureType sync/atomic.Bool
+          Type: 814 StructureType sync/atomic.Bool
     - __kind: StructureType
-      ID: 987
+      ID: 994
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1597216
@@ -7073,7 +7077,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 334
+      ID: 346
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1580640
@@ -7086,17 +7090,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 667
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 606
+      ID: 618
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1452224
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 539
+      ID: 551
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1534560
@@ -7106,7 +7110,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 909
+      ID: 916
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2011968
@@ -7114,22 +7118,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 679 GoInterfaceType net.Conn
+          Type: 691 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 679 GoInterfaceType net.Conn
+          Type: 691 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 332
+      ID: 344
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 870
+      ID: 877
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1276640
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 362
+      ID: 374
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1709152
@@ -7145,7 +7149,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 360
+      ID: 372
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1581280
@@ -7158,11 +7162,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 375
+      ID: 387
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 279
+      ID: 291
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 829632
@@ -7170,22 +7174,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 281 PointerType *net/textproto.ProtocolError.str
+          Type: 293 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 280 GoStringDataType net/textproto.ProtocolError.str
+      Data: 292 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 280
+      ID: 292
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 660
+      ID: 672
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 285
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 829440
@@ -7193,18 +7197,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *net/url.EscapeError.str
+          Type: 287 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType net/url.EscapeError.str
+      Data: 286 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 286
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 276
+      ID: 288
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 829536
@@ -7212,18 +7216,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 278 PointerType *net/url.InvalidHostError.str
+          Type: 290 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 277 GoStringDataType net/url.InvalidHostError.str
+      Data: 289 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 277
+      ID: 289
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 829
+      ID: 836
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2112256
@@ -7237,7 +7241,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 949 PointerType *net/url.Userinfo
+          Type: 956 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7263,99 +7267,99 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 957
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 831
+      ID: 838
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1870528
       GoKind: 21
-      HeaderType: 813 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 820 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 193
+      ID: 236
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 679264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 194 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 237 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 797
+      ID: 804
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 776000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 798 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 805 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 249
+      ID: 252
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 698496
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 250 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 253 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 961
+      ID: 968
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 962 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 969 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 824
+      ID: 831
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 825 StructureType noalg.struct { key string; elem []string }
+      Element: 832 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 227
+      ID: 216
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 698400
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 228 StructureType noalg.struct { key string; elem float64 }
+      Element: 217 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 700
+      ID: 712
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 753568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 701 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 713 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 219
+      ID: 208
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 675616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 220 StructureType noalg.struct { key string; elem interface {} }
+      Element: 209 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 211
+      ID: 200
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 212 StructureType noalg.struct { key string; elem string }
+      Element: 201 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 192
+      ID: 235
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1278944
@@ -7366,9 +7370,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 193 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 236 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 796
+      ID: 803
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1356256
@@ -7379,9 +7383,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 797 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 804 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 248
+      ID: 251
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1296352
@@ -7392,9 +7396,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 249 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 252 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 960
+      ID: 967
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1289824
@@ -7405,9 +7409,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 961 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 968 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 823
+      ID: 830
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1280352
@@ -7418,9 +7422,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 824 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 831 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 226
+      ID: 215
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1296096
@@ -7431,9 +7435,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 227 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 216 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 699
+      ID: 711
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1337824
@@ -7444,9 +7448,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 700 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 712 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 218
+      ID: 207
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1277792
@@ -7457,9 +7461,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 219 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 208 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 210
+      ID: 199
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1282656
@@ -7470,9 +7474,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 211 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 200 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 194
+      ID: 237
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1278816
@@ -7480,12 +7484,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 195 GoInterfaceType context.canceler
+          Type: 238 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 196 StructureType struct {}
+          Type: 239 StructureType struct {}
     - __kind: StructureType
-      ID: 798
+      ID: 805
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1356128
@@ -7493,12 +7497,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 799 BaseType github.com/cihub/seelog.LogLevel
+          Type: 806 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 250
+      ID: 253
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1296224
@@ -7509,9 +7513,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 251 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 254 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 962
+      ID: 969
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1289696
@@ -7522,9 +7526,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 963 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 970 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 825
+      ID: 832
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1280224
@@ -7535,9 +7539,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 682 GoSliceHeaderType []string
+          Type: 694 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 228
+      ID: 217
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1295968
@@ -7550,7 +7554,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 701
+      ID: 713
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1337696
@@ -7561,9 +7565,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 689 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 701 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 220
+      ID: 209
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1277664
@@ -7574,9 +7578,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 134 GoEmptyInterfaceType interface {}
+          Type: 161 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 212
+      ID: 201
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1282528
@@ -7589,15 +7593,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 949
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 543
+      ID: 555
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 173
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1100320
@@ -7610,11 +7614,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 610
+      ID: 622
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 940
+      ID: 947
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2333440
@@ -7622,12 +7626,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 944 StructureType os.noReadFrom
+          Type: 951 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 941 PointerType *os.File
+          Type: 948 PointerType *os.File
     - __kind: StructureType
-      ID: 938
+      ID: 945
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2332640
@@ -7635,32 +7639,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 943 StructureType os.noWriteTo
+          Type: 950 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 941 PointerType *os.File
+          Type: 948 PointerType *os.File
     - __kind: StructureType
-      ID: 944
+      ID: 951
       Name: os.noReadFrom
       GoRuntimeType: 1100192
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 943
+      ID: 950
       Name: os.noWriteTo
       GoRuntimeType: 1100064
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 574
+      ID: 586
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 695
+      ID: 707
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 576
+      ID: 588
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1684480
@@ -7673,7 +7677,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 127
+      ID: 169
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1952448
@@ -7684,17 +7688,17 @@ Types:
           Type: 115 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 147 GoSubroutineType context.CancelFunc
+          Type: 170 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 148 GoSliceHeaderType []os.Signal
+          Type: 171 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 151 GoChannelType chan os.Signal
+          Type: 174 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 304
+      ID: 316
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 833952
@@ -7702,36 +7706,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 306 PointerType *os/user.UnknownGroupIdError.str
+          Type: 318 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 305 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 317 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 305
+      ID: 317
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 303
+      ID: 315
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 358
+      ID: 370
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 433
+      ID: 445
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 551
+      ID: 563
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 555
+      ID: 567
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7743,7 +7747,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 553
+      ID: 565
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1870080
@@ -7760,9 +7764,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 693 BaseType runtime.boundsErrorCode
+          Type: 705 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 693
+      ID: 705
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 580576
@@ -7782,7 +7786,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 612
+      ID: 624
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1739648
@@ -7795,7 +7799,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 519
+      ID: 531
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 977664
@@ -7803,13 +7807,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 521 PointerType *runtime.errorString.str
+          Type: 533 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 520 GoStringDataType runtime.errorString.str
+      Data: 532 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 520
+      ID: 532
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8465,7 +8469,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 522
+      ID: 534
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 977760
@@ -8473,13 +8477,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 524 PointerType *runtime.plainError.str
+          Type: 536 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 523 GoStringDataType runtime.plainError.str
+      Data: 535 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 523
+      ID: 535
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8565,7 +8569,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 547
+      ID: 559
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8577,18 +8581,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 184 PointerType *string.str
+          Type: 191 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 183 GoStringDataType string.str
+      Data: 190 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 183
+      ID: 190
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 728
+      ID: 735
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1932032
@@ -8596,12 +8600,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 742
+      ID: 749
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2009664
@@ -8609,15 +8613,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 724
+      ID: 731
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1931520
@@ -8625,12 +8629,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 734
+      ID: 741
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2008512
@@ -8638,15 +8642,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 748
+      ID: 755
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2070944
@@ -8654,18 +8658,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 736
+      ID: 743
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2008800
@@ -8673,15 +8677,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 732
+      ID: 739
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2008224
@@ -8689,15 +8693,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 744
+      ID: 751
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2070304
@@ -8705,18 +8709,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 752
+      ID: 759
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2130688
@@ -8724,21 +8728,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 746
+      ID: 753
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2070624
@@ -8746,18 +8750,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 754 GoInterfaceType net/http.Flusher
+          Type: 761 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 730
+      ID: 737
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1932288
@@ -8765,12 +8769,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 726
+      ID: 733
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1931776
@@ -8778,12 +8782,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 738
+      ID: 745
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2009088
@@ -8791,15 +8795,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 750
+      ID: 757
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2071264
@@ -8807,18 +8811,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 756 GoInterfaceType net/http.CloseNotifier
+          Type: 763 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 740
+      ID: 747
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2009376
@@ -8826,15 +8830,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 753 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 760 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 755 GoInterfaceType net/http.Pusher
+          Type: 762 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 757 GoInterfaceType net/http.Hijacker
+          Type: 764 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 872
+      ID: 879
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1689472
@@ -8842,18 +8846,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 889 GoInterfaceType io.Reader
+          Type: 896 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 899 GoInterfaceType io.Closer
+          Type: 906 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 196
+      ID: 239
       Name: struct {}
       GoRuntimeType: 840192
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 130
+      ID: 118
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1455424
@@ -8861,12 +8865,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 131 StructureType sync.noCopy
+          Type: 119 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 132 StructureType internal/sync.Mutex
+          Type: 120 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 154
+      ID: 117
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1823712
@@ -8874,7 +8878,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 130 StructureType sync.Mutex
+          Type: 118 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -8883,18 +8887,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 155 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 155 StructureType sync/atomic.Int32
+          Type: 121 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 131
+      ID: 119
       Name: sync.noCopy
       GoRuntimeType: 977280
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 807
+      ID: 814
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1456544
@@ -8902,12 +8906,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 122 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 155
+      ID: 121
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1456704
@@ -8915,12 +8919,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 156 StructureType sync/atomic.noCopy
+          Type: 122 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 133
+      ID: 177
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1184800
@@ -8928,27 +8932,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 134 GoEmptyInterfaceType interface {}
+          Type: 161 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 156
+      ID: 122
       Name: sync/atomic.noCopy
       GoRuntimeType: 977376
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 645
+      ID: 657
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1268704
       GoKind: 12
     - __kind: BaseType
-      ID: 716
+      ID: 723
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 978624
       GoKind: 2
     - __kind: StructureType
-      ID: 189
+      ID: 232
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -8970,9 +8974,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 190 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 233 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 793
+      ID: 800
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -8994,9 +8998,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 794 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 801 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 245
+      ID: 248
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9018,9 +9022,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 246 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 249 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 957
+      ID: 964
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9042,9 +9046,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 958 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 965 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 820
+      ID: 827
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9066,9 +9070,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 821 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 828 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 223
+      ID: 212
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9090,9 +9094,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 224 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 213 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 696
+      ID: 708
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9114,9 +9118,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 697 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 709 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 215
+      ID: 204
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9138,9 +9142,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 216 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 205 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 207
+      ID: 196
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9162,9 +9166,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 208 GoSwissMapGroupsType groupReference<string,string>
+          Type: 197 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 592
+      ID: 604
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1688704
@@ -9177,13 +9181,13 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 916
+      ID: 923
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1896448
       GoKind: 6
     - __kind: StructureType
-      ID: 145
+      ID: 189
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1957824
@@ -9194,10 +9198,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 199 GoSliceHeaderType []time.zone
+          Type: 242 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 202 GoSliceHeaderType []time.zoneTrans
+          Type: 245 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9209,13 +9213,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 200 PointerType *time.zone
+          Type: 243 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 352
+      ID: 364
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 143
+      ID: 187
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2348320
@@ -9229,7 +9233,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 144 PointerType *time.Location
+          Type: 188 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9239,7 +9243,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 142
+      ID: 186
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1453024
@@ -9247,12 +9251,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 710 GoChannelType <-chan time.Time
+          Type: 722 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 268
+      ID: 280
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 827616
@@ -9260,18 +9264,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 270 PointerType *time.fileSizeError.str
+          Type: 282 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 269 GoStringDataType time.fileSizeError.str
+      Data: 281 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 269
+      ID: 281
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 201
+      ID: 244
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1602208
@@ -9287,7 +9291,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 204
+      ID: 247
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1736576
@@ -9348,7 +9352,7 @@ Types:
       GoRuntimeType: 580512
       GoKind: 26
     - __kind: StructureType
-      ID: 674
+      ID: 686
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2044384
@@ -9359,10 +9363,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 675 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 687 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 676 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 688 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9377,18 +9381,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 677 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 689 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 677
+      ID: 689
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 978720
       GoKind: 9
     - __kind: StructureType
-      ID: 675
+      ID: 687
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1899008
@@ -9413,17 +9417,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 376
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 676
+      ID: 688
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 581408
       GoKind: 8
     - __kind: StructureType
-      ID: 377
+      ID: 389
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1407136
@@ -9433,13 +9437,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 282
+      ID: 294
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 829728
       GoKind: 2
     - __kind: StructureType
-      ID: 560
+      ID: 572
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1683904
@@ -9452,7 +9456,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 526
+      ID: 538
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 979584

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -131,23 +131,23 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 685 PointerType *crypto/x509.Certificate
+      Pointee: 697 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 733
+      ID: 268
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 148 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 986 PointerType *mime/multipart.FileHeader
+      Pointee: 993 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
       ID: 65
       Name: '**runtime.p'
@@ -155,111 +155,111 @@ Types:
       GoKind: 22
       Pointee: 66 PointerType *runtime.p
     - __kind: PointerType
-      ID: 140
+      ID: 183
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 141 PointerType *table<context.canceler,struct {}>
+      Pointee: 184 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 797 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 804 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 241
+      ID: 230
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 242 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 231 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 977 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 984 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 836 PointerType *table<string,[]string>
+      Pointee: 843 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 172
+      ID: 138
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 173 PointerType *table<string,float64>
+      Pointee: 139 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 690
+      ID: 702
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 703 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 167
+      ID: 133
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<string,interface {}>
+      Pointee: 134 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 162
+      ID: 128
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 163 PointerType *table<string,string>
+      Pointee: 129 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 993 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 1000 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 1002
+      ID: 1009
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 1001 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1008 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 736
+      ID: 271
       Name: '*[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       ByteSize: 8
-      Pointee: 735 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Pointee: 270 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 990 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 997 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 193
+      ID: 200
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType []*runtime.p.array
-    - __kind: PointerType
-      ID: 1004
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 1003 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 1006
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 1005 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 728
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 727 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 237
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
-      ByteSize: 8
-      Pointee: 236 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
-    - __kind: PointerType
-      ID: 245
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 244 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 199 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 1011
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1010 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1013
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1012 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 740
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 739 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 226
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
+      ByteSize: 8
+      Pointee: 225 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+    - __kind: PointerType
+      ID: 234
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1018
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1010 GoSliceDataType []net/http.segment.array
+      Pointee: 1017 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 211
+      ID: 236
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 210 GoSliceDataType []os.Signal.array
+      Pointee: 235 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -268,77 +268,77 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 726
+      ID: 738
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 725 GoSliceDataType []string.array
+      Pointee: 737 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 247
+      ID: 264
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []time.zone.array
+      Pointee: 263 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 249
+      ID: 266
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []time.zoneTrans.array
+      Pointee: 265 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 481440
       GoKind: 22
       Pointee: 40 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 188
+      ID: 195
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []uint8.array
+      Pointee: 194 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 190
+      ID: 197
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []uintptr.array
+      Pointee: 196 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 518
+      ID: 530
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 945472
       GoKind: 22
-      Pointee: 519 GoSliceHeaderType archive/tar.headerError
+      Pointee: 531 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 520 GoSliceDataType archive/tar.headerError.array
+      Pointee: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1256000
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 910 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1083040
       GoKind: 22
-      Pointee: 889 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 896 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1443328
       GoKind: 22
-      Pointee: 907 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 914 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1082784
       GoKind: 22
-      Pointee: 887 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 894 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -347,12 +347,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1951776
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType bufio.Writer
+      Pointee: 837 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 114
       Name: '*bytes.Buffer'
@@ -361,372 +361,372 @@ Types:
       GoKind: 22
       Pointee: 115 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 439
+      ID: 451
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 918880
       GoKind: 22
-      Pointee: 306 BaseType compress/flate.CorruptInputError
+      Pointee: 318 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 440
+      ID: 452
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 918976
       GoKind: 22
-      Pointee: 307 GoStringHeaderType compress/flate.InternalError
+      Pointee: 319 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 309
+      ID: 321
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 308 GoStringDataType compress/flate.InternalError.str
+      Pointee: 320 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 1982560
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 946 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1626304
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 925 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 1017
+      ID: 166
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1542304
       GoKind: 22
-      Pointee: 130 StructureType context.backgroundCtx
+      Pointee: 167 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 118
+      ID: 177
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1716736
       GoKind: 22
-      Pointee: 119 StructureType context.cancelCtx
+      Pointee: 178 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 615
+      ID: 627
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1181760
       GoKind: 22
-      Pointee: 616 StructureType context.deadlineExceededError
+      Pointee: 628 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1012
+      ID: 152
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1406848
       GoKind: 22
-      Pointee: 131 StructureType context.emptyCtx
+      Pointee: 153 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 120
+      ID: 154
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1407008
       GoKind: 22
-      Pointee: 121 StructureType context.stopCtx
+      Pointee: 155 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 122
+      ID: 185
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1716928
       GoKind: 22
-      Pointee: 123 StructureType context.timerCtx
+      Pointee: 186 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1018
+      ID: 168
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1542464
       GoKind: 22
-      Pointee: 148 StructureType context.todoCtx
+      Pointee: 169 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 124
+      ID: 161
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1541984
       GoKind: 22
-      Pointee: 125 StructureType context.valueCtx
+      Pointee: 162 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 126
+      ID: 164
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1542144
       GoKind: 22
-      Pointee: 127 StructureType context.withoutCancelCtx
+      Pointee: 165 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 435
+      ID: 447
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 917632
       GoKind: 22
-      Pointee: 302 BaseType crypto/aes.KeySizeError
+      Pointee: 314 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 917824
       GoKind: 22
-      Pointee: 303 BaseType crypto/des.KeySizeError
+      Pointee: 315 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 437
+      ID: 449
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 304 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 316 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1052960
       GoKind: 22
-      Pointee: 597 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 609 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 438
+      ID: 450
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 918400
       GoKind: 22
-      Pointee: 305 BaseType crypto/rc4.KeySizeError
+      Pointee: 317 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 908416
       GoKind: 22
-      Pointee: 276 BaseType crypto/tls.AlertError
+      Pointee: 288 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 572
+      ID: 584
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1037216
       GoKind: 22
-      Pointee: 573 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 585 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2370144
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 976 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 856 StructureType crypto/tls.ConnectionState
+      Pointee: 863 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 377
+      ID: 389
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 908128
       GoKind: 22
-      Pointee: 378 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 390 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 375
+      ID: 387
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 908032
       GoKind: 22
-      Pointee: 376 StructureType crypto/tls.RecordHeaderError
+      Pointee: 388 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 571
+      ID: 583
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1035552
       GoKind: 22
-      Pointee: 540 BaseType crypto/tls.alert
+      Pointee: 552 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 908224
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 392 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 676
+      ID: 688
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1415328
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 689 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 685
+      ID: 697
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2043200
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 698 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 431
+      ID: 443
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 917440
       GoKind: 22
-      Pointee: 432 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 444 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 916960
       GoKind: 22
-      Pointee: 426 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 438 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 917056
       GoKind: 22
-      Pointee: 428 StructureType crypto/x509.HostnameError
+      Pointee: 440 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 424
+      ID: 436
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 916864
       GoKind: 22
-      Pointee: 301 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 313 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1045792
       GoKind: 22
-      Pointee: 589 StructureType crypto/x509.SystemRootsError
+      Pointee: 601 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 433
+      ID: 445
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 434 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 446 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 429
+      ID: 441
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 917344
       GoKind: 22
-      Pointee: 430 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 442 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 475
+      ID: 487
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 927712
       GoKind: 22
-      Pointee: 476 StructureType encoding/asn1.StructuralError
+      Pointee: 488 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 479
+      ID: 491
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927904
       GoKind: 22
-      Pointee: 480 StructureType encoding/asn1.SyntaxError
+      Pointee: 492 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 477
+      ID: 489
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927808
       GoKind: 22
-      Pointee: 478 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 490 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 382
+      ID: 394
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 908512
       GoKind: 22
-      Pointee: 277 BaseType encoding/base64.CorruptInputError
+      Pointee: 289 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 915616
       GoKind: 22
-      Pointee: 297 BaseType encoding/hex.InvalidByteError
+      Pointee: 309 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 401
+      ID: 413
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 912064
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 414 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 584
+      ID: 596
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1042208
       GoKind: 22
-      Pointee: 585 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 597 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 393
+      ID: 405
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 911680
       GoKind: 22
-      Pointee: 394 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 406 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 911968
       GoKind: 22
-      Pointee: 400 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 412 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 911872
       GoKind: 22
-      Pointee: 398 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 410 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 395
+      ID: 407
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 911776
       GoKind: 22
-      Pointee: 396 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 408 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 912448
       GoKind: 22
-      Pointee: 404 StructureType encoding/json.jsonError
+      Pointee: 416 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 509 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 521 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 506
+      ID: 518
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 939232
       GoKind: 22
-      Pointee: 507 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 519 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 510
+      ID: 522
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 939424
       GoKind: 22
-      Pointee: 315 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 327 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 317
+      ID: 329
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 316 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 328 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 939520
       GoKind: 22
-      Pointee: 512 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 524 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -735,19 +735,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 361
+      ID: 373
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 903328
       GoKind: 22
-      Pointee: 362 UnresolvedPointeeType errors.errorString
+      Pointee: 374 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1028512
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType errors.joinError
+      Pointee: 572 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -763,799 +763,799 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 543
+      ID: 555
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1018144
       GoKind: 22
-      Pointee: 544 UnresolvedPointeeType fmt.wrapError
+      Pointee: 556 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 545
+      ID: 557
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1018272
       GoKind: 22
-      Pointee: 546 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 558 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915136
       GoKind: 22
-      Pointee: 415 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 427 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2013056
       GoKind: 22
-      Pointee: 799 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 806 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 406
+      ID: 418
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 913792
       GoKind: 22
-      Pointee: 407 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 419 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 913888
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 421 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 705
+      ID: 717
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 913600
       GoKind: 22
-      Pointee: 706 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 718 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 914176
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 425 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 707
+      ID: 719
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 913696
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 720 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 410
+      ID: 422
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 913984
       GoKind: 22
-      Pointee: 291 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 303 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 293
+      ID: 305
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 292 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 304 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 913504
       GoKind: 22
-      Pointee: 288 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 300 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 290
+      ID: 302
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 301 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 411
+      ID: 423
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 914080
       GoKind: 22
-      Pointee: 294 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 306 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 296
+      ID: 308
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 928576
       GoKind: 22
-      Pointee: 485 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 497 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 481
+      ID: 493
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 928384
       GoKind: 22
-      Pointee: 310 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 322 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 482
+      ID: 494
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 928480
       GoKind: 22
-      Pointee: 483 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
+      Pointee: 495 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 449
+      ID: 461
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 924544
       GoKind: 22
-      Pointee: 450 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 462 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 924736
       GoKind: 22
-      Pointee: 454 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 466 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 451
+      ID: 463
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 924640
       GoKind: 22
-      Pointee: 452 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 464 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 447
+      ID: 459
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 448 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 460 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 730
+      ID: 742
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 741 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 461
+      ID: 473
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 462 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 474 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 924832
       GoKind: 22
-      Pointee: 456 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 468 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 459
+      ID: 471
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 925024
       GoKind: 22
-      Pointee: 460 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 472 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 457
+      ID: 469
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 924928
       GoKind: 22
-      Pointee: 458 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 470 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 463
+      ID: 475
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 925216
       GoKind: 22
-      Pointee: 464 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 476 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 469
+      ID: 481
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 925504
       GoKind: 22
-      Pointee: 470 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 482 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 471
+      ID: 483
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 925600
       GoKind: 22
-      Pointee: 472 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 484 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 467
+      ID: 479
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 925408
       GoKind: 22
-      Pointee: 468 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 480 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 465
+      ID: 477
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 925312
       GoKind: 22
-      Pointee: 466 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 478 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 473
+      ID: 485
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 474 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 486 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2312800
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 820 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2298368
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 814 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2305760
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 816 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2306400
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 818 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 494
+      ID: 506
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 936544
       GoKind: 22
-      Pointee: 495 StructureType github.com/cihub/seelog.baseError
+      Pointee: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1803872
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 799 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 936640
       GoKind: 22
-      Pointee: 497 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 509 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1434048
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 791 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1660864
       GoKind: 22
-      Pointee: 786 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 793 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1661632
       GoKind: 22
-      Pointee: 790 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 797 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 500
+      ID: 512
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 936832
       GoKind: 22
-      Pointee: 501 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 513 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1661056
       GoKind: 22
-      Pointee: 788 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 795 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2277856
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 812 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 498
+      ID: 510
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 936736
       GoKind: 22
-      Pointee: 499 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 511 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 502
+      ID: 514
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 936928
       GoKind: 22
-      Pointee: 503 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 515 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1247808
       GoKind: 22
-      Pointee: 901 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 908 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1735744
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 929 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 602
+      ID: 614
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1065376
       GoKind: 22
-      Pointee: 603 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 615 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 604
+      ID: 616
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1065504
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 617 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 594
+      ID: 606
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1050144
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 607 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 417
+      ID: 429
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 915808
       GoKind: 22
-      Pointee: 418 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 430 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 598
+      ID: 610
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1053728
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 611 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 644
+      ID: 656
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1204032
       GoKind: 22
-      Pointee: 645 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 638
+      ID: 650
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1203648
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 651 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 578
+      ID: 590
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1041312
       GoKind: 22
-      Pointee: 579 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1204416
       GoKind: 22
-      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1041184
       GoKind: 22
-      Pointee: 542 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 554 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 642
+      ID: 654
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1203904
       GoKind: 22
-      Pointee: 643 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 640
+      ID: 652
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1203776
       GoKind: 22
-      Pointee: 641 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1204288
       GoKind: 22
-      Pointee: 649 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 646
+      ID: 658
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1204160
       GoKind: 22
-      Pointee: 647 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 654
+      ID: 666
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1204800
       GoKind: 22
-      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1041568
       GoKind: 22
-      Pointee: 583 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 595 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 580
+      ID: 592
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1041440
       GoKind: 22
-      Pointee: 581 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 652
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1204672
       GoKind: 22
-      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944704
       GoKind: 22
-      Pointee: 318 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 330 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 320
+      ID: 332
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 331 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 693
+      ID: 705
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1659904
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 706 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 608
+      ID: 620
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1082144
       GoKind: 22
-      Pointee: 609 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 621 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 522
+      ID: 534
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 946720
       GoKind: 22
-      Pointee: 321 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 333 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 662
+      ID: 674
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1257664
       GoKind: 22
-      Pointee: 663 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 675 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 525
+      ID: 537
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 947008
       GoKind: 22
-      Pointee: 526 StructureType golang.org/x/net/http2.connError
+      Pointee: 538 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 524
+      ID: 536
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946912
       GoKind: 22
-      Pointee: 325 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 337 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 327
+      ID: 339
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 338 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 947200
       GoKind: 22
-      Pointee: 331 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 343 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 333
+      ID: 345
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 344 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 947104
       GoKind: 22
-      Pointee: 328 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 340 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 330
+      ID: 342
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 341 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946816
       GoKind: 22
-      Pointee: 322 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 334 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 324
+      ID: 336
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 335 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 529
+      ID: 541
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 947296
       GoKind: 22
-      Pointee: 530 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 542 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 531
+      ID: 543
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 947392
       GoKind: 22
-      Pointee: 334 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 346 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 504
+      ID: 516
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 938752
       GoKind: 22
-      Pointee: 505 StructureType google.golang.org/grpc.dropError
+      Pointee: 517 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 660
+      ID: 672
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1254464
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 673 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 680
+      ID: 692
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1439808
       GoKind: 22
-      Pointee: 681 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 693 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 942976
       GoKind: 22
-      Pointee: 516 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 528 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1806560
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 935 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 606
+      ID: 618
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1076384
       GoKind: 22
-      Pointee: 607 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 619 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1561824
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 919 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 486
+      ID: 498
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 930784
       GoKind: 22
-      Pointee: 487 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 499 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 600
+      ID: 612
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1055136
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 613 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 658
+      ID: 670
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1220672
       GoKind: 22
-      Pointee: 659 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 671 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 656
+      ID: 668
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1220416
       GoKind: 22
-      Pointee: 657 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 669 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 391
+      ID: 403
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 910720
       GoKind: 22
-      Pointee: 392 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 404 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 742
+      ID: 749
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1549984
       GoKind: 22
-      Pointee: 743 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 750 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 175
+      ID: 141
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1201984
       GoKind: 22
-      Pointee: 176 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Pointee: 142 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1894848
       GoKind: 22
-      Pointee: 934 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 941 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1797600
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+      Pointee: 933 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 154
+      ID: 148
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoRuntimeType: 2303840
       GoKind: 22
-      Pointee: 155 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 118 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 180
+      ID: 146
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext'
       ByteSize: 8
       GoRuntimeType: 1973632
       GoKind: 22
-      Pointee: 181 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+      Pointee: 147 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
     - __kind: PointerType
-      ID: 178
+      ID: 144
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1188928
       GoKind: 22
-      Pointee: 179 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Pointee: 145 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 740
+      ID: 747
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1189568
       GoKind: 22
-      Pointee: 741 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 748 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 256
+      ID: 259
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1189696
       GoKind: 22
-      Pointee: 257 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 260 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 182
+      ID: 149
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2217952
       GoKind: 22
-      Pointee: 183 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+      Pointee: 150 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2169152
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
+      Pointee: 810 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1015
+      ID: 159
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1418528
       GoKind: 22
-      Pointee: 1016 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
+      Pointee: 160 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2149792
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
+      Pointee: 808 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1048480
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
+      Pointee: 892 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 443
+      ID: 455
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 444 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 456 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 931360
       GoKind: 22
-      Pointee: 489 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 501 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 490
+      ID: 502
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 931456
       GoKind: 22
-      Pointee: 491 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 503 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 940288
       GoKind: 22
-      Pointee: 514 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 526 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 948160
       GoKind: 22
-      Pointee: 533 UnresolvedPointeeType html/template.Error
+      Pointee: 545 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 102
       Name: '*int'
@@ -1592,347 +1592,347 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType int8
     - __kind: PointerType
-      ID: 682
+      ID: 694
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2204960
       GoKind: 22
-      Pointee: 683 UnresolvedPointeeType internal/abi.Type
+      Pointee: 695 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 916480
       GoKind: 22
-      Pointee: 423 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 435 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 916384
       GoKind: 22
-      Pointee: 421 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 433 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1197504
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 649 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2364896
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType internal/poll.FD
+      Pointee: 974 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 634
+      ID: 646
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1197376
       GoKind: 22
-      Pointee: 635 StructureType internal/poll.errNetClosing
+      Pointee: 647 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 903712
       GoKind: 22
-      Pointee: 364 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 376 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 419
+      ID: 431
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 916288
       GoKind: 22
-      Pointee: 298 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 310 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 300
+      ID: 312
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 299 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 311 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 586
+      ID: 598
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1044768
       GoKind: 22
-      Pointee: 587 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 599 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1838240
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType io.PipeReader
+      Pointee: 939 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1546624
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType io.SectionReader
+      Pointee: 943 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1029024
       GoKind: 22
-      Pointee: 883 StructureType io.nopCloser
+      Pointee: 890 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1192128
       GoKind: 22
-      Pointee: 899 StructureType io.nopCloserWriterTo
+      Pointee: 906 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 632
+      ID: 644
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1196352
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType io/fs.PathError
+      Pointee: 645 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 138
+      ID: 181
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 139 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 182 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 795 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 802 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 239
+      ID: 228
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 240 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 229 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 975 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 982 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 834 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 841 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 170
+      ID: 136
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 171 GoSwissMapHeaderType map<string,float64>
+      Pointee: 137 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 688
+      ID: 700
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 701 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 165
+      ID: 131
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 160
+      ID: 126
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 161 GoSwissMapHeaderType map<string,string>
+      Pointee: 127 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 919552
       GoKind: 22
-      Pointee: 442 StructureType math/big.ErrNaN
+      Pointee: 454 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 996 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 854 StructureType mime/multipart.Form
+      Pointee: 861 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1625344
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 921 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1625536
       GoKind: 22
-      Pointee: 916 StructureType mime/multipart.sectionReadCloser
+      Pointee: 923 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1182912
       GoKind: 22
-      Pointee: 619 UnresolvedPointeeType net.AddrError
+      Pointee: 631 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 667
+      ID: 679
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1407648
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType net.DNSError
+      Pointee: 680 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2221536
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType net.IPConn
+      Pointee: 950 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 665
+      ID: 677
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1407328
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType net.OpError
+      Pointee: 678 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1183040
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType net.ParseError
+      Pointee: 633 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2253280
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType net.TCPConn
+      Pointee: 958 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2296544
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType net.UDPConn
+      Pointee: 962 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2252768
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType net.UnixConn
+      Pointee: 956 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 617
+      ID: 629
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1182144
       GoKind: 22
-      Pointee: 612 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 624 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 613 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 625 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 547
+      ID: 559
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1019168
       GoKind: 22
-      Pointee: 548 StructureType net.canceledError
+      Pointee: 560 StructureType net.canceledError
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2008736
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType net.conn
+      Pointee: 948 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 711
+      ID: 723
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1832192
       GoKind: 22
-      Pointee: 712 StructureType net.dialResult·1
+      Pointee: 724 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2299584
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType net.netFD
+      Pointee: 964 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 335
+      ID: 347
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 896320
       GoKind: 22
-      Pointee: 336 UnresolvedPointeeType net.notFoundError
+      Pointee: 348 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1013
+      ID: 157
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1407488
       GoKind: 22
-      Pointee: 1014 StructureType net.onlyValuesCtx
+      Pointee: 158 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 337
+      ID: 349
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 896992
       GoKind: 22
-      Pointee: 338 StructureType net.result·2
+      Pointee: 350 StructureType net.result·2
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2238336
       GoKind: 22
-      Pointee: 947 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 954 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2237856
       GoKind: 22
-      Pointee: 945 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 952 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 622
+      ID: 634
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1183680
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net.temporaryError
+      Pointee: 635 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 669
+      ID: 681
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1407968
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType net.timeoutError
+      Pointee: 682 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 343
+      ID: 355
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 899584
       GoKind: 22
-      Pointee: 344 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 356 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1022624
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 562 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 112
       Name: '*net/http.Request'
@@ -1941,559 +1941,559 @@ Types:
       GoKind: 22
       Pointee: 113 StructureType net/http.Request
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1718272
       GoKind: 22
-      Pointee: 859 StructureType net/http.Response
+      Pointee: 866 StructureType net/http.Response
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1796704
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/http.body
+      Pointee: 931 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1186240
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 902 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1022496
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 882 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1893824
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType net/http.conn
+      Pointee: 833 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1021216
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 872 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1024800
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 886 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 345
+      ID: 357
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 899776
       GoKind: 22
-      Pointee: 260 BaseType net/http.http2ConnectionError
+      Pointee: 272 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 899872
       GoKind: 22
-      Pointee: 347 StructureType net/http.http2GoAwayError
+      Pointee: 359 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 671
+      ID: 683
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1408928
       GoKind: 22
-      Pointee: 672 StructureType net/http.http2StreamError
+      Pointee: 684 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2010176
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 916 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 352
+      ID: 364
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 900928
       GoKind: 22
-      Pointee: 353 StructureType net/http.http2connError
+      Pointee: 365 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 349
+      ID: 361
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900352
       GoKind: 22
-      Pointee: 264 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 276 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 266
+      ID: 278
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 277 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 900448
       GoKind: 22
-      Pointee: 351 StructureType net/http.http2goAwayFlowError
+      Pointee: 363 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1022240
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 880 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 355
+      ID: 367
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 901120
       GoKind: 22
-      Pointee: 270 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 282 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 272
+      ID: 284
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 271 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 283 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 901024
       GoKind: 22
-      Pointee: 267 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 279 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 269
+      ID: 281
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 268 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 280 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 626
+      ID: 638
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1187520
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 639 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1021984
       GoKind: 22
-      Pointee: 869 StructureType net/http.http2missingBody
+      Pointee: 876 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1025056
       GoKind: 22
-      Pointee: 881 StructureType net/http.http2noBodyReader
+      Pointee: 888 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 555
+      ID: 567
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1024928
       GoKind: 22
-      Pointee: 556 StructureType net/http.http2noCachedConnError
+      Pointee: 568 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900256
       GoKind: 22
-      Pointee: 261 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 273 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 263
+      ID: 275
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 262 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 274 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1023136
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 884 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2009600
       GoKind: 22
-      Pointee: 780 StructureType net/http.http2responseWriter
+      Pointee: 787 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1609984
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 831 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1022112
       GoKind: 22
-      Pointee: 871 StructureType net/http.http2transportResponseBody
+      Pointee: 878 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1021472
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 874 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1186368
       GoKind: 22
-      Pointee: 897 StructureType net/http.noBody
+      Pointee: 904 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 551
+      ID: 563
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1024544
       GoKind: 22
-      Pointee: 552 StructureType net/http.nothingWrittenError
+      Pointee: 564 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1608064
       GoKind: 22
-      Pointee: 861 StructureType net/http.pattern
+      Pointee: 868 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1020832
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 870 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1409248
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 912 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 901312
       GoKind: 22
-      Pointee: 357 StructureType net/http.requestBodyReadError
+      Pointee: 369 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2217504
       GoKind: 22
-      Pointee: 782 StructureType net/http.response
+      Pointee: 789 StructureType net/http.response
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 391712
       GoKind: 22
-      Pointee: 1009 StructureType net/http.segment
+      Pointee: 1016 StructureType net/http.segment
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 899488
       GoKind: 22
-      Pointee: 342 StructureType net/http.statusError
+      Pointee: 354 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 673
+      ID: 685
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1410528
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 686 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 624
+      ID: 636
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1187392
       GoKind: 22
-      Pointee: 625 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 637 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 553
+      ID: 565
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1024672
       GoKind: 22
-      Pointee: 554 StructureType net/http.transportReadFromServerError
+      Pointee: 566 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1833760
       GoKind: 22
-      Pointee: 930 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 937 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 339
+      ID: 351
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 898720
       GoKind: 22
-      Pointee: 340 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 352 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1083424
       GoKind: 22
-      Pointee: 891 StructureType net/http/httputil.failureToReadBody
+      Pointee: 898 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 906400
       GoKind: 22
-      Pointee: 372 StructureType net/netip.parseAddrError
+      Pointee: 384 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 906304
       GoKind: 22
-      Pointee: 370 StructureType net/netip.parsePrefixError
+      Pointee: 382 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 386
+      ID: 398
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 909760
       GoKind: 22
-      Pointee: 387 UnresolvedPointeeType net/textproto.Error
+      Pointee: 399 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 909664
       GoKind: 22
-      Pointee: 284 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 296 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 286
+      ID: 298
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 285 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 297 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 678
+      ID: 690
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1415648
       GoKind: 22
-      Pointee: 679 UnresolvedPointeeType net/url.Error
+      Pointee: 691 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 278 GoStringHeaderType net/url.EscapeError
+      Pointee: 290 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 280
+      ID: 292
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 279 GoStringDataType net/url.EscapeError.str
+      Pointee: 291 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 384
+      ID: 396
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 281 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 293 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 283
+      ID: 295
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 282 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 294 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2112832
       GoKind: 22
-      Pointee: 850 StructureType net/url.URL
+      Pointee: 857 StructureType net/url.URL
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1200064
       GoKind: 22
-      Pointee: 971 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 978 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 196
+      ID: 239
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 197 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 240 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 816
+      ID: 823
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 824 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 252
+      ID: 255
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 256 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 981 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 988 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 844 StructureType noalg.map.group[string][]string
+      Pointee: 851 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 230
+      ID: 219
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 231 StructureType noalg.map.group[string]float64
+      Pointee: 220 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 719
+      ID: 731
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 732 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 222
+      ID: 211
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 223 StructureType noalg.map.group[string]interface {}
+      Pointee: 212 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 214
+      ID: 203
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 215 StructureType noalg.map.group[string]string
+      Pointee: 204 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2341248
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType os.File
+      Pointee: 970 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 557
+      ID: 569
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1026976
       GoKind: 22
-      Pointee: 558 UnresolvedPointeeType os.LinkError
+      Pointee: 570 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 151
+      ID: 174
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 394528
       GoKind: 22
-      Pointee: 152 GoInterfaceType os.Signal
+      Pointee: 175 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1187904
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType os.SyscallError
+      Pointee: 641 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2339008
       GoKind: 22
-      Pointee: 961 StructureType os.fileWithoutReadFrom
+      Pointee: 968 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2338272
       GoKind: 22
-      Pointee: 959 StructureType os.fileWithoutWriteTo
+      Pointee: 966 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 590
+      ID: 602
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1048736
       GoKind: 22
-      Pointee: 591 UnresolvedPointeeType os/exec.Error
+      Pointee: 603 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 715
+      ID: 727
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2088576
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 728 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 592
+      ID: 604
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1048864
       GoKind: 22
-      Pointee: 593 StructureType os/exec.wrappedError
+      Pointee: 605 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 128
+      ID: 170
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1612672
       GoKind: 22
-      Pointee: 129 StructureType os/signal.signalCtx
+      Pointee: 171 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 493
+      ID: 505
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 935584
       GoKind: 22
-      Pointee: 312 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 324 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 314
+      ID: 326
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 313 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 325 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 492
+      ID: 504
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 935488
       GoKind: 22
-      Pointee: 311 BaseType os/user.UnknownUserIdError
+      Pointee: 323 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 904480
       GoKind: 22
-      Pointee: 366 UnresolvedPointeeType reflect.ValueError
+      Pointee: 378 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 445
+      ID: 457
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 446 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 458 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1031584
       GoKind: 22
-      Pointee: 566 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 578 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 569
+      ID: 581
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1033376
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 582 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -2509,12 +2509,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1031712
       GoKind: 22
-      Pointee: 568 StructureType runtime.boundsError
+      Pointee: 580 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -2530,24 +2530,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1195840
       GoKind: 22
-      Pointee: 631 StructureType runtime.errorAddressString
+      Pointee: 643 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 563
+      ID: 575
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1031200
       GoKind: 22
-      Pointee: 534 GoStringHeaderType runtime.errorString
+      Pointee: 546 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 536
+      ID: 548
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 535 GoStringDataType runtime.errorString.str
+      Pointee: 547 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -2568,19 +2568,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1032736
       GoKind: 22
-      Pointee: 191 UnresolvedPointeeType runtime.p
+      Pointee: 198 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 564
+      ID: 576
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1031328
       GoKind: 22
-      Pointee: 537 GoStringHeaderType runtime.plainError
+      Pointee: 549 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 538 GoStringDataType runtime.plainError.str
+      Pointee: 550 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -2596,12 +2596,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 367
+      ID: 379
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 906016
       GoKind: 22
-      Pointee: 368 StructureType runtime.synctestDeadlockError
+      Pointee: 380 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -2617,12 +2617,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 561
+      ID: 573
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1030816
       GoKind: 22
-      Pointee: 562 UnresolvedPointeeType strconv.NumError
+      Pointee: 574 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -2631,235 +2631,235 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 186
+      ID: 193
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 185 GoStringDataType string.str
+      Pointee: 192 GoStringDataType string.str
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1687936
       GoKind: 22
-      Pointee: 749 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 756 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1741696
       GoKind: 22
-      Pointee: 763 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 770 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1687552
       GoKind: 22
-      Pointee: 745 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 752 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1740928
       GoKind: 22
-      Pointee: 755 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 762 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1813504
       GoKind: 22
-      Pointee: 769 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 776 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1741120
       GoKind: 22
-      Pointee: 757 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 764 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1740736
       GoKind: 22
-      Pointee: 753 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 760 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1813056
       GoKind: 22
-      Pointee: 765 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 772 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1882144
       GoKind: 22
-      Pointee: 773 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 780 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1813280
       GoKind: 22
-      Pointee: 767 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 774 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1688128
       GoKind: 22
-      Pointee: 751 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 758 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1687744
       GoKind: 22
-      Pointee: 747 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 754 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1741312
       GoKind: 22
-      Pointee: 759 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 766 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1813728
       GoKind: 22
-      Pointee: 771 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 778 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1741504
       GoKind: 22
-      Pointee: 761 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 768 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1090560
       GoKind: 22
-      Pointee: 893 StructureType struct { io.Reader; io.Closer }
+      Pointee: 900 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 675
+      ID: 687
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1414528
       GoKind: 22
-      Pointee: 664 BaseType syscall.Errno
+      Pointee: 676 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1033888
       GoKind: 22
-      Pointee: 737 BaseType syscall.Signal
+      Pointee: 744 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 141
+      ID: 184
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 194 StructureType table<context.canceler,struct {}>
+      Pointee: 237 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 814 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 821 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 242
+      ID: 231
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 250 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 253 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 978 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 985 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 841 StructureType table<string,[]string>
+      Pointee: 848 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 173
+      ID: 139
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 228 StructureType table<string,float64>
+      Pointee: 217 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 691
+      ID: 703
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 717 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 729 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 168
+      ID: 134
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 220 StructureType table<string,interface {}>
+      Pointee: 209 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 163
+      ID: 129
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 212 StructureType table<string,string>
+      Pointee: 201 StructureType table<string,string>
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1086624
       GoKind: 22
-      Pointee: 611 StructureType text/template.ExecError
+      Pointee: 623 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 146
+      ID: 190
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1613056
       GoKind: 22
-      Pointee: 147 StructureType time.Location
+      Pointee: 191 StructureType time.Location
     - __kind: PointerType
-      ID: 359
+      ID: 371
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902176
       GoKind: 22
-      Pointee: 360 UnresolvedPointeeType time.ParseError
+      Pointee: 372 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 143
+      ID: 187
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1027488
       GoKind: 22
-      Pointee: 144 StructureType time.Timer
+      Pointee: 188 StructureType time.Timer
     - __kind: PointerType
-      ID: 358
+      ID: 370
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902080
       GoKind: 22
-      Pointee: 273 GoStringHeaderType time.fileSizeError
+      Pointee: 285 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 275
+      ID: 287
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 274 GoStringDataType time.fileSizeError.str
+      Pointee: 286 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 205
+      ID: 248
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394784
       GoKind: 22
-      Pointee: 206 StructureType time.zone
+      Pointee: 249 StructureType time.zone
     - __kind: PointerType
-      ID: 208
+      ID: 251
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394848
       GoKind: 22
-      Pointee: 209 StructureType time.zoneTrans
+      Pointee: 252 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -2903,47 +2903,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 373
+      ID: 385
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 907168
       GoKind: 22
-      Pointee: 374 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 386 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 909952
       GoKind: 22
-      Pointee: 389 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 401 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 910048
       GoKind: 22
-      Pointee: 287 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 299 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1038752
       GoKind: 22
-      Pointee: 575 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 587 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 576
+      ID: 588
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1038880
       GoKind: 22
-      Pointee: 541 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 553 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 857
+      ID: 864
       Name: <-chan struct {}
       GoRuntimeType: 597472
       GoKind: 18
     - __kind: GoChannelType
-      ID: 731
+      ID: 743
       Name: <-chan time.Time
       GoRuntimeType: 600736
       GoKind: 18
@@ -3022,7 +3022,7 @@ Types:
       HasCount: true
       Element: 95 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 838
+      ID: 845
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 682912
@@ -3031,7 +3031,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 837
+      ID: 844
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 682816
@@ -3103,7 +3103,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 839
+      ID: 846
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 683008
@@ -3121,7 +3121,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 699
+      ID: 711
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 700800
@@ -3148,7 +3148,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 993
+      ID: 1000
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502272
@@ -3156,22 +3156,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 994 PointerType **crypto/x509.Certificate
+          Type: 1001 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1001 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1008 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1001
+      ID: 1008
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 685 PointerType *crypto/x509.Certificate
+      Element: 697 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 732
+      ID: 267
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 24
       GoRuntimeType: 490208
@@ -3179,22 +3179,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 733 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 268 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 735 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Data: 270 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: GoSliceDataType
-      ID: 735
+      ID: 270
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Element: 148 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: GoSliceHeaderType
-      ID: 984
+      ID: 991
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 487168
@@ -3202,20 +3202,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 985 PointerType **mime/multipart.FileHeader
+          Type: 992 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 990 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 997 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 990
+      ID: 997
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 986 PointerType *mime/multipart.FileHeader
+      Element: 993 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 64
       Name: '[]*runtime.p'
@@ -3232,69 +3232,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 192 GoSliceDataType []*runtime.p.array
+      Data: 199 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 199
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 66 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 245
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 141 PointerType *table<context.canceler,struct {}>
+      Element: 184 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 821
+      ID: 828
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 797 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 804 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 261
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 242 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 231 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 987
+      ID: 994
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 977 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 984 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 847
+      ID: 854
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 836 PointerType *table<string,[]string>
+      Element: 843 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 223
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 173 PointerType *table<string,float64>
+      Element: 139 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 723
+      ID: 735
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 691 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 703 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 215
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<string,interface {}>
+      Element: 134 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 207
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 163 PointerType *table<string,string>
+      Element: 129 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 995
+      ID: 1002
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 502336
@@ -3302,22 +3302,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 996 PointerType *[]*crypto/x509.Certificate
+          Type: 1003 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1003 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1010 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1003
+      ID: 1010
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 993 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 1000 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 997
+      ID: 1004
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -3325,22 +3325,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 998 PointerType *[]uint8
+          Type: 1005 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1005 GoSliceDataType [][]uint8.array
+      Data: 1012 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 1005
+      ID: 1012
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 40 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 704
+      ID: 716
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 496032
@@ -3355,15 +3355,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 727 GoSliceDataType []float64.array
+      Data: 739 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 727
+      ID: 739
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 174
+      ID: 140
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 24
       GoRuntimeType: 489952
@@ -3371,22 +3371,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 175 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 141 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 236 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 225 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 225
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 176 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Element: 142 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 177
+      ID: 143
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 490144
@@ -3394,22 +3394,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 178 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 144 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 244 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 233 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 233
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 179 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Element: 145 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1007
+      ID: 1014
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 484480
@@ -3417,76 +3417,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1008 PointerType *net/http.segment
+          Type: 1015 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1010 GoSliceDataType []net/http.segment.array
+      Data: 1017 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1010
+      ID: 1017
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1009 StructureType net/http.segment
+      Element: 1016 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 246
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 197 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 240 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 822
+      ID: 829
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 824 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 262
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 256 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 988
+      ID: 995
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 981 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 988 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 848
+      ID: 855
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 844 StructureType noalg.map.group[string][]string
+      Element: 851 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 224
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 231 StructureType noalg.map.group[string]float64
+      Element: 220 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 724
+      ID: 736
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 732 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 216
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 223 StructureType noalg.map.group[string]interface {}
+      Element: 212 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 208
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 215 StructureType noalg.map.group[string]string
+      Element: 204 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 150
+      ID: 173
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -3494,26 +3494,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 151 PointerType *os.Signal
+          Type: 174 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 210 GoSliceDataType []os.Signal.array
+      Data: 235 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 235
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 152 GoInterfaceType os.Signal
+      Element: 175 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 703
+      ID: 715
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -3528,15 +3528,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 725 GoSliceDataType []string.array
+      Data: 737 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 725
+      ID: 737
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 204
+      ID: 247
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489344
@@ -3544,22 +3544,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 205 PointerType *time.zone
+          Type: 248 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 246 GoSliceDataType []time.zone.array
+      Data: 263 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 263
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 206 StructureType time.zone
+      Element: 249 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 207
+      ID: 250
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489408
@@ -3567,20 +3567,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 208 PointerType *time.zoneTrans
+          Type: 251 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 248 GoSliceDataType []time.zoneTrans.array
+      Data: 265 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 265
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 209 StructureType time.zoneTrans
+      Element: 252 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 40
       Name: '[]uint8'
@@ -3597,9 +3597,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 187 GoSliceDataType []uint8.array
+      Data: 194 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 194
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3620,15 +3620,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 189 GoSliceDataType []uintptr.array
+      Data: 196 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 196
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 519
+      ID: 531
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 945568
@@ -3643,27 +3643,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 520 GoSliceDataType archive/tar.headerError.array
+      Data: 532 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 532
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 889
+      ID: 896
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 907
+      ID: 914
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 887
+      ID: 894
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3673,7 +3673,7 @@ Types:
       GoRuntimeType: 585248
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3681,12 +3681,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 840
+      ID: 847
       Name: chan bool
       GoRuntimeType: 596896
       GoKind: 18
     - __kind: GoChannelType
-      ID: 153
+      ID: 176
       Name: chan os.Signal
       GoRuntimeType: 603808
       GoKind: 18
@@ -3703,13 +3703,13 @@ Types:
       GoRuntimeType: 584992
       GoKind: 15
     - __kind: BaseType
-      ID: 306
+      ID: 318
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 837504
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 307
+      ID: 319
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 837600
@@ -3717,26 +3717,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 309 PointerType *compress/flate.InternalError.str
+          Type: 321 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 308 GoStringDataType compress/flate.InternalError.str
+      Data: 320 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 308
+      ID: 320
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 149
+      ID: 172
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 676960
@@ -3755,19 +3755,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 130
+      ID: 167
       Name: context.backgroundCtx
       GoRuntimeType: 1795136
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 131 StructureType context.emptyCtx
+          Type: 153 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 119
+      ID: 178
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1966880
@@ -3778,23 +3778,23 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 132 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 135 StructureType sync/atomic.Value
+          Type: 179 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 137 GoMapType map[context.canceler]struct {}
+          Type: 180 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 135 StructureType sync/atomic.Value
+          Type: 179 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 16 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 200
+      ID: 243
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1107328
@@ -3807,13 +3807,13 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 616
+      ID: 628
       Name: context.deadlineExceededError
       GoRuntimeType: 1457088
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 131
+      ID: 153
       Name: context.emptyCtx
       GoRuntimeType: 1590176
       GoKind: 25
@@ -3822,7 +3822,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 121
+      ID: 155
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1821696
@@ -3833,11 +3833,11 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 142 GoSubroutineType func() bool
+          Type: 156 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 123
+      ID: 186
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1606144
@@ -3845,29 +3845,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 119 StructureType context.cancelCtx
+          Type: 178 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 143 PointerType *time.Timer
+          Type: 187 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 145 GoTimeType time.Time
+          Type: 189 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 148
+      ID: 169
       Name: context.todoCtx
       GoRuntimeType: 1795360
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 131 StructureType context.emptyCtx
+          Type: 153 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 162
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1830624
@@ -3878,14 +3878,14 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 163 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 163 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 127
+      ID: 165
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1794912
@@ -3897,51 +3897,51 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 302
+      ID: 314
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 2
     - __kind: BaseType
-      ID: 303
+      ID: 315
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837216
       GoKind: 2
     - __kind: BaseType
-      ID: 304
+      ID: 316
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837312
       GoKind: 2
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1282560
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 305
+      ID: 317
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837408
       GoKind: 2
     - __kind: BaseType
-      ID: 276
+      ID: 288
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 834720
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 573
+      ID: 585
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 976
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 856
+      ID: 863
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2261984
@@ -3961,7 +3961,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 992 BaseType crypto/tls.CurveID
+          Type: 999 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -3973,13 +3973,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 993 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 1000 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 995 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 1002 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 997 GoSliceHeaderType [][]uint8
+          Type: 1004 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 40 GoSliceHeaderType []uint8
@@ -3991,25 +3991,25 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 999 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 1006 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
           Type: 6 BaseType bool
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 186
-          Type: 1000 BaseType crypto/tls.SignatureScheme
+          Type: 1007 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 992
+      ID: 999
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 834432
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 378
+      ID: 390
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 376
+      ID: 388
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1722304
@@ -4020,36 +4020,36 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 699 ArrayType [5]uint8
+          Type: 711 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 700 GoInterfaceType net.Conn
+          Type: 712 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 1000
+      ID: 1007
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 834528
       GoKind: 9
     - __kind: BaseType
-      ID: 540
+      ID: 552
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 986848
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 392
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 689
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 698
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 432
+      ID: 444
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1724416
@@ -4057,21 +4057,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 697 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 709 BaseType crypto/x509.InvalidReason
+          Type: 721 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 426
+      ID: 438
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1113600
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 428
+      ID: 440
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1592736
@@ -4079,24 +4079,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 697 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 301
+      ID: 313
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836928
       GoKind: 2
     - __kind: BaseType
-      ID: 709
+      ID: 721
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 588000
       GoKind: 2
     - __kind: StructureType
-      ID: 589
+      ID: 601
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1553664
@@ -4106,13 +4106,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 434
+      ID: 446
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1113856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 430
+      ID: 442
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1724224
@@ -4120,15 +4120,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 697 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 685 PointerType *crypto/x509.Certificate
+          Type: 697 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 476
+      ID: 488
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1427648
@@ -4138,7 +4138,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 480
+      ID: 492
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1427808
@@ -4148,47 +4148,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 478
+      ID: 490
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 277
+      ID: 289
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834816
       GoKind: 6
     - __kind: BaseType
-      ID: 297
+      ID: 309
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 836640
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 414
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 585
+      ID: 597
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 394
+      ID: 406
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 400
+      ID: 412
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 398
+      ID: 410
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 396
+      ID: 408
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 404
+      ID: 416
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1418688
@@ -4198,15 +4198,15 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 509
+      ID: 521
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 507
+      ID: 519
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 315
+      ID: 327
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 840192
@@ -4214,18 +4214,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 317 PointerType *encoding/xml.UnmarshalError.str
+          Type: 329 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 316 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 328 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 316
+      ID: 328
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 512
+      ID: 524
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4242,11 +4242,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 362
+      ID: 374
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 572
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4262,11 +4262,11 @@ Types:
       GoRuntimeType: 585184
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 544
+      ID: 556
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 546
+      ID: 558
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4276,13 +4276,13 @@ Types:
       GoRuntimeType: 479904
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 851
+      ID: 858
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693216
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 142
+      ID: 156
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 595680
@@ -4294,23 +4294,23 @@ Types:
       GoRuntimeType: 854528
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 999
+      ID: 1006
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1002592
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 415
+      ID: 427
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 799
+      ID: 806
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2052480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 407
+      ID: 419
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1723456
@@ -4318,7 +4318,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 701 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 713 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4326,25 +4326,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 421
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 706
+      ID: 718
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 413
+      ID: 425
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1112704
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 720
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 291
+      ID: 303
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 836064
@@ -4352,18 +4352,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 293 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 305 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 292 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 304 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 292
+      ID: 304
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 701
+      ID: 713
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2212128
@@ -4371,13 +4371,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 702 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 714 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4386,7 +4386,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 704 GoSliceHeaderType []float64
+          Type: 716 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4395,13 +4395,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 705 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 717 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 707 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 719 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4412,13 +4412,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 702
+      ID: 714
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586784
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 288
+      ID: 300
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 835968
@@ -4426,18 +4426,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 290 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 302 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 289 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 301 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 289
+      ID: 301
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 294
+      ID: 306
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 836160
@@ -4445,36 +4445,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 296 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 308 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 295 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 295
+      ID: 307
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 485
+      ID: 497
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1116544
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 310
+      ID: 322
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 838752
       GoKind: 2
     - __kind: StructureType
-      ID: 483
+      ID: 495
       Name: github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
       GoRuntimeType: 1116416
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 450
+      ID: 462
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1593536
@@ -4487,7 +4487,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 454
+      ID: 466
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1726144
@@ -4503,7 +4503,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 452
+      ID: 464
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1426208
@@ -4513,7 +4513,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 448
+      ID: 460
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1425888
@@ -4523,14 +4523,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 687
+      ID: 699
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1499328
       GoKind: 21
-      HeaderType: 689 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 701 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 710
+      ID: 722
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1049760
@@ -4545,15 +4545,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 729 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 741 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 729
+      ID: 741
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 462
+      ID: 474
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1593856
@@ -4561,12 +4561,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 699 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 687 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 699 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 456
+      ID: 468
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1426368
@@ -4576,7 +4576,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 460
+      ID: 472
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1726336
@@ -4587,12 +4587,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 722 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 722 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 458
+      ID: 470
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1593696
@@ -4605,7 +4605,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 464
+      ID: 476
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1426528
@@ -4613,9 +4613,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 145 GoTimeType time.Time
+          Type: 189 GoTimeType time.Time
     - __kind: StructureType
-      ID: 470
+      ID: 482
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1594176
@@ -4628,7 +4628,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 472
+      ID: 484
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1426848
@@ -4638,7 +4638,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 468
+      ID: 480
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1594016
@@ -4651,7 +4651,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 466
+      ID: 478
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1426688
@@ -4661,7 +4661,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 474
+      ID: 486
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1594336
@@ -4674,29 +4674,29 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 820
+      ID: 827
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 839616
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 814
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 816
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 818
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 495
+      ID: 507
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1432768
@@ -4706,11 +4706,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 799
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 497
+      ID: 509
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1432928
@@ -4718,17 +4718,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 495 StructureType github.com/cihub/seelog.baseError
+          Type: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 791
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 786
+      ID: 793
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1824832
@@ -4736,12 +4736,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 785 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 792 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 793 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 800 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 501
+      ID: 513
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1433248
@@ -4749,9 +4749,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 495 StructureType github.com/cihub/seelog.baseError
+          Type: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 788
+      ID: 795
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1804096
@@ -4759,13 +4759,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 785 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 792 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 499
+      ID: 511
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1433088
@@ -4773,9 +4773,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 495 StructureType github.com/cihub/seelog.baseError
+          Type: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 503
+      ID: 515
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1433408
@@ -4783,9 +4783,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 495 StructureType github.com/cihub/seelog.baseError
+          Type: 507 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 919
+      ID: 926
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1121408
@@ -4798,7 +4798,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 901
+      ID: 908
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1667584
@@ -4806,36 +4806,36 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 919 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 926 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 603
+      ID: 615
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 617
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 607
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 418
+      ID: 430
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1419968
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 611
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 657
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1844736
@@ -4851,11 +4851,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 651
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 579
+      ID: 591
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1695712
@@ -4868,7 +4868,7 @@ Types:
           Offset: 1
           Type: 19 BaseType int8
     - __kind: StructureType
-      ID: 651
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1845184
@@ -4884,13 +4884,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 542
+      ID: 554
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 988000
       GoKind: 8
     - __kind: StructureType
-      ID: 643
+      ID: 655
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1844512
@@ -4906,13 +4906,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 713
+      ID: 725
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 835584
       GoKind: 8
     - __kind: StructureType
-      ID: 641
+      ID: 653
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1844288
@@ -4920,15 +4920,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 725 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 713 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 725 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 649
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1758944
@@ -4941,7 +4941,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 647
+      ID: 659
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1844960
@@ -4957,7 +4957,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 655
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1629760
@@ -4967,19 +4967,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 595
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1279104
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 581
+      ID: 593
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1278976
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 653
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1759136
@@ -4992,7 +4992,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 318
+      ID: 330
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 840864
@@ -5000,22 +5000,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 320 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 332 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 319 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 331 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 319
+      ID: 331
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 706
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 609
+      ID: 621
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1442528
@@ -5025,19 +5025,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 321
+      ID: 333
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 841440
       GoKind: 10
     - __kind: BaseType
-      ID: 692
+      ID: 704
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 999616
       GoKind: 10
     - __kind: StructureType
-      ID: 663
+      ID: 675
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1876992
@@ -5048,12 +5048,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 692 BaseType golang.org/x/net/http2.ErrCode
+          Type: 704 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 526
+      ID: 538
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1601056
@@ -5061,12 +5061,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 692 BaseType golang.org/x/net/http2.ErrCode
+          Type: 704 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 325
+      ID: 337
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841632
@@ -5074,18 +5074,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 327 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 339 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 326 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 338 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 326
+      ID: 338
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 331
+      ID: 343
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 841824
@@ -5093,18 +5093,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 333 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 345 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 332 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 344 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 332
+      ID: 344
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 328
+      ID: 340
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 841728
@@ -5112,18 +5112,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 330 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 342 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 329 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 341 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 329
+      ID: 341
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 322
+      ID: 334
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841536
@@ -5131,18 +5131,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 324 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 336 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 323 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 335 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 323
+      ID: 335
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 530
+      ID: 542
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1443808
@@ -5152,13 +5152,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 334
+      ID: 346
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 841920
       GoKind: 2
     - __kind: StructureType
-      ID: 505
+      ID: 517
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1438208
@@ -5168,11 +5168,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 673
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 681
+      ID: 693
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1904064
@@ -5188,7 +5188,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 516
+      ID: 528
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1600096
@@ -5201,11 +5201,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 607
+      ID: 619
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1561024
@@ -5215,33 +5215,33 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 919
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 487
+      ID: 499
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 613
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 659
+      ID: 671
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 669
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1507488
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 392
+      ID: 404
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 774
+      ID: 781
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1417248
@@ -5254,7 +5254,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 743
+      ID: 750
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1592256
@@ -5280,7 +5280,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 176
+      ID: 142
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
       ByteSize: 56
       GoRuntimeType: 1915968
@@ -5297,7 +5297,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -5305,7 +5305,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 934
+      ID: 941
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1967392
@@ -5313,29 +5313,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 925 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+          Type: 932 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 937 BaseType time.Duration
+          Type: 944 BaseType time.Duration
     - __kind: GoMapType
-      ID: 164
+      ID: 130
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1277568
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 933
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 734
+      ID: 269
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 584032
       GoKind: 10
     - __kind: DDTraceSpanType
-      ID: 155
+      ID: 118
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
       ByteSize: 288
       GoRuntimeType: 2331776
@@ -5343,7 +5343,7 @@ Types:
       RawFields:
         - Name: RWMutex
           Offset: 0
-          Type: 156 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: Name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -5364,13 +5364,13 @@ Types:
           Type: 15 BaseType int64
         - Name: Meta
           Offset: 104
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: MetaStruct
           Offset: 112
-          Type: 164 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
+          Type: 130 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
         - Name: Metrics
           Offset: 120
-          Type: 169 GoMapType map[string]float64
+          Type: 135 GoMapType map[string]float64
         - Name: SpanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -5385,10 +5385,10 @@ Types:
           Type: 14 BaseType int32
         - Name: SpanLinks
           Offset: 160
-          Type: 174 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 140 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: SpanEvents
           Offset: 184
-          Type: 177 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 143 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -5400,7 +5400,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 180 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+          Type: 146 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -5423,7 +5423,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 181
+      ID: 147
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
       ByteSize: 160
       GoRuntimeType: 2185344
@@ -5434,10 +5434,10 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 182 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+          Type: 149 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 148 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: errors
           Offset: 24
           Type: 14 BaseType int32
@@ -5449,16 +5449,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 184 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
+          Type: 151 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 156 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -5467,9 +5467,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 174 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 140 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: StructureType
-      ID: 179
+      ID: 145
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1750496
@@ -5483,16 +5483,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 238 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 227 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 243 GoMapType map[string]interface {}
+          Type: 232 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 741
+      ID: 748
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 257
+      ID: 260
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1911360
@@ -5500,7 +5500,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 739 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
+          Type: 746 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -5515,15 +5515,15 @@ Types:
           Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 740 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+          Type: 747 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 739
+      ID: 746
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 984256
       GoKind: 5
     - __kind: StructureType
-      ID: 183
+      ID: 150
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2101568
@@ -5531,16 +5531,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 156 StructureType sync.RWMutex
+          Type: 119 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 732 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 267 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: tags
           Offset: 48
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -5555,12 +5555,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 734 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
+          Type: 269 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 148 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: ArrayType
-      ID: 184
+      ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 902944
@@ -5569,11 +5569,11 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1016
+    - __kind: GoContextImplementationType
+      ID: 160
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1630336
@@ -5582,20 +5582,22 @@ Types:
         - Name: Context
           Offset: 0
           Type: 117 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 892
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 444
+      ID: 456
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 489
+      ID: 501
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1430048
@@ -5605,7 +5607,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 491
+      ID: 503
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1430208
@@ -5615,137 +5617,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 514
+      ID: 526
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 195
+      ID: 238
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 196 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 239 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 197 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 203 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 240 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 246 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 815
+      ID: 822
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 816 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 823 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 822 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 824 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 829 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 251
+      ID: 254
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 252 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 255 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 256 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 262 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 979
+      ID: 986
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 980 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 987 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 981 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 988 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 988 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 995 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 842
+      ID: 849
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 843 PointerType *noalg.map.group[string][]string
+          Type: 850 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 844 StructureType noalg.map.group[string][]string
-      GroupSliceType: 848 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 851 StructureType noalg.map.group[string][]string
+      GroupSliceType: 855 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 229
+      ID: 218
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 230 PointerType *noalg.map.group[string]float64
+          Type: 219 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 231 StructureType noalg.map.group[string]float64
-      GroupSliceType: 235 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 220 StructureType noalg.map.group[string]float64
+      GroupSliceType: 224 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 718
+      ID: 730
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 719 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 731 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 724 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 732 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 736 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 221
+      ID: 210
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 222 PointerType *noalg.map.group[string]interface {}
+          Type: 211 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 223 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 227 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 212 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 216 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 213
+      ID: 202
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 214 PointerType *noalg.map.group[string]string
+          Type: 203 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 215 StructureType noalg.map.group[string]string
-      GroupSliceType: 219 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 204 StructureType noalg.map.group[string]string
+      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 533
+      ID: 545
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5779,7 +5781,7 @@ Types:
       GoRuntimeType: 584288
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 136
+      ID: 163
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 854240
@@ -5792,11 +5794,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 683
+      ID: 695
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 423
+      ID: 435
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5822,25 +5824,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 421
+      ID: 433
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 649
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 974
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 635
+      ID: 647
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1474688
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 364
+      ID: 376
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5921,7 +5923,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 298
+      ID: 310
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 836832
@@ -5929,18 +5931,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 300 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 312 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 299 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 311 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 299
+      ID: 311
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 587
+      ID: 599
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1552704
@@ -5948,9 +5950,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 682 PointerType *internal/abi.Type
+          Type: 694 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 134
+      ID: 122
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1488288
@@ -5963,7 +5965,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 920
+      ID: 927
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1029536
@@ -5976,11 +5978,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 827
+      ID: 834
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1109760
@@ -5993,7 +5995,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 910
+      ID: 917
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1028896
@@ -6006,11 +6008,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 883
+      ID: 890
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1546464
@@ -6018,9 +6020,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 910 GoInterfaceType io.Reader
+          Type: 917 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1614592
@@ -6028,13 +6030,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 910 GoInterfaceType io.Reader
+          Type: 917 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 645
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 139
+      ID: 182
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -6047,7 +6049,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 140 PointerType **table<context.canceler,struct {}>
+          Type: 183 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6066,10 +6068,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 202 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 197 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 245 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 240 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 795
+      ID: 802
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6082,7 +6084,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 796 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 803 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6101,10 +6103,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 821 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 817 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 828 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 824 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 240
+      ID: 229
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6117,7 +6119,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 241 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 230 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6136,10 +6138,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 253 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 261 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 256 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 975
+      ID: 982
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6152,7 +6154,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 976 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 983 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6171,10 +6173,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 987 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 981 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 994 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 988 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 834
+      ID: 841
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6187,7 +6189,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 835 PointerType **table<string,[]string>
+          Type: 842 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6206,10 +6208,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 847 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 844 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 854 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 851 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 171
+      ID: 137
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6222,7 +6224,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 172 PointerType **table<string,float64>
+          Type: 138 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6241,10 +6243,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 234 GoSliceDataType []*table<string,float64>.array
-      GroupType: 231 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 223 GoSliceDataType []*table<string,float64>.array
+      GroupType: 220 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 689
+      ID: 701
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6257,7 +6259,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 690 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 702 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6276,10 +6278,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 723 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 720 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 735 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 732 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 132
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6292,7 +6294,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<string,interface {}>
+          Type: 133 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6311,10 +6313,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 226 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 223 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 215 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 212 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 161
+      ID: 127
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6327,7 +6329,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 162 PointerType **table<string,string>
+          Type: 128 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6346,66 +6348,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 218 GoSliceDataType []*table<string,string>.array
-      GroupType: 215 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 207 GoSliceDataType []*table<string,string>.array
+      GroupType: 204 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 137
+      ID: 180
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1126272
       GoKind: 21
-      HeaderType: 139 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 182 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 793
+      ID: 800
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1156320
       GoKind: 21
-      HeaderType: 795 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 802 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 238
+      ID: 227
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1132640
       GoKind: 21
-      HeaderType: 240 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 229 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 973
+      ID: 980
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1131648
       GoKind: 21
-      HeaderType: 975 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 982 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 972
+      ID: 979
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1127296
       GoKind: 21
-      HeaderType: 834 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 841 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 169
+      ID: 135
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1132512
       GoKind: 21
-      HeaderType: 171 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 137 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 243
+      ID: 232
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1125888
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 132 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 159
+      ID: 125
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1128320
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,string>
+      HeaderType: 127 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 442
+      ID: 454
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1422848
@@ -6415,11 +6417,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 996
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1477408
@@ -6427,16 +6429,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 972 GoMapType map[string][]string
+          Type: 979 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 973 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 980 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 921
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 923
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1914944
@@ -6444,16 +6446,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 935 PointerType *io.SectionReader
+          Type: 942 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 920 GoInterfaceType io.Closer
+          Type: 927 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 619
+      ID: 631
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 700
+      ID: 712
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1590336
@@ -6466,35 +6468,35 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 680
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 950
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 678
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 633
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 612
+      ID: 624
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1107584
@@ -6502,28 +6504,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 614 PointerType *net.UnknownNetworkError.str
+          Type: 626 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 613 GoStringDataType net.UnknownNetworkError.str
+      Data: 625 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 613
+      ID: 625
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 548
+      ID: 560
       Name: net.canceledError
       GoRuntimeType: 1276544
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 948
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 712
+      ID: 724
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2100512
@@ -6531,7 +6533,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 700 GoInterfaceType net.Conn
+          Type: 712 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -6542,27 +6544,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 964
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: net.noReadFrom
       GoRuntimeType: 1107840
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 952
+      ID: 959
       Name: net.noWriteTo
       GoRuntimeType: 1107712
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 336
+      ID: 348
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1014
+    - __kind: GoContextImplementationType
+      ID: 158
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1744736
@@ -6574,8 +6576,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 117 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 338
+      ID: 350
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1717696
@@ -6583,7 +6587,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 695 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 707 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6591,7 +6595,7 @@ Types:
           Offset: 96
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 947
+      ID: 954
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2281120
@@ -6599,12 +6603,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 953 StructureType net.noReadFrom
+          Type: 960 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 950 PointerType *net.TCPConn
+          Type: 957 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 945
+      ID: 952
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2280576
@@ -6612,20 +6616,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 952 StructureType net.noWriteTo
+          Type: 959 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 950 PointerType *net.TCPConn
+          Type: 957 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 635
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 682
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 777
+      ID: 784
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1026848
@@ -6638,7 +6642,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 775
+      ID: 782
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1025312
@@ -6651,14 +6655,14 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 832
+      ID: 839
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2100864
       GoKind: 21
-      HeaderType: 834 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 841 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 778
+      ID: 785
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1025440
@@ -6671,15 +6675,15 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 344
+      ID: 356
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 562
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 776
+      ID: 783
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1025696
@@ -6703,7 +6707,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 849 PointerType *net/url.URL
+          Type: 856 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6715,19 +6719,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 827 GoInterfaceType io.ReadCloser
+          Type: 834 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 851 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 858 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6736,16 +6740,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 852 GoMapType net/url.Values
+          Type: 859 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 852 GoMapType net/url.Values
+          Type: 859 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 853 PointerType *mime/multipart.Form
+          Type: 860 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6754,13 +6758,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 855 PointerType *crypto/tls.ConnectionState
+          Type: 862 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 857 GoChannelType <-chan struct {}
+          Type: 864 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 858 PointerType *net/http.Response
+          Type: 865 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6769,15 +6773,15 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 860 PointerType *net/http.pattern
+          Type: 867 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 159 GoMapType map[string]string
+          Type: 125 GoMapType map[string]string
     - __kind: StructureType
-      ID: 859
+      ID: 866
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2209888
@@ -6800,16 +6804,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 827 GoInterfaceType io.ReadCloser
+          Type: 834 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6818,13 +6822,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 112 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 855 PointerType *crypto/tls.ConnectionState
+          Type: 862 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 111
       Name: net/http.ResponseWriter
@@ -6839,19 +6843,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 931
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 902
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 831
+      ID: 838
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1746272
@@ -6859,10 +6863,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 781 PointerType *net/http.response
+          Type: 788 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6870,31 +6874,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 872
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 260
+      ID: 272
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 832704
       GoKind: 10
     - __kind: BaseType
-      ID: 684
+      ID: 696
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 984064
       GoKind: 10
     - __kind: StructureType
-      ID: 347
+      ID: 359
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1719424
@@ -6905,12 +6909,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 696 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 672
+      ID: 684
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1894080
@@ -6921,16 +6925,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 696 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 916
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 353
+      ID: 365
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1590816
@@ -6938,12 +6942,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 684 BaseType net/http.http2ErrCode
+          Type: 696 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 264
+      ID: 276
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832896
@@ -6951,28 +6955,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 266 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 278 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 265 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 277 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 265
+      ID: 277
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 351
+      ID: 363
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1108864
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 270
+      ID: 282
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833088
@@ -6980,18 +6984,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 272 PointerType *net/http.http2headerFieldNameError.str
+          Type: 284 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 271 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 283 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 271
+      ID: 283
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 267
+      ID: 279
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 832992
@@ -6999,40 +7003,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 269 PointerType *net/http.http2headerFieldValueError.str
+          Type: 281 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 268 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 280 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 268
+      ID: 280
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 639
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: net/http.http2missingBody
       GoRuntimeType: 1276800
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 881
+      ID: 888
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1277312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 556
+      ID: 568
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1277184
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 261
+      ID: 273
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832800
@@ -7040,22 +7044,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 263 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 275 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 262 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 274 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 262
+      ID: 274
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1185600
@@ -7063,13 +7067,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 823 PointerType *net/http.http2responseWriterState
+          Type: 830 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1543744
@@ -7077,19 +7081,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 908 PointerType *net/http.http2clientStream
+          Type: 915 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: net/http.noBody
       GoRuntimeType: 1460128
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 552
+      ID: 564
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1545024
@@ -7099,7 +7103,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 861
+      ID: 868
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1833088
@@ -7116,20 +7120,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1007 GoSliceHeaderType []net/http.segment
+          Type: 1014 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 870
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 912
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 357
+      ID: 369
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1411328
@@ -7139,7 +7143,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: net/http.response
       ByteSize: 232
       GoRuntimeType: 2340480
@@ -7147,16 +7151,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 825 PointerType *net/http.conn
+          Type: 832 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 112 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 827 GoInterfaceType io.ReadCloser
+          Type: 834 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 149 GoSubroutineType context.CancelFunc
+          Type: 172 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7168,19 +7172,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 132 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 828 StructureType sync/atomic.Bool
+          Type: 835 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 829 PointerType *bufio.Writer
+          Type: 836 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 831 StructureType net/http.chunkWriter
+          Type: 838 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 832 GoMapType net/http.Header
+          Type: 839 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7204,30 +7208,30 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 828 StructureType sync/atomic.Bool
+          Type: 835 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 837 ArrayType [29]uint8
+          Type: 844 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 838 ArrayType [10]uint8
+          Type: 845 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 839 ArrayType [3]uint8
+          Type: 846 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 132 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
-          Type: 840 GoChannelType chan bool
+          Type: 847 GoChannelType chan bool
         - Name: closeNotifyTriggered
           Offset: 224
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1009
+      ID: 1016
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1607872
@@ -7243,7 +7247,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 342
+      ID: 354
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1590656
@@ -7256,17 +7260,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 686
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 625
+      ID: 637
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1461728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 554
+      ID: 566
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1545184
@@ -7276,7 +7280,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 930
+      ID: 937
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2025440
@@ -7284,22 +7288,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 700 GoInterfaceType net.Conn
+          Type: 712 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 700 GoInterfaceType net.Conn
+          Type: 712 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 340
+      ID: 352
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1286016
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 372
+      ID: 384
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1721920
@@ -7315,7 +7319,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 370
+      ID: 382
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1591776
@@ -7328,11 +7332,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 387
+      ID: 399
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 284
+      ID: 296
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835104
@@ -7340,22 +7344,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 286 PointerType *net/textproto.ProtocolError.str
+          Type: 298 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 285 GoStringDataType net/textproto.ProtocolError.str
+      Data: 297 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 285
+      ID: 297
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 679
+      ID: 691
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 278
+      ID: 290
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 834912
@@ -7363,18 +7367,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 280 PointerType *net/url.EscapeError.str
+          Type: 292 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 279 GoStringDataType net/url.EscapeError.str
+      Data: 291 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 279
+      ID: 291
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 281
+      ID: 293
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 835008
@@ -7382,18 +7386,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 283 PointerType *net/url.InvalidHostError.str
+          Type: 295 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 282 GoStringDataType net/url.InvalidHostError.str
+      Data: 294 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 282
+      ID: 294
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 850
+      ID: 857
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2126816
@@ -7407,7 +7411,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 970 PointerType *net/url.Userinfo
+          Type: 977 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7433,99 +7437,99 @@ Types:
           Offset: 128
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 971
+      ID: 978
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 852
+      ID: 859
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1884384
       GoKind: 21
-      HeaderType: 834 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 841 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 198
+      ID: 241
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 684736
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 199 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 242 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 818
+      ID: 825
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 782944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 819 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 826 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 254
+      ID: 257
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 703488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 255 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 258 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 982
+      ID: 989
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 699072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 983 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 990 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 845
+      ID: 852
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 846 StructureType noalg.struct { key string; elem []string }
+      Element: 853 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 232
+      ID: 221
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 703392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 233 StructureType noalg.struct { key string; elem float64 }
+      Element: 222 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 721
+      ID: 733
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 760160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 722 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 734 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 224
+      ID: 213
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 680992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 225 StructureType noalg.struct { key string; elem interface {} }
+      Element: 214 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 216
+      ID: 205
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 217 StructureType noalg.struct { key string; elem string }
+      Element: 206 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 197
+      ID: 240
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1288320
@@ -7536,9 +7540,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 198 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 241 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 817
+      ID: 824
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1365248
@@ -7549,9 +7553,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 818 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 825 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 253
+      ID: 256
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1305344
@@ -7562,9 +7566,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 254 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 257 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 981
+      ID: 988
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1298816
@@ -7575,9 +7579,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 982 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 989 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 844
+      ID: 851
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1289728
@@ -7588,9 +7592,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 845 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 852 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 231
+      ID: 220
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1305088
@@ -7601,9 +7605,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 232 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 221 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 720
+      ID: 732
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1346944
@@ -7614,9 +7618,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 721 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 733 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 223
+      ID: 212
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1287168
@@ -7627,9 +7631,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 224 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 213 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 215
+      ID: 204
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1292160
@@ -7640,9 +7644,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 216 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 205 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 199
+      ID: 242
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1288192
@@ -7650,12 +7654,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 200 GoInterfaceType context.canceler
+          Type: 243 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 201 StructureType struct {}
+          Type: 244 StructureType struct {}
     - __kind: StructureType
-      ID: 819
+      ID: 826
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1365120
@@ -7663,12 +7667,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 820 BaseType github.com/cihub/seelog.LogLevel
+          Type: 827 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 255
+      ID: 258
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1305216
@@ -7679,9 +7683,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 256 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 259 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 983
+      ID: 990
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1298688
@@ -7692,9 +7696,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 984 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 991 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 846
+      ID: 853
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1289600
@@ -7705,9 +7709,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 703 GoSliceHeaderType []string
+          Type: 715 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 233
+      ID: 222
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1304960
@@ -7720,7 +7724,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 722
+      ID: 734
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1346816
@@ -7731,9 +7735,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 710 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 722 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 225
+      ID: 214
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1287040
@@ -7744,9 +7748,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 163 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 217
+      ID: 206
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1292032
@@ -7759,15 +7763,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 970
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 558
+      ID: 570
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 175
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1109504
@@ -7780,11 +7784,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 641
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 961
+      ID: 968
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2350624
@@ -7792,12 +7796,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 965 StructureType os.noReadFrom
+          Type: 972 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 962 PointerType *os.File
+          Type: 969 PointerType *os.File
     - __kind: StructureType
-      ID: 959
+      ID: 966
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2349824
@@ -7805,32 +7809,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 964 StructureType os.noWriteTo
+          Type: 971 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 962 PointerType *os.File
+          Type: 969 PointerType *os.File
     - __kind: StructureType
-      ID: 965
+      ID: 972
       Name: os.noReadFrom
       GoRuntimeType: 1109376
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 964
+      ID: 971
       Name: os.noWriteTo
       GoRuntimeType: 1109248
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 591
+      ID: 603
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 728
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 593
+      ID: 605
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1695904
@@ -7843,7 +7847,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 129
+      ID: 171
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1967136
@@ -7854,17 +7858,17 @@ Types:
           Type: 117 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 149 GoSubroutineType context.CancelFunc
+          Type: 172 GoSubroutineType context.CancelFunc
         - Name: signals
           Offset: 24
-          Type: 150 GoSliceHeaderType []os.Signal
+          Type: 173 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 153 GoChannelType chan os.Signal
+          Type: 176 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 312
+      ID: 324
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 839520
@@ -7872,36 +7876,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 314 PointerType *os/user.UnknownGroupIdError.str
+          Type: 326 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 313 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 325 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 313
+      ID: 325
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 311
+      ID: 323
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 839424
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 366
+      ID: 378
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 446
+      ID: 458
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 566
+      ID: 578
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 582
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7913,7 +7917,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 568
+      ID: 580
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1883936
@@ -7930,9 +7934,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 714 BaseType runtime.boundsErrorCode
+          Type: 726 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 714
+      ID: 726
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585376
@@ -7952,7 +7956,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 631
+      ID: 643
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1753568
@@ -7965,7 +7969,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 534
+      ID: 546
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 985312
@@ -7973,13 +7977,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 536 PointerType *runtime.errorString.str
+          Type: 548 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 535 GoStringDataType runtime.errorString.str
+      Data: 547 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 535
+      ID: 547
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8606,7 +8610,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 191
+      ID: 198
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -8642,7 +8646,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 537
+      ID: 549
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 985408
@@ -8650,13 +8654,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 539 PointerType *runtime.plainError.str
+          Type: 551 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 538 GoStringDataType runtime.plainError.str
+      Data: 550 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 538
+      ID: 550
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8697,7 +8701,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 368
+      ID: 380
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1591456
@@ -8755,7 +8759,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 562
+      ID: 574
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8767,18 +8771,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 186 PointerType *string.str
+          Type: 193 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 185 GoStringDataType string.str
+      Data: 192 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 185
+      ID: 192
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 749
+      ID: 756
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1946688
@@ -8786,12 +8790,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 763
+      ID: 770
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2022848
@@ -8799,15 +8803,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 745
+      ID: 752
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1946176
@@ -8815,12 +8819,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 755
+      ID: 762
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2021696
@@ -8828,15 +8832,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 769
+      ID: 776
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2084800
@@ -8844,18 +8848,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 757
+      ID: 764
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2021984
@@ -8863,15 +8867,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 753
+      ID: 760
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2021408
@@ -8879,15 +8883,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 765
+      ID: 772
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2084160
@@ -8895,18 +8899,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 773
+      ID: 780
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2145632
@@ -8914,21 +8918,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 767
+      ID: 774
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2084480
@@ -8936,18 +8940,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 775 GoInterfaceType net/http.Flusher
+          Type: 782 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 751
+      ID: 758
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1946944
@@ -8955,12 +8959,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 747
+      ID: 754
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1946432
@@ -8968,12 +8972,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2022272
@@ -8981,15 +8985,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 771
+      ID: 778
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2085120
@@ -8997,18 +9001,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 777 GoInterfaceType net/http.CloseNotifier
+          Type: 784 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2022560
@@ -9016,15 +9020,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 774 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 781 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 776 GoInterfaceType net/http.Pusher
+          Type: 783 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 778 GoInterfaceType net/http.Hijacker
+          Type: 785 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1701088
@@ -9032,18 +9036,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 910 GoInterfaceType io.Reader
+          Type: 917 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 920 GoInterfaceType io.Closer
+          Type: 927 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 201
+      ID: 244
       Name: struct {}
       GoRuntimeType: 845760
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 132
+      ID: 120
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1465088
@@ -9051,12 +9055,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 133 StructureType sync.noCopy
+          Type: 121 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 134 StructureType internal/sync.Mutex
+          Type: 122 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 156
+      ID: 119
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1838688
@@ -9064,7 +9068,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 132 StructureType sync.Mutex
+          Type: 120 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -9073,18 +9077,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 157 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 157 StructureType sync/atomic.Int32
+          Type: 123 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 133
+      ID: 121
       Name: sync.noCopy
       GoRuntimeType: 984928
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 828
+      ID: 835
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1466208
@@ -9092,12 +9096,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 158 StructureType sync/atomic.noCopy
+          Type: 124 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 157
+      ID: 123
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1466368
@@ -9105,12 +9109,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 158 StructureType sync/atomic.noCopy
+          Type: 124 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 135
+      ID: 179
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1193280
@@ -9118,27 +9122,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 136 GoEmptyInterfaceType interface {}
+          Type: 163 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 158
+      ID: 124
       Name: sync/atomic.noCopy
       GoRuntimeType: 985024
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 664
+      ID: 676
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1278080
       GoKind: 12
     - __kind: BaseType
-      ID: 737
+      ID: 744
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 986368
       GoKind: 2
     - __kind: StructureType
-      ID: 194
+      ID: 237
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9160,9 +9164,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 195 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 238 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 814
+      ID: 821
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9184,9 +9188,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 815 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 822 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 250
+      ID: 253
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9208,9 +9212,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 251 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 254 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9232,9 +9236,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 979 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 986 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9256,9 +9260,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 842 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 849 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 228
+      ID: 217
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9280,9 +9284,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 229 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 218 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 717
+      ID: 729
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9304,9 +9308,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 718 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 730 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 220
+      ID: 209
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9328,9 +9332,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 221 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 210 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 212
+      ID: 201
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9352,9 +9356,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 213 GoSwissMapGroupsType groupReference<string,string>
+          Type: 202 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 611
+      ID: 623
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1700128
@@ -9367,13 +9371,13 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 937
+      ID: 944
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1911104
       GoKind: 6
     - __kind: StructureType
-      ID: 147
+      ID: 191
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1972768
@@ -9384,10 +9388,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 204 GoSliceHeaderType []time.zone
+          Type: 247 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 207 GoSliceHeaderType []time.zoneTrans
+          Type: 250 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9399,13 +9403,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 205 PointerType *time.zone
+          Type: 248 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 360
+      ID: 372
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 145
+      ID: 189
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2363936
@@ -9419,7 +9423,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 146 PointerType *time.Location
+          Type: 190 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9429,7 +9433,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 144
+      ID: 188
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1462688
@@ -9437,12 +9441,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 731 GoChannelType <-chan time.Time
+          Type: 743 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 273
+      ID: 285
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 833184
@@ -9450,18 +9454,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 275 PointerType *time.fileSizeError.str
+          Type: 287 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 274 GoStringDataType time.fileSizeError.str
+      Data: 286 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 274
+      ID: 286
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 206
+      ID: 249
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1612864
@@ -9477,7 +9481,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 209
+      ID: 252
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1750304
@@ -9538,7 +9542,7 @@ Types:
       GoRuntimeType: 585312
       GoKind: 26
     - __kind: StructureType
-      ID: 695
+      ID: 707
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2057600
@@ -9549,10 +9553,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 696 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 708 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 697 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 709 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9567,18 +9571,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 698 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 710 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 698
+      ID: 710
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 986464
       GoKind: 9
     - __kind: StructureType
-      ID: 696
+      ID: 708
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1914176
@@ -9603,17 +9607,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 374
+      ID: 386
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 697
+      ID: 709
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 586208
       GoKind: 8
     - __kind: StructureType
-      ID: 389
+      ID: 401
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1416768
@@ -9623,13 +9627,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 287
+      ID: 299
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835200
       GoKind: 2
     - __kind: StructureType
-      ID: 575
+      ID: 587
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1695328
@@ -9642,7 +9646,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 541
+      ID: 553
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 987328

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.26rc1.yaml
@@ -131,23 +131,23 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1004
+      ID: 1011
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 695 PointerType *crypto/x509.Certificate
+      Pointee: 707 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 743
+      ID: 278
       Name: '**gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 165 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 995
+      ID: 1002
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 996 PointerType *mime/multipart.FileHeader
+      Pointee: 1003 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
       ID: 69
       Name: '**runtime.p'
@@ -155,111 +155,111 @@ Types:
       GoKind: 22
       Pointee: 70 PointerType *runtime.p
     - __kind: PointerType
-      ID: 146
+      ID: 189
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 147 PointerType *table<context.canceler,struct {}>
+      Pointee: 190 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '**table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 807 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 814 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 251
+      ID: 240
       Name: '**table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 252 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 241 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 987 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 994 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 845
+      ID: 852
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 846 PointerType *table<string,[]string>
+      Pointee: 853 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 144
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 183 PointerType *table<string,float64>
+      Pointee: 145 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 700
+      ID: 712
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 701 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 713 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 177
+      ID: 139
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 178 PointerType *table<string,interface {}>
+      Pointee: 140 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 172
+      ID: 134
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 173 PointerType *table<string,string>
+      Pointee: 135 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 1006
+      ID: 1013
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1003 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 1010 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 1012
+      ID: 1019
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 1011 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 1018 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 746
+      ID: 281
       Name: '*[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       ByteSize: 8
-      Pointee: 745 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Pointee: 280 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 1000 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 1007 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 203
+      ID: 210
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []*runtime.p.array
-    - __kind: PointerType
-      ID: 1014
-      Name: '*[][]*crypto/x509.Certificate.array'
-      ByteSize: 8
-      Pointee: 1013 GoSliceDataType [][]*crypto/x509.Certificate.array
-    - __kind: PointerType
-      ID: 1016
-      Name: '*[][]uint8.array'
-      ByteSize: 8
-      Pointee: 1015 GoSliceDataType [][]uint8.array
-    - __kind: PointerType
-      ID: 738
-      Name: '*[]float64.array'
-      ByteSize: 8
-      Pointee: 737 GoSliceDataType []float64.array
-    - __kind: PointerType
-      ID: 247
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
-      ByteSize: 8
-      Pointee: 246 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
-    - __kind: PointerType
-      ID: 255
-      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
-      ByteSize: 8
-      Pointee: 254 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Pointee: 209 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 1021
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 1020 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 1023
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 1022 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 750
+      Name: '*[]float64.array'
+      ByteSize: 8
+      Pointee: 749 GoSliceDataType []float64.array
+    - __kind: PointerType
+      ID: 236
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
+      ByteSize: 8
+      Pointee: 235 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+    - __kind: PointerType
+      ID: 244
+      Name: '*[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 1028
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 1020 GoSliceDataType []net/http.segment.array
+      Pointee: 1027 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 221
+      ID: 246
       Name: '*[]os.Signal.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType []os.Signal.array
+      Pointee: 245 GoSliceDataType []os.Signal.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -268,77 +268,77 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 736
+      ID: 748
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 735 GoSliceDataType []string.array
+      Pointee: 747 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 257
+      ID: 274
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []time.zone.array
+      Pointee: 273 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 259
+      ID: 276
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []time.zoneTrans.array
+      Pointee: 275 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 487168
       GoKind: 22
       Pointee: 41 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 198
+      ID: 205
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []uint8.array
+      Pointee: 204 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 200
+      ID: 207
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []uintptr.array
+      Pointee: 206 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 528
+      ID: 540
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 954880
       GoKind: 22
-      Pointee: 529 GoSliceHeaderType archive/tar.headerError
+      Pointee: 541 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 531
+      ID: 543
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 530 GoSliceDataType archive/tar.headerError.array
+      Pointee: 542 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*archive/zip.checksumReader'
       ByteSize: 8
       GoRuntimeType: 1265696
       GoKind: 22
-      Pointee: 909 UnresolvedPointeeType archive/zip.checksumReader
+      Pointee: 916 UnresolvedPointeeType archive/zip.checksumReader
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*archive/zip.dirReader'
       ByteSize: 8
       GoRuntimeType: 1091840
       GoKind: 22
-      Pointee: 895 UnresolvedPointeeType archive/zip.dirReader
+      Pointee: 902 UnresolvedPointeeType archive/zip.dirReader
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*archive/zip.openDir'
       ByteSize: 8
       GoRuntimeType: 1454528
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType archive/zip.openDir
+      Pointee: 920 UnresolvedPointeeType archive/zip.openDir
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*archive/zip.pooledFlateReader'
       ByteSize: 8
       GoRuntimeType: 1091584
       GoKind: 22
-      Pointee: 893 UnresolvedPointeeType archive/zip.pooledFlateReader
+      Pointee: 900 UnresolvedPointeeType archive/zip.pooledFlateReader
     - __kind: PointerType
       ID: 12
       Name: '*bool'
@@ -347,12 +347,12 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1972160
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType bufio.Writer
+      Pointee: 847 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
       ID: 120
       Name: '*bytes.Buffer'
@@ -368,353 +368,353 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 403
+      ID: 415
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 918880
       GoKind: 22
-      Pointee: 301 BaseType compress/flate.CorruptInputError
+      Pointee: 313 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 404
+      ID: 416
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 918976
       GoKind: 22
-      Pointee: 302 GoStringHeaderType compress/flate.InternalError
+      Pointee: 314 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 304
+      ID: 316
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 303 GoStringDataType compress/flate.InternalError.str
+      Pointee: 315 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*compress/flate.decompressor'
       ByteSize: 8
       GoRuntimeType: 1999456
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType compress/flate.decompressor
+      Pointee: 956 UnresolvedPointeeType compress/flate.decompressor
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*compress/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1642336
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType compress/gzip.Reader
+      Pointee: 935 UnresolvedPointeeType compress/gzip.Reader
     - __kind: PointerType
-      ID: 124
+      ID: 198
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 1734112
       GoKind: 22
-      Pointee: 125 StructureType context.afterFuncCtx
+      Pointee: 199 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 1027
+      ID: 172
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1555584
       GoKind: 22
-      Pointee: 151 StructureType context.backgroundCtx
+      Pointee: 173 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 126
+      ID: 183
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1733536
       GoKind: 22
-      Pointee: 127 StructureType context.cancelCtx
+      Pointee: 184 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 625
+      ID: 637
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1189920
       GoKind: 22
-      Pointee: 626 StructureType context.deadlineExceededError
+      Pointee: 638 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1022
+      ID: 158
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1417568
       GoKind: 22
-      Pointee: 152 StructureType context.emptyCtx
+      Pointee: 159 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 128
+      ID: 160
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1417728
       GoKind: 22
-      Pointee: 129 StructureType context.stopCtx
+      Pointee: 161 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 130
+      ID: 191
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1733728
       GoKind: 22
-      Pointee: 131 StructureType context.timerCtx
+      Pointee: 192 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1028
+      ID: 174
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1555744
       GoKind: 22
-      Pointee: 159 StructureType context.todoCtx
+      Pointee: 175 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 132
+      ID: 167
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1555264
       GoKind: 22
-      Pointee: 133 StructureType context.valueCtx
+      Pointee: 168 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 134
+      ID: 170
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1555424
       GoKind: 22
-      Pointee: 135 StructureType context.withoutCancelCtx
+      Pointee: 171 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 452
+      ID: 464
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927616
       GoKind: 22
-      Pointee: 320 BaseType crypto/aes.KeySizeError
+      Pointee: 332 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 453
+      ID: 465
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927808
       GoKind: 22
-      Pointee: 321 BaseType crypto/des.KeySizeError
+      Pointee: 333 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 454
+      ID: 466
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928096
       GoKind: 22
-      Pointee: 322 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 334 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 606
+      ID: 618
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1062272
       GoKind: 22
-      Pointee: 607 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 619 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 455
+      ID: 467
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 928384
       GoKind: 22
-      Pointee: 323 BaseType crypto/rc4.KeySizeError
+      Pointee: 335 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 392
+      ID: 404
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 916960
       GoKind: 22
-      Pointee: 290 BaseType crypto/tls.AlertError
+      Pointee: 302 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 582
+      ID: 594
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1046656
       GoKind: 22
-      Pointee: 583 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 595 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 978
+      ID: 985
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2392736
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 986 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 916576
       GoKind: 22
-      Pointee: 866 StructureType crypto/tls.ConnectionState
+      Pointee: 873 StructureType crypto/tls.ConnectionState
     - __kind: PointerType
-      ID: 393
+      ID: 405
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 917056
       GoKind: 22
-      Pointee: 394 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 406 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 390
+      ID: 402
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 916864
       GoKind: 22
-      Pointee: 391 StructureType crypto/tls.RecordHeaderError
+      Pointee: 403 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 581
+      ID: 593
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1044992
       GoKind: 22
-      Pointee: 550 BaseType crypto/tls.alert
+      Pointee: 562 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 395
+      ID: 407
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 917152
       GoKind: 22
-      Pointee: 396 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 408 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 686
+      ID: 698
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1425568
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 699 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 695
+      ID: 707
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2033984
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 708 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 448
+      ID: 460
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 927232
       GoKind: 22
-      Pointee: 449 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 461 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 442
+      ID: 454
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 926272
       GoKind: 22
-      Pointee: 443 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 455 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 444
+      ID: 456
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 926752
       GoKind: 22
-      Pointee: 445 StructureType crypto/x509.HostnameError
+      Pointee: 457 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 441
+      ID: 453
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 926176
       GoKind: 22
-      Pointee: 319 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 331 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 598
+      ID: 610
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1055360
       GoKind: 22
-      Pointee: 599 StructureType crypto/x509.SystemRootsError
+      Pointee: 611 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 450
+      ID: 462
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 927328
       GoKind: 22
-      Pointee: 451 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 463 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 446
+      ID: 458
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 927136
       GoKind: 22
-      Pointee: 447 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 459 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 490
+      ID: 502
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 937216
       GoKind: 22
-      Pointee: 491 StructureType encoding/asn1.StructuralError
+      Pointee: 503 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 494
+      ID: 506
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 495 StructureType encoding/asn1.SyntaxError
+      Pointee: 507 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 492
+      ID: 504
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 937312
       GoKind: 22
-      Pointee: 493 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 505 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 397
+      ID: 409
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 917344
       GoKind: 22
-      Pointee: 291 BaseType encoding/base64.CorruptInputError
+      Pointee: 303 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 433
+      ID: 445
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 924928
       GoKind: 22
-      Pointee: 315 BaseType encoding/hex.InvalidByteError
+      Pointee: 327 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 418
+      ID: 430
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 419 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 431 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 594
+      ID: 606
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1051648
       GoKind: 22
-      Pointee: 595 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 607 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 410
+      ID: 422
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 920992
       GoKind: 22
-      Pointee: 411 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 423 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 416
+      ID: 428
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 921280
       GoKind: 22
-      Pointee: 417 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 429 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 414
+      ID: 426
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 415 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 427 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 412
+      ID: 424
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 921088
       GoKind: 22
-      Pointee: 413 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 425 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 420
+      ID: 432
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 921760
       GoKind: 22
-      Pointee: 421 StructureType encoding/json.jsonError
+      Pointee: 433 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 521
+      ID: 533
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 948928
       GoKind: 22
-      Pointee: 522 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 534 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -723,19 +723,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 375
+      ID: 387
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 911872
       GoKind: 22
-      Pointee: 376 UnresolvedPointeeType errors.errorString
+      Pointee: 388 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 569
+      ID: 581
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1037824
       GoKind: 22
-      Pointee: 570 UnresolvedPointeeType errors.joinError
+      Pointee: 582 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -751,799 +751,799 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 553
+      ID: 565
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1027200
       GoKind: 22
-      Pointee: 554 UnresolvedPointeeType fmt.wrapError
+      Pointee: 566 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 555
+      ID: 567
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1027328
       GoKind: 22
-      Pointee: 556 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 568 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 431
+      ID: 443
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 432 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 444 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger'
       ByteSize: 8
       GoRuntimeType: 2035136
       GoKind: 22
-      Pointee: 809 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
+      Pointee: 816 StructureType github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
     - __kind: PointerType
-      ID: 423
+      ID: 435
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 923104
       GoKind: 22
-      Pointee: 424 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 436 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 425
+      ID: 437
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 923200
       GoKind: 22
-      Pointee: 426 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 438 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 715
+      ID: 727
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 728 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 429
+      ID: 441
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 923488
       GoKind: 22
-      Pointee: 430 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 442 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 717
+      ID: 729
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 923008
       GoKind: 22
-      Pointee: 718 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 730 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 427
+      ID: 439
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 923296
       GoKind: 22
-      Pointee: 309 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 321 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 311
+      ID: 323
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 310 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 322 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 422
+      ID: 434
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 306 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 318 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 308
+      ID: 320
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 319 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 428
+      ID: 440
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 923392
       GoKind: 22
-      Pointee: 312 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 324 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 314
+      ID: 326
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 313 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 325 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 499
+      ID: 511
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 938368
       GoKind: 22
-      Pointee: 500 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
+      Pointee: 512 StructureType github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
     - __kind: PointerType
-      ID: 496
+      ID: 508
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.RunError'
       ByteSize: 8
       GoRuntimeType: 938176
       GoKind: 22
-      Pointee: 324 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
+      Pointee: 336 BaseType github.com/DataDog/go-libddwaf/v3/errors.RunError
     - __kind: PointerType
-      ID: 497
+      ID: 509
       Name: '*github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 938272
       GoKind: 22
-      Pointee: 498 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
+      Pointee: 510 StructureType github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 464
+      ID: 476
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 934048
       GoKind: 22
-      Pointee: 465 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 477 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 468
+      ID: 480
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 934240
       GoKind: 22
-      Pointee: 469 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 481 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 466
+      ID: 478
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 934144
       GoKind: 22
-      Pointee: 467 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 479 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 462
+      ID: 474
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 933952
       GoKind: 22
-      Pointee: 463 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 475 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 740
+      ID: 752
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 739 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 751 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 476
+      ID: 488
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 934624
       GoKind: 22
-      Pointee: 477 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 489 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 470
+      ID: 482
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 934336
       GoKind: 22
-      Pointee: 471 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 483 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 474
+      ID: 486
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 934528
       GoKind: 22
-      Pointee: 475 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 487 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 472
+      ID: 484
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 934432
       GoKind: 22
-      Pointee: 473 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 485 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 478
+      ID: 490
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 934720
       GoKind: 22
-      Pointee: 479 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 491 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 484
+      ID: 496
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 935008
       GoKind: 22
-      Pointee: 485 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 497 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 486
+      ID: 498
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 935104
       GoKind: 22
-      Pointee: 487 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 499 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 482
+      ID: 494
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 934912
       GoKind: 22
-      Pointee: 483 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 495 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 480
+      ID: 492
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 934816
       GoKind: 22
-      Pointee: 481 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 493 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 488
+      ID: 500
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 935296
       GoKind: 22
-      Pointee: 489 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 501 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*github.com/cihub/seelog.asyncAdaptiveLogger'
       ByteSize: 8
       GoRuntimeType: 2333600
       GoKind: 22
-      Pointee: 823 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
+      Pointee: 830 UnresolvedPointeeType github.com/cihub/seelog.asyncAdaptiveLogger
     - __kind: PointerType
-      ID: 816
+      ID: 823
       Name: '*github.com/cihub/seelog.asyncLogger'
       ByteSize: 8
       GoRuntimeType: 2319808
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
+      Pointee: 824 UnresolvedPointeeType github.com/cihub/seelog.asyncLogger
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*github.com/cihub/seelog.asyncLoopLogger'
       ByteSize: 8
       GoRuntimeType: 2327200
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
+      Pointee: 826 UnresolvedPointeeType github.com/cihub/seelog.asyncLoopLogger
     - __kind: PointerType
-      ID: 820
+      ID: 827
       Name: '*github.com/cihub/seelog.asyncTimerLogger'
       ByteSize: 8
       GoRuntimeType: 2327840
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
+      Pointee: 828 UnresolvedPointeeType github.com/cihub/seelog.asyncTimerLogger
     - __kind: PointerType
-      ID: 509
+      ID: 521
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 946336
       GoKind: 22
-      Pointee: 510 StructureType github.com/cihub/seelog.baseError
+      Pointee: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1822592
       GoKind: 22
-      Pointee: 802 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 809 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 511
+      ID: 523
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 946432
       GoKind: 22
-      Pointee: 512 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 524 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 793
+      ID: 800
       Name: '*github.com/cihub/seelog.customReceiverDispatcher'
       ByteSize: 8
       GoRuntimeType: 1445248
       GoKind: 22
-      Pointee: 794 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
+      Pointee: 801 UnresolvedPointeeType github.com/cihub/seelog.customReceiverDispatcher
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*github.com/cihub/seelog.dispatcher'
       ByteSize: 8
       GoRuntimeType: 1678240
       GoKind: 22
-      Pointee: 796 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
+      Pointee: 803 UnresolvedPointeeType github.com/cihub/seelog.dispatcher
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*github.com/cihub/seelog.filterDispatcher'
       ByteSize: 8
       GoRuntimeType: 1679008
       GoKind: 22
-      Pointee: 800 StructureType github.com/cihub/seelog.filterDispatcher
+      Pointee: 807 StructureType github.com/cihub/seelog.filterDispatcher
     - __kind: PointerType
-      ID: 515
+      ID: 527
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 946624
       GoKind: 22
-      Pointee: 516 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 528 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*github.com/cihub/seelog.splitDispatcher'
       ByteSize: 8
       GoRuntimeType: 1678432
       GoKind: 22
-      Pointee: 798 StructureType github.com/cihub/seelog.splitDispatcher
+      Pointee: 805 StructureType github.com/cihub/seelog.splitDispatcher
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '*github.com/cihub/seelog.syncLogger'
       ByteSize: 8
       GoRuntimeType: 2298688
       GoKind: 22
-      Pointee: 815 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
+      Pointee: 822 UnresolvedPointeeType github.com/cihub/seelog.syncLogger
     - __kind: PointerType
-      ID: 513
+      ID: 525
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 946528
       GoKind: 22
-      Pointee: 514 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 526 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 517
+      ID: 529
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 946720
       GoKind: 22
-      Pointee: 518 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 530 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*github.com/cihub/seelog/archive.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1257504
       GoKind: 22
-      Pointee: 907 StructureType github.com/cihub/seelog/archive.nopCloser
+      Pointee: 914 StructureType github.com/cihub/seelog/archive.nopCloser
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*github.com/cihub/seelog/archive/gzip.Reader'
       ByteSize: 8
       GoRuntimeType: 1753696
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
+      Pointee: 939 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Reader
     - __kind: PointerType
-      ID: 612
+      ID: 624
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1074688
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 625 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 614
+      ID: 626
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1074816
       GoKind: 22
-      Pointee: 615 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 627 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 604
+      ID: 616
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1059456
       GoKind: 22
-      Pointee: 605 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 617 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 434
+      ID: 446
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 435 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 447 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 608
+      ID: 620
       Name: '*github.com/mitchellh/mapstructure.Error'
       ByteSize: 8
       GoRuntimeType: 1063040
       GoKind: 22
-      Pointee: 609 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
+      Pointee: 621 UnresolvedPointeeType github.com/mitchellh/mapstructure.Error
     - __kind: PointerType
-      ID: 654
+      ID: 666
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1213216
       GoKind: 22
-      Pointee: 655 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 667 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 648
+      ID: 660
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1212832
       GoKind: 22
-      Pointee: 649 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 661 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 588
+      ID: 600
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1050752
       GoKind: 22
-      Pointee: 589 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 601 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 660
+      ID: 672
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1213600
       GoKind: 22
-      Pointee: 661 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 673 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 587
+      ID: 599
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1050624
       GoKind: 22
-      Pointee: 552 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 564 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 652
+      ID: 664
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1213088
       GoKind: 22
-      Pointee: 653 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 650
+      ID: 662
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1212960
       GoKind: 22
-      Pointee: 651 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 658
+      ID: 670
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1213472
       GoKind: 22
-      Pointee: 659 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 671 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 656
+      ID: 668
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1213344
       GoKind: 22
-      Pointee: 657 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 669 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 664
+      ID: 676
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1213984
       GoKind: 22
-      Pointee: 665 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 677 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 592
+      ID: 604
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1051008
       GoKind: 22
-      Pointee: 593 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 605 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 590
+      ID: 602
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1050880
       GoKind: 22
-      Pointee: 591 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 603 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 662
+      ID: 674
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1213856
       GoKind: 22
-      Pointee: 663 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 675 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 527
+      ID: 539
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 954112
       GoKind: 22
-      Pointee: 329 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 341 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 331
+      ID: 343
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 342 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 703
+      ID: 715
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1677280
       GoKind: 22
-      Pointee: 704 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 716 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 618
+      ID: 630
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1090944
       GoKind: 22
-      Pointee: 619 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 631 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 532
+      ID: 544
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 956128
       GoKind: 22
-      Pointee: 332 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 344 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 672
+      ID: 684
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1267360
       GoKind: 22
-      Pointee: 673 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 685 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 535
+      ID: 547
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 956416
       GoKind: 22
-      Pointee: 536 StructureType golang.org/x/net/http2.connError
+      Pointee: 548 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 534
+      ID: 546
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 956320
       GoKind: 22
-      Pointee: 336 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 348 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 338
+      ID: 350
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 349 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 538
+      ID: 550
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 956608
       GoKind: 22
-      Pointee: 342 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 354 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 344
+      ID: 356
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 355 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 537
+      ID: 549
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 956512
       GoKind: 22
-      Pointee: 339 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 351 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 341
+      ID: 353
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 352 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 533
+      ID: 545
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 956224
       GoKind: 22
-      Pointee: 333 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 345 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 335
+      ID: 347
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 346 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 539
+      ID: 551
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 956704
       GoKind: 22
-      Pointee: 540 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 552 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 541
+      ID: 553
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 956800
       GoKind: 22
-      Pointee: 345 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 357 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 519
+      ID: 531
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 948544
       GoKind: 22
-      Pointee: 520 StructureType google.golang.org/grpc.dropError
+      Pointee: 532 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 670
+      ID: 682
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1264160
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 683 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 690
+      ID: 702
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1451008
       GoKind: 22
-      Pointee: 691 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 703 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 525
+      ID: 537
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 952384
       GoKind: 22
-      Pointee: 526 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 538 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1825280
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 945 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 616
+      ID: 628
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1085184
       GoKind: 22
-      Pointee: 617 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 629 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*google.golang.org/grpc/mem.sliceReader'
       ByteSize: 8
       GoRuntimeType: 1576544
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
+      Pointee: 929 UnresolvedPointeeType google.golang.org/grpc/mem.sliceReader
     - __kind: PointerType
-      ID: 501
+      ID: 513
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 940576
       GoKind: 22
-      Pointee: 502 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 514 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 610
+      ID: 622
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1064448
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 623 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 668
+      ID: 680
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1230752
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 681 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 666
+      ID: 678
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1230496
       GoKind: 22
-      Pointee: 667 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 679 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 408
+      ID: 420
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 920032
       GoKind: 22
-      Pointee: 409 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
+      Pointee: 421 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1564384
       GoKind: 22
-      Pointee: 753 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 760 StructureType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 185
+      ID: 147
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1211168
       GoKind: 22
-      Pointee: 186 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Pointee: 148 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload'
       ByteSize: 8
       GoRuntimeType: 1913696
       GoKind: 22
-      Pointee: 944 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
+      Pointee: 951 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload'
       ByteSize: 8
       GoRuntimeType: 1815872
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+      Pointee: 943 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
     - __kind: PointerType
-      ID: 165
+      ID: 154
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 8
       GoRuntimeType: 2325280
       GoKind: 22
-      Pointee: 166 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Pointee: 124 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
-      ID: 190
+      ID: 152
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext'
       ByteSize: 8
       GoRuntimeType: 1994560
       GoKind: 22
-      Pointee: 191 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+      Pointee: 153 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
     - __kind: PointerType
-      ID: 188
+      ID: 150
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1196832
       GoKind: 22
-      Pointee: 189 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Pointee: 151 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1197472
       GoKind: 22
-      Pointee: 751 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 758 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 266
+      ID: 269
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1197600
       GoKind: 22
-      Pointee: 267 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 270 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 192
+      ID: 155
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2240800
       GoKind: 22
-      Pointee: 193 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+      Pointee: 156 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor'
       ByteSize: 8
       GoRuntimeType: 2191648
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
+      Pointee: 820 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
     - __kind: PointerType
-      ID: 1025
+      ID: 165
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1429408
       GoKind: 22
-      Pointee: 1026 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
+      Pointee: 166 StructureType gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client'
       ByteSize: 8
       GoRuntimeType: 2171904
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
+      Pointee: 818 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser'
       ByteSize: 8
       GoRuntimeType: 1057792
       GoKind: 22
-      Pointee: 891 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
+      Pointee: 898 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
     - __kind: PointerType
-      ID: 458
+      ID: 470
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 932320
       GoKind: 22
-      Pointee: 459 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 471 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 503
+      ID: 515
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 941152
       GoKind: 22
-      Pointee: 504 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 516 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 505
+      ID: 517
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 941248
       GoKind: 22
-      Pointee: 506 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 518 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 523
+      ID: 535
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 949696
       GoKind: 22
-      Pointee: 524 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 536 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 542
+      ID: 554
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 957568
       GoKind: 22
-      Pointee: 543 UnresolvedPointeeType html/template.Error
+      Pointee: 555 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 107
       Name: '*int'
@@ -1580,54 +1580,54 @@ Types:
       GoKind: 22
       Pointee: 21 BaseType int8
     - __kind: PointerType
-      ID: 692
+      ID: 704
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2214912
       GoKind: 22
-      Pointee: 693 UnresolvedPointeeType internal/abi.Type
+      Pointee: 705 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 439
+      ID: 451
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 440 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 452 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 437
+      ID: 449
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 925696
       GoKind: 22
-      Pointee: 438 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 450 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 646
+      ID: 658
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1205792
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 659 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2388480
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType internal/poll.FD
+      Pointee: 984 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 644
+      ID: 656
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1205664
       GoKind: 22
-      Pointee: 645 StructureType internal/poll.errNetClosing
+      Pointee: 657 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 377
+      ID: 389
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 912256
       GoKind: 22
-      Pointee: 378 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 390 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -1636,305 +1636,305 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 436
+      ID: 448
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 925600
       GoKind: 22
-      Pointee: 316 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 328 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 318
+      ID: 330
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 317 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 329 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 596
+      ID: 608
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1054208
       GoKind: 22
-      Pointee: 597 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 609 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 387
+      ID: 399
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 289 BaseType internal/strconv.Error
+      Pointee: 301 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*io.PipeReader'
       ByteSize: 8
       GoRuntimeType: 1856960
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType io.PipeReader
+      Pointee: 949 UnresolvedPointeeType io.PipeReader
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*io.SectionReader'
       ByteSize: 8
       GoRuntimeType: 1560704
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType io.SectionReader
+      Pointee: 953 UnresolvedPointeeType io.SectionReader
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*io.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1038336
       GoKind: 22
-      Pointee: 889 StructureType io.nopCloser
+      Pointee: 896 StructureType io.nopCloser
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*io.nopCloserWriterTo'
       ByteSize: 8
       GoRuntimeType: 1200032
       GoKind: 22
-      Pointee: 905 StructureType io.nopCloserWriterTo
+      Pointee: 912 StructureType io.nopCloserWriterTo
     - __kind: PointerType
-      ID: 642
+      ID: 654
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1204640
       GoKind: 22
-      Pointee: 643 UnresolvedPointeeType io/fs.PathError
+      Pointee: 655 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 144
+      ID: 187
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 145 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 188 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*map<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 805 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 812 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 249
+      ID: 238
       Name: '*map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 250 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 239 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 984
+      ID: 991
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 985 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 992 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 844 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 851 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 180
+      ID: 142
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 181 GoSwissMapHeaderType map<string,float64>
+      Pointee: 143 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 698
+      ID: 710
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 699 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 711 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 175
+      ID: 137
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 170
+      ID: 132
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 171 GoSwissMapHeaderType map<string,string>
+      Pointee: 133 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 456
+      ID: 468
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 929056
       GoKind: 22
-      Pointee: 457 StructureType math/big.ErrNaN
+      Pointee: 469 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType mime/multipart.FileHeader
+      Pointee: 1006 UnresolvedPointeeType mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 918208
       GoKind: 22
-      Pointee: 864 StructureType mime/multipart.Form
+      Pointee: 871 StructureType mime/multipart.Form
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*mime/multipart.Part'
       ByteSize: 8
       GoRuntimeType: 1641184
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType mime/multipart.Part
+      Pointee: 931 UnresolvedPointeeType mime/multipart.Part
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*mime/multipart.sectionReadCloser'
       ByteSize: 8
       GoRuntimeType: 1641376
       GoKind: 22
-      Pointee: 926 StructureType mime/multipart.sectionReadCloser
+      Pointee: 933 StructureType mime/multipart.sectionReadCloser
     - __kind: PointerType
-      ID: 628
+      ID: 640
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1191072
       GoKind: 22
-      Pointee: 629 UnresolvedPointeeType net.AddrError
+      Pointee: 641 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 677
+      ID: 689
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1418368
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType net.DNSError
+      Pointee: 690 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2244832
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType net.IPConn
+      Pointee: 960 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 675
+      ID: 687
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1418048
       GoKind: 22
-      Pointee: 676 UnresolvedPointeeType net.OpError
+      Pointee: 688 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 630
+      ID: 642
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1191200
       GoKind: 22
-      Pointee: 631 UnresolvedPointeeType net.ParseError
+      Pointee: 643 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2275136
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType net.TCPConn
+      Pointee: 968 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2317376
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net.UDPConn
+      Pointee: 972 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2274624
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType net.UnixConn
+      Pointee: 966 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 627
+      ID: 639
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1190304
       GoKind: 22
-      Pointee: 622 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 634 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 624
+      ID: 636
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 623 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 635 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 557
+      ID: 569
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1028224
       GoKind: 22
-      Pointee: 558 StructureType net.canceledError
+      Pointee: 570 StructureType net.canceledError
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2029952
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType net.conn
+      Pointee: 958 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 721
+      ID: 733
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1850688
       GoKind: 22
-      Pointee: 722 StructureType net.dialResult·1
+      Pointee: 734 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2321024
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType net.netFD
+      Pointee: 974 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 346
+      ID: 358
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 904672
       GoKind: 22
-      Pointee: 347 UnresolvedPointeeType net.notFoundError
+      Pointee: 359 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1023
+      ID: 163
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1418208
       GoKind: 22
-      Pointee: 1024 StructureType net.onlyValuesCtx
+      Pointee: 164 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 348
+      ID: 360
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 905344
       GoKind: 22
-      Pointee: 349 StructureType net.result·2
+      Pointee: 361 StructureType net.result·2
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2261632
       GoKind: 22
-      Pointee: 957 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 964 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2261152
       GoKind: 22
-      Pointee: 955 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 962 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 632
+      ID: 644
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1191840
       GoKind: 22
-      Pointee: 633 UnresolvedPointeeType net.temporaryError
+      Pointee: 645 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 679
+      ID: 691
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1418688
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType net.timeoutError
+      Pointee: 692 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 354
+      ID: 366
       Name: '*net/http.MaxBytesError'
       ByteSize: 8
       GoRuntimeType: 907936
       GoKind: 22
-      Pointee: 355 UnresolvedPointeeType net/http.MaxBytesError
+      Pointee: 367 UnresolvedPointeeType net/http.MaxBytesError
     - __kind: PointerType
-      ID: 559
+      ID: 571
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1031936
       GoKind: 22
-      Pointee: 560 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 572 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
       ID: 118
       Name: '*net/http.Request'
@@ -1943,571 +1943,571 @@ Types:
       GoKind: 22
       Pointee: 119 StructureType net/http.Request
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1735264
       GoKind: 22
-      Pointee: 869 StructureType net/http.Response
+      Pointee: 876 StructureType net/http.Response
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*net/http.body'
       ByteSize: 8
       GoRuntimeType: 1814976
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net/http.body
+      Pointee: 941 UnresolvedPointeeType net/http.body
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*net/http.bodyEOFSignal'
       ByteSize: 8
       GoRuntimeType: 1194144
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType net/http.bodyEOFSignal
+      Pointee: 908 UnresolvedPointeeType net/http.bodyEOFSignal
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*net/http.cancelTimerBody'
       ByteSize: 8
       GoRuntimeType: 1031808
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType net/http.cancelTimerBody
+      Pointee: 890 UnresolvedPointeeType net/http.cancelTimerBody
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*net/http.conn'
       ByteSize: 8
       GoRuntimeType: 1911904
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType net/http.conn
+      Pointee: 843 UnresolvedPointeeType net/http.conn
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net/http.expectContinueReader'
       ByteSize: 8
       GoRuntimeType: 1030528
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType net/http.expectContinueReader
+      Pointee: 882 UnresolvedPointeeType net/http.expectContinueReader
     - __kind: PointerType
-      ID: 918
+      ID: 925
       Name: '*net/http.gzipReader'
       ByteSize: 8
       GoRuntimeType: 1559264
       GoKind: 22
-      Pointee: 919 UnresolvedPointeeType net/http.gzipReader
+      Pointee: 926 UnresolvedPointeeType net/http.gzipReader
     - __kind: PointerType
-      ID: 356
+      ID: 368
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 908128
       GoKind: 22
-      Pointee: 270 BaseType net/http.http2ConnectionError
+      Pointee: 282 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 357
+      ID: 369
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 908224
       GoKind: 22
-      Pointee: 358 StructureType net/http.http2GoAwayError
+      Pointee: 370 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 681
+      ID: 693
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1419488
       GoKind: 22
-      Pointee: 682 StructureType net/http.http2StreamError
+      Pointee: 694 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*net/http.http2clientStream'
       ByteSize: 8
       GoRuntimeType: 2031680
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType net/http.http2clientStream
+      Pointee: 922 UnresolvedPointeeType net/http.http2clientStream
     - __kind: PointerType
-      ID: 363
+      ID: 375
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 364 StructureType net/http.http2connError
+      Pointee: 376 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 360
+      ID: 372
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 274 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 286 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 276
+      ID: 288
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 275 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 287 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 361
+      ID: 373
       Name: '*net/http.http2goAwayFlowError'
       ByteSize: 8
       GoRuntimeType: 908800
       GoKind: 22
-      Pointee: 362 StructureType net/http.http2goAwayFlowError
+      Pointee: 374 StructureType net/http.http2goAwayFlowError
     - __kind: PointerType
-      ID: 916
+      ID: 923
       Name: '*net/http.http2gzipReader'
       ByteSize: 8
       GoRuntimeType: 1557664
       GoKind: 22
-      Pointee: 917 UnresolvedPointeeType net/http.http2gzipReader
+      Pointee: 924 UnresolvedPointeeType net/http.http2gzipReader
     - __kind: PointerType
-      ID: 366
+      ID: 378
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 909472
       GoKind: 22
-      Pointee: 280 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 292 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 282
+      ID: 294
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 281 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 293 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 365
+      ID: 377
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 277 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 289 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 279
+      ID: 291
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 278 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 290 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 636
+      ID: 648
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1195424
       GoKind: 22
-      Pointee: 637 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 649 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*net/http.http2missingBody'
       ByteSize: 8
       GoRuntimeType: 1031424
       GoKind: 22
-      Pointee: 879 StructureType net/http.http2missingBody
+      Pointee: 886 StructureType net/http.http2missingBody
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*net/http.http2noBodyReader'
       ByteSize: 8
       GoRuntimeType: 1034240
       GoKind: 22
-      Pointee: 887 StructureType net/http.http2noBodyReader
+      Pointee: 894 StructureType net/http.http2noBodyReader
     - __kind: PointerType
-      ID: 565
+      ID: 577
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1034112
       GoKind: 22
-      Pointee: 566 StructureType net/http.http2noCachedConnError
+      Pointee: 578 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 359
+      ID: 371
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 271 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 283 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 273
+      ID: 285
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 272 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 284 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*net/http.http2requestBody'
       ByteSize: 8
       GoRuntimeType: 1032448
       GoKind: 22
-      Pointee: 885 UnresolvedPointeeType net/http.http2requestBody
+      Pointee: 892 UnresolvedPointeeType net/http.http2requestBody
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2031104
       GoKind: 22
-      Pointee: 790 StructureType net/http.http2responseWriter
+      Pointee: 797 StructureType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*net/http.http2responseWriterState'
       ByteSize: 8
       GoRuntimeType: 1625824
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType net/http.http2responseWriterState
+      Pointee: 841 UnresolvedPointeeType net/http.http2responseWriterState
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*net/http.http2transportResponseBody'
       ByteSize: 8
       GoRuntimeType: 1031552
       GoKind: 22
-      Pointee: 881 StructureType net/http.http2transportResponseBody
+      Pointee: 888 StructureType net/http.http2transportResponseBody
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*net/http.maxBytesReader'
       ByteSize: 8
       GoRuntimeType: 1030784
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType net/http.maxBytesReader
+      Pointee: 884 UnresolvedPointeeType net/http.maxBytesReader
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*net/http.noBody'
       ByteSize: 8
       GoRuntimeType: 1194272
       GoKind: 22
-      Pointee: 903 StructureType net/http.noBody
+      Pointee: 910 StructureType net/http.noBody
     - __kind: PointerType
-      ID: 561
+      ID: 573
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1033856
       GoKind: 22
-      Pointee: 562 StructureType net/http.nothingWrittenError
+      Pointee: 574 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1624096
       GoKind: 22
-      Pointee: 871 StructureType net/http.pattern
+      Pointee: 878 StructureType net/http.pattern
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/http.readTrackingBody'
       ByteSize: 8
       GoRuntimeType: 1030144
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType net/http.readTrackingBody
+      Pointee: 880 UnresolvedPointeeType net/http.readTrackingBody
     - __kind: PointerType
-      ID: 910
+      ID: 917
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1419808
       GoKind: 22
-      Pointee: 911 UnresolvedPointeeType net/http.readWriteCloserBody
+      Pointee: 918 UnresolvedPointeeType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 367
+      ID: 379
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 909664
       GoKind: 22
-      Pointee: 368 StructureType net/http.requestBodyReadError
+      Pointee: 380 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2240352
       GoKind: 22
-      Pointee: 792 StructureType net/http.response
+      Pointee: 799 StructureType net/http.response
     - __kind: PointerType
-      ID: 1018
+      ID: 1025
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 396736
       GoKind: 22
-      Pointee: 1019 StructureType net/http.segment
+      Pointee: 1026 StructureType net/http.segment
     - __kind: PointerType
-      ID: 352
+      ID: 364
       Name: '*net/http.statusError'
       ByteSize: 8
       GoRuntimeType: 907840
       GoKind: 22
-      Pointee: 353 StructureType net/http.statusError
+      Pointee: 365 StructureType net/http.statusError
     - __kind: PointerType
-      ID: 683
+      ID: 695
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1420928
       GoKind: 22
-      Pointee: 684 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 696 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 634
+      ID: 646
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1195296
       GoKind: 22
-      Pointee: 635 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 647 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 563
+      ID: 575
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1033984
       GoKind: 22
-      Pointee: 564 StructureType net/http.transportReadFromServerError
+      Pointee: 576 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1852032
       GoKind: 22
-      Pointee: 940 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 947 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 350
+      ID: 362
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 907072
       GoKind: 22
-      Pointee: 351 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 363 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*net/http/httputil.failureToReadBody'
       ByteSize: 8
       GoRuntimeType: 1092224
       GoKind: 22
-      Pointee: 897 StructureType net/http/httputil.failureToReadBody
+      Pointee: 904 StructureType net/http/httputil.failureToReadBody
     - __kind: PointerType
-      ID: 385
+      ID: 397
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 915136
       GoKind: 22
-      Pointee: 386 StructureType net/netip.parseAddrError
+      Pointee: 398 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 383
+      ID: 395
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 915040
       GoKind: 22
-      Pointee: 384 StructureType net/netip.parsePrefixError
+      Pointee: 396 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 401
+      ID: 413
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 402 UnresolvedPointeeType net/textproto.Error
+      Pointee: 414 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 400
+      ID: 412
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 298 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 310 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 300
+      ID: 312
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 299 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 311 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 688
+      ID: 700
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1425888
       GoKind: 22
-      Pointee: 689 UnresolvedPointeeType net/url.Error
+      Pointee: 701 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 398
+      ID: 410
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 917440
       GoKind: 22
-      Pointee: 292 GoStringHeaderType net/url.EscapeError
+      Pointee: 304 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 294
+      ID: 306
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 293 GoStringDataType net/url.EscapeError.str
+      Pointee: 305 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 399
+      ID: 411
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 295 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 307 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 297
+      ID: 309
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 296 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 308 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2148544
       GoKind: 22
-      Pointee: 860 StructureType net/url.URL
+      Pointee: 867 StructureType net/url.URL
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1208736
       GoKind: 22
-      Pointee: 981 UnresolvedPointeeType net/url.Userinfo
+      Pointee: 988 UnresolvedPointeeType net/url.Userinfo
     - __kind: PointerType
-      ID: 206
+      ID: 249
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 207 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 250 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 826
+      ID: 833
       Name: '*noalg.map.group[github.com/cihub/seelog.LogLevel]bool'
       ByteSize: 8
-      Pointee: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Pointee: 834 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: PointerType
-      ID: 262
+      ID: 265
       Name: '*noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Pointee: 266 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 990
+      ID: 997
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 991 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 998 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 854 StructureType noalg.map.group[string][]string
+      Pointee: 861 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 240
+      ID: 229
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 241 StructureType noalg.map.group[string]float64
+      Pointee: 230 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 729
+      ID: 741
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 742 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 232
+      ID: 221
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 233 StructureType noalg.map.group[string]interface {}
+      Pointee: 222 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 224
+      ID: 213
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 225 StructureType noalg.map.group[string]string
+      Pointee: 214 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 972
+      ID: 979
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2362080
       GoKind: 22
-      Pointee: 973 UnresolvedPointeeType os.File
+      Pointee: 980 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 567
+      ID: 579
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1036288
       GoKind: 22
-      Pointee: 568 UnresolvedPointeeType os.LinkError
+      Pointee: 580 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 162
+      ID: 180
       Name: '*os.Signal'
       ByteSize: 8
       GoRuntimeType: 399680
       GoKind: 22
-      Pointee: 163 GoInterfaceType os.Signal
+      Pointee: 181 GoInterfaceType os.Signal
     - __kind: PointerType
-      ID: 638
+      ID: 650
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1195808
       GoKind: 22
-      Pointee: 639 UnresolvedPointeeType os.SyscallError
+      Pointee: 651 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2359808
       GoKind: 22
-      Pointee: 971 StructureType os.fileWithoutReadFrom
+      Pointee: 978 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2359072
       GoKind: 22
-      Pointee: 969 StructureType os.fileWithoutWriteTo
+      Pointee: 976 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 600
+      ID: 612
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1058048
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType os/exec.Error
+      Pointee: 613 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 725
+      ID: 737
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2110272
       GoKind: 22
-      Pointee: 726 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 738 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 602
+      ID: 614
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1058176
       GoKind: 22
-      Pointee: 603 StructureType os/exec.wrappedError
+      Pointee: 615 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 136
+      ID: 176
       Name: '*os/signal.signalCtx'
       ByteSize: 8
       GoRuntimeType: 1628128
       GoKind: 22
-      Pointee: 137 StructureType os/signal.signalCtx
+      Pointee: 177 StructureType os/signal.signalCtx
     - __kind: PointerType
-      ID: 369
+      ID: 381
       Name: '*os/signal.signalError'
       ByteSize: 8
       GoRuntimeType: 910432
       GoKind: 22
-      Pointee: 283 GoStringHeaderType os/signal.signalError
+      Pointee: 295 GoStringHeaderType os/signal.signalError
     - __kind: PointerType
-      ID: 285
+      ID: 297
       Name: '*os/signal.signalError.str'
       ByteSize: 8
-      Pointee: 284 GoStringDataType os/signal.signalError.str
+      Pointee: 296 GoStringDataType os/signal.signalError.str
     - __kind: PointerType
-      ID: 508
+      ID: 520
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 945376
       GoKind: 22
-      Pointee: 326 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 338 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 328
+      ID: 340
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 327 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 339 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 507
+      ID: 519
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 945280
       GoKind: 22
-      Pointee: 325 BaseType os/user.UnknownUserIdError
+      Pointee: 337 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 379
+      ID: 391
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 913024
       GoKind: 22
-      Pointee: 380 UnresolvedPointeeType reflect.ValueError
+      Pointee: 392 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 460
+      ID: 472
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 933280
       GoKind: 22
-      Pointee: 461 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 473 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 575
+      ID: 587
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1042176
       GoKind: 22
-      Pointee: 576 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 588 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 579
+      ID: 591
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1042816
       GoKind: 22
-      Pointee: 580 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 592 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -2523,12 +2523,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 577
+      ID: 589
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1042304
       GoKind: 22
-      Pointee: 578 StructureType runtime.boundsError
+      Pointee: 590 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -2544,24 +2544,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 640
+      ID: 652
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1204128
       GoKind: 22
-      Pointee: 641 StructureType runtime.errorAddressString
+      Pointee: 653 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 573
+      ID: 585
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1040512
       GoKind: 22
-      Pointee: 544 GoStringHeaderType runtime.errorString
+      Pointee: 556 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 546
+      ID: 558
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 545 GoStringDataType runtime.errorString.str
+      Pointee: 557 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -2582,19 +2582,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1041920
       GoKind: 22
-      Pointee: 201 UnresolvedPointeeType runtime.p
+      Pointee: 208 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 574
+      ID: 586
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1040640
       GoKind: 22
-      Pointee: 547 GoStringHeaderType runtime.plainError
+      Pointee: 559 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 549
+      ID: 561
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 548 GoStringDataType runtime.plainError.str
+      Pointee: 560 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -2610,12 +2610,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 381
+      ID: 393
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 914752
       GoKind: 22
-      Pointee: 382 StructureType runtime.synctestDeadlockError
+      Pointee: 394 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -2638,12 +2638,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 571
+      ID: 583
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1040128
       GoKind: 22
-      Pointee: 572 UnresolvedPointeeType strconv.NumError
+      Pointee: 584 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -2652,242 +2652,242 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 196
+      ID: 203
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 195 GoStringDataType string.str
+      Pointee: 202 GoStringDataType string.str
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1704928
       GoKind: 22
-      Pointee: 759 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 766 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1759648
       GoKind: 22
-      Pointee: 773 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 780 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1704544
       GoKind: 22
-      Pointee: 755 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 762 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1758880
       GoKind: 22
-      Pointee: 765 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 772 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 778
+      ID: 785
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1831776
       GoKind: 22
-      Pointee: 779 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 786 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1759072
       GoKind: 22
-      Pointee: 767 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 774 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1758688
       GoKind: 22
-      Pointee: 763 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 770 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 774
+      ID: 781
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1831328
       GoKind: 22
-      Pointee: 775 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 782 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 782
+      ID: 789
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1900416
       GoKind: 22
-      Pointee: 783 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 790 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1831552
       GoKind: 22
-      Pointee: 777 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 784 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1705120
       GoKind: 22
-      Pointee: 761 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 768 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1704736
       GoKind: 22
-      Pointee: 757 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 764 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1759264
       GoKind: 22
-      Pointee: 769 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 776 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1832000
       GoKind: 22
-      Pointee: 781 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 788 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1759456
       GoKind: 22
-      Pointee: 771 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 778 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*struct { io.Reader; io.Closer }'
       ByteSize: 8
       GoRuntimeType: 1099136
       GoKind: 22
-      Pointee: 899 StructureType struct { io.Reader; io.Closer }
+      Pointee: 906 StructureType struct { io.Reader; io.Closer }
     - __kind: PointerType
-      ID: 685
+      ID: 697
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1424768
       GoKind: 22
-      Pointee: 674 BaseType syscall.Errno
+      Pointee: 686 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*syscall.Signal'
       ByteSize: 8
       GoRuntimeType: 1043328
       GoKind: 22
-      Pointee: 747 BaseType syscall.Signal
+      Pointee: 754 BaseType syscall.Signal
     - __kind: PointerType
-      ID: 147
+      ID: 190
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 204 StructureType table<context.canceler,struct {}>
+      Pointee: 247 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*table<github.com/cihub/seelog.LogLevel,bool>'
       ByteSize: 8
-      Pointee: 824 StructureType table<github.com/cihub/seelog.LogLevel,bool>
+      Pointee: 831 StructureType table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: PointerType
-      ID: 252
+      ID: 241
       Name: '*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 260 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Pointee: 263 StructureType table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 988 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 995 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 851 StructureType table<string,[]string>
+      Pointee: 858 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 183
+      ID: 145
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 238 StructureType table<string,float64>
+      Pointee: 227 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 701
+      ID: 713
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 727 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 739 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
-      ID: 178
+      ID: 140
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 230 StructureType table<string,interface {}>
+      Pointee: 219 StructureType table<string,interface {}>
     - __kind: PointerType
-      ID: 173
+      ID: 135
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 222 StructureType table<string,string>
+      Pointee: 211 StructureType table<string,string>
     - __kind: PointerType
-      ID: 620
+      ID: 632
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1095424
       GoKind: 22
-      Pointee: 621 StructureType text/template.ExecError
+      Pointee: 633 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 157
+      ID: 196
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1628512
       GoKind: 22
-      Pointee: 158 StructureType time.Location
+      Pointee: 197 StructureType time.Location
     - __kind: PointerType
-      ID: 373
+      ID: 385
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 910720
       GoKind: 22
-      Pointee: 374 UnresolvedPointeeType time.ParseError
+      Pointee: 386 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 154
+      ID: 193
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1036800
       GoKind: 22
-      Pointee: 155 StructureType time.Timer
+      Pointee: 194 StructureType time.Timer
     - __kind: PointerType
-      ID: 370
+      ID: 382
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 910528
       GoKind: 22
-      Pointee: 286 GoStringHeaderType time.fileSizeError
+      Pointee: 298 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 288
+      ID: 300
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 287 GoStringDataType time.fileSizeError.str
+      Pointee: 299 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 371
+      ID: 383
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 910624
       GoKind: 22
-      Pointee: 372 UnresolvedPointeeType time.parseDurationError
+      Pointee: 384 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 215
+      ID: 258
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399936
       GoKind: 22
-      Pointee: 216 StructureType time.zone
+      Pointee: 259 StructureType time.zone
     - __kind: PointerType
-      ID: 218
+      ID: 261
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 400000
       GoKind: 22
-      Pointee: 219 StructureType time.zoneTrans
+      Pointee: 262 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -2931,47 +2931,47 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 388
+      ID: 400
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 389 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 401 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 405
+      ID: 417
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 406 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 418 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 407
+      ID: 419
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 919360
       GoKind: 22
-      Pointee: 305 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 317 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 584
+      ID: 596
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1048192
       GoKind: 22
-      Pointee: 585 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 597 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 586
+      ID: 598
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1048320
       GoKind: 22
-      Pointee: 551 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 563 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 867
+      ID: 874
       Name: <-chan struct {}
       GoRuntimeType: 603744
       GoKind: 18
     - __kind: GoChannelType
-      ID: 741
+      ID: 753
       Name: <-chan time.Time
       GoRuntimeType: 609440
       GoKind: 18
@@ -3050,7 +3050,7 @@ Types:
       HasCount: true
       Element: 98 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 848
+      ID: 855
       Name: '[10]uint8'
       ByteSize: 10
       GoRuntimeType: 690208
@@ -3059,7 +3059,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 847
+      ID: 854
       Name: '[29]uint8'
       ByteSize: 29
       GoRuntimeType: 690112
@@ -3131,7 +3131,7 @@ Types:
       HasCount: true
       Element: 35 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 849
+      ID: 856
       Name: '[3]uint8'
       ByteSize: 3
       GoRuntimeType: 690304
@@ -3149,7 +3149,7 @@ Types:
       HasCount: true
       Element: 10 BaseType uint64
     - __kind: ArrayType
-      ID: 709
+      ID: 721
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 707872
@@ -3176,7 +3176,7 @@ Types:
       HasCount: true
       Element: 91 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1003
+      ID: 1010
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 508128
@@ -3184,22 +3184,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1004 PointerType **crypto/x509.Certificate
+          Type: 1011 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1011 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 1018 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1011
+      ID: 1018
       Name: '[]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 695 PointerType *crypto/x509.Certificate
+      Element: 707 PointerType *crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 742
+      ID: 277
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
       ByteSize: 24
       GoRuntimeType: 496128
@@ -3207,22 +3207,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 743 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 278 PointerType **gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 745 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
+      Data: 280 GoSliceDataType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array
     - __kind: GoSliceDataType
-      ID: 745
+      ID: 280
       Name: '[]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 165 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      Element: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: GoSliceHeaderType
-      ID: 994
+      ID: 1001
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 493152
@@ -3230,20 +3230,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 995 PointerType **mime/multipart.FileHeader
+          Type: 1002 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1000 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 1007 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 1000
+      ID: 1007
       Name: '[]*mime/multipart.FileHeader.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 996 PointerType *mime/multipart.FileHeader
+      Element: 1003 PointerType *mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
       ID: 68
       Name: '[]*runtime.p'
@@ -3260,69 +3260,69 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 202 GoSliceDataType []*runtime.p.array
+      Data: 209 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 209
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 70 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 255
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 147 PointerType *table<context.canceler,struct {}>
+      Element: 190 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 831
+      ID: 838
       Name: '[]*table<github.com/cihub/seelog.LogLevel,bool>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 807 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
+      Element: 814 PointerType *table<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 271
       Name: '[]*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 252 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      Element: 241 PointerType *table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 997
+      ID: 1004
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 987 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 994 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 857
+      ID: 864
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 846 PointerType *table<string,[]string>
+      Element: 853 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 233
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 183 PointerType *table<string,float64>
+      Element: 145 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 733
+      ID: 745
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 701 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 713 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 225
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 178 PointerType *table<string,interface {}>
+      Element: 140 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 217
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 173 PointerType *table<string,string>
+      Element: 135 PointerType *table<string,string>
     - __kind: GoSliceHeaderType
-      ID: 1005
+      ID: 1012
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 508192
@@ -3330,22 +3330,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1006 PointerType *[]*crypto/x509.Certificate
+          Type: 1013 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1013 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 1020 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 1013
+      ID: 1020
       Name: '[][]*crypto/x509.Certificate.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1003 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 1010 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 1007
+      ID: 1014
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 487488
@@ -3353,22 +3353,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1008 PointerType *[]uint8
+          Type: 1015 PointerType *[]uint8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1015 GoSliceDataType [][]uint8.array
+      Data: 1022 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 1015
+      ID: 1022
       Name: '[][]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 24
       Element: 41 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 714
+      ID: 726
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 502016
@@ -3383,15 +3383,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 737 GoSliceDataType []float64.array
+      Data: 749 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 737
+      ID: 749
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 16 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 184
+      ID: 146
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink'
       ByteSize: 24
       GoRuntimeType: 495872
@@ -3399,22 +3399,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 185 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 147 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 246 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
+      Data: 235 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 235
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 186 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+      Element: 148 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 187
+      ID: 149
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 496064
@@ -3422,22 +3422,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 188 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 150 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 254 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
+      Data: 243 GoSliceDataType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 243
       Name: '[]gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 189 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+      Element: 151 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
-      ID: 1017
+      ID: 1024
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 490400
@@ -3445,76 +3445,76 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1018 PointerType *net/http.segment
+          Type: 1025 PointerType *net/http.segment
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1020 GoSliceDataType []net/http.segment.array
+      Data: 1027 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 1020
+      ID: 1027
       Name: '[]net/http.segment.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 1019 StructureType net/http.segment
+      Element: 1026 StructureType net/http.segment
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 256
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 207 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 250 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 832
+      ID: 839
       Name: '[]noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      Element: 834 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 272
       Name: '[]noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      Element: 266 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 998
+      ID: 1005
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 991 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 998 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 858
+      ID: 865
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 854 StructureType noalg.map.group[string][]string
+      Element: 861 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 234
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 241 StructureType noalg.map.group[string]float64
+      Element: 230 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 734
+      ID: 746
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 742 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 226
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 233 StructureType noalg.map.group[string]interface {}
+      Element: 222 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 218
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 225 StructureType noalg.map.group[string]string
+      Element: 214 StructureType noalg.map.group[string]string
     - __kind: GoSliceHeaderType
-      ID: 161
+      ID: 179
       Name: '[]os.Signal'
       ByteSize: 24
       GoRuntimeType: 487360
@@ -3522,26 +3522,26 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 162 PointerType *os.Signal
+          Type: 180 PointerType *os.Signal
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 220 GoSliceDataType []os.Signal.array
+      Data: 245 GoSliceDataType []os.Signal.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 245
       Name: '[]os.Signal.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 163 GoInterfaceType os.Signal
+      Element: 181 GoInterfaceType os.Signal
     - __kind: UnresolvedPointeeType
       ID: 43
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 713
+      ID: 725
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 502272
@@ -3556,15 +3556,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 735 GoSliceDataType []string.array
+      Data: 747 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 735
+      ID: 747
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 214
+      ID: 257
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 495264
@@ -3572,22 +3572,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 215 PointerType *time.zone
+          Type: 258 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 256 GoSliceDataType []time.zone.array
+      Data: 273 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 273
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 216 StructureType time.zone
+      Element: 259 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 260
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 495328
@@ -3595,20 +3595,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType *time.zoneTrans
+          Type: 261 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 258 GoSliceDataType []time.zoneTrans.array
+      Data: 275 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 275
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 219 StructureType time.zoneTrans
+      Element: 262 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 41
       Name: '[]uint8'
@@ -3625,9 +3625,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 197 GoSliceDataType []uint8.array
+      Data: 204 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 204
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -3648,15 +3648,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 199 GoSliceDataType []uintptr.array
+      Data: 206 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 206
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: GoSliceHeaderType
-      ID: 529
+      ID: 541
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 954976
@@ -3671,27 +3671,27 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 530 GoSliceDataType archive/tar.headerError.array
+      Data: 542 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 542
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 909
+      ID: 916
       Name: archive/zip.checksumReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 895
+      ID: 902
       Name: archive/zip.dirReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 920
       Name: archive/zip.openDir
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 893
+      ID: 900
       Name: archive/zip.pooledFlateReader
       ByteSize: 8
     - __kind: BaseType
@@ -3701,7 +3701,7 @@ Types:
       GoRuntimeType: 591072
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 847
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -3709,12 +3709,12 @@ Types:
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
-      ID: 850
+      ID: 857
       Name: chan bool
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: GoChannelType
-      ID: 164
+      ID: 182
       Name: chan os.Signal
       GoRuntimeType: 610144
       GoKind: 18
@@ -3731,13 +3731,13 @@ Types:
       GoRuntimeType: 590816
       GoKind: 15
     - __kind: BaseType
-      ID: 301
+      ID: 313
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 842176
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 302
+      ID: 314
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 842272
@@ -3745,32 +3745,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 304 PointerType *compress/flate.InternalError.str
+          Type: 316 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 303 GoStringDataType compress/flate.InternalError.str
+      Data: 315 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 303
+      ID: 315
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: compress/flate.decompressor
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: compress/gzip.Reader
       ByteSize: 8
     - __kind: GoSubroutineType
-      ID: 160
+      ID: 178
       Name: context.CancelCauseFunc
       ByteSize: 8
       GoRuntimeType: 838720
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 838
+      ID: 845
       Name: context.CancelFunc
       ByteSize: 8
       GoRuntimeType: 683296
@@ -3789,7 +3789,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 125
+      ID: 199
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 1733920
@@ -3797,29 +3797,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 127 StructureType context.cancelCtx
+          Type: 184 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 148 StructureType sync.Once
+          Type: 200 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 151
+      ID: 173
       Name: context.backgroundCtx
       GoRuntimeType: 1813632
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 152 StructureType context.emptyCtx
+          Type: 159 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 127
+      ID: 184
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1987520
@@ -3830,23 +3830,23 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 141 StructureType sync/atomic.Value
+          Type: 185 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 143 GoMapType map[context.canceler]struct {}
+          Type: 186 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 141 StructureType sync/atomic.Value
+          Type: 185 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 17 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 210
+      ID: 253
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1115936
@@ -3859,13 +3859,13 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 626
+      ID: 638
       Name: context.deadlineExceededError
       GoRuntimeType: 1468448
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 152
+      ID: 159
       Name: context.emptyCtx
       GoRuntimeType: 1605376
       GoKind: 25
@@ -3874,7 +3874,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 129
+      ID: 161
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1840416
@@ -3885,11 +3885,11 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 153 GoSubroutineType func() bool
+          Type: 162 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 131
+      ID: 192
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1621984
@@ -3897,29 +3897,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 127 StructureType context.cancelCtx
+          Type: 184 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 154 PointerType *time.Timer
+          Type: 193 PointerType *time.Timer
         - Name: deadline
           Offset: 88
-          Type: 156 GoTimeType time.Time
+          Type: 195 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 159
+      ID: 175
       Name: context.todoCtx
       GoRuntimeType: 1813856
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 152 StructureType context.emptyCtx
+          Type: 159 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 133
+      ID: 168
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1849120
@@ -3930,14 +3930,14 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: key
           Offset: 16
-          Type: 142 GoEmptyInterfaceType interface {}
+          Type: 169 GoEmptyInterfaceType interface {}
         - Name: val
           Offset: 32
-          Type: 142 GoEmptyInterfaceType interface {}
+          Type: 169 GoEmptyInterfaceType interface {}
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 135
+      ID: 171
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1813408
@@ -3949,51 +3949,51 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 320
+      ID: 332
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844384
       GoKind: 2
     - __kind: BaseType
-      ID: 321
+      ID: 333
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844480
       GoKind: 2
     - __kind: BaseType
-      ID: 322
+      ID: 334
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844576
       GoKind: 2
     - __kind: StructureType
-      ID: 607
+      ID: 619
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1293152
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 323
+      ID: 335
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 844672
       GoKind: 2
     - __kind: BaseType
-      ID: 290
+      ID: 302
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 841696
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 583
+      ID: 595
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 986
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 873
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2282816
@@ -4013,7 +4013,7 @@ Types:
           Type: 8 BaseType uint16
         - Name: CurveID
           Offset: 6
-          Type: 1002 BaseType crypto/tls.CurveID
+          Type: 1009 BaseType crypto/tls.CurveID
         - Name: NegotiatedProtocol
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -4025,13 +4025,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 1003 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 1010 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 1005 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 1012 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 1007 GoSliceHeaderType [][]uint8
+          Type: 1014 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
           Type: 41 GoSliceHeaderType []uint8
@@ -4046,22 +4046,22 @@ Types:
           Type: 6 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 1009 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 1016 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyPeerSignatureAlgorithm
           Offset: 184
-          Type: 1010 BaseType crypto/tls.SignatureScheme
+          Type: 1017 BaseType crypto/tls.SignatureScheme
     - __kind: BaseType
-      ID: 1002
+      ID: 1009
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 841408
       GoKind: 9
     - __kind: UnresolvedPointeeType
-      ID: 394
+      ID: 406
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 391
+      ID: 403
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1739872
@@ -4072,36 +4072,36 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 709 ArrayType [5]uint8
+          Type: 721 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 710 GoInterfaceType net.Conn
+          Type: 722 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 1010
+      ID: 1017
       Name: crypto/tls.SignatureScheme
       ByteSize: 2
       GoRuntimeType: 841504
       GoKind: 9
     - __kind: BaseType
-      ID: 550
+      ID: 562
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 996096
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 396
+      ID: 408
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 699
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 708
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 449
+      ID: 461
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1741984
@@ -4109,21 +4109,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 695 PointerType *crypto/x509.Certificate
+          Type: 707 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 719 BaseType crypto/x509.InvalidReason
+          Type: 731 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 443
+      ID: 455
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1122592
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 445
+      ID: 457
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1608256
@@ -4131,24 +4131,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 695 PointerType *crypto/x509.Certificate
+          Type: 707 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 319
+      ID: 331
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 844096
       GoKind: 2
     - __kind: BaseType
-      ID: 719
+      ID: 731
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 593760
       GoKind: 2
     - __kind: StructureType
-      ID: 599
+      ID: 611
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1568064
@@ -4158,13 +4158,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 451
+      ID: 463
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1122848
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 447
+      ID: 459
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1741792
@@ -4172,15 +4172,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 695 PointerType *crypto/x509.Certificate
+          Type: 707 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 695 PointerType *crypto/x509.Certificate
+          Type: 707 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 491
+      ID: 503
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1438848
@@ -4190,7 +4190,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 495
+      ID: 507
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1439008
@@ -4200,47 +4200,47 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 493
+      ID: 505
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 291
+      ID: 303
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 841792
       GoKind: 6
     - __kind: BaseType
-      ID: 315
+      ID: 327
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 843808
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 419
+      ID: 431
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 595
+      ID: 607
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 411
+      ID: 423
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 417
+      ID: 429
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 415
+      ID: 427
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 413
+      ID: 425
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: StructureType
-      ID: 421
+      ID: 433
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1429568
@@ -4250,7 +4250,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 522
+      ID: 534
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -4267,11 +4267,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 376
+      ID: 388
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 570
+      ID: 582
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -4287,11 +4287,11 @@ Types:
       GoRuntimeType: 591008
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 554
+      ID: 566
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 556
+      ID: 568
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -4301,13 +4301,13 @@ Types:
       GoRuntimeType: 485568
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 861
+      ID: 868
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 700576
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 153
+      ID: 162
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 601376
@@ -4319,23 +4319,23 @@ Types:
       GoRuntimeType: 858528
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 1009
+      ID: 1016
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1011936
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 432
+      ID: 444
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 809
+      ID: 816
       Name: github.com/DataDog/datadog-agent/pkg/trace/log.noopLogger
       GoRuntimeType: 2074208
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 424
+      ID: 436
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1741024
@@ -4343,7 +4343,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 711 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 723 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -4351,25 +4351,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 426
+      ID: 438
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 728
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 430
+      ID: 442
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1121568
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 718
+      ID: 730
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 309
+      ID: 321
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 843232
@@ -4377,18 +4377,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 311 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 323 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 310 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 322 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 310
+      ID: 322
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 711
+      ID: 723
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2234976
@@ -4396,13 +4396,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 712 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 724 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -4411,7 +4411,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 714 GoSliceHeaderType []float64
+          Type: 726 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -4420,13 +4420,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 715 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 727 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 717 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 729 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -4437,13 +4437,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 712
+      ID: 724
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 592544
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 306
+      ID: 318
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 843136
@@ -4451,18 +4451,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 320 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 319 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 319
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 312
+      ID: 324
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 843328
@@ -4470,36 +4470,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 314 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 326 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 313 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 325 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 313
+      ID: 325
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 500
+      ID: 512
       Name: github.com/DataDog/go-libddwaf/v3/errors.CgoDisabledError
       GoRuntimeType: 1125280
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 324
+      ID: 336
       Name: github.com/DataDog/go-libddwaf/v3/errors.RunError
       ByteSize: 8
       GoRuntimeType: 845824
       GoKind: 2
     - __kind: StructureType
-      ID: 498
+      ID: 510
       Name: github.com/DataDog/go-libddwaf/v3/errors.UnsupportedGoVersionError
       GoRuntimeType: 1125152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 465
+      ID: 477
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1609376
@@ -4512,7 +4512,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 469
+      ID: 481
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1744096
@@ -4528,7 +4528,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 467
+      ID: 479
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1437408
@@ -4538,7 +4538,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 463
+      ID: 475
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1437088
@@ -4548,14 +4548,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 697
+      ID: 709
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1512928
       GoKind: 21
-      HeaderType: 699 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 711 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 720
+      ID: 732
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1059072
@@ -4570,15 +4570,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 739 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 751 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 739
+      ID: 751
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 477
+      ID: 489
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1609696
@@ -4586,12 +4586,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 697 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 709 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 697 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 709 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 471
+      ID: 483
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1437568
@@ -4601,7 +4601,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 475
+      ID: 487
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1744288
@@ -4612,12 +4612,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 732 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 732 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 473
+      ID: 485
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1609536
@@ -4630,7 +4630,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 479
+      ID: 491
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1437728
@@ -4638,9 +4638,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 156 GoTimeType time.Time
+          Type: 195 GoTimeType time.Time
     - __kind: StructureType
-      ID: 485
+      ID: 497
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1610016
@@ -4653,7 +4653,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 487
+      ID: 499
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1438048
@@ -4663,7 +4663,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 483
+      ID: 495
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1609856
@@ -4676,7 +4676,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 481
+      ID: 493
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1437888
@@ -4686,7 +4686,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 489
+      ID: 501
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1610176
@@ -4699,29 +4699,29 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 830
+      ID: 837
       Name: github.com/cihub/seelog.LogLevel
       ByteSize: 1
       GoRuntimeType: 846688
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 823
+      ID: 830
       Name: github.com/cihub/seelog.asyncAdaptiveLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 824
       Name: github.com/cihub/seelog.asyncLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 826
       Name: github.com/cihub/seelog.asyncLoopLogger
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 828
       Name: github.com/cihub/seelog.asyncTimerLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 510
+      ID: 522
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1443968
@@ -4731,11 +4731,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 802
+      ID: 809
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 512
+      ID: 524
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1444128
@@ -4743,17 +4743,17 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 510 StructureType github.com/cihub/seelog.baseError
+          Type: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 794
+      ID: 801
       Name: github.com/cihub/seelog.customReceiverDispatcher
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 796
+      ID: 803
       Name: github.com/cihub/seelog.dispatcher
       ByteSize: 8
     - __kind: StructureType
-      ID: 800
+      ID: 807
       Name: github.com/cihub/seelog.filterDispatcher
       ByteSize: 16
       GoRuntimeType: 1843328
@@ -4761,12 +4761,12 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 795 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 802 PointerType *github.com/cihub/seelog.dispatcher
         - Name: allowList
           Offset: 8
-          Type: 803 GoMapType map[github.com/cihub/seelog.LogLevel]bool
+          Type: 810 GoMapType map[github.com/cihub/seelog.LogLevel]bool
     - __kind: StructureType
-      ID: 516
+      ID: 528
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1444448
@@ -4774,9 +4774,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 510 StructureType github.com/cihub/seelog.baseError
+          Type: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 798
+      ID: 805
       Name: github.com/cihub/seelog.splitDispatcher
       ByteSize: 8
       GoRuntimeType: 1822816
@@ -4784,13 +4784,13 @@ Types:
       RawFields:
         - Name: dispatcher
           Offset: 0
-          Type: 795 PointerType *github.com/cihub/seelog.dispatcher
+          Type: 802 PointerType *github.com/cihub/seelog.dispatcher
     - __kind: UnresolvedPointeeType
-      ID: 815
+      ID: 822
       Name: github.com/cihub/seelog.syncLogger
       ByteSize: 8
     - __kind: StructureType
-      ID: 514
+      ID: 526
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1444288
@@ -4798,9 +4798,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 510 StructureType github.com/cihub/seelog.baseError
+          Type: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 518
+      ID: 530
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1444608
@@ -4808,9 +4808,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 510 StructureType github.com/cihub/seelog.baseError
+          Type: 522 StructureType github.com/cihub/seelog.baseError
     - __kind: GoInterfaceType
-      ID: 929
+      ID: 936
       Name: github.com/cihub/seelog/archive.Reader
       ByteSize: 16
       GoRuntimeType: 1130144
@@ -4823,7 +4823,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 907
+      ID: 914
       Name: github.com/cihub/seelog/archive.nopCloser
       ByteSize: 16
       GoRuntimeType: 1684768
@@ -4831,36 +4831,36 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 929 GoInterfaceType github.com/cihub/seelog/archive.Reader
+          Type: 936 GoInterfaceType github.com/cihub/seelog/archive.Reader
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: github.com/cihub/seelog/archive/gzip.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 625
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 615
+      ID: 627
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 605
+      ID: 617
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 435
+      ID: 447
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1430848
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 609
+      ID: 621
       Name: github.com/mitchellh/mapstructure.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 667
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1863456
@@ -4876,11 +4876,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 649
+      ID: 661
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 589
+      ID: 601
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1713280
@@ -4893,7 +4893,7 @@ Types:
           Offset: 1
           Type: 21 BaseType int8
     - __kind: StructureType
-      ID: 661
+      ID: 673
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1863904
@@ -4909,13 +4909,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 552
+      ID: 564
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 997248
       GoKind: 8
     - __kind: StructureType
-      ID: 653
+      ID: 665
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1863232
@@ -4931,13 +4931,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 723
+      ID: 735
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 842752
       GoKind: 8
     - __kind: StructureType
-      ID: 651
+      ID: 663
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1863008
@@ -4945,15 +4945,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 723 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 735 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 723 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 735 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 659
+      ID: 671
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1777632
@@ -4966,7 +4966,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 657
+      ID: 669
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1863680
@@ -4982,7 +4982,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 665
+      ID: 677
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1645600
@@ -4992,19 +4992,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 593
+      ID: 605
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1289440
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 591
+      ID: 603
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1289312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 663
+      ID: 675
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1777824
@@ -5017,7 +5017,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 329
+      ID: 341
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 847840
@@ -5025,22 +5025,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 331 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 343 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 330 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 342 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 330
+      ID: 342
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 704
+      ID: 716
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 619
+      ID: 631
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1453728
@@ -5050,19 +5050,19 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 332
+      ID: 344
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 848416
       GoKind: 10
     - __kind: BaseType
-      ID: 702
+      ID: 714
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1008960
       GoKind: 10
     - __kind: StructureType
-      ID: 673
+      ID: 685
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1895264
@@ -5073,12 +5073,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 702 BaseType golang.org/x/net/http2.ErrCode
+          Type: 714 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 536
+      ID: 548
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1616896
@@ -5086,12 +5086,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 702 BaseType golang.org/x/net/http2.ErrCode
+          Type: 714 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 336
+      ID: 348
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 848608
@@ -5099,18 +5099,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 338 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 350 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 337 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 349 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 337
+      ID: 349
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 342
+      ID: 354
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 848800
@@ -5118,18 +5118,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 344 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 356 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 343 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 355 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 343
+      ID: 355
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 339
+      ID: 351
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 848704
@@ -5137,18 +5137,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 341 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 353 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 340 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 352 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 340
+      ID: 352
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 333
+      ID: 345
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 848512
@@ -5156,18 +5156,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 335 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 347 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 334 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 346 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 334
+      ID: 346
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 540
+      ID: 552
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1455008
@@ -5177,13 +5177,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 345
+      ID: 357
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 848896
       GoKind: 2
     - __kind: StructureType
-      ID: 520
+      ID: 532
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1449408
@@ -5193,11 +5193,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 683
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 691
+      ID: 703
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1923424
@@ -5213,7 +5213,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 526
+      ID: 538
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1615936
@@ -5226,11 +5226,11 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 945
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 617
+      ID: 629
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1575744
@@ -5240,33 +5240,33 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: google.golang.org/grpc/mem.sliceReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 502
+      ID: 514
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 623
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 681
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 679
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1521408
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 409
+      ID: 421
       Name: gopkg.in/DataDog/dd-trace-go.v1/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 784
+      ID: 791
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1428128
@@ -5279,7 +5279,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 753
+      ID: 760
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 24
       GoRuntimeType: 1607616
@@ -5305,7 +5305,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 186
+      ID: 148
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
       ByteSize: 56
       GoRuntimeType: 1935584
@@ -5322,7 +5322,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -5330,7 +5330,7 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 944
+      ID: 951
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityPayload
       ByteSize: 16
       GoRuntimeType: 1988032
@@ -5338,29 +5338,29 @@ Types:
       RawFields:
         - Name: payload
           Offset: 0
-          Type: 935 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
+          Type: 942 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
         - Name: serializationTime
           Offset: 8
-          Type: 947 BaseType time.Duration
+          Type: 954 BaseType time.Duration
     - __kind: GoMapType
-      ID: 174
+      ID: 136
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1288032
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.payload
       ByteSize: 8
     - __kind: BaseType
-      ID: 744
+      ID: 279
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 589856
       GoKind: 10
     - __kind: DDTraceSpanType
-      ID: 166
+      ID: 124
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
       ByteSize: 288
       GoRuntimeType: 2351840
@@ -5368,7 +5368,7 @@ Types:
       RawFields:
         - Name: RWMutex
           Offset: 0
-          Type: 167 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: Name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -5389,13 +5389,13 @@ Types:
           Type: 15 BaseType int64
         - Name: Meta
           Offset: 104
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: MetaStruct
           Offset: 112
-          Type: 174 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
+          Type: 136 GoMapType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.metaStructMap
         - Name: Metrics
           Offset: 120
-          Type: 179 GoMapType map[string]float64
+          Type: 141 GoMapType map[string]float64
         - Name: SpanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -5410,10 +5410,10 @@ Types:
           Type: 14 BaseType int32
         - Name: SpanLinks
           Offset: 160
-          Type: 184 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 146 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
         - Name: SpanEvents
           Offset: 184
-          Type: 187 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
+          Type: 149 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -5425,7 +5425,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 190 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
+          Type: 152 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -5448,7 +5448,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 191
+      ID: 153
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanContext
       ByteSize: 160
       GoRuntimeType: 2209088
@@ -5459,10 +5459,10 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 192 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
+          Type: 155 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 165 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: errors
           Offset: 24
           Type: 14 BaseType int32
@@ -5474,16 +5474,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 194 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
+          Type: 157 ArrayType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 167 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -5492,9 +5492,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 184 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
+          Type: 146 GoSliceHeaderType []gopkg.in/DataDog/dd-trace-go.v1/ddtrace.SpanLink
     - __kind: StructureType
-      ID: 189
+      ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1768608
@@ -5508,16 +5508,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 248 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 237 GoMapType map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 253 GoMapType map[string]interface {}
+          Type: 242 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 751
+      ID: 758
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 267
+      ID: 270
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1930464
@@ -5525,7 +5525,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 749 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
+          Type: 756 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -5540,15 +5540,15 @@ Types:
           Type: 16 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 750 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
+          Type: 757 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 749
+      ID: 756
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 993504
       GoKind: 5
     - __kind: StructureType
-      ID: 193
+      ID: 156
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2123264
@@ -5556,16 +5556,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 167 StructureType sync.RWMutex
+          Type: 125 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 742 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 277 GoSliceHeaderType []*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
         - Name: tags
           Offset: 48
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -5580,12 +5580,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 744 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
+          Type: 279 BaseType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 165 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+          Type: 154 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: ArrayType
-      ID: 194
+      ID: 157
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 911488
@@ -5594,11 +5594,11 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/datastreams.Processor
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1026
+    - __kind: GoContextImplementationType
+      ID: 166
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1646176
@@ -5607,20 +5607,22 @@ Types:
         - Name: Context
           Offset: 0
           Type: 123 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 818
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry.client
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 891
+      ID: 898
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.SumReaderCloser
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 459
+      ID: 471
       Name: gopkg.in/DataDog/dd-trace-go.v1/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 504
+      ID: 516
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1441248
@@ -5630,7 +5632,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 506
+      ID: 518
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1441408
@@ -5640,137 +5642,137 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 524
+      ID: 536
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 205
+      ID: 248
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 206 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 249 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 207 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 213 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 250 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 256 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 825
+      ID: 832
       Name: groupReference<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 826 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+          Type: 833 PointerType *noalg.map.group[github.com/cihub/seelog.LogLevel]bool
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
-      GroupSliceType: 832 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
+      GroupType: 834 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      GroupSliceType: 839 GoSliceDataType []noalg.map.group[github.com/cihub/seelog.LogLevel]bool.array
     - __kind: GoSwissMapGroupsType
-      ID: 261
+      ID: 264
       Name: groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 262 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 265 PointerType *noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 266 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 272 GoSliceDataType []noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 989
+      ID: 996
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 990 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 997 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 991 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 998 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupType: 998 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 1005 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: GoSwissMapGroupsType
-      ID: 852
+      ID: 859
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 853 PointerType *noalg.map.group[string][]string
+          Type: 860 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 854 StructureType noalg.map.group[string][]string
-      GroupSliceType: 858 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 861 StructureType noalg.map.group[string][]string
+      GroupSliceType: 865 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 239
+      ID: 228
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 240 PointerType *noalg.map.group[string]float64
+          Type: 229 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 241 StructureType noalg.map.group[string]float64
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 230 StructureType noalg.map.group[string]float64
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 728
+      ID: 740
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 729 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 741 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 734 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 742 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 746 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 231
+      ID: 220
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 232 PointerType *noalg.map.group[string]interface {}
+          Type: 221 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 233 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 222 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 226 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 223
+      ID: 212
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 224 PointerType *noalg.map.group[string]string
+          Type: 213 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 225 StructureType noalg.map.group[string]string
-      GroupSliceType: 229 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 214 StructureType noalg.map.group[string]string
+      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: UnresolvedPointeeType
-      ID: 543
+      ID: 555
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -5804,7 +5806,7 @@ Types:
       GoRuntimeType: 590112
       GoKind: 3
     - __kind: GoEmptyInterfaceType
-      ID: 142
+      ID: 169
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 862272
@@ -5817,17 +5819,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 724
+      ID: 736
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 593184
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 693
+      ID: 705
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 440
+      ID: 452
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -5853,25 +5855,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 438
+      ID: 450
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 659
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 984
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 657
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1486848
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 378
+      ID: 390
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -5943,7 +5945,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 316
+      ID: 328
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 844000
@@ -5951,18 +5953,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 318 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 330 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 317 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 329 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 317
+      ID: 329
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 597
+      ID: 609
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1567104
@@ -5970,15 +5972,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 692 PointerType *internal/abi.Type
+          Type: 704 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 289
+      ID: 301
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 841216
       GoKind: 2
     - __kind: StructureType
-      ID: 140
+      ID: 128
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1501408
@@ -5991,7 +5993,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 930
+      ID: 937
       Name: io.Closer
       ByteSize: 16
       GoRuntimeType: 1038848
@@ -6004,11 +6006,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 949
       Name: io.PipeReader
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 837
+      ID: 844
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1118368
@@ -6021,7 +6023,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 920
+      ID: 927
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1038208
@@ -6034,11 +6036,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 953
       Name: io.SectionReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 889
+      ID: 896
       Name: io.nopCloser
       ByteSize: 16
       GoRuntimeType: 1560544
@@ -6046,9 +6048,9 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 920 GoInterfaceType io.Reader
+          Type: 927 GoInterfaceType io.Reader
     - __kind: StructureType
-      ID: 905
+      ID: 912
       Name: io.nopCloserWriterTo
       ByteSize: 16
       GoRuntimeType: 1630048
@@ -6056,13 +6058,13 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 920 GoInterfaceType io.Reader
+          Type: 927 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 643
+      ID: 655
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: GoSwissMapHeaderType
-      ID: 145
+      ID: 188
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -6075,7 +6077,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 146 PointerType **table<context.canceler,struct {}>
+          Type: 189 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6094,10 +6096,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 212 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 207 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 255 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 250 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
-      ID: 805
+      ID: 812
       Name: map<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 48
       GoKind: 25
@@ -6110,7 +6112,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 806 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
+          Type: 813 PointerType **table<github.com/cihub/seelog.LogLevel,bool>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6129,10 +6131,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 831 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
-      GroupType: 827 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
+      TablePtrSliceType: 838 GoSliceDataType []*table<github.com/cihub/seelog.LogLevel,bool>.array
+      GroupType: 834 StructureType noalg.map.group[github.com/cihub/seelog.LogLevel]bool
     - __kind: GoSwissMapHeaderType
-      ID: 250
+      ID: 239
       Name: map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -6145,7 +6147,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 251 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 240 PointerType **table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6164,10 +6166,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 263 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 271 GoSliceDataType []*table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 266 StructureType noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
-      ID: 985
+      ID: 992
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
@@ -6180,7 +6182,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 986 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 993 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6199,10 +6201,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 997 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 991 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      TablePtrSliceType: 1004 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 998 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSwissMapHeaderType
-      ID: 844
+      ID: 851
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -6215,7 +6217,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 845 PointerType **table<string,[]string>
+          Type: 852 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6234,10 +6236,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 857 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 854 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 864 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 861 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 181
+      ID: 143
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -6250,7 +6252,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 182 PointerType **table<string,float64>
+          Type: 144 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6269,10 +6271,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,float64>.array
-      GroupType: 241 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 233 GoSliceDataType []*table<string,float64>.array
+      GroupType: 230 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 699
+      ID: 711
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -6285,7 +6287,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 700 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 712 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6304,10 +6306,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 733 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 730 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 745 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 742 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
-      ID: 176
+      ID: 138
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -6320,7 +6322,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 177 PointerType **table<string,interface {}>
+          Type: 139 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6339,10 +6341,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 233 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 225 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 222 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
-      ID: 171
+      ID: 133
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -6355,7 +6357,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 172 PointerType **table<string,string>
+          Type: 134 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -6374,66 +6376,66 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 228 GoSliceDataType []*table<string,string>.array
-      GroupType: 225 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 217 GoSliceDataType []*table<string,string>.array
+      GroupType: 214 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 143
+      ID: 186
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1135008
       GoKind: 21
-      HeaderType: 145 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 188 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
-      ID: 803
+      ID: 810
       Name: map[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 8
       GoRuntimeType: 1164704
       GoKind: 21
-      HeaderType: 805 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
+      HeaderType: 812 GoSwissMapHeaderType map<github.com/cihub/seelog.LogLevel,bool>
     - __kind: GoMapType
-      ID: 248
+      ID: 237
       Name: map[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1141376
       GoKind: 21
-      HeaderType: 250 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 239 GoSwissMapHeaderType map<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
-      ID: 983
+      ID: 990
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1140384
       GoKind: 21
-      HeaderType: 985 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 992 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoMapType
-      ID: 982
+      ID: 989
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1136032
       GoKind: 21
-      HeaderType: 844 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 851 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 179
+      ID: 141
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1141248
       GoKind: 21
-      HeaderType: 181 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 143 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
-      ID: 253
+      ID: 242
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1134624
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 138 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
-      ID: 169
+      ID: 131
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1137056
       GoKind: 21
-      HeaderType: 171 GoSwissMapHeaderType map<string,string>
+      HeaderType: 133 GoSwissMapHeaderType map<string,string>
     - __kind: StructureType
-      ID: 457
+      ID: 469
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1434048
@@ -6443,11 +6445,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1006
       Name: mime/multipart.FileHeader
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 871
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1489888
@@ -6455,16 +6457,16 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 982 GoMapType map[string][]string
+          Type: 989 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 983 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 990 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 931
       Name: mime/multipart.Part
       ByteSize: 8
     - __kind: StructureType
-      ID: 926
+      ID: 933
       Name: mime/multipart.sectionReadCloser
       ByteSize: 24
       GoRuntimeType: 1934304
@@ -6472,16 +6474,16 @@ Types:
       RawFields:
         - Name: SectionReader
           Offset: 0
-          Type: 945 PointerType *io.SectionReader
+          Type: 952 PointerType *io.SectionReader
         - Name: Closer
           Offset: 8
-          Type: 930 GoInterfaceType io.Closer
+          Type: 937 GoInterfaceType io.Closer
     - __kind: UnresolvedPointeeType
-      ID: 629
+      ID: 641
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 710
+      ID: 722
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1605536
@@ -6494,35 +6496,35 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 690
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 960
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 676
+      ID: 688
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 631
+      ID: 643
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 968
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 972
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 966
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 622
+      ID: 634
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1116192
@@ -6530,28 +6532,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 624 PointerType *net.UnknownNetworkError.str
+          Type: 636 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 623 GoStringDataType net.UnknownNetworkError.str
+      Data: 635 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 623
+      ID: 635
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 558
+      ID: 570
       Name: net.canceledError
       GoRuntimeType: 1286752
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 722
+      ID: 734
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2122208
@@ -6559,7 +6561,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 710 GoInterfaceType net.Conn
+          Type: 722 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -6570,27 +6572,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 974
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 963
+      ID: 970
       Name: net.noReadFrom
       GoRuntimeType: 1116448
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 962
+      ID: 969
       Name: net.noWriteTo
       GoRuntimeType: 1116320
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 347
+      ID: 359
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1024
+    - __kind: GoContextImplementationType
+      ID: 164
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1762848
@@ -6602,8 +6604,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 123 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 349
+      ID: 361
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1734880
@@ -6611,7 +6615,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 705 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 717 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -6619,7 +6623,7 @@ Types:
           Offset: 96
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 957
+      ID: 964
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2301952
@@ -6627,12 +6631,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 963 StructureType net.noReadFrom
+          Type: 970 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 960 PointerType *net.TCPConn
+          Type: 967 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 955
+      ID: 962
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2301408
@@ -6640,20 +6644,20 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 962 StructureType net.noWriteTo
+          Type: 969 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 960 PointerType *net.TCPConn
+          Type: 967 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 633
+      ID: 645
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 692
       Name: net.timeoutError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 787
+      ID: 794
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1036160
@@ -6666,7 +6670,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 785
+      ID: 792
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1034496
@@ -6679,14 +6683,14 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 842
+      ID: 849
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2122560
       GoKind: 21
-      HeaderType: 844 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 851 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 788
+      ID: 795
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1034624
@@ -6699,15 +6703,15 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 355
+      ID: 367
       Name: net/http.MaxBytesError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 560
+      ID: 572
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 786
+      ID: 793
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1034880
@@ -6731,7 +6735,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 859 PointerType *net/url.URL
+          Type: 866 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -6743,19 +6747,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 837 GoInterfaceType io.ReadCloser
+          Type: 844 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 861 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 868 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 6 BaseType bool
@@ -6764,16 +6768,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 862 GoMapType net/url.Values
+          Type: 869 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 862 GoMapType net/url.Values
+          Type: 869 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 863 PointerType *mime/multipart.Form
+          Type: 870 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -6782,13 +6786,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 865 PointerType *crypto/tls.ConnectionState
+          Type: 872 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 867 GoChannelType <-chan struct {}
+          Type: 874 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 868 PointerType *net/http.Response
+          Type: 875 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
@@ -6797,15 +6801,15 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 870 PointerType *net/http.pattern
+          Type: 877 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 169 GoMapType map[string]string
+          Type: 131 GoMapType map[string]string
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2232736
@@ -6828,16 +6832,16 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 837 GoInterfaceType io.ReadCloser
+          Type: 844 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
           Type: 15 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
           Type: 6 BaseType bool
@@ -6846,13 +6850,13 @@ Types:
           Type: 6 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: Request
           Offset: 128
           Type: 118 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 865 PointerType *crypto/tls.ConnectionState
+          Type: 872 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
       ID: 117
       Name: net/http.ResponseWriter
@@ -6867,19 +6871,19 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 941
       Name: net/http.body
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 908
       Name: net/http.bodyEOFSignal
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 890
       Name: net/http.cancelTimerBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: net/http.chunkWriter
       ByteSize: 24
       GoRuntimeType: 1764384
@@ -6887,10 +6891,10 @@ Types:
       RawFields:
         - Name: res
           Offset: 0
-          Type: 791 PointerType *net/http.response
+          Type: 798 PointerType *net/http.response
         - Name: header
           Offset: 8
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: wroteHeader
           Offset: 16
           Type: 6 BaseType bool
@@ -6898,31 +6902,31 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 843
       Name: net/http.conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: net/http.expectContinueReader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 919
+      ID: 926
       Name: net/http.gzipReader
       ByteSize: 8
     - __kind: BaseType
-      ID: 270
+      ID: 282
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 839488
       GoKind: 10
     - __kind: BaseType
-      ID: 694
+      ID: 706
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 993312
       GoKind: 10
     - __kind: StructureType
-      ID: 358
+      ID: 370
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1736608
@@ -6933,12 +6937,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 694 BaseType net/http.http2ErrCode
+          Type: 706 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 682
+      ID: 694
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1912160
@@ -6949,16 +6953,16 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 694 BaseType net/http.http2ErrCode
+          Type: 706 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 922
       Name: net/http.http2clientStream
       ByteSize: 8
     - __kind: StructureType
-      ID: 364
+      ID: 376
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1606016
@@ -6966,12 +6970,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 694 BaseType net/http.http2ErrCode
+          Type: 706 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 274
+      ID: 286
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839680
@@ -6979,28 +6983,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 276 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 288 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 275 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 287 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 275
+      ID: 287
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 362
+      ID: 374
       Name: net/http.http2goAwayFlowError
       GoRuntimeType: 1117472
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 917
+      ID: 924
       Name: net/http.http2gzipReader
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 280
+      ID: 292
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 839872
@@ -7008,18 +7012,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 282 PointerType *net/http.http2headerFieldNameError.str
+          Type: 294 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 281 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 293 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 281
+      ID: 293
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 277
+      ID: 289
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 839776
@@ -7027,40 +7031,40 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 279 PointerType *net/http.http2headerFieldValueError.str
+          Type: 291 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 278 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 290 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 278
+      ID: 290
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 637
+      ID: 649
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 879
+      ID: 886
       Name: net/http.http2missingBody
       GoRuntimeType: 1287264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 887
+      ID: 894
       Name: net/http.http2noBodyReader
       GoRuntimeType: 1287776
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 566
+      ID: 578
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1287648
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 271
+      ID: 283
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 839584
@@ -7068,22 +7072,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 273 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 285 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 272 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 284 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 272
+      ID: 284
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 885
+      ID: 892
       Name: net/http.http2requestBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: net/http.http2responseWriter
       ByteSize: 8
       GoRuntimeType: 1193504
@@ -7091,13 +7095,13 @@ Types:
       RawFields:
         - Name: rws
           Offset: 0
-          Type: 833 PointerType *net/http.http2responseWriterState
+          Type: 840 PointerType *net/http.http2responseWriterState
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 841
       Name: net/http.http2responseWriterState
       ByteSize: 8
     - __kind: StructureType
-      ID: 881
+      ID: 888
       Name: net/http.http2transportResponseBody
       ByteSize: 8
       GoRuntimeType: 1557504
@@ -7105,19 +7109,19 @@ Types:
       RawFields:
         - Name: cs
           Offset: 0
-          Type: 914 PointerType *net/http.http2clientStream
+          Type: 921 PointerType *net/http.http2clientStream
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: net/http.maxBytesReader
       ByteSize: 8
     - __kind: StructureType
-      ID: 903
+      ID: 910
       Name: net/http.noBody
       GoRuntimeType: 1471488
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 562
+      ID: 574
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1558944
@@ -7127,7 +7131,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1851584
@@ -7144,20 +7148,20 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 1017 GoSliceHeaderType []net/http.segment
+          Type: 1024 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: net/http.readTrackingBody
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 911
+      ID: 918
       Name: net/http.readWriteCloserBody
       ByteSize: 8
     - __kind: StructureType
-      ID: 368
+      ID: 380
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1421728
@@ -7167,7 +7171,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 792
+      ID: 799
       Name: net/http.response
       ByteSize: 232
       GoRuntimeType: 2360544
@@ -7175,16 +7179,16 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 835 PointerType *net/http.conn
+          Type: 842 PointerType *net/http.conn
         - Name: req
           Offset: 8
           Type: 118 PointerType *net/http.Request
         - Name: reqBody
           Offset: 16
-          Type: 837 GoInterfaceType io.ReadCloser
+          Type: 844 GoInterfaceType io.ReadCloser
         - Name: cancelCtx
           Offset: 32
-          Type: 838 GoSubroutineType context.CancelFunc
+          Type: 845 GoSubroutineType context.CancelFunc
         - Name: wroteHeader
           Offset: 40
           Type: 6 BaseType bool
@@ -7196,19 +7200,19 @@ Types:
           Type: 6 BaseType bool
         - Name: writeContinueMu
           Offset: 44
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: canWriteContinue
           Offset: 52
-          Type: 149 StructureType sync/atomic.Bool
+          Type: 201 StructureType sync/atomic.Bool
         - Name: w
           Offset: 56
-          Type: 839 PointerType *bufio.Writer
+          Type: 846 PointerType *bufio.Writer
         - Name: cw
           Offset: 64
-          Type: 841 StructureType net/http.chunkWriter
+          Type: 848 StructureType net/http.chunkWriter
         - Name: handlerHeader
           Offset: 88
-          Type: 842 GoMapType net/http.Header
+          Type: 849 GoMapType net/http.Header
         - Name: calledHeader
           Offset: 96
           Type: 6 BaseType bool
@@ -7232,30 +7236,30 @@ Types:
           Type: 6 BaseType bool
         - Name: trailers
           Offset: 136
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
         - Name: handlerDone
           Offset: 160
-          Type: 149 StructureType sync/atomic.Bool
+          Type: 201 StructureType sync/atomic.Bool
         - Name: dateBuf
           Offset: 164
-          Type: 847 ArrayType [29]uint8
+          Type: 854 ArrayType [29]uint8
         - Name: clenBuf
           Offset: 193
-          Type: 848 ArrayType [10]uint8
+          Type: 855 ArrayType [10]uint8
         - Name: statusBuf
           Offset: 203
-          Type: 849 ArrayType [3]uint8
+          Type: 856 ArrayType [3]uint8
         - Name: lazyCloseNotifyMu
           Offset: 208
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: closeNotifyCh
           Offset: 216
-          Type: 850 GoChannelType chan bool
+          Type: 857 GoChannelType chan bool
         - Name: closeNotifyTriggered
           Offset: 224
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1019
+      ID: 1026
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1623904
@@ -7271,7 +7275,7 @@ Types:
           Offset: 17
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 353
+      ID: 365
       Name: net/http.statusError
       ByteSize: 24
       GoRuntimeType: 1605856
@@ -7284,17 +7288,17 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 684
+      ID: 696
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 635
+      ID: 647
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1472928
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 564
+      ID: 576
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1559104
@@ -7304,7 +7308,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 940
+      ID: 947
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2047520
@@ -7312,22 +7316,22 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 710 GoInterfaceType net.Conn
+          Type: 722 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 710 GoInterfaceType net.Conn
+          Type: 722 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 351
+      ID: 363
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: net/http/httputil.failureToReadBody
       GoRuntimeType: 1296608
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 386
+      ID: 398
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1739488
@@ -7343,7 +7347,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 384
+      ID: 396
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1607136
@@ -7356,11 +7360,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 402
+      ID: 414
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 298
+      ID: 310
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 842080
@@ -7368,22 +7372,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 300 PointerType *net/textproto.ProtocolError.str
+          Type: 312 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 299 GoStringDataType net/textproto.ProtocolError.str
+      Data: 311 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 299
+      ID: 311
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 689
+      ID: 701
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 292
+      ID: 304
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 841888
@@ -7391,18 +7395,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 294 PointerType *net/url.EscapeError.str
+          Type: 306 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 293 GoStringDataType net/url.EscapeError.str
+      Data: 305 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 293
+      ID: 305
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 295
+      ID: 307
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 841984
@@ -7410,18 +7414,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 297 PointerType *net/url.InvalidHostError.str
+          Type: 309 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 296 GoStringDataType net/url.InvalidHostError.str
+      Data: 308 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 296
+      ID: 308
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 860
+      ID: 867
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2148928
@@ -7435,7 +7439,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 980 PointerType *net/url.Userinfo
+          Type: 987 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
           Type: 11 GoStringHeaderType string
@@ -7461,99 +7465,99 @@ Types:
           Offset: 137
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 981
+      ID: 988
       Name: net/url.Userinfo
       ByteSize: 8
     - __kind: GoMapType
-      ID: 862
+      ID: 869
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1902656
       GoKind: 21
-      HeaderType: 844 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 851 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 208
+      ID: 251
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 692032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 209 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 252 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 828
+      ID: 835
       Name: noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 16
       GoRuntimeType: 790304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 829 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
+      Element: 836 StructureType noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: ArrayType
-      ID: 264
+      ID: 267
       Name: noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 710944
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 265 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+      Element: 268 StructureType noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 992
+      ID: 999
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 706240
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 993 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 1000 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 855
+      ID: 862
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 696544
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 856 StructureType noalg.struct { key string; elem []string }
+      Element: 863 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 242
+      ID: 231
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 710848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 243 StructureType noalg.struct { key string; elem float64 }
+      Element: 232 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 731
+      ID: 743
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 767136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 732 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 744 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 234
+      ID: 223
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 687328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 235 StructureType noalg.struct { key string; elem interface {} }
+      Element: 224 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 226
+      ID: 215
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 700768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 227 StructureType noalg.struct { key string; elem string }
+      Element: 216 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 207
+      ID: 250
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1298912
@@ -7564,9 +7568,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 208 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 251 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 827
+      ID: 834
       Name: noalg.map.group[github.com/cihub/seelog.LogLevel]bool
       ByteSize: 24
       GoRuntimeType: 1375840
@@ -7577,9 +7581,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 828 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
+          Type: 835 ArrayType noalg.[8]struct { key github.com/cihub/seelog.LogLevel; elem bool }
     - __kind: StructureType
-      ID: 263
+      ID: 266
       Name: noalg.map.group[string]*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1316320
@@ -7590,9 +7594,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 264 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
+          Type: 267 ArrayType noalg.[8]struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 991
+      ID: 998
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1309536
@@ -7603,9 +7607,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 992 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 999 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1300448
@@ -7616,9 +7620,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 855 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 862 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 241
+      ID: 230
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1316064
@@ -7629,9 +7633,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 242 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 231 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 730
+      ID: 742
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1357536
@@ -7642,9 +7646,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 731 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 743 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 233
+      ID: 222
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1297760
@@ -7655,9 +7659,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 234 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 223 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 225
+      ID: 214
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1302880
@@ -7668,9 +7672,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 226 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 215 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 209
+      ID: 252
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1298784
@@ -7678,12 +7682,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 210 GoInterfaceType context.canceler
+          Type: 253 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
-          Type: 211 StructureType struct {}
+          Type: 254 StructureType struct {}
     - __kind: StructureType
-      ID: 829
+      ID: 836
       Name: noalg.struct { key github.com/cihub/seelog.LogLevel; elem bool }
       ByteSize: 2
       GoRuntimeType: 1375712
@@ -7691,12 +7695,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 830 BaseType github.com/cihub/seelog.LogLevel
+          Type: 837 BaseType github.com/cihub/seelog.LogLevel
         - Name: elem
           Offset: 1
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 265
+      ID: 268
       Name: noalg.struct { key string; elem *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1316192
@@ -7707,9 +7711,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 266 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
+          Type: 269 PointerType *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 993
+      ID: 1000
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1309408
@@ -7720,9 +7724,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 994 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 1001 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 856
+      ID: 863
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1300320
@@ -7733,9 +7737,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 713 GoSliceHeaderType []string
+          Type: 725 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 243
+      ID: 232
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1315936
@@ -7748,7 +7752,7 @@ Types:
           Offset: 16
           Type: 16 BaseType float64
     - __kind: StructureType
-      ID: 732
+      ID: 744
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1357408
@@ -7759,9 +7763,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 720 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 732 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 235
+      ID: 224
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1297632
@@ -7772,9 +7776,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 142 GoEmptyInterfaceType interface {}
+          Type: 169 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 227
+      ID: 216
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1302752
@@ -7787,15 +7791,15 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 973
+      ID: 980
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 568
+      ID: 580
       Name: os.LinkError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 163
+      ID: 181
       Name: os.Signal
       ByteSize: 16
       GoRuntimeType: 1118112
@@ -7808,11 +7812,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 639
+      ID: 651
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 971
+      ID: 978
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2371488
@@ -7820,12 +7824,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 975 StructureType os.noReadFrom
+          Type: 982 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 972 PointerType *os.File
+          Type: 979 PointerType *os.File
     - __kind: StructureType
-      ID: 969
+      ID: 976
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2370688
@@ -7833,32 +7837,32 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 974 StructureType os.noWriteTo
+          Type: 981 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 972 PointerType *os.File
+          Type: 979 PointerType *os.File
     - __kind: StructureType
-      ID: 975
+      ID: 982
       Name: os.noReadFrom
       GoRuntimeType: 1117984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 974
+      ID: 981
       Name: os.noWriteTo
       GoRuntimeType: 1117856
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 613
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 726
+      ID: 738
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: StructureType
-      ID: 603
+      ID: 615
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1713472
@@ -7871,7 +7875,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: GoContextImplementationType
-      ID: 137
+      ID: 177
       Name: os/signal.signalCtx
       ByteSize: 56
       GoRuntimeType: 1987776
@@ -7882,17 +7886,17 @@ Types:
           Type: 123 GoInterfaceType context.Context
         - Name: cancel
           Offset: 16
-          Type: 160 GoSubroutineType context.CancelCauseFunc
+          Type: 178 GoSubroutineType context.CancelCauseFunc
         - Name: signals
           Offset: 24
-          Type: 161 GoSliceHeaderType []os.Signal
+          Type: 179 GoSliceHeaderType []os.Signal
         - Name: ch
           Offset: 48
-          Type: 164 GoChannelType chan os.Signal
+          Type: 182 GoChannelType chan os.Signal
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoStringHeaderType
-      ID: 283
+      ID: 295
       Name: os/signal.signalError
       ByteSize: 16
       GoRuntimeType: 839968
@@ -7900,18 +7904,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 285 PointerType *os/signal.signalError.str
+          Type: 297 PointerType *os/signal.signalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 284 GoStringDataType os/signal.signalError.str
+      Data: 296 GoStringDataType os/signal.signalError.str
     - __kind: GoStringDataType
-      ID: 284
+      ID: 296
       Name: os/signal.signalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 326
+      ID: 338
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 846592
@@ -7919,36 +7923,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 328 PointerType *os/user.UnknownGroupIdError.str
+          Type: 340 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 327 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 339 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 327
+      ID: 339
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 325
+      ID: 337
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 846496
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 380
+      ID: 392
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 461
+      ID: 473
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 576
+      ID: 588
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 580
+      ID: 592
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -7960,7 +7964,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 578
+      ID: 590
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1902208
@@ -7977,7 +7981,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 724 BaseType internal/abi.BoundsErrorCode
+          Type: 736 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -7993,7 +7997,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 641
+      ID: 653
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1771680
@@ -8006,7 +8010,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 544
+      ID: 556
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 994560
@@ -8014,13 +8018,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 546 PointerType *runtime.errorString.str
+          Type: 558 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 545 GoStringDataType runtime.errorString.str
+      Data: 557 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 545
+      ID: 557
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8669,7 +8673,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 201
+      ID: 208
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -8705,7 +8709,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 547
+      ID: 559
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 994656
@@ -8713,13 +8717,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 549 PointerType *runtime.plainError.str
+          Type: 561 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 548 GoStringDataType runtime.plainError.str
+      Data: 560 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 548
+      ID: 560
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -8760,7 +8764,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 382
+      ID: 394
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1606816
@@ -8832,7 +8836,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 572
+      ID: 584
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -8844,18 +8848,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 196 PointerType *string.str
+          Type: 203 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 195 GoStringDataType string.str
+      Data: 202 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 195
+      ID: 202
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1967072
@@ -8863,12 +8867,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 773
+      ID: 780
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2045216
@@ -8876,15 +8880,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 755
+      ID: 762
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1966560
@@ -8892,12 +8896,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 765
+      ID: 772
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2044064
@@ -8905,15 +8909,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 779
+      ID: 786
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2106848
@@ -8921,18 +8925,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 767
+      ID: 774
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2044352
@@ -8940,15 +8944,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 763
+      ID: 770
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2043776
@@ -8956,15 +8960,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 775
+      ID: 782
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2106208
@@ -8972,18 +8976,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 783
+      ID: 790
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2167744
@@ -8991,21 +8995,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 777
+      ID: 784
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2106528
@@ -9013,18 +9017,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 785 GoInterfaceType net/http.Flusher
+          Type: 792 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1967328
@@ -9032,12 +9036,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 757
+      ID: 764
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1966816
@@ -9045,12 +9049,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 769
+      ID: 776
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2044640
@@ -9058,15 +9062,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 781
+      ID: 788
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2107168
@@ -9074,18 +9078,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 787 GoInterfaceType net/http.CloseNotifier
+          Type: 794 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 771
+      ID: 778
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2044928
@@ -9093,15 +9097,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 784 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 791 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 786 GoInterfaceType net/http.Pusher
+          Type: 793 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 788 GoInterfaceType net/http.Hijacker
+          Type: 795 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: struct { io.Reader; io.Closer }
       ByteSize: 32
       GoRuntimeType: 1718656
@@ -9109,18 +9113,18 @@ Types:
       RawFields:
         - Name: Reader
           Offset: 0
-          Type: 920 GoInterfaceType io.Reader
+          Type: 927 GoInterfaceType io.Reader
         - Name: Closer
           Offset: 16
-          Type: 930 GoInterfaceType io.Closer
+          Type: 937 GoInterfaceType io.Closer
     - __kind: StructureType
-      ID: 211
+      ID: 254
       Name: struct {}
       GoRuntimeType: 853408
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 138
+      ID: 126
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1476448
@@ -9128,12 +9132,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 139 StructureType sync.noCopy
+          Type: 127 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 140 StructureType internal/sync.Mutex
+          Type: 128 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 148
+      ID: 200
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1631392
@@ -9141,15 +9145,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 139 StructureType sync.noCopy
+          Type: 127 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 149 StructureType sync/atomic.Bool
+          Type: 201 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 167
+      ID: 125
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1857408
@@ -9157,7 +9161,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 138 StructureType sync.Mutex
+          Type: 126 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -9166,18 +9170,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 168 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 168 StructureType sync/atomic.Int32
+          Type: 129 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 139
+      ID: 127
       Name: sync.noCopy
       GoRuntimeType: 994176
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 149
+      ID: 201
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1477568
@@ -9185,12 +9189,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 130 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 168
+      ID: 129
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1477728
@@ -9198,12 +9202,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 130 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 141
+      ID: 185
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1201184
@@ -9211,27 +9215,27 @@ Types:
       RawFields:
         - Name: v
           Offset: 0
-          Type: 142 GoEmptyInterfaceType interface {}
+          Type: 169 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 150
+      ID: 130
       Name: sync/atomic.noCopy
       GoRuntimeType: 994272
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 674
+      ID: 686
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1288416
       GoKind: 12
     - __kind: BaseType
-      ID: 747
+      ID: 754
       Name: syscall.Signal
       ByteSize: 8
       GoRuntimeType: 995616
       GoKind: 2
     - __kind: StructureType
-      ID: 204
+      ID: 247
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -9253,9 +9257,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 205 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 248 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 824
+      ID: 831
       Name: table<github.com/cihub/seelog.LogLevel,bool>
       ByteSize: 32
       GoKind: 25
@@ -9277,9 +9281,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 825 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
+          Type: 832 GoSwissMapGroupsType groupReference<github.com/cihub/seelog.LogLevel,bool>
     - __kind: StructureType
-      ID: 260
+      ID: 263
       Name: table<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -9301,9 +9305,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 261 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
+          Type: 264 GoSwissMapGroupsType groupReference<string,*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 988
+      ID: 995
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
@@ -9325,9 +9329,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 989 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 996 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 851
+      ID: 858
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -9349,9 +9353,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 852 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 859 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 238
+      ID: 227
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -9373,9 +9377,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 239 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 228 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 727
+      ID: 739
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -9397,9 +9401,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 728 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 740 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 230
+      ID: 219
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -9421,9 +9425,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 231 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 220 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 222
+      ID: 211
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -9445,9 +9449,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 223 GoSwissMapGroupsType groupReference<string,string>
+          Type: 212 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 621
+      ID: 633
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1717696
@@ -9460,13 +9464,13 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 947
+      ID: 954
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1930208
       GoKind: 6
     - __kind: StructureType
-      ID: 158
+      ID: 197
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1993696
@@ -9477,10 +9481,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 214 GoSliceHeaderType []time.zone
+          Type: 257 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 217 GoSliceHeaderType []time.zoneTrans
+          Type: 260 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -9492,13 +9496,13 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 215 PointerType *time.zone
+          Type: 258 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 374
+      ID: 386
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
-      ID: 156
+      ID: 195
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2386496
@@ -9512,7 +9516,7 @@ Types:
           Type: 15 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 157 PointerType *time.Location
+          Type: 196 PointerType *time.Location
       ExtFieldOffset: 8
       LocFieldOffset: 16
       CacheResolved: true
@@ -9522,7 +9526,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 155
+      ID: 194
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1474048
@@ -9530,12 +9534,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 741 GoChannelType <-chan time.Time
+          Type: 753 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 286
+      ID: 298
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 840064
@@ -9543,22 +9547,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 288 PointerType *time.fileSizeError.str
+          Type: 300 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 287 GoStringDataType time.fileSizeError.str
+      Data: 299 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 287
+      ID: 299
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 372
+      ID: 384
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 216
+      ID: 259
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1628320
@@ -9574,7 +9578,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 219
+      ID: 262
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1768416
@@ -9635,7 +9639,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 26
     - __kind: StructureType
-      ID: 705
+      ID: 717
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2079008
@@ -9646,10 +9650,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 706 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 718 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 707 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 719 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -9664,18 +9668,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 708 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 720 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 708
+      ID: 720
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995712
       GoKind: 9
     - __kind: StructureType
-      ID: 706
+      ID: 718
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1933280
@@ -9700,17 +9704,17 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 389
+      ID: 401
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 707
+      ID: 719
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 591968
       GoKind: 8
     - __kind: StructureType
-      ID: 406
+      ID: 418
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1427648
@@ -9720,13 +9724,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 305
+      ID: 317
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 842368
       GoKind: 2
     - __kind: StructureType
-      ID: 585
+      ID: 597
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1712896
@@ -9739,7 +9743,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 551
+      ID: 563
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 996576

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -11559,21 +11559,21 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1202
+      ID: 1208
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 134
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 135 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1207
+      ID: 1214
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1208 PointerType *main.deepSlice3
+      Pointee: 1215 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1236
       Name: '**main.deepSlice8'
@@ -11591,7 +11591,7 @@ Types:
       GoKind: 22
       Pointee: 151 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1197
+      ID: 1204
       Name: '**main.t'
       ByteSize: 8
       Pointee: 250 PointerType *main.t
@@ -11603,20 +11603,20 @@ Types:
       GoKind: 22
       Pointee: 90 PointerType *string
     - __kind: PointerType
-      ID: 1205
+      ID: 1211
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1204 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1210 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 424
+      ID: 431
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 423 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 430 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1211
+      ID: 1218
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1210 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1217 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1240
       Name: '*[]*main.deepSlice8.array'
@@ -11628,95 +11628,95 @@ Types:
       ByteSize: 8
       Pointee: 1245 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 421
+      ID: 428
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 420 GoSliceDataType []*string.array
+      Pointee: 427 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 490
+      ID: 497
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 496 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 285
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 282 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 488
+      ID: 495
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 494 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 283
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 280 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 486
+      ID: 493
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 492 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 281
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 278 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 484
+      ID: 491
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 490 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 279
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 276 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 482
+      ID: 489
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 488 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 470
+      ID: 477
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 469 GoSliceDataType [][]uint.array
+      Pointee: 476 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 474
+      ID: 481
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 473 GoSliceDataType []bool.array
+      Pointee: 480 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 990 GoSliceDataType []float64.array
+      Pointee: 997 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 527
+      ID: 531
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 526 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 530 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 535
+      ID: 539
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 534 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 538 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 516
+      ID: 523
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 515 GoSliceDataType []go.shape.float64.array
+      Pointee: 522 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 512
+      ID: 519
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 511 GoSliceDataType []go.shape.int.array
+      Pointee: 518 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 514
+      ID: 521
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 513 GoSliceDataType []go.shape.string.array
+      Pointee: 520 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
       ID: 1249
       Name: '*[]interface {}.array'
@@ -11728,20 +11728,20 @@ Types:
       ByteSize: 8
       Pointee: 274 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 480
+      ID: 487
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 479 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 486 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 537
+      ID: 544
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 536 GoSliceDataType []main.structWithMap.array
+      Pointee: 543 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 472
+      ID: 479
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 471 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 478 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -11750,111 +11750,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 432
+      ID: 439
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 431 GoSliceDataType []string.array
+      Pointee: 438 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 478
+      ID: 485
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 477 GoSliceDataType []struct {}.array
+      Pointee: 484 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 539
+      ID: 546
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 538 GoSliceDataType []time.zone.array
+      Pointee: 545 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 541
+      ID: 548
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 540 GoSliceDataType []time.zoneTrans.array
+      Pointee: 547 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 261
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 259 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 468
+      ID: 475
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 467 GoSliceDataType []uint.array
+      Pointee: 474 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 476
+      ID: 483
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 475 GoSliceDataType []uint16.array
+      Pointee: 482 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 417
+      ID: 424
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 416 GoSliceDataType []uint8.array
+      Pointee: 423 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 419
+      ID: 426
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 418 GoSliceDataType []uintptr.array
+      Pointee: 425 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1116
+      ID: 1123
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1858080
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1124 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 861792
       GoKind: 22
-      Pointee: 772 GoSliceHeaderType archive/tar.headerError
+      Pointee: 779 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 774
+      ID: 781
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 773 GoSliceDataType archive/tar.headerError.array
+      Pointee: 780 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1259264
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1064 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1004
+      ID: 1011
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 861984
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1012 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1006
+      ID: 1013
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 862080
       GoKind: 22
-      Pointee: 1007 StructureType archive/zip.dirWriter
+      Pointee: 1014 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1103
+      ID: 1110
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1782368
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1111 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1032
+      ID: 1039
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1021248
       GoKind: 22
-      Pointee: 1033 StructureType archive/zip.nopCloser
+      Pointee: 1040 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1034
+      ID: 1041
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1021504
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1042 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -11883,20 +11883,20 @@ Types:
       ByteSize: 8
       Pointee: 204 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 377
+      ID: 415
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 378 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 416 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
       ID: 142
       Name: '*bucket<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 143 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1215
+      ID: 1222
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1223 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1253
       Name: '*bucket<int,*main.deepMap8>'
@@ -11928,10 +11928,10 @@ Types:
       ByteSize: 8
       Pointee: 209 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 531
+      ID: 535
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 536 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 198
       Name: '*bucket<string,[]main.structWithMap>'
@@ -11943,35 +11943,35 @@ Types:
       ByteSize: 8
       Pointee: 187 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 401
+      ID: 378
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 402 GoHMapBucketType bucket<string,float64>
+      Pointee: 379 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 968 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 181
       Name: '*bucket<string,int>'
       ByteSize: 8
       Pointee: 182 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 396
+      ID: 373
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 397 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 374 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
       ID: 176
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 177 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 391
+      ID: 368
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 392 GoHMapBucketType bucket<string,string>
+      Pointee: 369 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 233
       Name: '*bucket<struct {},int>'
@@ -12023,449 +12023,449 @@ Types:
       ByteSize: 8
       Pointee: 214 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 1080
+      ID: 1087
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2039264
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType bufio.Reader
+      Pointee: 1088 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1107
+      ID: 1114
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1824576
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType bufio.Writer
+      Pointee: 1115 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1152
+      ID: 1159
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2132224
       GoKind: 22
-      Pointee: 1153 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1160 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 682
+      ID: 689
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 844320
       GoKind: 22
-      Pointee: 579 BaseType compress/flate.CorruptInputError
+      Pointee: 586 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 844416
       GoKind: 22
-      Pointee: 580 GoStringHeaderType compress/flate.InternalError
+      Pointee: 587 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 582
+      ID: 589
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 581 GoStringDataType compress/flate.InternalError.str
+      Pointee: 588 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1249504
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1062 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1000
+      ID: 1007
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 844512
       GoKind: 22
-      Pointee: 1001 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1008 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1076
+      ID: 1083
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1609376
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1084 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1229
+      ID: 405
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1370016
       GoKind: 22
-      Pointee: 370 StructureType context.backgroundCtx
+      Pointee: 406 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 360
+      ID: 409
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1606880
       GoKind: 22
-      Pointee: 361 StructureType context.cancelCtx
+      Pointee: 410 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1109984
       GoKind: 22
-      Pointee: 884 StructureType context.deadlineExceededError
+      Pointee: 891 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1224
+      ID: 392
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1238304
       GoKind: 22
-      Pointee: 371 StructureType context.emptyCtx
+      Pointee: 393 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 362
+      ID: 394
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1238464
       GoKind: 22
-      Pointee: 363 StructureType context.stopCtx
+      Pointee: 395 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 364
+      ID: 417
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1607072
       GoKind: 22
-      Pointee: 365 StructureType context.timerCtx
+      Pointee: 418 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1230
+      ID: 407
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1370176
       GoKind: 22
-      Pointee: 382 StructureType context.todoCtx
+      Pointee: 408 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 366
+      ID: 401
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1369696
       GoKind: 22
-      Pointee: 367 StructureType context.valueCtx
+      Pointee: 402 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 368
+      ID: 403
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1369856
       GoKind: 22
-      Pointee: 369 StructureType context.withoutCancelCtx
+      Pointee: 404 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 856704
       GoKind: 22
-      Pointee: 593 BaseType crypto/aes.KeySizeError
+      Pointee: 600 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 856896
       GoKind: 22
-      Pointee: 594 BaseType crypto/des.KeySizeError
+      Pointee: 601 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 1066
+      ID: 1073
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1380896
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 1074 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1687776
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1099 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 857184
       GoKind: 22
-      Pointee: 595 BaseType crypto/rc4.KeySizeError
+      Pointee: 602 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1099
+      ID: 1106
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1779552
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1107 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1688448
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 1101 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1688896
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 1103 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 845952
       GoKind: 22
-      Pointee: 583 BaseType crypto/tls.AlertError
+      Pointee: 590 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1008832
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 863 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1178
+      ID: 1185
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2241344
       GoKind: 22
-      Pointee: 1179 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1186 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 686
+      ID: 693
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 845760
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 694 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 22
-      Pointee: 685 StructureType crypto/tls.RecordHeaderError
+      Pointee: 692 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1007168
       GoKind: 22
-      Pointee: 811 BaseType crypto/tls.alert
+      Pointee: 818 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1378016
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1072 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1071
+      ID: 1078
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1458176
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1079 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1249824
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 958 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1915232
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 970 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 855552
       GoKind: 22
-      Pointee: 759 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 766 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 855072
       GoKind: 22
-      Pointee: 753 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 760 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 855168
       GoKind: 22
-      Pointee: 755 StructureType crypto/x509.HostnameError
+      Pointee: 762 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 854976
       GoKind: 22
-      Pointee: 592 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 599 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1014720
       GoKind: 22
-      Pointee: 861 StructureType crypto/x509.SystemRootsError
+      Pointee: 868 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 855648
       GoKind: 22
-      Pointee: 761 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 768 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 855456
       GoKind: 22
-      Pointee: 757 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 764 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 862272
       GoKind: 22
-      Pointee: 776 StructureType encoding/asn1.StructuralError
+      Pointee: 783 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 862464
       GoKind: 22
-      Pointee: 780 StructureType encoding/asn1.SyntaxError
+      Pointee: 787 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 862368
       GoKind: 22
-      Pointee: 778 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 785 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 676
+      ID: 683
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 842016
       GoKind: 22
-      Pointee: 577 BaseType encoding/base64.CorruptInputError
+      Pointee: 584 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1022
+      ID: 1029
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1003328
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1030 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 842880
       GoKind: 22
-      Pointee: 578 BaseType encoding/hex.InvalidByteError
+      Pointee: 585 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 836736
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 655 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 998976
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 854 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 836352
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 647 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 836640
       GoKind: 22
-      Pointee: 646 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 653 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 836544
       GoKind: 22
-      Pointee: 644 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 651 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 641
+      ID: 648
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 836448
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 649 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1158
+      ID: 1165
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2157792
       GoKind: 22
-      Pointee: 1159 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1166 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 837120
       GoKind: 22
-      Pointee: 650 StructureType encoding/json.jsonError
+      Pointee: 657 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1030
+      ID: 1037
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1017792
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1038 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 854016
       GoKind: 22
-      Pointee: 747 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 754 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 853920
       GoKind: 22
-      Pointee: 745 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 752 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 854112
       GoKind: 22
-      Pointee: 589 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 596 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 591
+      ID: 598
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 590 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 597 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 854208
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 757 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1136
+      ID: 1143
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2027744
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1144 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -12474,19 +12474,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 617
+      ID: 624
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 827712
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType errors.errorString
+      Pointee: 625 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 984512
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType errors.joinError
+      Pointee: 821 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -12502,625 +12502,625 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 1146
+      ID: 1153
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2123520
       GoKind: 22
-      Pointee: 1147 UnresolvedPointeeType fmt.pp
+      Pointee: 1154 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 984640
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType fmt.wrapError
+      Pointee: 823 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 984768
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 825 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 677
+      ID: 684
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 842400
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 685 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 658
+      ID: 665
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 839520
       GoKind: 22
-      Pointee: 659 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 666 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 660
+      ID: 667
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 839616
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 668 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 839328
       GoKind: 22
-      Pointee: 975 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 982 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 664
+      ID: 671
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 839904
       GoKind: 22
-      Pointee: 665 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 672 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 839424
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 984 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 839712
       GoKind: 22
-      Pointee: 571 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 578 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 573
+      ID: 580
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 579 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 657
+      ID: 664
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 839232
       GoKind: 22
-      Pointee: 568 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 575 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 570
+      ID: 577
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 576 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 663
+      ID: 670
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 839808
       GoKind: 22
-      Pointee: 574 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 581 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 576
+      ID: 583
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 582 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1044
+      ID: 1051
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1128288
       GoKind: 22
-      Pointee: 1045 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1052 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1124
+      ID: 1131
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1929920
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1132 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 860736
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 777 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 383
+      ID: 388
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2142464
       GoKind: 22
-      Pointee: 384 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 360 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 409
+      ID: 386
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1879840
       GoKind: 22
-      Pointee: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 387 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 404
+      ID: 381
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1110240
       GoKind: 22
-      Pointee: 405 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 382 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 407
+      ID: 384
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1110368
       GoKind: 22
-      Pointee: 408 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 385 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1222
+      ID: 1229
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1111008
       GoKind: 22
-      Pointee: 1223 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1230 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 543
+      ID: 550
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1111136
       GoKind: 22
-      Pointee: 544 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 551 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 411
+      ID: 389
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2089344
       GoKind: 22
-      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 390 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 918
+      ID: 925
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1131616
       GoKind: 22
-      Pointee: 919 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 926 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1154
+      ID: 1161
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2133760
       GoKind: 22
-      Pointee: 1155 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1162 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1225
+      ID: 397
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1243744
       GoKind: 22
-      Pointee: 1226 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 398 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 695
+      ID: 702
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 703 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 850560
       GoKind: 22
-      Pointee: 703 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 710 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 697
+      ID: 704
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 850272
       GoKind: 22
-      Pointee: 588 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 595 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 850464
       GoKind: 22
-      Pointee: 701 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 708 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 850368
       GoKind: 22
-      Pointee: 699 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 706 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 852480
       GoKind: 22
-      Pointee: 719 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 726 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 852672
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 730 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 852576
       GoKind: 22
-      Pointee: 721 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 728 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 852384
       GoKind: 22
-      Pointee: 717 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 724 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 992 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 999 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 730
+      ID: 737
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 853056
       GoKind: 22
-      Pointee: 731 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 738 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 724
+      ID: 731
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 852768
       GoKind: 22
-      Pointee: 725 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 732 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 852960
       GoKind: 22
-      Pointee: 729 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 736 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 852864
       GoKind: 22
-      Pointee: 727 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 734 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 853152
       GoKind: 22
-      Pointee: 733 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 740 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 853440
       GoKind: 22
-      Pointee: 739 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 746 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 740
+      ID: 747
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 853536
       GoKind: 22
-      Pointee: 741 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 748 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 736
+      ID: 743
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 853344
       GoKind: 22
-      Pointee: 737 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 744 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 853248
       GoKind: 22
-      Pointee: 735 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 742 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 742
+      ID: 749
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 743 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 750 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 666
+      ID: 673
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 841056
       GoKind: 22
-      Pointee: 667 StructureType github.com/cihub/seelog.baseError
+      Pointee: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1684864
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1091 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 668
+      ID: 675
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 841152
       GoKind: 22
-      Pointee: 669 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 676 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1376416
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1070 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1018
+      ID: 1025
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1002304
       GoKind: 22
-      Pointee: 1019 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1026 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1247424
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1060 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 672
+      ID: 679
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 841344
       GoKind: 22
-      Pointee: 673 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 680 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1847712
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1122 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2002400
       GoKind: 22
-      Pointee: 1126 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1133 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1128
+      ID: 1135
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2002016
       GoKind: 22
-      Pointee: 1127 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1134 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1020
+      ID: 1027
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1002432
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1028 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 670
+      ID: 677
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 841248
       GoKind: 22
-      Pointee: 671 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 678 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 674
+      ID: 681
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 841440
       GoKind: 22
-      Pointee: 675 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 682 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1087
+      ID: 1094
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1686432
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1095 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1120
+      ID: 1127
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1884160
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1128 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1122
+      ID: 1129
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1914912
       GoKind: 22
-      Pointee: 1123 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1130 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1261664
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 960 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1029184
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 876 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1029056
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 874 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1033152
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 878 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1033280
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 880 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1073
+      ID: 1080
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1486208
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1081 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1015488
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 870 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 680
+      ID: 687
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 843072
       GoKind: 22
-      Pointee: 681 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 688 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1170
+      ID: 1177
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2220448
       GoKind: 22
-      Pointee: 1171 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1178 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1140576
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 934 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1118816
       GoKind: 22
-      Pointee: 896 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 903 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1118432
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 897 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 993088
       GoKind: 22
-      Pointee: 833 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 840 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1119200
       GoKind: 22
-      Pointee: 902 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 909 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 992960
       GoKind: 22
-      Pointee: 810 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 817 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1118688
       GoKind: 22
-      Pointee: 894 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 901 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1118560
       GoKind: 22
-      Pointee: 892 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 899 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1119072
       GoKind: 22
-      Pointee: 900 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 907 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1118944
       GoKind: 22
-      Pointee: 898 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 905 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1174
+      ID: 1181
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2231488
       GoKind: 22
-      Pointee: 1175 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1182 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1119584
       GoKind: 22
-      Pointee: 906 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 913 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 993344
       GoKind: 22
-      Pointee: 837 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 844 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 993216
       GoKind: 22
-      Pointee: 835 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 842 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1119456
       GoKind: 22
-      Pointee: 904 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 911 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 874368
       GoKind: 22
-      Pointee: 600 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 607 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 602
+      ID: 609
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 601 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 608 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
       ID: 356
       Name: '*go.shape.float64'
@@ -13143,10 +13143,10 @@ Types:
       GoKind: 22
       Pointee: 329 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 510
+      ID: 517
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 509 GoStringDataType go.shape.string.str
+      Pointee: 516 GoStringDataType go.shape.string.str
     - __kind: PointerType
       ID: 335
       Name: '*go.shape.struct { Name string }'
@@ -13166,242 +13166,242 @@ Types:
       GoKind: 22
       Pointee: 351 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1484672
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 973 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1048128
       GoKind: 22
-      Pointee: 877 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 884 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1050
+      ID: 1057
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1179616
       GoKind: 22
-      Pointee: 1051 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1058 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1134
+      ID: 1141
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2017376
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1142 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1036
+      ID: 1043
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1050432
       GoKind: 22
-      Pointee: 1037 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1044 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 875616
       GoKind: 22
-      Pointee: 603 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 610 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1181280
       GoKind: 22
-      Pointee: 935 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 942 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 875904
       GoKind: 22
-      Pointee: 796 StructureType golang.org/x/net/http2.connError
+      Pointee: 803 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 875808
       GoKind: 22
-      Pointee: 607 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 614 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 609
+      ID: 616
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 608 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 615 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 876096
       GoKind: 22
-      Pointee: 613 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 620 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 615
+      ID: 622
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 614 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 621 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 876000
       GoKind: 22
-      Pointee: 610 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 617 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 612
+      ID: 619
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 611 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 618 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 793
+      ID: 800
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 875712
       GoKind: 22
-      Pointee: 604 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 611 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 606
+      ID: 613
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 605 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 612 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1132
+      ID: 1139
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2015456
       GoKind: 22
-      Pointee: 1133 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1140 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 876192
       GoKind: 22
-      Pointee: 800 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 807 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 876288
       GoKind: 22
-      Pointee: 616 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 623 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 869760
       GoKind: 22
-      Pointee: 788 StructureType google.golang.org/grpc.dropError
+      Pointee: 795 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1178208
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 940 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1269024
       GoKind: 22
-      Pointee: 955 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 962 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 872640
       GoKind: 22
-      Pointee: 790 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 797 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1097
+      ID: 1104
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1693376
       GoKind: 22
-      Pointee: 1098 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1105 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1048
+      ID: 1055
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1174752
       GoKind: 22
-      Pointee: 1049 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1056 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1042368
       GoKind: 22
-      Pointee: 875 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 882 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 872736
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1016 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 858624
       GoKind: 22
-      Pointee: 768 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 775 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1019200
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 872 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1146464
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 938 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1146208
       GoKind: 22
-      Pointee: 929 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 936 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 863328
       GoKind: 22
-      Pointee: 782 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 789 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 863424
       GoKind: 22
-      Pointee: 784 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 791 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 710
+      ID: 717
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 850944
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 718 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1685536
       GoKind: 22
-      Pointee: 1086 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1093 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 226
       Name: '*hash<[4]int,[4]int>'
@@ -13423,20 +13423,20 @@ Types:
       ByteSize: 8
       Pointee: 202 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 375
+      ID: 413
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 376 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 414 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
       ID: 140
       Name: '*hash<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 141 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1213
+      ID: 1220
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1214 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1221 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1251
       Name: '*hash<int,*main.deepMap8>'
@@ -13468,10 +13468,10 @@ Types:
       ByteSize: 8
       Pointee: 207 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 529
+      ID: 533
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 530 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 534 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 196
       Name: '*hash<string,[]main.structWithMap>'
@@ -13483,35 +13483,35 @@ Types:
       ByteSize: 8
       Pointee: 185 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 399
+      ID: 376
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 400 GoHMapHeaderType hash<string,float64>
+      Pointee: 377 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 959 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 966 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 179
       Name: '*hash<string,int>'
       ByteSize: 8
       Pointee: 180 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 394
+      ID: 371
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 395 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 372 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
       ID: 174
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 175 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 389
+      ID: 366
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 390 GoHMapHeaderType hash<string,string>
+      Pointee: 367 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 231
       Name: '*hash<struct {},int>'
@@ -13563,12 +13563,12 @@ Types:
       ByteSize: 8
       Pointee: 212 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 877056
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType html/template.Error
+      Pointee: 810 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 95
       Name: '*int'
@@ -13612,82 +13612,82 @@ Types:
       GoKind: 22
       Pointee: 159 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 856224
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 770 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 843456
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1006 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1132768
       GoKind: 22
-      Pointee: 925 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 932 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1176
+      ID: 1183
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2236160
       GoKind: 22
-      Pointee: 1177 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1184 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 922
+      ID: 929
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1132640
       GoKind: 22
-      Pointee: 923 StructureType internal/poll.errNetClosing
+      Pointee: 930 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 622
+      ID: 629
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 831840
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 630 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1040
+      ID: 1047
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1109728
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1048 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1109344
       GoKind: 22
-      Pointee: 1039 StructureType io.discard
+      Pointee: 1046 StructureType io.discard
     - __kind: PointerType
-      ID: 1012
+      ID: 1019
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 985536
       GoKind: 22
-      Pointee: 1013 UnresolvedPointeeType io.multiWriter
+      Pointee: 1020 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 920
+      ID: 927
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1132384
       GoKind: 22
-      Pointee: 921 UnresolvedPointeeType io/fs.PathError
+      Pointee: 928 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1089
+      ID: 1096
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1686656
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1097 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 342
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
@@ -13707,19 +13707,19 @@ Types:
       GoKind: 22
       Pointee: 319 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 428
+      ID: 435
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 357952
       GoKind: 22
-      Pointee: 429 StructureType main.deepMap2
+      Pointee: 436 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1218
+      ID: 1225
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 357888
       GoKind: 22
-      Pointee: 1219 UnresolvedPointeeType main.deepMap3
+      Pointee: 1226 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 146
       Name: '*main.deepMap7'
@@ -13749,12 +13749,12 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1180
+      ID: 1187
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 358464
       GoKind: 22
-      Pointee: 1181 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1188 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 130
       Name: '*main.deepPtr7'
@@ -13782,14 +13782,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 359104
       GoKind: 22
-      Pointee: 422 StructureType main.deepSlice2
+      Pointee: 429 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1208
+      ID: 1215
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 359040
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1216 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 136
       Name: '*main.deepSlice7'
@@ -13825,7 +13825,7 @@ Types:
       GoKind: 22
       Pointee: 162 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1194
+      ID: 1201
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 827424
@@ -13858,19 +13858,19 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1195
+      ID: 1202
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 827520
       GoKind: 22
-      Pointee: 1196 StructureType main.secondBehavior
+      Pointee: 1203 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1186
+      ID: 1193
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 827616
       GoKind: 22
-      Pointee: 1187 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1194 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 148
       Name: '*main.stringType1'
@@ -13878,16 +13878,16 @@ Types:
       GoKind: 22
       Pointee: 149 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1183
+      ID: 1190
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1182 GoStringDataType main.stringType1.str
+      Pointee: 1189 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1184 GoStringHeaderType main.stringType2
+      Pointee: 1191 GoStringHeaderType main.stringType2
     - __kind: PointerType
       ID: 1276
       Name: '*main.stringType2.str'
@@ -13899,7 +13899,7 @@ Types:
       ByteSize: 8
       Pointee: 273 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 447
+      ID: 454
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 357440
@@ -13923,10 +13923,10 @@ Types:
       GoKind: 22
       Pointee: 251 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1199
+      ID: 1206
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1198 GoSliceDataType main.t.array
+      Pointee: 1205 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 270
       Name: '*main.threeStringStruct'
@@ -13940,561 +13940,561 @@ Types:
       GoKind: 22
       Pointee: 178 GoMapType map[string]int
     - __kind: PointerType
-      ID: 714
+      ID: 721
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 851808
       GoKind: 22
-      Pointee: 715 StructureType math/big.ErrNaN
+      Pointee: 722 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1002
+      ID: 1009
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 846432
       GoKind: 22
-      Pointee: 1003 StructureType mime/multipart.writerOnly·1
+      Pointee: 1010 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1125856
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType net.AddrError
+      Pointee: 920 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1245664
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType net.DNSError
+      Pointee: 951 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1140
+      ID: 1147
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2095712
       GoKind: 22
-      Pointee: 1141 UnresolvedPointeeType net.IPConn
+      Pointee: 1148 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1245344
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType net.OpError
+      Pointee: 949 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1125984
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType net.ParseError
+      Pointee: 922 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1150
+      ID: 1157
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2125568
       GoKind: 22
-      Pointee: 1151 UnresolvedPointeeType net.TCPConn
+      Pointee: 1158 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1160
+      ID: 1167
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2170528
       GoKind: 22
-      Pointee: 1161 UnresolvedPointeeType net.UDPConn
+      Pointee: 1168 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1148
+      ID: 1155
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2125056
       GoKind: 22
-      Pointee: 1149 UnresolvedPointeeType net.UnixConn
+      Pointee: 1156 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1125088
       GoKind: 22
-      Pointee: 880 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 887 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 881 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 888 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 999744
       GoKind: 22
-      Pointee: 849 StructureType net.canceledError
+      Pointee: 856 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1118
+      ID: 1125
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1881856
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType net.conn
+      Pointee: 1126 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1725184
       GoKind: 22
-      Pointee: 984 StructureType net.dialResult·1
+      Pointee: 991 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1162
+      ID: 1169
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2174784
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType net.netFD
+      Pointee: 1170 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 651
+      ID: 658
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 838080
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType net.notFoundError
+      Pointee: 659 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1227
+      ID: 399
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1245504
       GoKind: 22
-      Pointee: 1228 StructureType net.onlyValuesCtx
+      Pointee: 400 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 653
+      ID: 660
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 838752
       GoKind: 22
-      Pointee: 654 StructureType net.result·2
+      Pointee: 661 StructureType net.result·2
     - __kind: PointerType
-      ID: 1144
+      ID: 1151
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2110080
       GoKind: 22
-      Pointee: 1145 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1152 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1142
+      ID: 1149
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2109600
       GoKind: 22
-      Pointee: 1143 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1150 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 916
+      ID: 923
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1126624
       GoKind: 22
-      Pointee: 917 UnresolvedPointeeType net.temporaryError
+      Pointee: 924 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1245824
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType net.timeoutError
+      Pointee: 953 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 995776
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 846 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 833952
       GoKind: 22
-      Pointee: 995 StructureType net/http.bufioFlushWriter
+      Pointee: 1002 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 628
+      ID: 635
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 834624
       GoKind: 22
-      Pointee: 549 BaseType net/http.http2ConnectionError
+      Pointee: 556 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 834720
       GoKind: 22
-      Pointee: 630 StructureType net/http.http2GoAwayError
+      Pointee: 637 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1241824
       GoKind: 22
-      Pointee: 938 StructureType net/http.http2StreamError
+      Pointee: 945 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 633
+      ID: 640
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 835200
       GoKind: 22
-      Pointee: 634 StructureType net/http.http2connError
+      Pointee: 641 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1373696
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1066 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 632
+      ID: 639
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 835104
       GoKind: 22
-      Pointee: 553 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 560 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 555
+      ID: 562
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 561 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 636
+      ID: 643
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 835392
       GoKind: 22
-      Pointee: 559 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 566 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 561
+      ID: 568
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 560 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 567 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 635
+      ID: 642
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 835296
       GoKind: 22
-      Pointee: 556 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 563 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 558
+      ID: 565
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 557 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 564 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1121760
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 917 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 996416
       GoKind: 22
-      Pointee: 845 StructureType net/http.http2noCachedConnError
+      Pointee: 852 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1109
+      ID: 1116
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1825600
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1117 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 835008
       GoKind: 22
-      Pointee: 550 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 557 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 552
+      ID: 559
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 551 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 558 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 835488
       GoKind: 22
-      Pointee: 997 StructureType net/http.http2stickyErrWriter
+      Pointee: 1004 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 840
+      ID: 847
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 996032
       GoKind: 22
-      Pointee: 841 StructureType net/http.nothingWrittenError
+      Pointee: 848 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2040512
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1068 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1016
+      ID: 1023
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 995904
       GoKind: 22
-      Pointee: 1017 StructureType net/http.persistConnWriter
+      Pointee: 1024 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1042
+      ID: 1049
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1120736
       GoKind: 22
-      Pointee: 1043 StructureType net/http.readWriteCloserBody
+      Pointee: 1050 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 835584
       GoKind: 22
-      Pointee: 638 StructureType net/http.requestBodyReadError
+      Pointee: 645 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1242944
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 947 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1121632
       GoKind: 22
-      Pointee: 908 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 915 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 996160
       GoKind: 22
-      Pointee: 843 StructureType net/http.transportReadFromServerError
+      Pointee: 850 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 626
+      ID: 633
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 833856
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 634 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1111
+      ID: 1118
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1827392
       GoKind: 22
-      Pointee: 1112 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1119 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1009856
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1034 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 706
+      ID: 713
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 22
-      Pointee: 707 StructureType net/netip.parseAddrError
+      Pointee: 714 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 850656
       GoKind: 22
-      Pointee: 705 StructureType net/netip.parsePrefixError
+      Pointee: 712 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1068
+      ID: 1075
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1990176
       GoKind: 22
-      Pointee: 1069 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1076 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1014976
       GoKind: 22
-      Pointee: 1029 StructureType net/smtp.dataCloser
+      Pointee: 1036 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 690
+      ID: 697
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 846624
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType net/textproto.Error
+      Pointee: 698 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 846528
       GoKind: 22
-      Pointee: 584 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 591 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 586
+      ID: 593
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 585 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 592 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1009216
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1032 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 947
+      ID: 954
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1246144
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType net/url.Error
+      Pointee: 955 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 655
+      ID: 662
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 838848
       GoKind: 22
-      Pointee: 562 GoStringHeaderType net/url.EscapeError
+      Pointee: 569 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 564
+      ID: 571
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 563 GoStringDataType net/url.EscapeError.str
+      Pointee: 570 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 838944
       GoKind: 22
-      Pointee: 565 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 572 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 567
+      ID: 574
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 566 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 573 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 1168
+      ID: 1175
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2212032
       GoKind: 22
-      Pointee: 1169 UnresolvedPointeeType os.File
+      Pointee: 1176 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 989376
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType os.LinkError
+      Pointee: 829 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1114336
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType os.SyscallError
+      Pointee: 893 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1166
+      ID: 1173
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2209088
       GoKind: 22
-      Pointee: 1167 StructureType os.fileWithoutReadFrom
+      Pointee: 1174 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1164
+      ID: 1171
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2208352
       GoKind: 22
-      Pointee: 1165 StructureType os.fileWithoutWriteTo
+      Pointee: 1172 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1005888
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType os/exec.Error
+      Pointee: 858 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1961440
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 994 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1046
+      ID: 1053
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1133408
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1054 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1006016
       GoKind: 22
-      Pointee: 853 StructureType os/exec.wrappedError
+      Pointee: 860 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 867840
       GoKind: 22
-      Pointee: 597 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 604 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 599
+      ID: 606
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 598 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 605 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 867744
       GoKind: 22
-      Pointee: 596 BaseType os/user.UnknownUserIdError
+      Pointee: 603 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 624
+      ID: 631
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 832608
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType reflect.ValueError
+      Pointee: 632 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 851424
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 720 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 824
+      ID: 831
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 990272
       GoKind: 22
-      Pointee: 825 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 832 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 992192
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 837 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14510,12 +14510,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 826
+      ID: 833
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 990400
       GoKind: 22
-      Pointee: 827 StructureType runtime.boundsError
+      Pointee: 834 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -14531,24 +14531,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1116640
       GoKind: 22
-      Pointee: 888 StructureType runtime.errorAddressString
+      Pointee: 895 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 990016
       GoKind: 22
-      Pointee: 804 GoStringHeaderType runtime.errorString
+      Pointee: 811 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 805 GoStringDataType runtime.errorString.str
+      Pointee: 812 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -14571,17 +14571,17 @@ Types:
       GoKind: 22
       Pointee: 145 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 828
+      ID: 835
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 991936
       GoKind: 22
-      Pointee: 807 GoStringHeaderType runtime.plainError
+      Pointee: 814 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 808 GoStringDataType runtime.plainError.str
+      Pointee: 815 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14604,12 +14604,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 988224
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType strconv.NumError
+      Pointee: 827 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -14618,57 +14618,57 @@ Types:
       GoKind: 22
       Pointee: 13 GoStringHeaderType string
     - __kind: PointerType
-      ID: 415
+      ID: 422
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 414 GoStringDataType string.str
+      Pointee: 421 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1105
+      ID: 1112
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1824064
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType strings.Builder
+      Pointee: 1113 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1014
+      ID: 1021
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 988352
       GoKind: 22
-      Pointee: 1015 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1022 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1010
+      ID: 1017
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 1011 StructureType struct { io.Writer }
+      Pointee: 1018 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 268
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 120 StructureType struct {}
     - __kind: PointerType
-      ID: 949
+      ID: 956
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1248384
       GoKind: 22
-      Pointee: 936 BaseType syscall.Errno
+      Pointee: 943 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 1138
+      ID: 1145
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2028128
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1146 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1051968
       GoKind: 22
-      Pointee: 879 StructureType text/template.ExecError
+      Pointee: 886 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 324
       Name: '*time.Location'
@@ -14677,45 +14677,45 @@ Types:
       GoKind: 22
       Pointee: 325 StructureType time.Location
     - __kind: PointerType
-      ID: 620
+      ID: 627
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 830112
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType time.ParseError
+      Pointee: 628 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 380
+      ID: 419
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 989760
       GoKind: 22
-      Pointee: 381 StructureType time.Timer
+      Pointee: 420 StructureType time.Timer
     - __kind: PointerType
-      ID: 619
+      ID: 626
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 830016
       GoKind: 22
-      Pointee: 546 GoStringHeaderType time.fileSizeError
+      Pointee: 553 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 548
+      ID: 555
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 547 GoStringDataType time.fileSizeError.str
+      Pointee: 554 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 504
+      ID: 511
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 364800
       GoKind: 22
-      Pointee: 505 StructureType time.zone
+      Pointee: 512 StructureType time.zone
     - __kind: PointerType
-      ID: 507
+      ID: 514
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 364864
       GoKind: 22
-      Pointee: 508 StructureType time.zoneTrans
+      Pointee: 515 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -14759,56 +14759,56 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 1101
+      ID: 1108
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1780832
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 1109 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 708
+      ID: 715
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 850848
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 716 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1130
+      ID: 1137
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2004704
       GoKind: 22
-      Pointee: 1131 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1138 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 847008
       GoKind: 22
-      Pointee: 693 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 700 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 22
-      Pointee: 587 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 594 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1009600
       GoKind: 22
-      Pointee: 858 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 865 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1009728
       GoKind: 22
-      Pointee: 812 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 819 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1200
+      ID: 1212
       Name: <-chan time.Time
       GoRuntimeType: 546784
       GoKind: 18
@@ -25520,7 +25520,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 457
+      ID: 464
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 625856
@@ -25529,7 +25529,7 @@ Types:
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 442
+      ID: 449
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 626144
@@ -25555,7 +25555,7 @@ Types:
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 978
+      ID: 985
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 627200
@@ -25564,7 +25564,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1185
+      ID: 1192
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25590,7 +25590,7 @@ Types:
       HasCount: true
       Element: 81 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 425
+      ID: 432
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 623072
@@ -25599,7 +25599,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 1201
+      ID: 1207
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 452224
@@ -25607,20 +25607,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1202 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1208 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1204 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1210 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1204
+      ID: 1210
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 133
       Name: '[]*main.deepSlice2'
@@ -25637,15 +25637,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 423 GoSliceDataType []*main.deepSlice2.array
+      Data: 430 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 423
+      ID: 430
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 135 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1206
+      ID: 1213
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 448704
@@ -25653,20 +25653,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1207 PointerType **main.deepSlice3
+          Type: 1214 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1210 GoSliceDataType []*main.deepSlice3.array
+      Data: 1217 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1210
+      ID: 1217
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1208 PointerType *main.deepSlice3
+      Element: 1215 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1235
       Name: '[]*main.deepSlice8'
@@ -25729,9 +25729,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 420 GoSliceDataType []*string.array
+      Data: 427 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 420
+      ID: 427
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -25751,9 +25751,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 496 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 489
+      ID: 496
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25773,9 +25773,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 494 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 494
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25795,9 +25795,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 492 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 485
+      ID: 492
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25817,9 +25817,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 490 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 483
+      ID: 490
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25839,9 +25839,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 488 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 481
+      ID: 488
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25861,9 +25861,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 469 GoSliceDataType [][]uint.array
+      Data: 476 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 476
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -25884,55 +25884,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 473 GoSliceDataType []bool.array
+      Data: 480 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 473
+      ID: 480
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 468
       Name: '[]bucket<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 528
       Element: 229 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 467
       Name: '[]bucket<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 224 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 444
+      ID: 451
       Name: '[]bucket<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 656
       Element: 192 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 451
+      ID: 458
       Name: '[]bucket<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 152
       Element: 204 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 542
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 378 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 416 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 430
+      ID: 437
       Name: '[]bucket<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 143 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1220
+      ID: 1227
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1223 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1258
       Name: '[]bucket<int,*main.deepMap8>.array'
@@ -25946,7 +25946,7 @@ Types:
       ByteSize: 144
       Element: 1263 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 434
+      ID: 441
       Name: '[]bucket<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
@@ -25958,133 +25958,133 @@ Types:
       ByteSize: 208
       Element: 1272 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 472
       Name: '[]bucket<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 239 GoHMapBucketType bucket<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 460
       Name: '[]bucket<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
       Element: 209 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 545
+      ID: 552
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 536 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 448
+      ID: 455
       Name: '[]bucket<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 199 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 440
+      ID: 447
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 187 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 525
+      ID: 529
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 402 GoHMapBucketType bucket<string,float64>
+      Element: 379 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 989
+      ID: 996
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 968 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 445
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 182 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 523
+      ID: 527
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 397 GoHMapBucketType bucket<string,interface {}>
+      Element: 374 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 444
       Name: '[]bucket<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 177 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 521
+      ID: 525
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 392 GoHMapBucketType bucket<string,string>
+      Element: 369 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 470
       Name: '[]bucket<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 234 GoHMapBucketType bucket<struct {},int>
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 499
       Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 400
       Element: 291 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 494
+      ID: 501
       Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 296 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 503
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 301 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 498
+      ID: 505
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 306 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 507
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 311 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 502
+      ID: 509
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 316 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 466
+      ID: 473
       Name: '[]bucket<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
       Element: 244 GoHMapBucketType bucket<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 458
+      ID: 465
       Name: '[]bucket<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 219 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 462
       Name: '[]bucket<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
       Element: 214 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 973
+      ID: 980
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 456704
@@ -26099,15 +26099,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 990 GoSliceDataType []float64.array
+      Data: 997 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 990
+      ID: 997
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 19 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 403
+      ID: 380
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 451776
@@ -26115,22 +26115,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 404 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 381 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 526 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 530 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 526
+      ID: 530
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 405 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 382 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 406
+      ID: 383
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 451968
@@ -26138,20 +26138,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 407 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 384 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 534 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 538 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 534
+      ID: 538
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 408 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 385 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
       ID: 355
       Name: '[]go.shape.float64'
@@ -26168,9 +26168,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 515 GoSliceDataType []go.shape.float64.array
+      Data: 522 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 515
+      ID: 522
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26190,9 +26190,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 511 GoSliceDataType []go.shape.int.array
+      Data: 518 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 511
+      ID: 518
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26213,9 +26213,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 513 GoSliceDataType []go.shape.string.array
+      Data: 520 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 513
+      ID: 520
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26244,55 +26244,55 @@ Types:
       ByteSize: 16
       Element: 159 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 459
+      ID: 466
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 457 ArrayType [4]int
+      Element: 464 ArrayType [4]int
     - __kind: ArrayType
-      ID: 441
+      ID: 448
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 442 ArrayType [4]string
+      Element: 449 ArrayType [4]string
     - __kind: ArrayType
-      ID: 449
+      ID: 456
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 517
+      ID: 540
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 518 GoInterfaceType context.canceler
+      Element: 541 GoInterfaceType context.canceler
     - __kind: ArrayType
-      ID: 426
+      ID: 433
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 435
+      ID: 442
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 462
+      ID: 469
       Name: '[]key<struct {}>'
       Count: 8
       HasCount: true
       Element: 120 StructureType struct {}
     - __kind: ArrayType
-      ID: 454
+      ID: 461
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -26313,15 +26313,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 479 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 486 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 486
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 273 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 446
+      ID: 453
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 449344
@@ -26329,16 +26329,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 447 PointerType *main.structWithMap
+          Type: 454 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 536 GoSliceDataType []main.structWithMap.array
+      Data: 543 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 536
+      ID: 543
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26358,9 +26358,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 471 GoSliceDataType []main.structWithNoStrings.array
+      Data: 478 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 478
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26385,9 +26385,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 431 GoSliceDataType []string.array
+      Data: 438 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 431
+      ID: 438
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26408,14 +26408,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 477 GoSliceDataType []struct {}.array
+      Data: 484 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 484
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 120 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 503
+      ID: 510
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 455424
@@ -26423,22 +26423,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 504 PointerType *time.zone
+          Type: 511 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 538 GoSliceDataType []time.zone.array
+      Data: 545 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 538
+      ID: 545
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 505 StructureType time.zone
+      Element: 512 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 506
+      ID: 513
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 455488
@@ -26446,20 +26446,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 507 PointerType *time.zoneTrans
+          Type: 514 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 540 GoSliceDataType []time.zoneTrans.array
+      Data: 547 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 547
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 508 StructureType time.zoneTrans
+      Element: 515 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 259
       Name: '[]uint'
@@ -26476,9 +26476,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 467 GoSliceDataType []uint.array
+      Data: 474 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 467
+      ID: 474
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26499,9 +26499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 475 GoSliceDataType []uint16.array
+      Data: 482 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 475
+      ID: 482
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26522,9 +26522,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 416 GoSliceDataType []uint8.array
+      Data: 423 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 416
+      ID: 423
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -26545,34 +26545,34 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 418 GoSliceDataType []uintptr.array
+      Data: 425 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 418
+      ID: 425
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 542
+      ID: 549
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 543 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 550 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 427
+      ID: 434
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 428 PointerType *main.deepMap2
+      Element: 435 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1217
+      ID: 1224
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1218 PointerType *main.deepMap3
+      Element: 1225 PointerType *main.deepMap3
     - __kind: ArrayType
       ID: 1255
       Name: '[]val<*main.deepMap8>'
@@ -26588,143 +26588,143 @@ Types:
       HasCount: true
       Element: 1265 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 443
+      ID: 450
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 108 ArrayType [2]int
     - __kind: ArrayType
-      ID: 456
+      ID: 463
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 457 ArrayType [4]int
+      Element: 464 ArrayType [4]int
     - __kind: ArrayType
-      ID: 445
+      ID: 452
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 446 GoSliceHeaderType []main.structWithMap
+      Element: 453 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 439
+      ID: 446
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 156 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 524
+      ID: 528
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 988
+      ID: 995
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 987 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 433
+      ID: 440
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 522
+      ID: 526
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 159 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 436
+      ID: 443
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 118 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 450
+      ID: 457
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 248 StructureType main.node
     - __kind: ArrayType
-      ID: 491
+      ID: 498
       Name: '[]val<main.structWithCyclicMaps>'
       ByteSize: 384
       Count: 8
       HasCount: true
       Element: 286 StructureType main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 493
+      ID: 500
       Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 287 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 495
+      ID: 502
       Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 292 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 497
+      ID: 504
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 297 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 499
+      ID: 506
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 501
+      ID: 508
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 520
+      ID: 524
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 464
+      ID: 471
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
       Element: 120 StructureType struct {}
     - __kind: ArrayType
-      ID: 452
+      ID: 459
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1124
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 772
+      ID: 779
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 861888
@@ -26739,33 +26739,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 773 GoSliceDataType archive/tar.headerError.array
+      Data: 780 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 773
+      ID: 780
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1064
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1012
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1007
+      ID: 1014
       Name: archive/zip.dirWriter
       GoRuntimeType: 1083968
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1111
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1033
+      ID: 1040
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1383616
@@ -26775,7 +26775,7 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1042
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -26791,18 +26791,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 459 ArrayType []key<[4]int>
+          Type: 466 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 456 ArrayType []val<[4]int>
+          Type: 463 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 228 PointerType *bucket<[4]int,[4]int>
-      KeyType: 457 ArrayType [4]int
-      ValueType: 457 ArrayType [4]int
+      KeyType: 464 ArrayType [4]int
+      ValueType: 464 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 224
       Name: bucket<[4]int,uint8>
@@ -26810,17 +26810,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 459 ArrayType []key<[4]int>
+          Type: 466 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 452 ArrayType []val<uint8>
+          Type: 459 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 223 PointerType *bucket<[4]int,uint8>
-      KeyType: 457 ArrayType [4]int
+      KeyType: 464 ArrayType [4]int
       ValueType: 5 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 192
@@ -26829,17 +26829,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 441 ArrayType []key<[4]string>
+          Type: 448 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 443 ArrayType []val<[2]int>
+          Type: 450 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 191 PointerType *bucket<[4]string,[2]int>
-      KeyType: 442 ArrayType [4]string
+      KeyType: 449 ArrayType [4]string
       ValueType: 108 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 204
@@ -26848,36 +26848,36 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 449 ArrayType []key<bool>
+          Type: 456 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 450 ArrayType []val<main.node>
+          Type: 457 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 203 PointerType *bucket<bool,main.node>
       KeyType: 6 BaseType bool
       ValueType: 248 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 378
+      ID: 416
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 517 ArrayType []key<context.canceler>
+          Type: 540 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 464 ArrayType []val<struct {}>
+          Type: 471 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 377 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 518 GoInterfaceType context.canceler
+          Type: 415 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 541 GoInterfaceType context.canceler
       ValueType: 120 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 143
@@ -26886,37 +26886,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 427 ArrayType []val<*main.deepMap2>
+          Type: 434 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 142 PointerType *bucket<int,*main.deepMap2>
       KeyType: 11 BaseType int
-      ValueType: 428 PointerType *main.deepMap2
+      ValueType: 435 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1216
+      ID: 1223
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1217 ArrayType []val<*main.deepMap3>
+          Type: 1224 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1215 PointerType *bucket<int,*main.deepMap3>
+          Type: 1222 PointerType *bucket<int,*main.deepMap3>
       KeyType: 11 BaseType int
-      ValueType: 1218 PointerType *main.deepMap3
+      ValueType: 1225 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
       ID: 1254
       Name: bucket<int,*main.deepMap8>
@@ -26924,10 +26924,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 1255 ArrayType []val<*main.deepMap8>
@@ -26943,10 +26943,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 1264 ArrayType []val<*main.deepMap9>
@@ -26962,13 +26962,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 433 ArrayType []val<int>
+          Type: 440 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 171 PointerType *bucket<int,int>
@@ -26981,13 +26981,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 522 ArrayType []val<interface {}>
+          Type: 526 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
           Type: 1271 PointerType *bucket<int,interface {}>
@@ -27000,13 +27000,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 464 ArrayType []val<struct {}>
+          Type: 471 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 238 PointerType *bucket<int,struct {}>
@@ -27019,37 +27019,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 452 ArrayType []val<uint8>
+          Type: 459 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 208 PointerType *bucket<int,uint8>
       KeyType: 11 BaseType int
       ValueType: 5 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 532
+      ID: 536
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 542 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 549 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 535 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 543 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 550 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 199
       Name: bucket<string,[]main.structWithMap>
@@ -27057,18 +27057,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 445 ArrayType []val<[]main.structWithMap>
+          Type: 452 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 198 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 446 GoSliceHeaderType []main.structWithMap
+      ValueType: 453 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 187
       Name: bucket<string,[]string>
@@ -27076,56 +27076,56 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 439 ArrayType []val<[]string>
+          Type: 446 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 186 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 156 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 402
+      ID: 379
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 524 ArrayType []val<float64>
+          Type: 528 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 401 PointerType *bucket<string,float64>
+          Type: 378 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 961
+      ID: 968
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 988 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 995 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 967 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 987 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 182
       Name: bucket<string,int>
@@ -27133,35 +27133,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 433 ArrayType []val<int>
+          Type: 440 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 181 PointerType *bucket<string,int>
       KeyType: 13 GoStringHeaderType string
       ValueType: 11 BaseType int
     - __kind: GoHMapBucketType
-      ID: 397
+      ID: 374
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 522 ArrayType []val<interface {}>
+          Type: 526 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 396 PointerType *bucket<string,interface {}>
+          Type: 373 PointerType *bucket<string,interface {}>
       KeyType: 13 GoStringHeaderType string
       ValueType: 159 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -27171,35 +27171,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 436 ArrayType []val<main.nestedStruct>
+          Type: 443 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 176 PointerType *bucket<string,main.nestedStruct>
       KeyType: 13 GoStringHeaderType string
       ValueType: 118 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 392
+      ID: 369
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 520 ArrayType []val<string>
+          Type: 524 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 391 PointerType *bucket<string,string>
+          Type: 368 PointerType *bucket<string,string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 13 GoStringHeaderType string
     - __kind: GoHMapBucketType
@@ -27209,13 +27209,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 433 ArrayType []val<int>
+          Type: 440 ArrayType []val<int>
         - Name: overflow
           Offset: 72
           Type: 233 PointerType *bucket<struct {},int>
@@ -27228,13 +27228,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 491 ArrayType []val<main.structWithCyclicMaps>
+          Type: 498 ArrayType []val<main.structWithCyclicMaps>
         - Name: overflow
           Offset: 392
           Type: 290 PointerType *bucket<struct {},main.structWithCyclicMaps>
@@ -27247,13 +27247,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 493 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+          Type: 500 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 295 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -27266,13 +27266,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 495 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 502 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 300 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27285,13 +27285,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 497 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 504 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 305 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27304,13 +27304,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 499 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 506 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 310 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27323,13 +27323,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 501 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 508 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 315 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27342,13 +27342,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 464 ArrayType []val<struct {}>
+          Type: 471 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 8
           Type: 243 PointerType *bucket<struct {},struct {}>
@@ -27361,18 +27361,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 454 ArrayType []key<uint8>
+          Type: 461 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 456 ArrayType []val<[4]int>
+          Type: 463 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 218 PointerType *bucket<uint8,[4]int>
       KeyType: 5 BaseType uint8
-      ValueType: 457 ArrayType [4]int
+      ValueType: 464 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 214
       Name: bucket<uint8,uint8>
@@ -27380,28 +27380,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 454 ArrayType []key<uint8>
+          Type: 461 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 452 ArrayType []val<uint8>
+          Type: 459 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 213 PointerType *bucket<uint8,uint8>
       KeyType: 5 BaseType uint8
       ValueType: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1088
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1115
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1153
+      ID: 1160
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -27427,13 +27427,13 @@ Types:
       GoRuntimeType: 534560
       GoKind: 15
     - __kind: BaseType
-      ID: 579
+      ID: 586
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 767712
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 580
+      ID: 587
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 767808
@@ -27441,26 +27441,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 582 PointerType *compress/flate.InternalError.str
+          Type: 589 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 581 GoStringDataType compress/flate.InternalError.str
+      Data: 588 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 581
+      ID: 588
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1001
+      ID: 1008
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1084
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27477,19 +27477,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 406
       Name: context.backgroundCtx
       GoRuntimeType: 1681056
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 371 StructureType context.emptyCtx
+          Type: 393 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 361
+      ID: 410
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1837888
@@ -27500,13 +27500,13 @@ Types:
           Type: 152 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 372 StructureType sync.Mutex
+          Type: 362 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 373 StructureType sync/atomic.Value
+          Type: 411 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 374 GoMapType map[context.canceler]struct {}
+          Type: 412 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -27516,7 +27516,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 518
+      ID: 541
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1074624
@@ -27529,13 +27529,13 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: context.deadlineExceededError
       GoRuntimeType: 1288352
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 371
+      ID: 393
       Name: context.emptyCtx
       GoRuntimeType: 1412128
       GoKind: 25
@@ -27544,7 +27544,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 363
+      ID: 395
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1703616
@@ -27555,11 +27555,11 @@ Types:
           Type: 152 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 379 GoSubroutineType func() bool
+          Type: 396 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 365
+      ID: 418
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1429760
@@ -27567,29 +27567,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 361 StructureType context.cancelCtx
+          Type: 410 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 380 PointerType *time.Timer
+          Type: 419 PointerType *time.Timer
         - Name: deadline
           Offset: 88
           Type: 323 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 382
+      ID: 408
       Name: context.todoCtx
       GoRuntimeType: 1681280
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 371 StructureType context.emptyCtx
+          Type: 393 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 367
+      ID: 402
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1715104
@@ -27607,7 +27607,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 369
+      ID: 404
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1680832
@@ -27619,63 +27619,63 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 593
+      ID: 600
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770304
       GoKind: 2
     - __kind: BaseType
-      ID: 594
+      ID: 601
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770400
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1074
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1099
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 595
+      ID: 602
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770496
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1107
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1101
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1103
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 583
+      ID: 590
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 768288
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1179
+      ID: 1186
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 694
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 685
+      ID: 692
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1614176
@@ -27686,34 +27686,34 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 978 ArrayType [5]uint8
+          Type: 985 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 979 GoInterfaceType net.Conn
+          Type: 986 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 811
+      ID: 818
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 956096
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1072
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1079
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 970
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1617248
@@ -27721,21 +27721,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 962 PointerType *crypto/x509.Certificate
+          Type: 969 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 981 BaseType crypto/x509.InvalidReason
+          Type: 988 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 753
+      ID: 760
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1081280
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 755
+      ID: 762
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1415968
@@ -27743,24 +27743,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 962 PointerType *crypto/x509.Certificate
+          Type: 969 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 592
+      ID: 599
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 769920
       GoKind: 2
     - __kind: BaseType
-      ID: 981
+      ID: 988
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 540064
       GoKind: 2
     - __kind: StructureType
-      ID: 861
+      ID: 868
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1379936
@@ -27770,13 +27770,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1081536
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 757
+      ID: 764
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1617056
@@ -27784,15 +27784,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 962 PointerType *crypto/x509.Certificate
+          Type: 969 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 962 PointerType *crypto/x509.Certificate
+          Type: 969 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 776
+      ID: 783
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1259904
@@ -27802,7 +27802,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1260064
@@ -27812,55 +27812,55 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 778
+      ID: 785
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 577
+      ID: 584
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 767328
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1030
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 578
+      ID: 585
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 767520
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 655
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 854
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 647
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 646
+      ID: 653
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 644
+      ID: 651
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 649
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1159
+      ID: 1166
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1244384
@@ -27870,19 +27870,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1038
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 747
+      ID: 754
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 745
+      ID: 752
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 589
+      ID: 596
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 769824
@@ -27890,22 +27890,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 591 PointerType *encoding/xml.UnmarshalError.str
+          Type: 598 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 590 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 597 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 590
+      ID: 597
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 757
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1144
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27922,11 +27922,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 625
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 821
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27942,15 +27942,15 @@ Types:
       GoRuntimeType: 534752
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1147
+      ID: 1154
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27960,7 +27960,7 @@ Types:
       GoRuntimeType: 447040
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 379
+      ID: 396
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 545632
@@ -28005,11 +28005,11 @@ Types:
           Offset: 0
           Type: 329 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 685
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 659
+      ID: 666
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1612448
@@ -28017,7 +28017,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 971 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 978 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -28025,25 +28025,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 668
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 975
+      ID: 982
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 672
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1077440
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 984
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 571
+      ID: 578
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 766752
@@ -28051,18 +28051,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 573 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 580 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 579 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 572
+      ID: 579
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 971
+      ID: 978
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2083968
@@ -28070,7 +28070,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 972 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 979 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -28085,7 +28085,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 973 GoSliceHeaderType []float64
+          Type: 980 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -28094,10 +28094,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 974 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 981 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 976 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 983 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 156 GoSliceHeaderType []string
@@ -28111,13 +28111,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 972
+      ID: 979
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 536416
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 568
+      ID: 575
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 766656
@@ -28125,18 +28125,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 570 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 577 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 576 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 569
+      ID: 576
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 574
+      ID: 581
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 766848
@@ -28144,30 +28144,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 576 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 583 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 582 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 575
+      ID: 582
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1045
+      ID: 1052
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1132
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 777
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 384
+      ID: 360
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2204128
@@ -28175,7 +28175,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 385 StructureType sync.RWMutex
+          Type: 361 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -28196,13 +28196,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 393 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 370 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 398 GoMapType map[string]float64
+          Type: 375 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 12 BaseType uint64
@@ -28217,10 +28217,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 403 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 380 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 406 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 383 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -28232,7 +28232,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 386 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 13 GoStringHeaderType string
@@ -28255,7 +28255,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 410
+      ID: 387
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2081280
@@ -28266,13 +28266,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 386 StructureType sync/atomic.Int32
+          Type: 363 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -28281,16 +28281,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 413 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 391 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 12 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 385 StructureType sync.RWMutex
+          Type: 361 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -28299,12 +28299,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 403 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 380 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 405
+      ID: 382
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1788224
@@ -28321,7 +28321,7 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -28329,20 +28329,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 393
+      ID: 370
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 987328
       GoKind: 21
-      HeaderType: 395 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 372 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 1203
+      ID: 1209
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 533536
       GoKind: 10
     - __kind: StructureType
-      ID: 408
+      ID: 385
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1632576
@@ -28356,16 +28356,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 528 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 532 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 533 GoMapType map[string]interface {}
+          Type: 537 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1223
+      ID: 1230
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 544
+      ID: 551
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1788480
@@ -28373,7 +28373,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1221 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1228 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -28388,15 +28388,15 @@ Types:
           Type: 19 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1221
+      ID: 1228
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 951392
       GoKind: 5
     - __kind: StructureType
-      ID: 412
+      ID: 390
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 1976128
@@ -28404,16 +28404,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 385 StructureType sync.RWMutex
+          Type: 361 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1201 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1207 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 11 BaseType int
@@ -28428,12 +28428,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1203 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1209 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 413
+      ID: 391
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 828672
@@ -28442,15 +28442,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 919
+      ID: 926
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1155
+      ID: 1162
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1226
+    - __kind: GoContextImplementationType
+      ID: 398
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1443968
@@ -28459,30 +28459,32 @@ Types:
         - Name: Context
           Offset: 0
           Type: 152 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 703
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 703
+      ID: 710
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1080512
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 588
+      ID: 595
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 768960
       GoKind: 2
     - __kind: StructureType
-      ID: 701
+      ID: 708
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1080384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 699
+      ID: 706
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1414048
@@ -28495,7 +28497,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1414848
@@ -28508,7 +28510,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 723
+      ID: 730
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1616480
@@ -28524,7 +28526,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 721
+      ID: 728
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1254304
@@ -28534,7 +28536,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 717
+      ID: 724
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1253984
@@ -28544,14 +28546,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 957
+      ID: 964
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1140832
       GoKind: 21
-      HeaderType: 959 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 966 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 980
+      ID: 987
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1013312
@@ -28566,15 +28568,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 992 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 999 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 992
+      ID: 999
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 731
+      ID: 738
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1415168
@@ -28582,12 +28584,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 957 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 964 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 957 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 964 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 725
+      ID: 732
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1254464
@@ -28597,7 +28599,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 729
+      ID: 736
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1616672
@@ -28608,12 +28610,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 987 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 987 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 727
+      ID: 734
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1415008
@@ -28626,7 +28628,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 733
+      ID: 740
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1254624
@@ -28636,7 +28638,7 @@ Types:
           Offset: 0
           Type: 323 GoTimeType time.Time
     - __kind: StructureType
-      ID: 739
+      ID: 746
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1415488
@@ -28649,7 +28651,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 741
+      ID: 748
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1254944
@@ -28659,7 +28661,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 737
+      ID: 744
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1415328
@@ -28672,7 +28674,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 735
+      ID: 742
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1254784
@@ -28682,7 +28684,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 743
+      ID: 750
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1415648
@@ -28695,7 +28697,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1246624
@@ -28705,11 +28707,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1091
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 676
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1246784
@@ -28717,21 +28719,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 667 StructureType github.com/cihub/seelog.baseError
+          Type: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1070
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1019
+      ID: 1026
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1060
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 673
+      ID: 680
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1247104
@@ -28739,13 +28741,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 667 StructureType github.com/cihub/seelog.baseError
+          Type: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1122
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1126
+      ID: 1133
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1978240
@@ -28753,12 +28755,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1114 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1121 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 1127
+      ID: 1134
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2001632
@@ -28766,7 +28768,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1114 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1121 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -28774,11 +28776,11 @@ Types:
           Offset: 24
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1028
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 671
+      ID: 678
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1246944
@@ -28786,9 +28788,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 667 StructureType github.com/cihub/seelog.baseError
+          Type: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 675
+      ID: 682
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1247264
@@ -28796,64 +28798,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 667 StructureType github.com/cihub/seelog.baseError
+          Type: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1095
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1128
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1123
+      ID: 1130
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 960
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 876
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 878
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1081
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 870
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 681
+      ID: 688
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1248224
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1171
+      ID: 1178
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 934
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 896
+      ID: 903
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1720480
@@ -28869,11 +28871,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 833
+      ID: 840
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1518176
@@ -28886,7 +28888,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 902
+      ID: 909
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1720928
@@ -28902,13 +28904,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 810
+      ID: 817
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 953216
       GoKind: 8
     - __kind: StructureType
-      ID: 894
+      ID: 901
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1720256
@@ -28924,13 +28926,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 982
+      ID: 989
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 765024
       GoKind: 8
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1720032
@@ -28938,15 +28940,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 982 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 989 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 982 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 989 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 907
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1638336
@@ -28959,7 +28961,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 898
+      ID: 905
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1720704
@@ -28975,11 +28977,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1175
+      ID: 1182
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1439744
@@ -28989,19 +28991,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 837
+      ID: 844
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1200672
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1200544
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1638528
@@ -29014,7 +29016,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 600
+      ID: 607
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 772320
@@ -29022,13 +29024,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 602 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 609 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 601 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 608 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 601
+      ID: 608
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29059,13 +29061,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 510 PointerType *go.shape.string.str
+          Type: 517 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 509 GoStringDataType go.shape.string.str
+      Data: 516 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 509
+      ID: 516
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29121,11 +29123,11 @@ Types:
           Offset: 32
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 973
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 884
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1271744
@@ -29135,7 +29137,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 1051
+      ID: 1058
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1495040
@@ -29143,13 +29145,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1075 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1082 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1142
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1075
+      ID: 1082
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1091392
@@ -29162,7 +29164,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1037
+      ID: 1044
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1388416
@@ -29172,19 +29174,19 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 603
+      ID: 610
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 772896
       GoKind: 10
     - __kind: BaseType
-      ID: 964
+      ID: 971
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 966752
       GoKind: 10
     - __kind: StructureType
-      ID: 935
+      ID: 942
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1759680
@@ -29195,12 +29197,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 964 BaseType golang.org/x/net/http2.ErrCode
+          Type: 971 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 796
+      ID: 803
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1422848
@@ -29208,12 +29210,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 964 BaseType golang.org/x/net/http2.ErrCode
+          Type: 971 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 607
+      ID: 614
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 773088
@@ -29221,18 +29223,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 609 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 616 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 608 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 615 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 608
+      ID: 615
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 613
+      ID: 620
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 773280
@@ -29240,18 +29242,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 615 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 622 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 614 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 621 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 614
+      ID: 621
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 610
+      ID: 617
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 773184
@@ -29259,18 +29261,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 612 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 619 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 611 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 618 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 611
+      ID: 618
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 604
+      ID: 611
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 772992
@@ -29278,22 +29280,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 606 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 613 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 605 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 612 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 605
+      ID: 612
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1133
+      ID: 1140
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 800
+      ID: 807
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1272384
@@ -29303,13 +29305,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 616
+      ID: 623
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 773376
       GoKind: 2
     - __kind: StructureType
-      ID: 788
+      ID: 795
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1267424
@@ -29319,11 +29321,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 940
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 955
+      ID: 962
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1785440
@@ -29339,7 +29341,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1422368
@@ -29352,7 +29354,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1098
+      ID: 1105
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1838912
@@ -29360,16 +29362,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 979 GoInterfaceType net.Conn
+          Type: 986 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1113 GoInterfaceType io.Reader
+          Type: 1120 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1049
+      ID: 1056
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1386016
@@ -29379,29 +29381,29 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1016
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 768
+      ID: 775
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 872
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 929
+      ID: 936
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1332832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1260704
@@ -29411,7 +29413,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 784
+      ID: 791
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1260864
@@ -29421,11 +29423,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 718
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1086
+      ID: 1093
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -29461,7 +29463,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 229 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 461 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 468 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 222
       Name: hash<[4]int,uint8>
@@ -29495,7 +29497,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 224 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 460 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 467 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 190
       Name: hash<[4]string,[2]int>
@@ -29529,7 +29531,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 192 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 444 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 451 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 202
       Name: hash<bool,main.node>
@@ -29563,9 +29565,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 204 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 451 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 458 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 376
+      ID: 414
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -29586,18 +29588,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 377 PointerType *bucket<context.canceler,struct {}>
+          Type: 415 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 377 PointerType *bucket<context.canceler,struct {}>
+          Type: 415 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 378 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 519 GoSliceDataType []bucket<context.canceler,struct {}>.array
+      BucketType: 416 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 542 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 141
       Name: hash<int,*main.deepMap2>
@@ -29631,9 +29633,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 143 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 430 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 437 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1214
+      ID: 1221
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -29654,18 +29656,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1215 PointerType *bucket<int,*main.deepMap3>
+          Type: 1222 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1215 PointerType *bucket<int,*main.deepMap3>
+          Type: 1222 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1220 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1223 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1227 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
       ID: 1252
       Name: hash<int,*main.deepMap8>
@@ -29767,7 +29769,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 172 GoHMapBucketType bucket<int,int>
-      BucketsType: 434 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 441 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
       ID: 1270
       Name: hash<int,interface {}>
@@ -29835,7 +29837,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 239 GoHMapBucketType bucket<int,struct {}>
-      BucketsType: 465 GoSliceDataType []bucket<int,struct {}>.array
+      BucketsType: 472 GoSliceDataType []bucket<int,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 207
       Name: hash<int,uint8>
@@ -29869,9 +29871,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 209 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 453 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 460 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 530
+      ID: 534
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -29892,18 +29894,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 535 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 535 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 545 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 536 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 552 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
       ID: 197
       Name: hash<string,[]main.structWithMap>
@@ -29937,7 +29939,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 199 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 448 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 455 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 185
       Name: hash<string,[]string>
@@ -29971,9 +29973,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 187 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 440 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 447 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 400
+      ID: 377
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -29994,20 +29996,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 401 PointerType *bucket<string,float64>
+          Type: 378 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 401 PointerType *bucket<string,float64>
+          Type: 378 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 402 GoHMapBucketType bucket<string,float64>
-      BucketsType: 525 GoSliceDataType []bucket<string,float64>.array
+      BucketType: 379 GoHMapBucketType bucket<string,float64>
+      BucketsType: 529 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 959
+      ID: 966
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -30028,18 +30030,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 967 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 967 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 989 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 968 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 996 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 180
       Name: hash<string,int>
@@ -30073,9 +30075,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 182 GoHMapBucketType bucket<string,int>
-      BucketsType: 438 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 445 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 395
+      ID: 372
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -30096,18 +30098,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 396 PointerType *bucket<string,interface {}>
+          Type: 373 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 396 PointerType *bucket<string,interface {}>
+          Type: 373 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 397 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 523 GoSliceDataType []bucket<string,interface {}>.array
+      BucketType: 374 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 527 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 175
       Name: hash<string,main.nestedStruct>
@@ -30141,9 +30143,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 177 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 437 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 444 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 390
+      ID: 367
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -30164,18 +30166,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 391 PointerType *bucket<string,string>
+          Type: 368 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 391 PointerType *bucket<string,string>
+          Type: 368 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 392 GoHMapBucketType bucket<string,string>
-      BucketsType: 521 GoSliceDataType []bucket<string,string>.array
+      BucketType: 369 GoHMapBucketType bucket<string,string>
+      BucketsType: 525 GoSliceDataType []bucket<string,string>.array
     - __kind: GoHMapHeaderType
       ID: 232
       Name: hash<struct {},int>
@@ -30209,7 +30211,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 234 GoHMapBucketType bucket<struct {},int>
-      BucketsType: 463 GoSliceDataType []bucket<struct {},int>.array
+      BucketsType: 470 GoSliceDataType []bucket<struct {},int>.array
     - __kind: GoHMapHeaderType
       ID: 289
       Name: hash<struct {},main.structWithCyclicMaps>
@@ -30243,7 +30245,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 291 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
-      BucketsType: 492 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+      BucketsType: 499 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 294
       Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -30277,7 +30279,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 296 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 494 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 501 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 299
       Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30311,7 +30313,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 301 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 496 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 503 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 304
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30345,7 +30347,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 306 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 498 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 505 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 309
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30379,7 +30381,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 311 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 500 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 507 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 314
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30413,7 +30415,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 316 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 502 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 509 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 242
       Name: hash<struct {},struct {}>
@@ -30447,7 +30449,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 244 GoHMapBucketType bucket<struct {},struct {}>
-      BucketsType: 466 GoSliceDataType []bucket<struct {},struct {}>.array
+      BucketsType: 473 GoSliceDataType []bucket<struct {},struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 217
       Name: hash<uint8,[4]int>
@@ -30481,7 +30483,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 219 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 458 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 465 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 212
       Name: hash<uint8,uint8>
@@ -30515,9 +30517,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 214 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 455 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 462 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -30564,7 +30566,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 770
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -30590,25 +30592,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1006
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 925
+      ID: 932
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1177
+      ID: 1184
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 923
+      ID: 930
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1313312
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 630
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -30689,11 +30691,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1048
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1082
+      ID: 1089
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1109472
@@ -30706,7 +30708,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1113
+      ID: 1120
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 985664
@@ -30719,7 +30721,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1070
+      ID: 1077
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1074112
@@ -30745,21 +30747,21 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1039
+      ID: 1046
       Name: io.discard
       GoRuntimeType: 1288032
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1013
+      ID: 1020
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 921
+      ID: 928
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1097
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -30853,7 +30855,7 @@ Types:
           Offset: 0
           Type: 139 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 429
+      ID: 436
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1105632
@@ -30861,9 +30863,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1212 GoMapType map[int]*main.deepMap3
+          Type: 1219 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1219
+      ID: 1226
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -30915,9 +30917,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1180 PointerType *main.deepPtr3
+          Type: 1187 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1181
+      ID: 1188
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -30961,7 +30963,7 @@ Types:
           Offset: 0
           Type: 133 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 422
+      ID: 429
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1107936
@@ -30969,9 +30971,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1206 GoSliceHeaderType []*main.deepSlice3
+          Type: 1213 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1216
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -31021,16 +31023,16 @@ Types:
           Type: 157 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 372 StructureType sync.Mutex
+          Type: 362 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1188 StructureType sync.Once
+          Type: 1195 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1190 StructureType sync.WaitGroup
+          Type: 1197 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 386 StructureType sync/atomic.Int32
+          Type: 363 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 157
       Name: main.esotericStack
@@ -31448,9 +31450,9 @@ Types:
           Type: 11 BaseType int
         - Name: data
           Offset: 8
-          Type: 1185 ArrayType [63]uint64
+          Type: 1192 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1196
+      ID: 1203
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1237984
@@ -31470,7 +31472,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1187
+      ID: 1194
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -31481,18 +31483,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1183 PointerType *main.stringType1.str
+          Type: 1190 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 1182 GoStringDataType main.stringType1.str
+      Data: 1189 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1182
+      ID: 1189
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1184
+      ID: 1191
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
@@ -31621,16 +31623,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1197 PointerType **main.t
+          Type: 1204 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1198 GoSliceDataType main.t.array
+      Data: 1205 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1198
+      ID: 1205
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -31786,12 +31788,12 @@ Types:
       GoKind: 21
       HeaderType: 202 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 374
+      ID: 412
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 886560
       GoKind: 21
-      HeaderType: 376 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 414 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 139
       Name: map[int]*main.deepMap2
@@ -31800,12 +31802,12 @@ Types:
       GoKind: 21
       HeaderType: 141 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1212
+      ID: 1219
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 884064
       GoKind: 21
-      HeaderType: 1214 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1221 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1250
       Name: map[int]*main.deepMap8
@@ -31849,12 +31851,12 @@ Types:
       GoKind: 21
       HeaderType: 207 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 528
+      ID: 532
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 886752
       GoKind: 21
-      HeaderType: 530 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 534 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 195
       Name: map[string][]main.structWithMap
@@ -31870,12 +31872,12 @@ Types:
       GoKind: 21
       HeaderType: 185 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 398
+      ID: 375
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 886656
       GoKind: 21
-      HeaderType: 400 GoHMapHeaderType hash<string,float64>
+      HeaderType: 377 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
       ID: 178
       Name: map[string]int
@@ -31884,12 +31886,12 @@ Types:
       GoKind: 21
       HeaderType: 180 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 533
+      ID: 537
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 882816
       GoKind: 21
-      HeaderType: 395 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 372 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
       ID: 173
       Name: map[string]main.nestedStruct
@@ -31898,12 +31900,12 @@ Types:
       GoKind: 21
       HeaderType: 175 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 388
+      ID: 365
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 885792
       GoKind: 21
-      HeaderType: 390 GoHMapHeaderType hash<string,string>
+      HeaderType: 367 GoHMapHeaderType hash<string,string>
     - __kind: GoMapType
       ID: 230
       Name: map[struct {}]int
@@ -31969,7 +31971,7 @@ Types:
       GoKind: 21
       HeaderType: 212 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 715
+      ID: 722
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1253664
@@ -31979,7 +31981,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1003
+      ID: 1010
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1250464
@@ -31989,11 +31991,11 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 920
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 979
+      ID: 986
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1412768
@@ -32006,35 +32008,35 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 951
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1141
+      ID: 1148
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 949
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 922
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1151
+      ID: 1158
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1161
+      ID: 1168
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1149
+      ID: 1156
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 880
+      ID: 887
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1077056
@@ -32042,28 +32044,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 882 PointerType *net.UnknownNetworkError.str
+          Type: 889 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 881 GoStringDataType net.UnknownNetworkError.str
+      Data: 888 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 881
+      ID: 888
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 849
+      ID: 856
       Name: net.canceledError
       GoRuntimeType: 1201440
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1126
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 984
+      ID: 991
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1977536
@@ -32071,7 +32073,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 979 GoInterfaceType net.Conn
+          Type: 986 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -32082,27 +32084,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1170
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1157
+      ID: 1164
       Name: net.noReadFrom
       GoRuntimeType: 1077312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1156
+      ID: 1163
       Name: net.noWriteTo
       GoRuntimeType: 1077184
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 659
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1228
+    - __kind: GoContextImplementationType
+      ID: 400
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1643328
@@ -32114,8 +32116,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 152 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 654
+      ID: 661
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1612256
@@ -32123,7 +32127,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 967 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 974 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -32131,7 +32135,7 @@ Types:
           Offset: 96
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 1145
+      ID: 1152
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2153856
@@ -32139,12 +32143,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1157 StructureType net.noReadFrom
+          Type: 1164 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1150 PointerType *net.TCPConn
+          Type: 1157 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1143
+      ID: 1150
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2153312
@@ -32152,24 +32156,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1156 StructureType net.noWriteTo
+          Type: 1163 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1150 PointerType *net.TCPConn
+          Type: 1157 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 917
+      ID: 924
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 953
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 846
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 995
+      ID: 1002
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1242144
@@ -32179,19 +32183,19 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 549
+      ID: 556
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 765504
       GoKind: 10
     - __kind: BaseType
-      ID: 956
+      ID: 963
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 953312
       GoKind: 10
     - __kind: StructureType
-      ID: 630
+      ID: 637
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1610720
@@ -32202,12 +32206,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 956 BaseType net/http.http2ErrCode
+          Type: 963 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 938
+      ID: 945
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1775712
@@ -32218,12 +32222,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 956 BaseType net/http.http2ErrCode
+          Type: 963 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 634
+      ID: 641
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1412448
@@ -32231,16 +32235,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 956 BaseType net/http.http2ErrCode
+          Type: 963 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 553
+      ID: 560
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 765696
@@ -32248,18 +32252,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 555 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 562 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 561 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 554
+      ID: 561
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 559
+      ID: 566
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 765888
@@ -32267,18 +32271,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 561 PointerType *net/http.http2headerFieldNameError.str
+          Type: 568 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 560 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 567 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 560
+      ID: 567
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 556
+      ID: 563
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 765792
@@ -32286,32 +32290,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 558 PointerType *net/http.http2headerFieldValueError.str
+          Type: 565 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 557 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 564 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 557
+      ID: 564
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 917
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 852
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1200928
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1117
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 550
+      ID: 557
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 765600
@@ -32319,18 +32323,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 552 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 559 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 551 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 558 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 551
+      ID: 558
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 997
+      ID: 1004
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1611488
@@ -32338,22 +32342,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 979 GoInterfaceType net.Conn
+          Type: 986 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1078 BaseType time.Duration
+          Type: 1085 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 101 PointerType *error
     - __kind: ArrayType
-      ID: 1079
+      ID: 1086
       Name: net/http.incomparable
       GoRuntimeType: 833664
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1374336
@@ -32363,11 +32367,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1068
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1017
+      ID: 1024
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1374176
@@ -32375,9 +32379,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1060 PointerType *net/http.persistConn
+          Type: 1067 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1043
+      ID: 1050
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1682848
@@ -32385,15 +32389,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1079 ArrayType net/http.incomparable
+          Type: 1086 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1080 PointerType *bufio.Reader
+          Type: 1087 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1082 GoInterfaceType io.ReadWriteCloser
+          Type: 1089 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 638
+      ID: 645
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1243104
@@ -32403,17 +32407,17 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 947
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 908
+      ID: 915
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1300352
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 843
+      ID: 850
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1374496
@@ -32423,11 +32427,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 634
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1112
+      ID: 1119
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1913952
@@ -32435,13 +32439,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1107 PointerType *bufio.Writer
+          Type: 1114 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1034
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 707
+      ID: 714
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1616096
@@ -32457,7 +32461,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 705
+      ID: 712
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1414208
@@ -32470,11 +32474,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1069
+      ID: 1076
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1029
+      ID: 1036
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1416128
@@ -32482,16 +32486,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1068 PointerType *net/smtp.Client
+          Type: 1075 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1070 GoInterfaceType io.WriteCloser
+          Type: 1077 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 698
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 584
+      ID: 591
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 768384
@@ -32499,26 +32503,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 586 PointerType *net/textproto.ProtocolError.str
+          Type: 593 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 585 GoStringDataType net/textproto.ProtocolError.str
+      Data: 592 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 585
+      ID: 592
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1032
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 955
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 562
+      ID: 569
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 766368
@@ -32526,18 +32530,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 564 PointerType *net/url.EscapeError.str
+          Type: 571 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 563 GoStringDataType net/url.EscapeError.str
+      Data: 570 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 563
+      ID: 570
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 565
+      ID: 572
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 766464
@@ -32545,30 +32549,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 567 PointerType *net/url.InvalidHostError.str
+          Type: 574 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 566 GoStringDataType net/url.InvalidHostError.str
+      Data: 573 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 566
+      ID: 573
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1169
+      ID: 1176
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1167
+      ID: 1174
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2222048
@@ -32576,12 +32580,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1173 StructureType os.noReadFrom
+          Type: 1180 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1168 PointerType *os.File
+          Type: 1175 PointerType *os.File
     - __kind: StructureType
-      ID: 1165
+      ID: 1172
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2221248
@@ -32589,36 +32593,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1172 StructureType os.noWriteTo
+          Type: 1179 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1168 PointerType *os.File
+          Type: 1175 PointerType *os.File
     - __kind: StructureType
-      ID: 1173
+      ID: 1180
       Name: os.noReadFrom
       GoRuntimeType: 1075392
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1172
+      ID: 1179
       Name: os.noWriteTo
       GoRuntimeType: 1075264
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 858
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 994
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1054
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1518752
@@ -32631,7 +32635,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 597
+      ID: 604
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 771552
@@ -32639,36 +32643,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 599 PointerType *os/user.UnknownGroupIdError.str
+          Type: 606 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 598 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 605 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 598
+      ID: 605
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 596
+      ID: 603
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 771456
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 632
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 720
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 825
+      ID: 832
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -32680,7 +32684,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 827
+      ID: 834
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1765280
@@ -32697,9 +32701,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 985 BaseType runtime.boundsErrorCode
+          Type: 992 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 985
+      ID: 992
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 534944
@@ -32719,7 +32723,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 888
+      ID: 895
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1636416
@@ -32732,7 +32736,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 804
+      ID: 811
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 952448
@@ -32740,13 +32744,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 806 PointerType *runtime.errorString.str
+          Type: 813 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 805 GoStringDataType runtime.errorString.str
+      Data: 812 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 805
+      ID: 812
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -33372,7 +33376,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 807
+      ID: 814
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 953024
@@ -33380,13 +33384,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 809 PointerType *runtime.plainError.str
+          Type: 816 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 808 GoStringDataType runtime.plainError.str
+      Data: 815 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 808
+      ID: 815
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -33468,7 +33472,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -33480,26 +33484,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 415 PointerType *string.str
+          Type: 422 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 414 GoStringDataType string.str
+      Data: 421 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 414
+      ID: 421
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1113
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1015
+      ID: 1022
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1011
+      ID: 1018
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1279552
@@ -33515,7 +33519,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 372
+      ID: 362
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1291072
@@ -33528,7 +33532,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1188
+      ID: 1195
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1292192
@@ -33536,12 +33540,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1189 StructureType sync/atomic.Uint32
+          Type: 1196 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 372 StructureType sync.Mutex
+          Type: 362 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 385
+      ID: 361
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1717792
@@ -33549,7 +33553,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 372 StructureType sync.Mutex
+          Type: 362 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -33558,12 +33562,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 386 StructureType sync/atomic.Int32
+          Type: 363 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 386 StructureType sync/atomic.Int32
+          Type: 363 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1190
+      ID: 1197
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1432064
@@ -33571,21 +33575,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1191 StructureType sync.noCopy
+          Type: 1198 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1192 StructureType sync/atomic.Uint64
+          Type: 1199 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1191
+      ID: 1198
       Name: sync.noCopy
       GoRuntimeType: 952064
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 386
+      ID: 363
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1292512
@@ -33593,12 +33597,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 387 StructureType sync/atomic.noCopy
+          Type: 364 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 1189
+      ID: 1196
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1292672
@@ -33606,12 +33610,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 387 StructureType sync/atomic.noCopy
+          Type: 364 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1192
+      ID: 1199
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1432448
@@ -33619,15 +33623,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 387 StructureType sync/atomic.noCopy
+          Type: 364 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1193 StructureType sync/atomic.align64
+          Type: 1200 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 12 BaseType uint64
     - __kind: StructureType
-      ID: 373
+      ID: 411
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1113824
@@ -33637,29 +33641,29 @@ Types:
           Offset: 0
           Type: 159 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1193
+      ID: 1200
       Name: sync/atomic.align64
       GoRuntimeType: 952256
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 387
+      ID: 364
       Name: sync/atomic.noCopy
       GoRuntimeType: 952160
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 936
+      ID: 943
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1202208
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1146
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 879
+      ID: 886
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1523168
@@ -33672,7 +33676,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 1078
+      ID: 1085
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1790016
@@ -33689,10 +33693,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 503 GoSliceHeaderType []time.zone
+          Type: 510 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 506 GoSliceHeaderType []time.zoneTrans
+          Type: 513 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -33704,9 +33708,9 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 504 PointerType *time.zone
+          Type: 511 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 628
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
@@ -33734,7 +33738,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 381
+      ID: 420
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1293312
@@ -33742,12 +33746,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1200 GoChannelType <-chan time.Time
+          Type: 1212 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 546
+      ID: 553
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 763968
@@ -33755,18 +33759,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 548 PointerType *time.fileSizeError.str
+          Type: 555 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 547 GoStringDataType time.fileSizeError.str
+      Data: 554 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 547
+      ID: 554
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 505
+      ID: 512
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1433408
@@ -33782,7 +33786,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 508
+      ID: 515
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1635264
@@ -33843,11 +33847,11 @@ Types:
       GoRuntimeType: 534880
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1109
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 967
+      ID: 974
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1935680
@@ -33858,10 +33862,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 968 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 975 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 969 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 976 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -33876,18 +33880,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 970 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 977 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 970
+      ID: 977
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 957728
       GoKind: 9
     - __kind: StructureType
-      ID: 968
+      ID: 975
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1802048
@@ -33912,21 +33916,21 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 716
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 969
+      ID: 976
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 538528
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1131
+      ID: 1138
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 693
+      ID: 700
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1250784
@@ -33936,13 +33940,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 587
+      ID: 594
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 768480
       GoKind: 2
     - __kind: StructureType
-      ID: 858
+      ID: 865
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1518944
@@ -33955,7 +33959,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 812
+      ID: 819
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 956576

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -11559,21 +11559,21 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1383
+      ID: 1389
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 139
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 140 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1388
+      ID: 1395
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1389 PointerType *main.deepSlice3
+      Pointee: 1396 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1423
       Name: '**main.deepSlice8'
@@ -11591,7 +11591,7 @@ Types:
       GoKind: 22
       Pointee: 154 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1378
+      ID: 1385
       Name: '**main.t'
       ByteSize: 8
       Pointee: 253 PointerType *main.t
@@ -11623,20 +11623,20 @@ Types:
       ByteSize: 8
       Pointee: 207 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 382
+      ID: 420
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 383 PointerType *table<context.canceler,struct {}>
+      Pointee: 421 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 147
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 148 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1396
+      ID: 1403
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1397 PointerType *table<int,*main.deepMap3>
+      Pointee: 1404 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1440
       Name: '**table<int,*main.deepMap8>'
@@ -11668,10 +11668,10 @@ Types:
       ByteSize: 8
       Pointee: 212 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 690
+      ID: 688
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 691 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 689 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 201
       Name: '**table<string,[]main.structWithMap>'
@@ -11683,35 +11683,35 @@ Types:
       ByteSize: 8
       Pointee: 190 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 406
+      ID: 383
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 407 PointerType *table<string,float64>
+      Pointee: 384 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1130 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1137 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 184
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 185 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 401
+      ID: 378
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 402 PointerType *table<string,interface {}>
+      Pointee: 379 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 179
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 180 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 396
+      ID: 373
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 397 PointerType *table<string,string>
+      Pointee: 374 PointerType *table<string,string>
     - __kind: PointerType
       ID: 236
       Name: '**table<struct {},int>'
@@ -11763,20 +11763,20 @@ Types:
       ByteSize: 8
       Pointee: 217 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1386
+      ID: 1392
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1385 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1391 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 429
+      ID: 436
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 428 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 435 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1392
+      ID: 1399
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1391 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1398 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1427
       Name: '*[]*main.deepSlice8.array'
@@ -11788,95 +11788,95 @@ Types:
       ByteSize: 8
       Pointee: 1432 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 426
+      ID: 433
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 425 GoSliceDataType []*string.array
+      Pointee: 432 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 589
+      ID: 596
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 588 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 595 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 587
+      ID: 594
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 586 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 593 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 585
+      ID: 592
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 584 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 591 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 583
+      ID: 590
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 582 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 589 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 282
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 581
+      ID: 588
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 580 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 587 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 569
+      ID: 576
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 568 GoSliceDataType [][]uint.array
+      Pointee: 575 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 573
+      ID: 580
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 572 GoSliceDataType []bool.array
+      Pointee: 579 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1166
+      ID: 1173
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1165 GoSliceDataType []float64.array
+      Pointee: 1172 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 686
+      ID: 684
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 685 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 683 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 694
+      ID: 692
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 691 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 651
+      ID: 658
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 650 GoSliceDataType []go.shape.float64.array
+      Pointee: 657 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 646 GoSliceDataType []go.shape.int.array
+      Pointee: 653 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 648 GoSliceDataType []go.shape.string.array
+      Pointee: 655 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
       ID: 1436
       Name: '*[]interface {}.array'
@@ -11888,20 +11888,20 @@ Types:
       ByteSize: 8
       Pointee: 277 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 579
+      ID: 586
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 578 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 585 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 695 GoSliceDataType []main.structWithMap.array
+      Pointee: 702 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 571
+      ID: 578
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 570 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 577 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -11910,111 +11910,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 441
+      ID: 448
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 440 GoSliceDataType []string.array
+      Pointee: 447 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 577
+      ID: 584
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 576 GoSliceDataType []struct {}.array
+      Pointee: 583 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 697 GoSliceDataType []time.zone.array
+      Pointee: 704 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 699 GoSliceDataType []time.zoneTrans.array
+      Pointee: 706 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 264
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 262 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 567
+      ID: 574
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 566 GoSliceDataType []uint.array
+      Pointee: 573 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 575
+      ID: 582
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 574 GoSliceDataType []uint16.array
+      Pointee: 581 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 422
+      ID: 429
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 421 GoSliceDataType []uint8.array
+      Pointee: 428 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 424
+      ID: 431
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 423 GoSliceDataType []uintptr.array
+      Pointee: 430 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1296
+      ID: 1303
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1987904
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1304 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 931008
       GoKind: 22
-      Pointee: 941 GoSliceHeaderType archive/tar.headerError
+      Pointee: 948 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 942 GoSliceDataType archive/tar.headerError.array
+      Pointee: 949 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1231
+      ID: 1238
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1439136
       GoKind: 22
-      Pointee: 1232 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1239 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1179
+      ID: 1186
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 931200
       GoKind: 22
-      Pointee: 1180 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1187 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1181
+      ID: 1188
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 931296
       GoKind: 22
-      Pointee: 1182 StructureType archive/zip.dirWriter
+      Pointee: 1189 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1279
+      ID: 1286
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1907584
       GoKind: 22
-      Pointee: 1280 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1287 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1207
+      ID: 1214
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1058592
       GoKind: 22
-      Pointee: 1208 StructureType archive/zip.nopCloser
+      Pointee: 1215 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1209
+      ID: 1216
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1058848
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1217 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -12023,477 +12023,477 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1254
+      ID: 1261
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2176736
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType bufio.Reader
+      Pointee: 1262 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1285
+      ID: 1292
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1952864
       GoKind: 22
-      Pointee: 1286 UnresolvedPointeeType bufio.Writer
+      Pointee: 1293 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1334
+      ID: 1341
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2274016
       GoKind: 22
-      Pointee: 1335 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1342 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 913440
       GoKind: 22
-      Pointee: 744 BaseType compress/flate.CorruptInputError
+      Pointee: 751 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 913536
       GoKind: 22
-      Pointee: 745 GoStringHeaderType compress/flate.InternalError
+      Pointee: 752 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 746 GoStringDataType compress/flate.InternalError.str
+      Pointee: 753 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1229
+      ID: 1236
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1428576
       GoKind: 22
-      Pointee: 1230 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1237 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1175
+      ID: 1182
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 913632
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1183 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1251
+      ID: 1258
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1729728
       GoKind: 22
-      Pointee: 1252 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1259 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1416
+      ID: 410
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1554816
       GoKind: 22
-      Pointee: 373 StructureType context.backgroundCtx
+      Pointee: 411 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 363
+      ID: 414
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1727424
       GoKind: 22
-      Pointee: 364 StructureType context.cancelCtx
+      Pointee: 415 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1193408
       GoKind: 22
-      Pointee: 1053 StructureType context.deadlineExceededError
+      Pointee: 1060 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1411
+      ID: 397
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1417216
       GoKind: 22
-      Pointee: 374 StructureType context.emptyCtx
+      Pointee: 398 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 365
+      ID: 399
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1417376
       GoKind: 22
-      Pointee: 366 StructureType context.stopCtx
+      Pointee: 400 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 367
+      ID: 422
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1727616
       GoKind: 22
-      Pointee: 368 StructureType context.timerCtx
+      Pointee: 423 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1417
+      ID: 412
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1554976
       GoKind: 22
-      Pointee: 387 StructureType context.todoCtx
+      Pointee: 413 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 369
+      ID: 406
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1554496
       GoKind: 22
-      Pointee: 370 StructureType context.valueCtx
+      Pointee: 407 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 371
+      ID: 408
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1554656
       GoKind: 22
-      Pointee: 372 StructureType context.withoutCancelCtx
+      Pointee: 409 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925632
       GoKind: 22
-      Pointee: 758 BaseType crypto/aes.KeySizeError
+      Pointee: 765 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925824
       GoKind: 22
-      Pointee: 759 BaseType crypto/des.KeySizeError
+      Pointee: 766 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926112
       GoKind: 22
-      Pointee: 760 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 767 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1241
+      ID: 1248
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1570176
       GoKind: 22
-      Pointee: 1242 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1249 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1275
+      ID: 1282
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1866016
       GoKind: 22
-      Pointee: 1276 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1283 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1307
+      ID: 1314
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2124064
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1315 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1281
+      ID: 1288
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1908096
       GoKind: 22
-      Pointee: 1282 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1289 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1277
+      ID: 1284
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1866688
       GoKind: 22
-      Pointee: 1278 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1285 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1273
+      ID: 1280
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1858624
       GoKind: 22
-      Pointee: 1274 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1281 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926400
       GoKind: 22
-      Pointee: 761 BaseType crypto/rc4.KeySizeError
+      Pointee: 768 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1291
+      ID: 1298
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1957472
       GoKind: 22
-      Pointee: 1292 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1299 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1263
+      ID: 1270
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1812832
       GoKind: 22
-      Pointee: 1264 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1271 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 915168
       GoKind: 22
-      Pointee: 748 BaseType crypto/tls.AlertError
+      Pointee: 755 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1046944
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1032 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1360
+      ID: 1367
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2385888
       GoKind: 22
-      Pointee: 1361 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1368 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 914976
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 862 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 914880
       GoKind: 22
-      Pointee: 853 StructureType crypto/tls.RecordHeaderError
+      Pointee: 860 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1023
+      ID: 1030
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1045280
       GoKind: 22
-      Pointee: 980 BaseType crypto/tls.alert
+      Pointee: 987 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1239
+      ID: 1246
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1563136
       GoKind: 22
-      Pointee: 1240 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1247 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1246
+      ID: 1253
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1646656
       GoKind: 22
-      Pointee: 1247 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1254 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1119
+      ID: 1126
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1428896
       GoKind: 22
-      Pointee: 1120 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1127 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1131
+      ID: 1138
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2045952
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1139 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 924576
       GoKind: 22
-      Pointee: 927 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 934 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 920
+      ID: 927
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 924096
       GoKind: 22
-      Pointee: 921 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 928 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 922
+      ID: 929
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 924192
       GoKind: 22
-      Pointee: 923 StructureType crypto/x509.HostnameError
+      Pointee: 930 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 924000
       GoKind: 22
-      Pointee: 757 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 764 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1029
+      ID: 1036
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1052704
       GoKind: 22
-      Pointee: 1030 StructureType crypto/x509.SystemRootsError
+      Pointee: 1037 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 924672
       GoKind: 22
-      Pointee: 929 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 936 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 925 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 932 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 931488
       GoKind: 22
-      Pointee: 945 StructureType encoding/asn1.StructuralError
+      Pointee: 952 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 931680
       GoKind: 22
-      Pointee: 949 StructureType encoding/asn1.SyntaxError
+      Pointee: 956 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 931584
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 954 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 910944
       GoKind: 22
-      Pointee: 742 BaseType encoding/base64.CorruptInputError
+      Pointee: 749 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1197
+      ID: 1204
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1041824
       GoKind: 22
-      Pointee: 1198 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1205 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 845
+      ID: 852
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 911808
       GoKind: 22
-      Pointee: 743 BaseType encoding/hex.InvalidByteError
+      Pointee: 750 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 905664
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 821 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1038112
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1023 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 905280
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 813 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 905568
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 819 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 810 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 817 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 905376
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 815 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1340
+      ID: 1347
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2299040
       GoKind: 22
-      Pointee: 1341 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1348 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 906048
       GoKind: 22
-      Pointee: 816 StructureType encoding/json.jsonError
+      Pointee: 823 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1205
+      ID: 1212
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1055520
       GoKind: 22
-      Pointee: 1206 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1213 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923040
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 922 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 922944
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 920 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 916
+      ID: 923
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 923136
       GoKind: 22
-      Pointee: 754 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 761 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 755 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 762 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 923232
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 925 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1318
+      ID: 1325
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2162496
       GoKind: 22
-      Pointee: 1319 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1326 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -12502,19 +12502,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896640
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType errors.errorString
+      Pointee: 791 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 982
+      ID: 989
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1023904
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType errors.joinError
+      Pointee: 990 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -12530,625 +12530,625 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 1328
+      ID: 1335
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2266336
       GoKind: 22
-      Pointee: 1329 UnresolvedPointeeType fmt.pp
+      Pointee: 1336 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 984
+      ID: 991
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1024032
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType fmt.wrapError
+      Pointee: 992 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1024160
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 994 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 911328
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 851 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 824
+      ID: 831
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 908448
       GoKind: 22
-      Pointee: 825 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 832 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 826
+      ID: 833
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 908544
       GoKind: 22
-      Pointee: 827 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 834 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1143
+      ID: 1150
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 1144 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1151 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 830
+      ID: 837
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 908832
       GoKind: 22
-      Pointee: 831 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 838 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1145
+      ID: 1152
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1153 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 828
+      ID: 835
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 908640
       GoKind: 22
-      Pointee: 736 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 743 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 737 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 744 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 908160
       GoKind: 22
-      Pointee: 733 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 740 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 741 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 908736
       GoKind: 22
-      Pointee: 739 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 746 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 740 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 747 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1219
+      ID: 1226
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1210944
       GoKind: 22
-      Pointee: 1220 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1227 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1304
+      ID: 1311
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2060640
       GoKind: 22
-      Pointee: 1305 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1312 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 929952
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 946 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 388
+      ID: 393
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2284256
       GoKind: 22
-      Pointee: 389 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 363 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 414
+      ID: 391
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2009952
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 392 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 409
+      ID: 386
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1193664
       GoKind: 22
-      Pointee: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 387 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 412
+      ID: 389
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1193792
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 390 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1409
+      ID: 1416
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1194432
       GoKind: 22
-      Pointee: 1410 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1417 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 707
+      ID: 714
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1194560
       GoKind: 22
-      Pointee: 708 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 715 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 416
+      ID: 394
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2228928
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 395 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1087
+      ID: 1094
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1214528
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1095 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1336
+      ID: 1343
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2276064
       GoKind: 22
-      Pointee: 1337 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1344 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1412
+      ID: 402
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1422816
       GoKind: 22
-      Pointee: 1413 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 403 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 918528
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 871 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 919584
       GoKind: 22
-      Pointee: 871 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 878 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 919296
       GoKind: 22
-      Pointee: 753 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 760 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 919488
       GoKind: 22
-      Pointee: 869 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 876 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 919392
       GoKind: 22
-      Pointee: 867 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 874 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 921504
       GoKind: 22
-      Pointee: 887 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 894 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 921696
       GoKind: 22
-      Pointee: 891 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 898 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 921600
       GoKind: 22
-      Pointee: 889 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 896 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 921408
       GoKind: 22
-      Pointee: 885 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 892 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1168
+      ID: 1175
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1167 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1174 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 922080
       GoKind: 22
-      Pointee: 899 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 906 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 921792
       GoKind: 22
-      Pointee: 893 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 900 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 921984
       GoKind: 22
-      Pointee: 897 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 904 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 921888
       GoKind: 22
-      Pointee: 895 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 902 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 922176
       GoKind: 22
-      Pointee: 901 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 908 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 922464
       GoKind: 22
-      Pointee: 907 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 914 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 909 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 916 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 922368
       GoKind: 22
-      Pointee: 905 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 912 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 922272
       GoKind: 22
-      Pointee: 903 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 910 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 910
+      ID: 917
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 911 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 918 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 833 StructureType github.com/cihub/seelog.baseError
+      Pointee: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1257
+      ID: 1264
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1805216
       GoKind: 22
-      Pointee: 1258 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1265 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 910080
       GoKind: 22
-      Pointee: 835 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 842 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1237
+      ID: 1244
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1561376
       GoKind: 22
-      Pointee: 1238 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1245 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1193
+      ID: 1200
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1040800
       GoKind: 22
-      Pointee: 1194 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1201 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1227
+      ID: 1234
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1426496
       GoKind: 22
-      Pointee: 1228 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1235 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 910272
       GoKind: 22
-      Pointee: 839 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 846 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1294
+      ID: 1301
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1977248
       GoKind: 22
-      Pointee: 1295 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1302 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1311
+      ID: 1318
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2135648
       GoKind: 22
-      Pointee: 1306 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1313 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1310
+      ID: 1317
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2135264
       GoKind: 22
-      Pointee: 1309 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1316 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1195
+      ID: 1202
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1040928
       GoKind: 22
-      Pointee: 1196 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1203 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 910176
       GoKind: 22
-      Pointee: 837 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 844 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 840
+      ID: 847
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 910368
       GoKind: 22
-      Pointee: 841 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 848 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1259
+      ID: 1266
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1807008
       GoKind: 22
-      Pointee: 1260 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1267 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1300
+      ID: 1307
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2014560
       GoKind: 22
-      Pointee: 1301 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1308 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1302
+      ID: 1309
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2045632
       GoKind: 22
-      Pointee: 1303 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1310 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1121
+      ID: 1128
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1441536
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1129 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1037
+      ID: 1044
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1067040
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1045 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1035
+      ID: 1042
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1066912
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1043 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1039
+      ID: 1046
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1071008
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1047 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1041
+      ID: 1048
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1071136
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1049 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1248
+      ID: 1255
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1674112
       GoKind: 22
-      Pointee: 1249 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1256 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1031
+      ID: 1038
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1053344
       GoKind: 22
-      Pointee: 1032 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1039 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 912000
       GoKind: 22
-      Pointee: 847 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 854 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1352
+      ID: 1359
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2362112
       GoKind: 22
-      Pointee: 1353 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1360 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1223744
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1103 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1201856
       GoKind: 22
-      Pointee: 1065 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1072 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1201472
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1066 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1032352
       GoKind: 22
-      Pointee: 1002 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1009 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1070
+      ID: 1077
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1202240
       GoKind: 22
-      Pointee: 1071 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1078 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1000
+      ID: 1007
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1032224
       GoKind: 22
-      Pointee: 979 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 986 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1201728
       GoKind: 22
-      Pointee: 1063 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1070 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1201600
       GoKind: 22
-      Pointee: 1061 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1068 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1068
+      ID: 1075
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1202112
       GoKind: 22
-      Pointee: 1069 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1076 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1066
+      ID: 1073
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1201984
       GoKind: 22
-      Pointee: 1067 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1074 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1356
+      ID: 1363
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2373920
       GoKind: 22
-      Pointee: 1357 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1364 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1074
+      ID: 1081
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1202624
       GoKind: 22
-      Pointee: 1075 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1082 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1005
+      ID: 1012
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1032608
       GoKind: 22
-      Pointee: 1006 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1013 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1032480
       GoKind: 22
-      Pointee: 1004 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1011 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1072
+      ID: 1079
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1202496
       GoKind: 22
-      Pointee: 1073 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1080 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 944448
       GoKind: 22
-      Pointee: 766 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 773 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 767 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 774 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
       ID: 359
       Name: '*go.shape.float64'
@@ -13171,10 +13171,10 @@ Types:
       GoKind: 22
       Pointee: 332 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 644 GoStringDataType go.shape.string.str
+      Pointee: 651 GoStringDataType go.shape.string.str
     - __kind: PointerType
       ID: 338
       Name: '*go.shape.struct { Name string }'
@@ -13194,249 +13194,249 @@ Types:
       GoKind: 22
       Pointee: 354 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1134
+      ID: 1141
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1672576
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1142 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1045
+      ID: 1052
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1085856
       GoKind: 22
-      Pointee: 1046 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1053 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1225
+      ID: 1232
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1263424
       GoKind: 22
-      Pointee: 1226 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1233 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1316
+      ID: 1323
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2150624
       GoKind: 22
-      Pointee: 1317 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1324 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1211
+      ID: 1218
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1088160
       GoKind: 22
-      Pointee: 1212 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1219 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 945696
       GoKind: 22
-      Pointee: 769 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 776 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1103
+      ID: 1110
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1265088
       GoKind: 22
-      Pointee: 1104 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1111 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 945984
       GoKind: 22
-      Pointee: 965 StructureType golang.org/x/net/http2.connError
+      Pointee: 972 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945888
       GoKind: 22
-      Pointee: 773 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 780 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 774 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 781 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 946176
       GoKind: 22
-      Pointee: 779 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 786 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 780 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 787 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 946080
       GoKind: 22
-      Pointee: 776 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 783 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 778
+      ID: 785
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 777 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 784 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945792
       GoKind: 22
-      Pointee: 770 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 777 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 771 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 778 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1314
+      ID: 1321
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2148704
       GoKind: 22
-      Pointee: 1315 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1322 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 946272
       GoKind: 22
-      Pointee: 969 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 976 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 946368
       GoKind: 22
-      Pointee: 782 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 789 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 939648
       GoKind: 22
-      Pointee: 957 StructureType google.golang.org/grpc.dropError
+      Pointee: 964 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1101
+      ID: 1108
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1262144
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1109 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1123
+      ID: 1130
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1448896
       GoKind: 22
-      Pointee: 1124 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1131 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 942720
       GoKind: 22
-      Pointee: 959 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 966 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1265
+      ID: 1272
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1813280
       GoKind: 22
-      Pointee: 1266 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1273 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1223
+      ID: 1230
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1258688
       GoKind: 22
-      Pointee: 1224 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1231 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1043
+      ID: 1050
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1080096
       GoKind: 22
-      Pointee: 1044 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1051 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1183
+      ID: 1190
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 942816
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1191 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 927840
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 944 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1033
+      ID: 1040
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1056928
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1041 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1099
+      ID: 1106
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1230144
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1107 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1097
+      ID: 1104
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1229888
       GoKind: 22
-      Pointee: 1098 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1105 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 932544
       GoKind: 22
-      Pointee: 951 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 958 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 932640
       GoKind: 22
-      Pointee: 953 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 960 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 919968
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 886 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1271
+      ID: 1278
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1853696
       GoKind: 22
-      Pointee: 1272 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1279 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 947136
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType html/template.Error
+      Pointee: 979 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -13480,89 +13480,89 @@ Types:
       GoKind: 22
       Pointee: 162 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 925248
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 938 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 913152
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 856 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1173
+      ID: 1180
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 912384
       GoKind: 22
-      Pointee: 1174 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1181 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1215680
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1101 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1358
+      ID: 1365
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2379552
       GoKind: 22
-      Pointee: 1359 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1366 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1215552
       GoKind: 22
-      Pointee: 1092 StructureType internal/poll.errNetClosing
+      Pointee: 1099 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900768
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 796 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1215
+      ID: 1222
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1193152
       GoKind: 22
-      Pointee: 1216 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1223 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1213
+      ID: 1220
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1192768
       GoKind: 22
-      Pointee: 1214 StructureType io.discard
+      Pointee: 1221 StructureType io.discard
     - __kind: PointerType
-      ID: 1187
+      ID: 1194
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1024928
       GoKind: 22
-      Pointee: 1188 UnresolvedPointeeType io.multiWriter
+      Pointee: 1195 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1089
+      ID: 1096
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1215296
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1097 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1261
+      ID: 1268
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1807232
       GoKind: 22
-      Pointee: 1262 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1269 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 345
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
@@ -13582,19 +13582,19 @@ Types:
       GoKind: 22
       Pointee: 322 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 436
+      ID: 443
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 385344
       GoKind: 22
-      Pointee: 437 StructureType main.deepMap2
+      Pointee: 444 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1404
+      ID: 1411
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385280
       GoKind: 22
-      Pointee: 1405 UnresolvedPointeeType main.deepMap3
+      Pointee: 1412 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepMap7'
@@ -13624,12 +13624,12 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1362
+      ID: 1369
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 385856
       GoKind: 22
-      Pointee: 1363 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1370 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr7'
@@ -13657,14 +13657,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 386496
       GoKind: 22
-      Pointee: 427 StructureType main.deepSlice2
+      Pointee: 434 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1389
+      ID: 1396
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 386432
       GoKind: 22
-      Pointee: 1390 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1397 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepSlice7'
@@ -13700,7 +13700,7 @@ Types:
       GoKind: 22
       Pointee: 165 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1375
+      ID: 1382
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 896352
@@ -13733,19 +13733,19 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1376
+      ID: 1383
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 896448
       GoKind: 22
-      Pointee: 1377 StructureType main.secondBehavior
+      Pointee: 1384 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1368
+      ID: 1375
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 896544
       GoKind: 22
-      Pointee: 1369 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1376 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType1'
@@ -13753,16 +13753,16 @@ Types:
       GoKind: 22
       Pointee: 152 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1365
+      ID: 1372
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1364 GoStringDataType main.stringType1.str
+      Pointee: 1371 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 154
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1366 GoStringHeaderType main.stringType2
+      Pointee: 1373 GoStringHeaderType main.stringType2
     - __kind: PointerType
       ID: 1482
       Name: '*main.stringType2.str'
@@ -13774,7 +13774,7 @@ Types:
       ByteSize: 8
       Pointee: 276 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 490
+      ID: 497
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 384832
@@ -13798,10 +13798,10 @@ Types:
       GoKind: 22
       Pointee: 254 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1380
+      ID: 1387
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1379 GoSliceDataType main.t.array
+      Pointee: 1386 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 273
       Name: '*main.threeStringStruct'
@@ -13829,20 +13829,20 @@ Types:
       ByteSize: 8
       Pointee: 205 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 380
+      ID: 418
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 381 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 419 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 145
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1394
+      ID: 1401
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1395 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1402 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1438
       Name: '*map<int,*main.deepMap8>'
@@ -13874,10 +13874,10 @@ Types:
       ByteSize: 8
       Pointee: 210 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 688
+      ID: 686
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 689 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 687 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 199
       Name: '*map<string,[]main.structWithMap>'
@@ -13889,35 +13889,35 @@ Types:
       ByteSize: 8
       Pointee: 188 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 404
+      ID: 381
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 405 GoSwissMapHeaderType map<string,float64>
+      Pointee: 382 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1127
+      ID: 1134
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1128 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1135 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 182
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 183 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 399
+      ID: 376
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 400 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 377 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 177
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 178 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 394
+      ID: 371
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 395 GoSwissMapHeaderType map<string,string>
+      Pointee: 372 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 234
       Name: '*map<struct {},int>'
@@ -13975,493 +13975,493 @@ Types:
       GoKind: 22
       Pointee: 181 GoMapType map[string]int
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 920832
       GoKind: 22
-      Pointee: 883 StructureType math/big.ErrNaN
+      Pointee: 890 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1177
+      ID: 1184
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 915648
       GoKind: 22
-      Pointee: 1178 StructureType mime/multipart.writerOnly·1
+      Pointee: 1185 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1081
+      ID: 1088
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1208768
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType net.AddrError
+      Pointee: 1089 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1112
+      ID: 1119
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1424736
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType net.DNSError
+      Pointee: 1120 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1322
+      ID: 1329
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2236672
       GoKind: 22
-      Pointee: 1323 UnresolvedPointeeType net.IPConn
+      Pointee: 1330 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1110
+      ID: 1117
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1424416
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType net.OpError
+      Pointee: 1118 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1208896
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType net.ParseError
+      Pointee: 1091 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1332
+      ID: 1339
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2267360
       GoKind: 22
-      Pointee: 1333 UnresolvedPointeeType net.TCPConn
+      Pointee: 1340 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1342
+      ID: 1349
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2312352
       GoKind: 22
-      Pointee: 1343 UnresolvedPointeeType net.UDPConn
+      Pointee: 1350 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1330
+      ID: 1337
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2266848
       GoKind: 22
-      Pointee: 1331 UnresolvedPointeeType net.UnixConn
+      Pointee: 1338 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1080
+      ID: 1087
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1208000
       GoKind: 22
-      Pointee: 1049 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1056 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1051
+      ID: 1058
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1050 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1057 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1039008
       GoKind: 22
-      Pointee: 1018 StructureType net.canceledError
+      Pointee: 1025 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1298
+      ID: 1305
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2011680
       GoKind: 22
-      Pointee: 1299 UnresolvedPointeeType net.conn
+      Pointee: 1306 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1152
+      ID: 1159
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1848320
       GoKind: 22
-      Pointee: 1153 StructureType net.dialResult·1
+      Pointee: 1160 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1344
+      ID: 1351
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2316608
       GoKind: 22
-      Pointee: 1345 UnresolvedPointeeType net.netFD
+      Pointee: 1352 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net.notFoundError
+      Pointee: 825 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1414
+      ID: 404
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1424576
       GoKind: 22
-      Pointee: 1415 StructureType net.onlyValuesCtx
+      Pointee: 405 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 907680
       GoKind: 22
-      Pointee: 820 StructureType net.result·2
+      Pointee: 827 StructureType net.result·2
     - __kind: PointerType
-      ID: 1326
+      ID: 1333
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2253376
       GoKind: 22
-      Pointee: 1327 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1334 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1324
+      ID: 1331
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2252896
       GoKind: 22
-      Pointee: 1325 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1332 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1209536
       GoKind: 22
-      Pointee: 1086 UnresolvedPointeeType net.temporaryError
+      Pointee: 1093 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1424896
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType net.timeoutError
+      Pointee: 1122 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1035040
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1015 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1169
+      ID: 1176
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 902784
       GoKind: 22
-      Pointee: 1170 StructureType net/http.bufioFlushWriter
+      Pointee: 1177 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 903456
       GoKind: 22
-      Pointee: 714 BaseType net/http.http2ConnectionError
+      Pointee: 721 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 903552
       GoKind: 22
-      Pointee: 796 StructureType net/http.http2GoAwayError
+      Pointee: 803 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1106
+      ID: 1113
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1420896
       GoKind: 22
-      Pointee: 1107 StructureType net/http.http2StreamError
+      Pointee: 1114 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 904128
       GoKind: 22
-      Pointee: 800 StructureType net/http.http2connError
+      Pointee: 807 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1233
+      ID: 1240
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1558496
       GoKind: 22
-      Pointee: 1234 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1241 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 22
-      Pointee: 718 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 725 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 719 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 726 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 904320
       GoKind: 22
-      Pointee: 724 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 731 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 725 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 732 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 904224
       GoKind: 22
-      Pointee: 721 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 728 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 723
+      ID: 730
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 722 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 729 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1078
+      ID: 1085
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1204672
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1086 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1035680
       GoKind: 22
-      Pointee: 1014 StructureType net/http.http2noCachedConnError
+      Pointee: 1021 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1287
+      ID: 1294
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1953888
       GoKind: 22
-      Pointee: 1288 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1295 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 903936
       GoKind: 22
-      Pointee: 715 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 722 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 717
+      ID: 724
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 716 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 723 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1171
+      ID: 1178
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 904416
       GoKind: 22
-      Pointee: 1172 StructureType net/http.http2stickyErrWriter
+      Pointee: 1179 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1035296
       GoKind: 22
-      Pointee: 1010 StructureType net/http.nothingWrittenError
+      Pointee: 1017 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1235
+      ID: 1242
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2177984
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1243 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1191
+      ID: 1198
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1035168
       GoKind: 22
-      Pointee: 1192 StructureType net/http.persistConnWriter
+      Pointee: 1199 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1217
+      ID: 1224
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1203776
       GoKind: 22
-      Pointee: 1218 StructureType net/http.readWriteCloserBody
+      Pointee: 1225 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 803
+      ID: 810
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 804 StructureType net/http.requestBodyReadError
+      Pointee: 811 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1108
+      ID: 1115
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1422016
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1116 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1076
+      ID: 1083
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1204544
       GoKind: 22
-      Pointee: 1077 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1084 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1035424
       GoKind: 22
-      Pointee: 1012 StructureType net/http.transportReadFromServerError
+      Pointee: 1019 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1269
+      ID: 1276
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1845184
       GoKind: 22
-      Pointee: 1270 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1277 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 800 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1289
+      ID: 1296
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1955680
       GoKind: 22
-      Pointee: 1290 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1297 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1201
+      ID: 1208
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1048096
       GoKind: 22
-      Pointee: 1202 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1209 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 919776
       GoKind: 22
-      Pointee: 875 StructureType net/netip.parseAddrError
+      Pointee: 882 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 919680
       GoKind: 22
-      Pointee: 873 StructureType net/netip.parsePrefixError
+      Pointee: 880 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1243
+      ID: 1250
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2122656
       GoKind: 22
-      Pointee: 1244 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1251 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1203
+      ID: 1210
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1052960
       GoKind: 22
-      Pointee: 1204 StructureType net/smtp.dataCloser
+      Pointee: 1211 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 915840
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType net/textproto.Error
+      Pointee: 866 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 915744
       GoKind: 22
-      Pointee: 749 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 756 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 757 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1199
+      ID: 1206
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1047328
       GoKind: 22
-      Pointee: 1200 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1207 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1116
+      ID: 1123
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1425216
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType net/url.Error
+      Pointee: 1124 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 907776
       GoKind: 22
-      Pointee: 727 GoStringHeaderType net/url.EscapeError
+      Pointee: 734 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 729
+      ID: 736
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 728 GoStringDataType net/url.EscapeError.str
+      Pointee: 735 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 907872
       GoKind: 22
-      Pointee: 730 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 737 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 731 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 738 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 536
+      ID: 543
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 537 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 544 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 528
+      ID: 535
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 529 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 536 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 476
+      ID: 483
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 477 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 484 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 495
+      ID: 502
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 496 StructureType noalg.map.group[bool]main.node
+      Pointee: 503 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 654
+      ID: 695
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 655 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 696 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 432
+      ID: 439
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 433 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 440 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1400
+      ID: 1407
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1401 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1408 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1444
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -14473,230 +14473,230 @@ Types:
       ByteSize: 8
       Pointee: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 444
+      ID: 451
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 445 StructureType noalg.map.group[int]int
+      Pointee: 452 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 1474
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 552
+      ID: 559
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 553 StructureType noalg.map.group[int]struct {}
+      Pointee: 560 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 503
+      ID: 510
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 504 StructureType noalg.map.group[int]uint8
+      Pointee: 511 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 703
+      ID: 710
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 711 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 485
+      ID: 492
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 486 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 493 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 468
+      ID: 475
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 469 StructureType noalg.map.group[string][]string
+      Pointee: 476 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 679
+      ID: 677
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 680 StructureType noalg.map.group[string]float64
+      Pointee: 678 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1159
+      ID: 1166
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1167 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 460
+      ID: 467
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 461 StructureType noalg.map.group[string]int
+      Pointee: 468 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 671
+      ID: 669
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 672 StructureType noalg.map.group[string]interface {}
+      Pointee: 670 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 452
+      ID: 459
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 453 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 460 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 663
+      ID: 661
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 664 StructureType noalg.map.group[string]string
+      Pointee: 662 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 544
+      ID: 551
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 545 StructureType noalg.map.group[struct {}]int
+      Pointee: 552 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 600 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 600
+      ID: 607
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 608 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 608
+      ID: 615
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 616
+      ID: 623
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 624
+      ID: 631
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 632
+      ID: 639
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 560
+      ID: 567
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 561 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 568 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 519
+      ID: 526
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 520 StructureType noalg.map.group[uint8][4]int
+      Pointee: 527 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 511
+      ID: 518
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 512 StructureType noalg.map.group[uint8]uint8
+      Pointee: 519 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1350
+      ID: 1357
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2355264
       GoKind: 22
-      Pointee: 1351 UnresolvedPointeeType os.File
+      Pointee: 1358 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 990
+      ID: 997
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1028640
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType os.LinkError
+      Pointee: 998 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1197760
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType os.SyscallError
+      Pointee: 1062 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1348
+      ID: 1355
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2351584
       GoKind: 22
-      Pointee: 1349 StructureType os.fileWithoutReadFrom
+      Pointee: 1356 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1346
+      ID: 1353
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2350848
       GoKind: 22
-      Pointee: 1347 StructureType os.fileWithoutWriteTo
+      Pointee: 1354 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1044000
       GoKind: 22
-      Pointee: 1020 UnresolvedPointeeType os/exec.Error
+      Pointee: 1027 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1155
+      ID: 1162
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2091808
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1163 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1221
+      ID: 1228
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1216576
       GoKind: 22
-      Pointee: 1222 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1229 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1044128
       GoKind: 22
-      Pointee: 1022 StructureType os/exec.wrappedError
+      Pointee: 1029 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 955
+      ID: 962
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 937728
       GoKind: 22
-      Pointee: 763 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 770 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 764 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 771 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 937632
       GoKind: 22
-      Pointee: 762 BaseType os/user.UnknownUserIdError
+      Pointee: 769 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 901440
       GoKind: 22
-      Pointee: 791 UnresolvedPointeeType reflect.ValueError
+      Pointee: 798 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 920448
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 888 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1029664
       GoKind: 22
-      Pointee: 995 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1002 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1031456
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1006 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14712,12 +14712,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1029792
       GoKind: 22
-      Pointee: 997 StructureType runtime.boundsError
+      Pointee: 1004 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -14733,24 +14733,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1200064
       GoKind: 22
-      Pointee: 1057 StructureType runtime.errorAddressString
+      Pointee: 1064 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 992
+      ID: 999
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1029280
       GoKind: 22
-      Pointee: 973 GoStringHeaderType runtime.errorString
+      Pointee: 980 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 974 GoStringDataType runtime.errorString.str
+      Pointee: 981 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -14766,17 +14766,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1029408
       GoKind: 22
-      Pointee: 976 GoStringHeaderType runtime.plainError
+      Pointee: 983 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 978
+      ID: 985
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 977 GoStringDataType runtime.plainError.str
+      Pointee: 984 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14806,12 +14806,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 988
+      ID: 995
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1027488
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType strconv.NumError
+      Pointee: 996 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -14820,78 +14820,78 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 420
+      ID: 427
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 419 GoStringDataType string.str
+      Pointee: 426 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1283
+      ID: 1290
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1952352
       GoKind: 22
-      Pointee: 1284 UnresolvedPointeeType strings.Builder
+      Pointee: 1291 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1189
+      ID: 1196
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1027616
       GoKind: 22
-      Pointee: 1190 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1197 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1185
+      ID: 1192
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 971488
       GoKind: 22
-      Pointee: 1186 StructureType struct { io.Writer }
+      Pointee: 1193 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 271
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 125 StructureType struct {}
     - __kind: PointerType
-      ID: 1118
+      ID: 1125
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1427456
       GoKind: 22
-      Pointee: 1105 BaseType syscall.Errno
+      Pointee: 1112 BaseType syscall.Errno
     - __kind: PointerType
       ID: 232
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 534 StructureType table<[4]int,[4]int>
+      Pointee: 541 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 227
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 526 StructureType table<[4]int,uint8>
+      Pointee: 533 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 195
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 474 StructureType table<[4]string,[2]int>
+      Pointee: 481 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 207
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 493 StructureType table<bool,main.node>
+      Pointee: 500 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 383
+      ID: 421
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 652 StructureType table<context.canceler,struct {}>
+      Pointee: 693 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 148
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 430 StructureType table<int,*main.deepMap2>
+      Pointee: 437 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1397
+      ID: 1404
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1398 StructureType table<int,*main.deepMap3>
+      Pointee: 1405 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1441
       Name: '*table<int,*main.deepMap8>'
@@ -14906,7 +14906,7 @@ Types:
       ID: 175
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 442 StructureType table<int,int>
+      Pointee: 449 StructureType table<int,int>
     - __kind: PointerType
       ID: 1471
       Name: '*table<int,interface {}>'
@@ -14916,121 +14916,121 @@ Types:
       ID: 242
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 550 StructureType table<int,struct {}>
+      Pointee: 557 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 212
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 501 StructureType table<int,uint8>
+      Pointee: 508 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 691
+      ID: 689
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 701 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 708 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 202
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 483 StructureType table<string,[]main.structWithMap>
+      Pointee: 490 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 190
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 466 StructureType table<string,[]string>
+      Pointee: 473 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 407
+      ID: 384
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 677 StructureType table<string,float64>
+      Pointee: 675 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1130
+      ID: 1137
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1157 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1164 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 185
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 458 StructureType table<string,int>
+      Pointee: 465 StructureType table<string,int>
     - __kind: PointerType
-      ID: 402
+      ID: 379
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 669 StructureType table<string,interface {}>
+      Pointee: 667 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 180
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 450 StructureType table<string,main.nestedStruct>
+      Pointee: 457 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 397
+      ID: 374
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 661 StructureType table<string,string>
+      Pointee: 659 StructureType table<string,string>
     - __kind: PointerType
       ID: 237
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 542 StructureType table<struct {},int>
+      Pointee: 549 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 294
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 590 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 597 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 299
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 598 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 605 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 304
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 606 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 613 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 309
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 614 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 621 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 314
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 622 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 629 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 319
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 630 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 637 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 247
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 558 StructureType table<struct {},struct {}>
+      Pointee: 565 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 222
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 517 StructureType table<uint8,[4]int>
+      Pointee: 524 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 217
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 509 StructureType table<uint8,uint8>
+      Pointee: 516 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1320
+      ID: 1327
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2162880
       GoKind: 22
-      Pointee: 1321 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1328 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1047
+      ID: 1054
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1089696
       GoKind: 22
-      Pointee: 1048 StructureType text/template.ExecError
+      Pointee: 1055 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 327
       Name: '*time.Location'
@@ -15039,45 +15039,45 @@ Types:
       GoKind: 22
       Pointee: 328 StructureType time.Location
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 899040
       GoKind: 22
-      Pointee: 787 UnresolvedPointeeType time.ParseError
+      Pointee: 794 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 385
+      ID: 424
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1029024
       GoKind: 22
-      Pointee: 386 StructureType time.Timer
+      Pointee: 425 StructureType time.Timer
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 898944
       GoKind: 22
-      Pointee: 711 GoStringHeaderType time.fileSizeError
+      Pointee: 718 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 713
+      ID: 720
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 712 GoStringDataType time.fileSizeError.str
+      Pointee: 719 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 392128
       GoKind: 22
-      Pointee: 640 StructureType time.zone
+      Pointee: 647 StructureType time.zone
     - __kind: PointerType
-      ID: 642
+      ID: 649
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 392192
       GoKind: 22
-      Pointee: 643 StructureType time.zoneTrans
+      Pointee: 650 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -15121,49 +15121,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 919872
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 884 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1312
+      ID: 1319
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2138336
       GoKind: 22
-      Pointee: 1313 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1320 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 916032
       GoKind: 22
-      Pointee: 861 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 868 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 916128
       GoKind: 22
-      Pointee: 752 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 759 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1047840
       GoKind: 22
-      Pointee: 1027 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1034 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1047968
       GoKind: 22
-      Pointee: 981 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 988 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1381
+      ID: 1393
       Name: <-chan time.Time
       GoRuntimeType: 596576
       GoKind: 18
@@ -25891,7 +25891,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 523
+      ID: 530
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 683072
@@ -25900,7 +25900,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 480
+      ID: 487
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 683360
@@ -25926,7 +25926,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1147
+      ID: 1154
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684896
@@ -25935,7 +25935,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1367
+      ID: 1374
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25961,7 +25961,7 @@ Types:
       HasCount: true
       Element: 85 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1382
+      ID: 1388
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 481408
@@ -25969,20 +25969,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1383 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1389 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1385 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1391 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1385
+      ID: 1391
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 138
       Name: '[]*main.deepSlice2'
@@ -25999,15 +25999,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 428 GoSliceDataType []*main.deepSlice2.array
+      Data: 435 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 428
+      ID: 435
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 140 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1387
+      ID: 1394
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477312
@@ -26015,20 +26015,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1388 PointerType **main.deepSlice3
+          Type: 1395 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1391 GoSliceDataType []*main.deepSlice3.array
+      Data: 1398 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1391
+      ID: 1398
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1389 PointerType *main.deepSlice3
+      Element: 1396 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1422
       Name: '[]*main.deepSlice8'
@@ -26091,55 +26091,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 425 GoSliceDataType []*string.array
+      Data: 432 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 425
+      ID: 432
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 95 PointerType *string
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 547
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 232 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 532
+      ID: 539
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 227 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 481
+      ID: 488
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 195 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 499
+      ID: 506
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 207 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 659
+      ID: 700
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 383 PointerType *table<context.canceler,struct {}>
+      Element: 421 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 445
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 148 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1406
+      ID: 1413
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1397 PointerType *table<int,*main.deepMap3>
+      Element: 1404 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1450
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -26153,7 +26153,7 @@ Types:
       ByteSize: 8
       Element: 1456 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 448
+      ID: 455
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26165,127 +26165,127 @@ Types:
       ByteSize: 8
       Element: 1471 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 556
+      ID: 563
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 242 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 507
+      ID: 514
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 212 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 709
+      ID: 716
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 691 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 689 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 491
+      ID: 498
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 202 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 479
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 190 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 681
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 407 PointerType *table<string,float64>
+      Element: 384 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1163
+      ID: 1170
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1130 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1137 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 471
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 185 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 675
+      ID: 673
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 402 PointerType *table<string,interface {}>
+      Element: 379 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 456
+      ID: 463
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 180 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 667
+      ID: 665
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 397 PointerType *table<string,string>
+      Element: 374 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 548
+      ID: 555
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 237 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 596
+      ID: 603
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 294 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 604
+      ID: 611
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 299 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 612
+      ID: 619
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 304 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 620
+      ID: 627
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 309 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 628
+      ID: 635
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 314 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 636
+      ID: 643
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 319 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 564
+      ID: 571
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 247 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 524
+      ID: 531
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 222 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 515
+      ID: 522
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26305,9 +26305,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 588 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 595 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 588
+      ID: 595
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26327,9 +26327,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 586 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 593 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 586
+      ID: 593
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26349,9 +26349,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 584 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 591 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 584
+      ID: 591
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26371,9 +26371,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 582 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 589 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 582
+      ID: 589
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26393,9 +26393,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 580 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 587 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 580
+      ID: 587
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26415,9 +26415,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 568 GoSliceDataType [][]uint.array
+      Data: 575 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 568
+      ID: 575
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26438,15 +26438,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 572 GoSliceDataType []bool.array
+      Data: 579 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 572
+      ID: 579
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1142
+      ID: 1149
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487296
@@ -26461,15 +26461,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1165 GoSliceDataType []float64.array
+      Data: 1172 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1165
+      ID: 1172
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 20 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 408
+      ID: 385
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 480960
@@ -26477,22 +26477,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 386 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 685 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 683 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 685
+      ID: 683
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 387 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 411
+      ID: 388
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 481152
@@ -26500,20 +26500,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 412 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 691 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 693
+      ID: 691
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 413 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 390 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
       ID: 358
       Name: '[]go.shape.float64'
@@ -26530,9 +26530,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 650 GoSliceDataType []go.shape.float64.array
+      Data: 657 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 650
+      ID: 657
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26552,9 +26552,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 646 GoSliceDataType []go.shape.int.array
+      Data: 653 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 646
+      ID: 653
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26574,9 +26574,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 648 GoSliceDataType []go.shape.string.array
+      Data: 655 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 648
+      ID: 655
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26619,15 +26619,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 578 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 585 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 578
+      ID: 585
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 276 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 489
+      ID: 496
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 477952
@@ -26635,16 +26635,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 490 PointerType *main.structWithMap
+          Type: 497 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 695 GoSliceDataType []main.structWithMap.array
+      Data: 702 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 695
+      ID: 702
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26664,55 +26664,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 570 GoSliceDataType []main.structWithNoStrings.array
+      Data: 577 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 570
+      ID: 577
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 267 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 541
+      ID: 548
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 537 StructureType noalg.map.group[[4]int][4]int
+      Element: 544 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 533
+      ID: 540
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 529 StructureType noalg.map.group[[4]int]uint8
+      Element: 536 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 489
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 477 StructureType noalg.map.group[[4]string][2]int
+      Element: 484 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 507
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 496 StructureType noalg.map.group[bool]main.node
+      Element: 503 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 660
+      ID: 701
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 655 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 696 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 446
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 433 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 440 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1407
+      ID: 1414
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1401 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1408 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1451
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -26726,11 +26726,11 @@ Types:
       ByteSize: 136
       Element: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 449
+      ID: 456
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 445 StructureType noalg.map.group[int]int
+      Element: 452 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 1479
       Name: '[]noalg.map.group[int]interface {}.array'
@@ -26738,131 +26738,131 @@ Types:
       ByteSize: 200
       Element: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 557
+      ID: 564
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 553 StructureType noalg.map.group[int]struct {}
+      Element: 560 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 508
+      ID: 515
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 504 StructureType noalg.map.group[int]uint8
+      Element: 511 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 710
+      ID: 717
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 711 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 499
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 486 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 493 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 473
+      ID: 480
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 469 StructureType noalg.map.group[string][]string
+      Element: 476 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 684
+      ID: 682
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 680 StructureType noalg.map.group[string]float64
+      Element: 678 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1164
+      ID: 1171
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1167 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 472
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 461 StructureType noalg.map.group[string]int
+      Element: 468 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 676
+      ID: 674
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 672 StructureType noalg.map.group[string]interface {}
+      Element: 670 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 457
+      ID: 464
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 453 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 460 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 668
+      ID: 666
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 664 StructureType noalg.map.group[string]string
+      Element: 662 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 549
+      ID: 556
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 545 StructureType noalg.map.group[struct {}]int
+      Element: 552 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 597
+      ID: 604
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 600 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 605
+      ID: 612
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 608 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 613
+      ID: 620
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 621
+      ID: 628
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 629
+      ID: 636
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 637
+      ID: 644
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 565
+      ID: 572
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 561 StructureType noalg.map.group[struct {}]struct {}
+      Element: 568 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 525
+      ID: 532
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 520 StructureType noalg.map.group[uint8][4]int
+      Element: 527 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 516
+      ID: 523
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 512 StructureType noalg.map.group[uint8]uint8
+      Element: 519 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -26883,9 +26883,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 440 GoSliceDataType []string.array
+      Data: 447 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 440
+      ID: 447
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26905,14 +26905,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 576 GoSliceDataType []struct {}.array
+      Data: 583 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 576
+      ID: 583
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 125 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 638
+      ID: 645
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -26920,22 +26920,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 639 PointerType *time.zone
+          Type: 646 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 697 GoSliceDataType []time.zone.array
+      Data: 704 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 697
+      ID: 704
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 640 StructureType time.zone
+      Element: 647 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 641
+      ID: 648
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 486016
@@ -26943,20 +26943,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 642 PointerType *time.zoneTrans
+          Type: 649 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 699 GoSliceDataType []time.zoneTrans.array
+      Data: 706 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 699
+      ID: 706
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 643 StructureType time.zoneTrans
+      Element: 650 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 262
       Name: '[]uint'
@@ -26973,9 +26973,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 566 GoSliceDataType []uint.array
+      Data: 573 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 566
+      ID: 573
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26996,9 +26996,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 574 GoSliceDataType []uint16.array
+      Data: 581 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 574
+      ID: 581
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -27019,9 +27019,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 421 GoSliceDataType []uint8.array
+      Data: 428 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 421
+      ID: 428
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -27042,19 +27042,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 423 GoSliceDataType []uintptr.array
+      Data: 430 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 423
+      ID: 430
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1304
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 941
+      ID: 948
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 931104
@@ -27069,33 +27069,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 942 GoSliceDataType archive/tar.headerError.array
+      Data: 949 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 942
+      ID: 949
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1232
+      ID: 1239
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1180
+      ID: 1187
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1182
+      ID: 1189
       Name: archive/zip.dirWriter
       GoRuntimeType: 1121728
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1280
+      ID: 1287
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1208
+      ID: 1215
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1569056
@@ -27105,7 +27105,7 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1217
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -27115,15 +27115,15 @@ Types:
       GoRuntimeType: 584544
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1262
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1286
+      ID: 1293
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1335
+      ID: 1342
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -27149,13 +27149,13 @@ Types:
       GoRuntimeType: 584288
       GoKind: 15
     - __kind: BaseType
-      ID: 744
+      ID: 751
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835232
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 745
+      ID: 752
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 835328
@@ -27163,26 +27163,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 747 PointerType *compress/flate.InternalError.str
+          Type: 754 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 746 GoStringDataType compress/flate.InternalError.str
+      Data: 753 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 746
+      ID: 753
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1230
+      ID: 1237
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1183
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1252
+      ID: 1259
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27199,19 +27199,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 373
+      ID: 411
       Name: context.backgroundCtx
       GoRuntimeType: 1801408
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 374 StructureType context.emptyCtx
+          Type: 398 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 364
+      ID: 415
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1967712
@@ -27222,13 +27222,13 @@ Types:
           Type: 155 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 375 StructureType sync.Mutex
+          Type: 365 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 378 StructureType sync/atomic.Value
+          Type: 416 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 379 GoMapType map[context.canceler]struct {}
+          Type: 417 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 15 GoInterfaceType error
@@ -27238,7 +27238,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 658
+      ID: 699
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1112384
@@ -27251,13 +27251,13 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1053
+      ID: 1060
       Name: context.deadlineExceededError
       GoRuntimeType: 1468096
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 374
+      ID: 398
       Name: context.emptyCtx
       GoRuntimeType: 1599936
       GoKind: 25
@@ -27266,7 +27266,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 400
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1825632
@@ -27277,11 +27277,11 @@ Types:
           Type: 155 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 384 GoSubroutineType func() bool
+          Type: 401 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 423
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1618048
@@ -27289,29 +27289,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 364 StructureType context.cancelCtx
+          Type: 415 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 385 PointerType *time.Timer
+          Type: 424 PointerType *time.Timer
         - Name: deadline
           Offset: 88
           Type: 326 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 387
+      ID: 413
       Name: context.todoCtx
       GoRuntimeType: 1801632
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 374 StructureType context.emptyCtx
+          Type: 398 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 407
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1837568
@@ -27329,7 +27329,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 409
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1801184
@@ -27341,81 +27341,81 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 758
+      ID: 765
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837824
       GoKind: 2
     - __kind: BaseType
-      ID: 759
+      ID: 766
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837920
       GoKind: 2
     - __kind: BaseType
-      ID: 760
+      ID: 767
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838016
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1242
+      ID: 1249
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1276
+      ID: 1283
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1315
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1282
+      ID: 1289
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1278
+      ID: 1285
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1274
+      ID: 1281
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 761
+      ID: 768
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838112
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1292
+      ID: 1299
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1264
+      ID: 1271
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 748
+      ID: 755
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835808
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1032
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1361
+      ID: 1368
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 862
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1733952
@@ -27426,34 +27426,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1147 ArrayType [5]uint8
+          Type: 1154 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 980
+      ID: 987
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 994304
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1240
+      ID: 1247
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1247
+      ID: 1254
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1120
+      ID: 1127
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1139
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 927
+      ID: 934
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1736832
@@ -27461,21 +27461,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1131 PointerType *crypto/x509.Certificate
+          Type: 1138 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1150 BaseType crypto/x509.InvalidReason
+          Type: 1157 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 921
+      ID: 928
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1119296
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 923
+      ID: 930
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1603776
@@ -27483,24 +27483,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1131 PointerType *crypto/x509.Certificate
+          Type: 1138 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 757
+      ID: 764
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 837440
       GoKind: 2
     - __kind: BaseType
-      ID: 1150
+      ID: 1157
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 589728
       GoKind: 2
     - __kind: StructureType
-      ID: 1030
+      ID: 1037
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1565056
@@ -27510,13 +27510,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 929
+      ID: 936
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1119552
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 925
+      ID: 932
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1736640
@@ -27524,15 +27524,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1131 PointerType *crypto/x509.Certificate
+          Type: 1138 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1131 PointerType *crypto/x509.Certificate
+          Type: 1138 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 945
+      ID: 952
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1439776
@@ -27542,7 +27542,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 949
+      ID: 956
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1439936
@@ -27552,55 +27552,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 954
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 742
+      ID: 749
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834848
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1198
+      ID: 1205
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 743
+      ID: 750
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 835040
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 821
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1023
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 813
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 819
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 810
+      ID: 817
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 815
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1341
+      ID: 1348
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 816
+      ID: 823
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1423456
@@ -27610,19 +27610,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1206
+      ID: 1213
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 922
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 920
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 754
+      ID: 761
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 837344
@@ -27630,22 +27630,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 756 PointerType *encoding/xml.UnmarshalError.str
+          Type: 763 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 755 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 762 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 755
+      ID: 762
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1319
+      ID: 1326
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27662,11 +27662,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 791
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 990
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27682,15 +27682,15 @@ Types:
       GoRuntimeType: 584480
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1329
+      ID: 1336
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 992
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 994
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27700,7 +27700,7 @@ Types:
       GoRuntimeType: 475456
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 384
+      ID: 401
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 595424
@@ -27745,11 +27745,11 @@ Types:
           Offset: 0
           Type: 332 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 851
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 832
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1732800
@@ -27757,7 +27757,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1140 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1147 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -27765,25 +27765,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 834
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1144
+      ID: 1151
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 831
+      ID: 838
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1115072
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1153
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 736
+      ID: 743
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 834272
@@ -27791,18 +27791,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 738 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 745 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 737 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 744 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 737
+      ID: 744
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1140
+      ID: 1147
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2222688
@@ -27810,7 +27810,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1141 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1148 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27825,7 +27825,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1142 GoSliceHeaderType []float64
+          Type: 1149 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -27834,10 +27834,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1143 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1150 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1145 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1152 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 159 GoSliceHeaderType []string
@@ -27851,13 +27851,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 1141
+      ID: 1148
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 586144
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 733
+      ID: 740
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 834176
@@ -27865,18 +27865,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 742 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 741 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 734
+      ID: 741
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 739
+      ID: 746
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 834368
@@ -27884,30 +27884,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 741 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 748 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 740 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 747 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 740
+      ID: 747
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1220
+      ID: 1227
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1305
+      ID: 1312
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 389
+      ID: 363
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2345920
@@ -27915,7 +27915,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 390 StructureType sync.RWMutex
+          Type: 364 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -27936,13 +27936,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 398 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 375 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 403 GoMapType map[string]float64
+          Type: 380 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -27957,10 +27957,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 408 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 385 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 411 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 388 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -27972,7 +27972,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 414 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 391 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -27995,7 +27995,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 415
+      ID: 392
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2219552
@@ -28006,13 +28006,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 394 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 391 StructureType sync/atomic.Int32
+          Type: 368 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28021,16 +28021,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 418 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 396 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 390 StructureType sync.RWMutex
+          Type: 364 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -28039,12 +28039,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 408 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 385 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 410
+      ID: 387
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1913952
@@ -28061,7 +28061,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28069,20 +28069,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 398
+      ID: 375
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1285120
       GoKind: 21
-      HeaderType: 400 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 377 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1384
+      ID: 1390
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 583264
       GoKind: 10
     - __kind: StructureType
-      ID: 413
+      ID: 390
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1751776
@@ -28096,16 +28096,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 687 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 685 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 692 GoMapType map[string]interface {}
+          Type: 690 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1410
+      ID: 1417
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 708
+      ID: 715
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1914208
@@ -28113,7 +28113,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1408 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1415 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28128,15 +28128,15 @@ Types:
           Type: 20 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1408
+      ID: 1415
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 989312
       GoKind: 5
     - __kind: StructureType
-      ID: 417
+      ID: 395
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2108608
@@ -28144,16 +28144,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 390 StructureType sync.RWMutex
+          Type: 364 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1382 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1388 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -28168,12 +28168,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1384 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1390 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 418
+      ID: 396
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 897600
@@ -28182,15 +28182,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1095
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1337
+      ID: 1344
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1413
+    - __kind: GoContextImplementationType
+      ID: 403
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1631872
@@ -28199,30 +28199,32 @@ Types:
         - Name: Context
           Offset: 0
           Type: 155 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 871
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1118528
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 753
+      ID: 760
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 836480
       GoKind: 2
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1118400
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 867
+      ID: 874
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1601856
@@ -28235,7 +28237,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 887
+      ID: 894
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1602656
@@ -28248,7 +28250,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1736064
@@ -28264,7 +28266,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 889
+      ID: 896
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1433376
@@ -28274,7 +28276,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1433056
@@ -28284,14 +28286,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1126
+      ID: 1133
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1504096
       GoKind: 21
-      HeaderType: 1128 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1135 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1149
+      ID: 1156
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1051424
@@ -28306,15 +28308,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1167 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1174 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1167
+      ID: 1174
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1602976
@@ -28322,12 +28324,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1126 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1133 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1126 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1133 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1433536
@@ -28337,7 +28339,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1736256
@@ -28348,12 +28350,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1156 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1156 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1602816
@@ -28366,7 +28368,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 901
+      ID: 908
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1433696
@@ -28376,7 +28378,7 @@ Types:
           Offset: 0
           Type: 326 GoTimeType time.Time
     - __kind: StructureType
-      ID: 907
+      ID: 914
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1603296
@@ -28389,7 +28391,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 909
+      ID: 916
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1434016
@@ -28399,7 +28401,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 905
+      ID: 912
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1603136
@@ -28412,7 +28414,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 903
+      ID: 910
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1433856
@@ -28422,7 +28424,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 911
+      ID: 918
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1603456
@@ -28435,7 +28437,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 833
+      ID: 840
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1425696
@@ -28445,11 +28447,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1258
+      ID: 1265
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1425856
@@ -28457,21 +28459,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 833 StructureType github.com/cihub/seelog.baseError
+          Type: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1238
+      ID: 1245
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1194
+      ID: 1201
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1228
+      ID: 1235
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 839
+      ID: 846
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1426176
@@ -28479,13 +28481,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 833 StructureType github.com/cihub/seelog.baseError
+          Type: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1295
+      ID: 1302
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1306
+      ID: 1313
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2111072
@@ -28493,12 +28495,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1294 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1301 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 1309
+      ID: 1316
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2134880
@@ -28506,7 +28508,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1294 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1301 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28514,11 +28516,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1196
+      ID: 1203
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 837
+      ID: 844
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1426016
@@ -28526,9 +28528,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 833 StructureType github.com/cihub/seelog.baseError
+          Type: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1426336
@@ -28536,64 +28538,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 833 StructureType github.com/cihub/seelog.baseError
+          Type: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1260
+      ID: 1267
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1301
+      ID: 1308
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1303
+      ID: 1310
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1129
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1045
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1043
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1047
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1049
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1249
+      ID: 1256
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1032
+      ID: 1039
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 847
+      ID: 854
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1427296
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1353
+      ID: 1360
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1103
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1065
+      ID: 1072
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1843392
@@ -28609,11 +28611,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1002
+      ID: 1009
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1706848
@@ -28626,7 +28628,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 1071
+      ID: 1078
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1843840
@@ -28642,13 +28644,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 979
+      ID: 986
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 991136
       GoKind: 8
     - __kind: StructureType
-      ID: 1063
+      ID: 1070
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1843168
@@ -28664,13 +28666,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1151
+      ID: 1158
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 832544
       GoKind: 8
     - __kind: StructureType
-      ID: 1061
+      ID: 1068
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1842944
@@ -28678,15 +28680,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1151 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1158 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1151 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1158 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1069
+      ID: 1076
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1757344
@@ -28699,7 +28701,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1067
+      ID: 1074
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1843616
@@ -28715,11 +28717,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1357
+      ID: 1364
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1075
+      ID: 1082
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1627648
@@ -28729,19 +28731,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1006
+      ID: 1013
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1285632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1004
+      ID: 1011
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1285504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1073
+      ID: 1080
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1757536
@@ -28754,7 +28756,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 766
+      ID: 773
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 839936
@@ -28762,13 +28764,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 768 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 775 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 767 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 774 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 767
+      ID: 774
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -28799,13 +28801,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 645 PointerType *go.shape.string.str
+          Type: 652 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 644 GoStringDataType go.shape.string.str
+      Data: 651 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 644
+      ID: 651
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -28861,11 +28863,11 @@ Types:
           Offset: 32
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1142
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1046
+      ID: 1053
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1451616
@@ -28875,7 +28877,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1226
+      ID: 1233
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1682944
@@ -28883,13 +28885,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1250 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1257 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1317
+      ID: 1324
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1250
+      ID: 1257
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1129280
@@ -28902,7 +28904,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1212
+      ID: 1219
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1574016
@@ -28912,19 +28914,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 769
+      ID: 776
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 840512
       GoKind: 10
     - __kind: BaseType
-      ID: 1133
+      ID: 1140
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1004768
       GoKind: 10
     - __kind: StructureType
-      ID: 1104
+      ID: 1111
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1883264
@@ -28935,12 +28937,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1133 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1140 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 965
+      ID: 972
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1610496
@@ -28948,12 +28950,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1133 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1140 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 773
+      ID: 780
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840704
@@ -28961,18 +28963,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 775 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 782 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 774 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 781 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 774
+      ID: 781
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 779
+      ID: 786
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840896
@@ -28980,18 +28982,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 781 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 788 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 780 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 787 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 780
+      ID: 787
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 776
+      ID: 783
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840800
@@ -28999,18 +29001,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 778 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 785 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 777 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 784 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 777
+      ID: 784
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 770
+      ID: 777
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840608
@@ -29018,22 +29020,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 772 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 779 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 771 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 778 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 771
+      ID: 778
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1315
+      ID: 1322
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 969
+      ID: 976
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1452256
@@ -29043,13 +29045,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 782
+      ID: 789
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 840992
       GoKind: 2
     - __kind: StructureType
-      ID: 957
+      ID: 964
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1447296
@@ -29059,11 +29061,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1109
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1124
+      ID: 1131
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1911168
@@ -29079,7 +29081,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 959
+      ID: 966
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1610016
@@ -29092,7 +29094,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1266
+      ID: 1273
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1968736
@@ -29100,16 +29102,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1293 GoInterfaceType io.Reader
+          Type: 1300 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1224
+      ID: 1231
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1044
+      ID: 1051
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1571616
@@ -29119,29 +29121,29 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1191
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1041
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1107
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1098
+      ID: 1105
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1514656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 951
+      ID: 958
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1440576
@@ -29151,7 +29153,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1440736
@@ -29161,107 +29163,107 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 535
+      ID: 542
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 536 PointerType *noalg.map.group[[4]int][4]int
+          Type: 543 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 537 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 541 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 544 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 548 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 527
+      ID: 534
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 528 PointerType *noalg.map.group[[4]int]uint8
+          Type: 535 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 529 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 533 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 536 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 540 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 475
+      ID: 482
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 476 PointerType *noalg.map.group[[4]string][2]int
+          Type: 483 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 477 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 482 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 484 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 489 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 494
+      ID: 501
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 495 PointerType *noalg.map.group[bool]main.node
+          Type: 502 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 496 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 500 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 503 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 507 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 653
+      ID: 694
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 654 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 695 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 655 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 660 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 696 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 701 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 431
+      ID: 438
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 432 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 439 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 433 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 439 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 440 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 446 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1399
+      ID: 1406
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1400 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1407 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1401 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1407 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1408 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1414 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1443
       Name: groupReference<int,*main.deepMap8>
@@ -29291,19 +29293,19 @@ Types:
       GroupType: 1460 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 1466 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 443
+      ID: 450
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 444 PointerType *noalg.map.group[int]int
+          Type: 451 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 445 StructureType noalg.map.group[int]int
-      GroupSliceType: 449 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 452 StructureType noalg.map.group[int]int
+      GroupSliceType: 456 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 1473
       Name: groupReference<int,interface {}>
@@ -29319,305 +29321,305 @@ Types:
       GroupType: 1475 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 1479 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 551
+      ID: 558
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 552 PointerType *noalg.map.group[int]struct {}
+          Type: 559 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 553 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 557 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 560 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 564 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 502
+      ID: 509
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 503 PointerType *noalg.map.group[int]uint8
+          Type: 510 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 504 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 508 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 511 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 515 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 702
+      ID: 709
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 703 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 710 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 710 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 711 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 717 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 484
+      ID: 491
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 485 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 492 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 486 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 492 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 493 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 499 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 467
+      ID: 474
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 468 PointerType *noalg.map.group[string][]string
+          Type: 475 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 469 StructureType noalg.map.group[string][]string
-      GroupSliceType: 473 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 476 StructureType noalg.map.group[string][]string
+      GroupSliceType: 480 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 678
+      ID: 676
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 679 PointerType *noalg.map.group[string]float64
+          Type: 677 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 680 StructureType noalg.map.group[string]float64
-      GroupSliceType: 684 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 678 StructureType noalg.map.group[string]float64
+      GroupSliceType: 682 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1158
+      ID: 1165
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1159 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1166 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1164 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1167 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1171 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 459
+      ID: 466
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 460 PointerType *noalg.map.group[string]int
+          Type: 467 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 461 StructureType noalg.map.group[string]int
-      GroupSliceType: 465 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 468 StructureType noalg.map.group[string]int
+      GroupSliceType: 472 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 670
+      ID: 668
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 671 PointerType *noalg.map.group[string]interface {}
+          Type: 669 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 672 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 676 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 670 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 674 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 451
+      ID: 458
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 452 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 459 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 453 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 457 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 460 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 464 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 662
+      ID: 660
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 663 PointerType *noalg.map.group[string]string
+          Type: 661 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 664 StructureType noalg.map.group[string]string
-      GroupSliceType: 668 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 662 StructureType noalg.map.group[string]string
+      GroupSliceType: 666 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 543
+      ID: 550
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 544 PointerType *noalg.map.group[struct {}]int
+          Type: 551 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 545 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 549 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 552 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 556 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 591
+      ID: 598
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 592 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 599 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 597 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 600 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 604 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 599
+      ID: 606
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 600 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 607 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 605 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 608 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 612 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 607
+      ID: 614
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 608 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 615 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 613 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 620 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 615
+      ID: 622
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 616 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 623 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 621 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 628 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 623
+      ID: 630
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 624 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 631 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 629 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 636 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 631
+      ID: 638
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 632 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 639 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 637 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 644 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 559
+      ID: 566
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 560 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 567 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 561 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 565 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 568 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 572 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 518
+      ID: 525
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 519 PointerType *noalg.map.group[uint8][4]int
+          Type: 526 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 520 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 525 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 527 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 532 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 510
+      ID: 517
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 511 PointerType *noalg.map.group[uint8]uint8
+          Type: 518 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 512 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 516 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 519 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 523 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1272
+      ID: 1279
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 979
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29664,7 +29666,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29690,29 +29692,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 856
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1174
+      ID: 1181
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1101
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1359
+      ID: 1366
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1092
+      ID: 1099
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1493536
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 796
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29793,7 +29795,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 377
+      ID: 367
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1490976
@@ -29806,11 +29808,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1216
+      ID: 1223
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1256
+      ID: 1263
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1192896
@@ -29823,7 +29825,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1293
+      ID: 1300
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1025056
@@ -29836,7 +29838,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1245
+      ID: 1252
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1111872
@@ -29862,21 +29864,21 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1214
+      ID: 1221
       Name: io.discard
       GoRuntimeType: 1467776
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1188
+      ID: 1195
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1097
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1262
+      ID: 1269
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -29970,7 +29972,7 @@ Types:
           Offset: 0
           Type: 144 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 437
+      ID: 444
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1189056
@@ -29978,9 +29980,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1393 GoMapType map[int]*main.deepMap3
+          Type: 1400 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1405
+      ID: 1412
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -30032,9 +30034,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1362 PointerType *main.deepPtr3
+          Type: 1369 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1363
+      ID: 1370
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -30078,7 +30080,7 @@ Types:
           Offset: 0
           Type: 138 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 427
+      ID: 434
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1191360
@@ -30086,9 +30088,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1387 GoSliceHeaderType []*main.deepSlice3
+          Type: 1394 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1390
+      ID: 1397
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -30138,16 +30140,16 @@ Types:
           Type: 160 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 375 StructureType sync.Mutex
+          Type: 365 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1370 StructureType sync.Once
+          Type: 1377 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1372 StructureType sync.WaitGroup
+          Type: 1379 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 391 StructureType sync/atomic.Int32
+          Type: 368 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 160
       Name: main.esotericStack
@@ -30565,9 +30567,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1367 ArrayType [63]uint64
+          Type: 1374 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1377
+      ID: 1384
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1416896
@@ -30587,7 +30589,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1369
+      ID: 1376
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30598,18 +30600,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1365 PointerType *main.stringType1.str
+          Type: 1372 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1364 GoStringDataType main.stringType1.str
+      Data: 1371 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1364
+      ID: 1371
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1366
+      ID: 1373
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
@@ -30738,16 +30740,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1378 PointerType **main.t
+          Type: 1385 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1379 GoSliceDataType main.t.array
+      Data: 1386 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1379
+      ID: 1386
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -30904,8 +30906,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 540 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 537 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 547 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 544 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 225
       Name: map<[4]int,uint8>
@@ -30936,8 +30938,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 532 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 529 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 539 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 536 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 193
       Name: map<[4]string,[2]int>
@@ -30968,8 +30970,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 481 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 477 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 488 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 484 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 205
       Name: map<bool,main.node>
@@ -31000,10 +31002,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 499 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 496 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 506 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 503 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 381
+      ID: 419
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -31016,7 +31018,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 382 PointerType **table<context.canceler,struct {}>
+          Type: 420 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31032,8 +31034,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 659 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 655 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 700 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 696 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 146
       Name: map<int,*main.deepMap2>
@@ -31064,10 +31066,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 438 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 433 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 445 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 440 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1395
+      ID: 1402
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -31080,7 +31082,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1396 PointerType **table<int,*main.deepMap3>
+          Type: 1403 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31096,8 +31098,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1406 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1401 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1413 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1408 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1439
       Name: map<int,*main.deepMap8>
@@ -31192,8 +31194,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 448 GoSliceDataType []*table<int,int>.array
-      GroupType: 445 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 455 GoSliceDataType []*table<int,int>.array
+      GroupType: 452 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 1469
       Name: map<int,interface {}>
@@ -31256,8 +31258,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 556 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 553 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 563 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 560 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 210
       Name: map<int,uint8>
@@ -31288,10 +31290,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 507 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 504 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 514 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 511 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 689
+      ID: 687
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -31304,7 +31306,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 690 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 688 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31320,8 +31322,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 709 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 716 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 711 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 200
       Name: map<string,[]main.structWithMap>
@@ -31352,8 +31354,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 491 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 486 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 498 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 493 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 188
       Name: map<string,[]string>
@@ -31384,10 +31386,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 472 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 469 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 479 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 476 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 405
+      ID: 382
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -31400,7 +31402,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 406 PointerType **table<string,float64>
+          Type: 383 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31416,10 +31418,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 683 GoSliceDataType []*table<string,float64>.array
-      GroupType: 680 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 681 GoSliceDataType []*table<string,float64>.array
+      GroupType: 678 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1128
+      ID: 1135
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31432,7 +31434,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1129 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1136 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31448,8 +31450,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1163 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1170 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1167 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 183
       Name: map<string,int>
@@ -31480,10 +31482,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 464 GoSliceDataType []*table<string,int>.array
-      GroupType: 461 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 471 GoSliceDataType []*table<string,int>.array
+      GroupType: 468 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 400
+      ID: 377
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31496,7 +31498,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 401 PointerType **table<string,interface {}>
+          Type: 378 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31512,8 +31514,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 675 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 672 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 673 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 670 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 178
       Name: map<string,main.nestedStruct>
@@ -31544,10 +31546,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 456 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 453 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 463 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 460 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 395
+      ID: 372
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -31560,7 +31562,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 396 PointerType **table<string,string>
+          Type: 373 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31576,8 +31578,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 667 GoSliceDataType []*table<string,string>.array
-      GroupType: 664 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 665 GoSliceDataType []*table<string,string>.array
+      GroupType: 662 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 235
       Name: map<struct {},int>
@@ -31608,8 +31610,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 548 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 545 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 555 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 552 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 292
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31640,8 +31642,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 596 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 603 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 600 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 297
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31672,8 +31674,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 604 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 611 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 608 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 302
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31704,8 +31706,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 612 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 619 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 307
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31736,8 +31738,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 620 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 627 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 312
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31768,8 +31770,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 628 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 635 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 317
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31800,8 +31802,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 636 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 643 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 245
       Name: map<struct {},struct {}>
@@ -31832,8 +31834,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 564 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 561 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 571 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 568 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 220
       Name: map<uint8,[4]int>
@@ -31864,8 +31866,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 524 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 520 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 531 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 527 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 215
       Name: map<uint8,uint8>
@@ -31896,8 +31898,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 515 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 512 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 522 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 519 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 228
       Name: map[[4]int][4]int
@@ -31927,12 +31929,12 @@ Types:
       GoKind: 21
       HeaderType: 205 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 379
+      ID: 417
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1133504
       GoKind: 21
-      HeaderType: 381 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 419 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 144
       Name: map[int]*main.deepMap2
@@ -31941,12 +31943,12 @@ Types:
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1393
+      ID: 1400
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1131072
       GoKind: 21
-      HeaderType: 1395 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1402 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1437
       Name: map[int]*main.deepMap8
@@ -31990,12 +31992,12 @@ Types:
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 687
+      ID: 685
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1133760
       GoKind: 21
-      HeaderType: 689 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 687 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 198
       Name: map[string][]main.structWithMap
@@ -32011,12 +32013,12 @@ Types:
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 403
+      ID: 380
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1133632
       GoKind: 21
-      HeaderType: 405 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 382 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 181
       Name: map[string]int
@@ -32025,12 +32027,12 @@ Types:
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 692
+      ID: 690
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1130048
       GoKind: 21
-      HeaderType: 400 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 377 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 176
       Name: map[string]main.nestedStruct
@@ -32039,12 +32041,12 @@ Types:
       GoKind: 21
       HeaderType: 178 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 393
+      ID: 370
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1133376
       GoKind: 21
-      HeaderType: 395 GoSwissMapHeaderType map<string,string>
+      HeaderType: 372 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 233
       Name: map[struct {}]int
@@ -32110,7 +32112,7 @@ Types:
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 883
+      ID: 890
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1432736
@@ -32120,7 +32122,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1178
+      ID: 1185
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1429536
@@ -32130,11 +32132,11 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1089
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1148
+      ID: 1155
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1600576
@@ -32147,35 +32149,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1120
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1323
+      ID: 1330
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1118
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1091
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1333
+      ID: 1340
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1343
+      ID: 1350
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1331
+      ID: 1338
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1049
+      ID: 1056
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1114688
@@ -32183,28 +32185,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1051 PointerType *net.UnknownNetworkError.str
+          Type: 1058 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1050 GoStringDataType net.UnknownNetworkError.str
+      Data: 1057 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1050
+      ID: 1057
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1018
+      ID: 1025
       Name: net.canceledError
       GoRuntimeType: 1286528
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1299
+      ID: 1306
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1153
+      ID: 1160
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2110368
@@ -32212,7 +32214,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -32223,27 +32225,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1345
+      ID: 1352
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1339
+      ID: 1346
       Name: net.noReadFrom
       GoRuntimeType: 1114944
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1338
+      ID: 1345
       Name: net.noWriteTo
       GoRuntimeType: 1114816
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1415
+    - __kind: GoContextImplementationType
+      ID: 405
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1762336
@@ -32255,8 +32257,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 155 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 820
+      ID: 827
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1732608
@@ -32264,7 +32268,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1136 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1143 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -32272,7 +32276,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1327
+      ID: 1334
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2295104
@@ -32280,12 +32284,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1339 StructureType net.noReadFrom
+          Type: 1346 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1332 PointerType *net.TCPConn
+          Type: 1339 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1325
+      ID: 1332
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2294560
@@ -32293,24 +32297,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1338 StructureType net.noWriteTo
+          Type: 1345 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1332 PointerType *net.TCPConn
+          Type: 1339 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1086
+      ID: 1093
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1122
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1015
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1170
+      ID: 1177
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1421216
@@ -32320,19 +32324,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 714
+      ID: 721
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 833024
       GoKind: 10
     - __kind: BaseType
-      ID: 1125
+      ID: 1132
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 991232
       GoKind: 10
     - __kind: StructureType
-      ID: 796
+      ID: 803
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1731264
@@ -32343,12 +32347,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1125 BaseType net/http.http2ErrCode
+          Type: 1132 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1107
+      ID: 1114
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1902464
@@ -32359,12 +32363,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1125 BaseType net/http.http2ErrCode
+          Type: 1132 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 800
+      ID: 807
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1600256
@@ -32372,16 +32376,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1125 BaseType net/http.http2ErrCode
+          Type: 1132 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1234
+      ID: 1241
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 718
+      ID: 725
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833216
@@ -32389,18 +32393,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 720 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 727 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 719 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 726 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 719
+      ID: 726
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 724
+      ID: 731
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833408
@@ -32408,18 +32412,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 726 PointerType *net/http.http2headerFieldNameError.str
+          Type: 733 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 725 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 732 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 725
+      ID: 732
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 721
+      ID: 728
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 833312
@@ -32427,32 +32431,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 723 PointerType *net/http.http2headerFieldValueError.str
+          Type: 730 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 722 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 729 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 722
+      ID: 729
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1086
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1014
+      ID: 1021
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1285888
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1288
+      ID: 1295
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 715
+      ID: 722
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833120
@@ -32460,18 +32464,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 717 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 724 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 716 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 723 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 716
+      ID: 723
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1172
+      ID: 1179
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1826752
@@ -32479,18 +32483,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1267 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1274 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1268 BaseType time.Duration
+          Type: 1275 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1267
+      ID: 1274
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1420576
@@ -32503,14 +32507,14 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1253
+      ID: 1260
       Name: net/http.incomparable
       GoRuntimeType: 902496
       GoKind: 17
       HasCount: true
       Element: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1010
+      ID: 1017
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1559136
@@ -32520,11 +32524,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1243
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1192
+      ID: 1199
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1558976
@@ -32532,9 +32536,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1235 PointerType *net/http.persistConn
+          Type: 1242 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1218
+      ID: 1225
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1803200
@@ -32542,15 +32546,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1253 ArrayType net/http.incomparable
+          Type: 1260 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1254 PointerType *bufio.Reader
+          Type: 1261 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1256 GoInterfaceType io.ReadWriteCloser
+          Type: 1263 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 804
+      ID: 811
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1422176
@@ -32560,17 +32564,17 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1116
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1077
+      ID: 1084
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1480096
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1012
+      ID: 1019
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1559296
@@ -32580,7 +32584,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1270
+      ID: 1277
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2028640
@@ -32588,16 +32592,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1290
+      ID: 1297
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2044672
@@ -32605,13 +32609,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1285 PointerType *bufio.Writer
+          Type: 1292 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1202
+      ID: 1209
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1735680
@@ -32627,7 +32631,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 873
+      ID: 880
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1602016
@@ -32640,11 +32644,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1244
+      ID: 1251
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1204
+      ID: 1211
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1603936
@@ -32652,16 +32656,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1243 PointerType *net/smtp.Client
+          Type: 1250 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1245 GoInterfaceType io.WriteCloser
+          Type: 1252 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 866
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 756
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835904
@@ -32669,26 +32673,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *net/textproto.ProtocolError.str
+          Type: 758 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 750 GoStringDataType net/textproto.ProtocolError.str
+      Data: 757 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 757
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1200
+      ID: 1207
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1124
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 727
+      ID: 734
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 833888
@@ -32696,18 +32700,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 729 PointerType *net/url.EscapeError.str
+          Type: 736 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 728 GoStringDataType net/url.EscapeError.str
+      Data: 735 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 728
+      ID: 735
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 730
+      ID: 737
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 833984
@@ -32715,79 +32719,79 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 732 PointerType *net/url.InvalidHostError.str
+          Type: 739 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 731 GoStringDataType net/url.InvalidHostError.str
+      Data: 738 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 731
+      ID: 738
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 538
+      ID: 545
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 683168
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 539 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 546 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 530
+      ID: 537
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 683264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 531 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 538 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 478
+      ID: 485
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 479 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 486 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 497
+      ID: 504
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 683648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 498 StructureType noalg.struct { key bool; elem main.node }
+      Element: 505 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 656
+      ID: 697
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 689216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 657 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 698 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 434
+      ID: 441
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 682400
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 435 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 442 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1402
+      ID: 1409
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1403 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1410 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1446
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -32807,14 +32811,14 @@ Types:
       HasCount: true
       Element: 1462 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 446
+      ID: 453
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 680480
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 447 StructureType noalg.struct { key int; elem int }
+      Element: 454 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 1476
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -32825,189 +32829,189 @@ Types:
       HasCount: true
       Element: 1477 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 554
+      ID: 561
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 683744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 555 StructureType noalg.struct { key int; elem struct {} }
+      Element: 562 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 505
+      ID: 512
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 683840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 506 StructureType noalg.struct { key int; elem uint8 }
+      Element: 513 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 705
+      ID: 712
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 689856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 706 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 713 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 487
+      ID: 494
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 488 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 495 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 470
+      ID: 477
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 471 StructureType noalg.struct { key string; elem []string }
+      Element: 478 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 681
+      ID: 679
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 689760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 682 StructureType noalg.struct { key string; elem float64 }
+      Element: 680 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1161
+      ID: 1168
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 758848
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1162 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1169 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 462
+      ID: 469
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 684128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 463 StructureType noalg.struct { key string; elem int }
+      Element: 470 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 673
+      ID: 671
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 681248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 674 StructureType noalg.struct { key string; elem interface {} }
+      Element: 672 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 454
+      ID: 461
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 684224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 455 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 462 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 665
+      ID: 663
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 687392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 666 StructureType noalg.struct { key string; elem string }
+      Element: 664 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 546
+      ID: 553
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 684320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 547 StructureType noalg.struct { key struct {}; elem int }
+      Element: 554 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 594
+      ID: 601
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 595 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 602 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 602
+      ID: 609
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 603 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 610 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 610
+      ID: 617
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 611 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 618 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 618
+      ID: 625
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 619 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 626 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 626
+      ID: 633
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 627 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 634 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 634
+      ID: 641
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 635 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 642 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 562
+      ID: 569
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 684416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 563 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 570 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 521
+      ID: 528
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 684512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 522 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 529 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 513
+      ID: 520
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 684608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 514 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 521 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 537
+      ID: 544
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1298176
@@ -33018,9 +33022,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 538 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 545 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 529
+      ID: 536
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1298432
@@ -33031,9 +33035,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 530 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 537 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 477
+      ID: 484
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1298688
@@ -33044,9 +33048,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 478 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 485 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 496
+      ID: 503
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1298944
@@ -33057,9 +33061,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 497 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 504 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 655
+      ID: 696
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1303040
@@ -33070,9 +33074,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 656 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 697 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 433
+      ID: 440
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1297920
@@ -33083,9 +33087,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 434 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 441 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1401
+      ID: 1408
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1297664
@@ -33096,7 +33100,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1402 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1409 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1445
       Name: noalg.map.group[int]*main.deepMap8
@@ -33124,7 +33128,7 @@ Types:
           Offset: 8
           Type: 1461 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 445
+      ID: 452
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1294848
@@ -33135,7 +33139,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 446 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 453 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 1475
       Name: noalg.map.group[int]interface {}
@@ -33150,7 +33154,7 @@ Types:
           Offset: 8
           Type: 1476 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 553
+      ID: 560
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1299200
@@ -33161,9 +33165,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 554 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 561 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 504
+      ID: 511
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1299456
@@ -33174,9 +33178,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 505 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 512 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 704
+      ID: 711
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1303936
@@ -33187,9 +33191,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 705 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 712 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1299712
@@ -33200,9 +33204,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 487 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 494 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 469
+      ID: 476
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1299968
@@ -33213,9 +33217,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 470 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 477 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 680
+      ID: 678
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1303680
@@ -33226,9 +33230,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 681 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 679 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1160
+      ID: 1167
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1361920
@@ -33239,9 +33243,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1161 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1168 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 461
+      ID: 468
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1300224
@@ -33252,9 +33256,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 462 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 469 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 672
+      ID: 670
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1295616
@@ -33265,9 +33269,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 673 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 671 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 453
+      ID: 460
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1300480
@@ -33278,9 +33282,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 454 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 461 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 664
+      ID: 662
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1302272
@@ -33291,9 +33295,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 665 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 663 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 545
+      ID: 552
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1300736
@@ -33304,9 +33308,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 546 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 553 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 593
+      ID: 600
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -33316,9 +33320,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 594 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 601 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 601
+      ID: 608
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33328,9 +33332,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 602 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 609 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 609
+      ID: 616
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33340,9 +33344,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 610 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 617 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 617
+      ID: 624
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33352,9 +33356,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 618 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 625 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 625
+      ID: 632
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33364,9 +33368,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 626 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 633 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 633
+      ID: 640
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33376,9 +33380,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 634 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 641 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 561
+      ID: 568
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1300992
@@ -33389,9 +33393,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 562 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 569 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 520
+      ID: 527
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1301248
@@ -33402,9 +33406,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 521 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 528 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 512
+      ID: 519
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1301504
@@ -33415,9 +33419,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 513 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 520 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 539
+      ID: 546
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1298048
@@ -33425,12 +33429,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 523 ArrayType [4]int
+          Type: 530 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 523 ArrayType [4]int
+          Type: 530 ArrayType [4]int
     - __kind: StructureType
-      ID: 531
+      ID: 538
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1298304
@@ -33438,12 +33442,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 523 ArrayType [4]int
+          Type: 530 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 479
+      ID: 486
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1298560
@@ -33451,12 +33455,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 480 ArrayType [4]string
+          Type: 487 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 113 ArrayType [2]int
     - __kind: StructureType
-      ID: 498
+      ID: 505
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1298816
@@ -33469,7 +33473,7 @@ Types:
           Offset: 8
           Type: 251 StructureType main.node
     - __kind: StructureType
-      ID: 657
+      ID: 698
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1302912
@@ -33477,12 +33481,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 658 GoInterfaceType context.canceler
+          Type: 699 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 435
+      ID: 442
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1297792
@@ -33493,9 +33497,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 436 PointerType *main.deepMap2
+          Type: 443 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1403
+      ID: 1410
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1297536
@@ -33506,7 +33510,7 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1404 PointerType *main.deepMap3
+          Type: 1411 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1447
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -33534,7 +33538,7 @@ Types:
           Offset: 8
           Type: 1463 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 447
+      ID: 454
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1294720
@@ -33560,7 +33564,7 @@ Types:
           Offset: 8
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 555
+      ID: 562
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1299072
@@ -33573,7 +33577,7 @@ Types:
           Offset: 8
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 506
+      ID: 513
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1299328
@@ -33586,7 +33590,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 706
+      ID: 713
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1303808
@@ -33597,9 +33601,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 707 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 714 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 488
+      ID: 495
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1299584
@@ -33610,9 +33614,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 489 GoSliceHeaderType []main.structWithMap
+          Type: 496 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 471
+      ID: 478
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1299840
@@ -33625,7 +33629,7 @@ Types:
           Offset: 16
           Type: 159 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 682
+      ID: 680
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1303552
@@ -33638,7 +33642,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 1162
+      ID: 1169
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1361792
@@ -33649,9 +33653,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1156 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 463
+      ID: 470
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1300096
@@ -33664,7 +33668,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 674
+      ID: 672
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1295488
@@ -33677,7 +33681,7 @@ Types:
           Offset: 16
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 455
+      ID: 462
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1300352
@@ -33690,7 +33694,7 @@ Types:
           Offset: 16
           Type: 123 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 666
+      ID: 664
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1302144
@@ -33703,7 +33707,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 547
+      ID: 554
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1300608
@@ -33716,7 +33720,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 595
+      ID: 602
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -33728,7 +33732,7 @@ Types:
           Offset: 0
           Type: 289 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 603
+      ID: 610
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33740,7 +33744,7 @@ Types:
           Offset: 0
           Type: 290 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 611
+      ID: 618
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33752,7 +33756,7 @@ Types:
           Offset: 0
           Type: 295 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 619
+      ID: 626
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33764,7 +33768,7 @@ Types:
           Offset: 0
           Type: 300 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 627
+      ID: 634
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33776,7 +33780,7 @@ Types:
           Offset: 0
           Type: 305 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 635
+      ID: 642
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33788,7 +33792,7 @@ Types:
           Offset: 0
           Type: 310 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 563
+      ID: 570
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1300864
       GoKind: 25
@@ -33800,7 +33804,7 @@ Types:
           Offset: 0
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 522
+      ID: 529
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1301120
@@ -33811,9 +33815,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 523 ArrayType [4]int
+          Type: 530 ArrayType [4]int
     - __kind: StructureType
-      ID: 514
+      ID: 521
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1301376
@@ -33826,19 +33830,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1351
+      ID: 1358
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 998
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1349
+      ID: 1356
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2363712
@@ -33846,12 +33850,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1355 StructureType os.noReadFrom
+          Type: 1362 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1350 PointerType *os.File
+          Type: 1357 PointerType *os.File
     - __kind: StructureType
-      ID: 1347
+      ID: 1354
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2362912
@@ -33859,36 +33863,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1354 StructureType os.noWriteTo
+          Type: 1361 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1350 PointerType *os.File
+          Type: 1357 PointerType *os.File
     - __kind: StructureType
-      ID: 1355
+      ID: 1362
       Name: os.noReadFrom
       GoRuntimeType: 1113152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1354
+      ID: 1361
       Name: os.noWriteTo
       GoRuntimeType: 1113024
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1020
+      ID: 1027
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1163
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1222
+      ID: 1229
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1029
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1707424
@@ -33901,7 +33905,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 763
+      ID: 770
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 839168
@@ -33909,36 +33913,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 765 PointerType *os/user.UnknownGroupIdError.str
+          Type: 772 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 764 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 771 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 764
+      ID: 771
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 762
+      ID: 769
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 839072
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 791
+      ID: 798
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 888
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 995
+      ID: 1002
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1006
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -33950,7 +33954,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 997
+      ID: 1004
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1890880
@@ -33967,9 +33971,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1154 BaseType runtime.boundsErrorCode
+          Type: 1161 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1154
+      ID: 1161
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 584672
@@ -33989,7 +33993,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1057
+      ID: 1064
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1755424
@@ -34002,7 +34006,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 973
+      ID: 980
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 990368
@@ -34010,13 +34014,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 975 PointerType *runtime.errorString.str
+          Type: 982 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 974 GoStringDataType runtime.errorString.str
+      Data: 981 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 974
+      ID: 981
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34672,7 +34676,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 976
+      ID: 983
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 990464
@@ -34680,13 +34684,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 978 PointerType *runtime.plainError.str
+          Type: 985 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 977 GoStringDataType runtime.plainError.str
+      Data: 984 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 977
+      ID: 984
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34772,7 +34776,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 996
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -34784,26 +34788,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 420 PointerType *string.str
+          Type: 427 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 419 GoStringDataType string.str
+      Data: 426 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 419
+      ID: 426
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1284
+      ID: 1291
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1190
+      ID: 1197
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1186
+      ID: 1193
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1459456
@@ -34819,7 +34823,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 375
+      ID: 365
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1470816
@@ -34827,12 +34831,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 376 StructureType sync.noCopy
+          Type: 366 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 377 StructureType internal/sync.Mutex
+          Type: 367 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1370
+      ID: 1377
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1620352
@@ -34840,15 +34844,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 376 StructureType sync.noCopy
+          Type: 366 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1371 StructureType sync/atomic.Uint32
+          Type: 1378 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 375 StructureType sync.Mutex
+          Type: 365 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 390
+      ID: 364
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1840256
@@ -34856,7 +34860,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 375 StructureType sync.Mutex
+          Type: 365 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -34865,12 +34869,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 391 StructureType sync/atomic.Int32
+          Type: 368 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 391 StructureType sync/atomic.Int32
+          Type: 368 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1372
+      ID: 1379
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1620544
@@ -34878,21 +34882,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 376 StructureType sync.noCopy
+          Type: 366 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1373 StructureType sync/atomic.Uint64
+          Type: 1380 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 376
+      ID: 366
       Name: sync.noCopy
       GoRuntimeType: 989984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 391
+      ID: 368
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1472096
@@ -34900,12 +34904,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 392 StructureType sync/atomic.noCopy
+          Type: 369 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1371
+      ID: 1378
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1472256
@@ -34913,12 +34917,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 392 StructureType sync/atomic.noCopy
+          Type: 369 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1373
+      ID: 1380
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1620928
@@ -34926,15 +34930,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 392 StructureType sync/atomic.noCopy
+          Type: 369 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1374 StructureType sync/atomic.align64
+          Type: 1381 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 378
+      ID: 416
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1197248
@@ -34944,25 +34948,25 @@ Types:
           Offset: 0
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1374
+      ID: 1381
       Name: sync/atomic.align64
       GoRuntimeType: 990176
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 392
+      ID: 369
       Name: sync/atomic.noCopy
       GoRuntimeType: 990080
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1105
+      ID: 1112
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1287936
       GoKind: 12
     - __kind: StructureType
-      ID: 534
+      ID: 541
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -34984,9 +34988,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 535 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 542 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 526
+      ID: 533
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35008,9 +35012,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 527 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 534 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 474
+      ID: 481
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -35032,9 +35036,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 475 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 482 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 493
+      ID: 500
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -35056,9 +35060,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 494 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 501 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 652
+      ID: 693
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35080,9 +35084,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 653 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 694 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 430
+      ID: 437
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -35104,9 +35108,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 431 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 438 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1398
+      ID: 1405
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -35128,7 +35132,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1399 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1406 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1442
       Name: table<int,*main.deepMap8>
@@ -35178,7 +35182,7 @@ Types:
           Offset: 16
           Type: 1458 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 442
+      ID: 449
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -35200,7 +35204,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 443 GoSwissMapGroupsType groupReference<int,int>
+          Type: 450 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 1472
       Name: table<int,interface {}>
@@ -35226,7 +35230,7 @@ Types:
           Offset: 16
           Type: 1473 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 550
+      ID: 557
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35248,9 +35252,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 551 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 558 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 501
+      ID: 508
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35272,9 +35276,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 502 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 509 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 701
+      ID: 708
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -35296,9 +35300,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 702 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 709 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 483
+      ID: 490
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -35320,9 +35324,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 484 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 491 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 466
+      ID: 473
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35344,9 +35348,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 467 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 474 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 677
+      ID: 675
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35368,9 +35372,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 678 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 676 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1157
+      ID: 1164
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35392,9 +35396,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1158 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1165 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 458
+      ID: 465
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35416,9 +35420,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 459 GoSwissMapGroupsType groupReference<string,int>
+          Type: 466 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 669
+      ID: 667
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35440,9 +35444,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 670 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 668 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 450
+      ID: 457
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -35464,9 +35468,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 451 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 458 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 661
+      ID: 659
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -35488,9 +35492,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 662 GoSwissMapGroupsType groupReference<string,string>
+          Type: 660 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 542
+      ID: 549
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -35512,9 +35516,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 543 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 550 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 590
+      ID: 597
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35536,9 +35540,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 591 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 598 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 598
+      ID: 605
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35560,9 +35564,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 599 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 606 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 606
+      ID: 613
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35584,9 +35588,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 607 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 614 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 614
+      ID: 621
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35608,9 +35612,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 615 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 622 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 622
+      ID: 629
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35632,9 +35636,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 623 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 630 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 630
+      ID: 637
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35656,9 +35660,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 631 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 638 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 558
+      ID: 565
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35680,9 +35684,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 559 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 566 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 517
+      ID: 524
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35704,9 +35708,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 518 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 525 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 509
+      ID: 516
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35728,13 +35732,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 510 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 517 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1321
+      ID: 1328
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1048
+      ID: 1055
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1711840
@@ -35747,7 +35751,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 1268
+      ID: 1275
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1915744
@@ -35764,10 +35768,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 638 GoSliceHeaderType []time.zone
+          Type: 645 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 641 GoSliceHeaderType []time.zoneTrans
+          Type: 648 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -35779,9 +35783,9 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 639 PointerType *time.zone
+          Type: 646 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 787
+      ID: 794
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
@@ -35809,7 +35813,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 386
+      ID: 425
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1472896
@@ -35817,12 +35821,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1381 GoChannelType <-chan time.Time
+          Type: 1393 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 711
+      ID: 718
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 831488
@@ -35830,18 +35834,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 713 PointerType *time.fileSizeError.str
+          Type: 720 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 712 GoStringDataType time.fileSizeError.str
+      Data: 719 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 712
+      ID: 719
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1621888
@@ -35857,7 +35861,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 643
+      ID: 650
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1754272
@@ -35918,7 +35922,7 @@ Types:
       GoRuntimeType: 584608
       GoKind: 26
     - __kind: StructureType
-      ID: 1136
+      ID: 1143
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2066080
@@ -35929,10 +35933,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1137 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1144 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1138 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1145 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -35947,18 +35951,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1139 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1146 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1139
+      ID: 1146
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995936
       GoKind: 9
     - __kind: StructureType
-      ID: 1137
+      ID: 1144
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1927776
@@ -35983,21 +35987,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1138
+      ID: 1145
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588256
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1313
+      ID: 1320
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 861
+      ID: 868
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1429856
@@ -36007,13 +36011,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 752
+      ID: 759
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836000
       GoKind: 2
     - __kind: StructureType
-      ID: 1027
+      ID: 1034
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1707616
@@ -36026,7 +36030,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 981
+      ID: 988
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 994784

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -11549,21 +11549,21 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1402
+      ID: 1408
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 395 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 141
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 142 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1407
+      ID: 1414
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1408 PointerType *main.deepSlice3
+      Pointee: 1415 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1442
       Name: '**main.deepSlice8'
@@ -11581,7 +11581,7 @@ Types:
       GoKind: 22
       Pointee: 156 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1397
+      ID: 1404
       Name: '**main.t'
       ByteSize: 8
       Pointee: 255 PointerType *main.t
@@ -11619,20 +11619,20 @@ Types:
       ByteSize: 8
       Pointee: 209 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 384
+      ID: 422
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 385 PointerType *table<context.canceler,struct {}>
+      Pointee: 423 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 149
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 150 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1415
+      ID: 1422
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1416 PointerType *table<int,*main.deepMap3>
+      Pointee: 1423 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1459
       Name: '**table<int,*main.deepMap8>'
@@ -11664,10 +11664,10 @@ Types:
       ByteSize: 8
       Pointee: 214 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 695
+      ID: 693
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 696 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 694 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 203
       Name: '**table<string,[]main.structWithMap>'
@@ -11679,35 +11679,35 @@ Types:
       ByteSize: 8
       Pointee: 192 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 408
+      ID: 385
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 409 PointerType *table<string,float64>
+      Pointee: 386 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1148
+      ID: 1155
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1149 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1156 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 186
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 187 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 403
+      ID: 380
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 404 PointerType *table<string,interface {}>
+      Pointee: 381 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 181
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 182 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 398
+      ID: 375
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 399 PointerType *table<string,string>
+      Pointee: 376 PointerType *table<string,string>
     - __kind: PointerType
       ID: 238
       Name: '**table<struct {},int>'
@@ -11759,20 +11759,20 @@ Types:
       ByteSize: 8
       Pointee: 219 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1405
+      ID: 1411
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1404 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1410 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 434
+      ID: 441
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 433 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 440 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1411
+      ID: 1418
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1410 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1417 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1446
       Name: '*[]*main.deepSlice8.array'
@@ -11784,100 +11784,100 @@ Types:
       ByteSize: 8
       Pointee: 1451 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 429
+      ID: 436
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 428 GoSliceDataType []*runtime.p.array
+      Pointee: 435 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 431
+      ID: 438
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 430 GoSliceDataType []*string.array
+      Pointee: 437 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 594
+      ID: 601
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 593 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 600 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 591 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 598 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 590
+      ID: 597
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 589 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 596 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 588
+      ID: 595
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 587 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 594 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 586
+      ID: 593
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 585 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 592 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 574
+      ID: 581
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 573 GoSliceDataType [][]uint.array
+      Pointee: 580 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 578
+      ID: 585
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 577 GoSliceDataType []bool.array
+      Pointee: 584 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1185
+      ID: 1192
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1184 GoSliceDataType []float64.array
+      Pointee: 1191 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 691
+      ID: 689
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 690 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 688 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 699
+      ID: 697
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 696 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 655 GoSliceDataType []go.shape.float64.array
+      Pointee: 662 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 652
+      ID: 659
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 651 GoSliceDataType []go.shape.int.array
+      Pointee: 658 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 653 GoSliceDataType []go.shape.string.array
+      Pointee: 660 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
       ID: 1455
       Name: '*[]interface {}.array'
@@ -11889,20 +11889,20 @@ Types:
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 584
+      ID: 591
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 583 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 590 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 701
+      ID: 708
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 700 GoSliceDataType []main.structWithMap.array
+      Pointee: 707 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 576
+      ID: 583
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 575 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 582 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -11911,111 +11911,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 446
+      ID: 453
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 445 GoSliceDataType []string.array
+      Pointee: 452 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 582
+      ID: 589
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 581 GoSliceDataType []struct {}.array
+      Pointee: 588 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 703
+      ID: 710
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 702 GoSliceDataType []time.zone.array
+      Pointee: 709 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 705
+      ID: 712
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 704 GoSliceDataType []time.zoneTrans.array
+      Pointee: 711 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 266
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 264 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 572
+      ID: 579
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 571 GoSliceDataType []uint.array
+      Pointee: 578 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 580
+      ID: 587
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 579 GoSliceDataType []uint16.array
+      Pointee: 586 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 424
+      ID: 431
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 423 GoSliceDataType []uint8.array
+      Pointee: 430 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 426
+      ID: 433
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 425 GoSliceDataType []uintptr.array
+      Pointee: 432 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1315
+      ID: 1322
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1996928
       GoKind: 22
-      Pointee: 1316 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1323 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 935744
       GoKind: 22
-      Pointee: 954 GoSliceHeaderType archive/tar.headerError
+      Pointee: 961 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 955 GoSliceDataType archive/tar.headerError.array
+      Pointee: 962 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1250
+      ID: 1257
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1443456
       GoKind: 22
-      Pointee: 1251 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1258 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1198
+      ID: 1205
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 935936
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1206 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1200
+      ID: 1207
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 936032
       GoKind: 22
-      Pointee: 1201 StructureType archive/zip.dirWriter
+      Pointee: 1208 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1294
+      ID: 1301
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1915072
       GoKind: 22
-      Pointee: 1295 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1302 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1226
+      ID: 1233
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1063104
       GoKind: 22
-      Pointee: 1227 StructureType archive/zip.nopCloser
+      Pointee: 1234 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1228
+      ID: 1235
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1063360
       GoKind: 22
-      Pointee: 1229 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1236 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -12024,491 +12024,491 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1273
+      ID: 1280
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2185728
       GoKind: 22
-      Pointee: 1274 UnresolvedPointeeType bufio.Reader
+      Pointee: 1281 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1304
+      ID: 1311
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1960576
       GoKind: 22
-      Pointee: 1305 UnresolvedPointeeType bufio.Writer
+      Pointee: 1312 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1353
+      ID: 1360
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2278592
       GoKind: 22
-      Pointee: 1354 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1361 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 918080
       GoKind: 22
-      Pointee: 752 BaseType compress/flate.CorruptInputError
+      Pointee: 759 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 918176
       GoKind: 22
-      Pointee: 753 GoStringHeaderType compress/flate.InternalError
+      Pointee: 760 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 754 GoStringDataType compress/flate.InternalError.str
+      Pointee: 761 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1248
+      ID: 1255
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1433056
       GoKind: 22
-      Pointee: 1249 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1256 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1194
+      ID: 1201
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 918272
       GoKind: 22
-      Pointee: 1195 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1202 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1270
+      ID: 1277
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1736736
       GoKind: 22
-      Pointee: 1271 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1278 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1435
+      ID: 412
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1560000
       GoKind: 22
-      Pointee: 375 StructureType context.backgroundCtx
+      Pointee: 413 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 365
+      ID: 416
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1734432
       GoKind: 22
-      Pointee: 366 StructureType context.cancelCtx
+      Pointee: 417 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1069
+      ID: 1076
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1197376
       GoKind: 22
-      Pointee: 1070 StructureType context.deadlineExceededError
+      Pointee: 1077 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1430
+      ID: 399
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1421056
       GoKind: 22
-      Pointee: 376 StructureType context.emptyCtx
+      Pointee: 400 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 367
+      ID: 401
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1421216
       GoKind: 22
-      Pointee: 368 StructureType context.stopCtx
+      Pointee: 402 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 369
+      ID: 424
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1734624
       GoKind: 22
-      Pointee: 370 StructureType context.timerCtx
+      Pointee: 425 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1436
+      ID: 414
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1560160
       GoKind: 22
-      Pointee: 389 StructureType context.todoCtx
+      Pointee: 415 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 371
+      ID: 408
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1559680
       GoKind: 22
-      Pointee: 372 StructureType context.valueCtx
+      Pointee: 409 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 373
+      ID: 410
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1559840
       GoKind: 22
-      Pointee: 374 StructureType context.withoutCancelCtx
+      Pointee: 411 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930368
       GoKind: 22
-      Pointee: 766 BaseType crypto/aes.KeySizeError
+      Pointee: 773 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930560
       GoKind: 22
-      Pointee: 767 BaseType crypto/des.KeySizeError
+      Pointee: 774 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 947
+      ID: 954
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930848
       GoKind: 22
-      Pointee: 768 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 775 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1265
+      ID: 1272
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1677088
       GoKind: 22
-      Pointee: 1266 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1273 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1050
+      ID: 1057
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1070912
       GoKind: 22
-      Pointee: 1051 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 1058 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1296
+      ID: 1303
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1915584
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1304 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1326
+      ID: 1333
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2130880
       GoKind: 22
-      Pointee: 1327 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1334 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1300
+      ID: 1307
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1916096
       GoKind: 22
-      Pointee: 1301 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1298
+      ID: 1305
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1915840
       GoKind: 22
-      Pointee: 1299 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1306 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1292
+      ID: 1299
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1913280
       GoKind: 22
-      Pointee: 1293 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1300 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 931136
       GoKind: 22
-      Pointee: 769 BaseType crypto/rc4.KeySizeError
+      Pointee: 776 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1313
+      ID: 1320
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1994048
       GoKind: 22
-      Pointee: 1314 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1321 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1288
+      ID: 1295
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1882656
       GoKind: 22
-      Pointee: 1289 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1296 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 869
+      ID: 876
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 919904
       GoKind: 22
-      Pointee: 756 BaseType crypto/tls.AlertError
+      Pointee: 763 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1039
+      ID: 1046
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1051456
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1047 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1379
+      ID: 1386
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2390112
       GoKind: 22
-      Pointee: 1380 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1387 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 919616
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 873 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 919520
       GoKind: 22
-      Pointee: 864 StructureType crypto/tls.RecordHeaderError
+      Pointee: 871 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1049792
       GoKind: 22
-      Pointee: 993 BaseType crypto/tls.alert
+      Pointee: 1000 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1258
+      ID: 1265
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1568480
       GoKind: 22
-      Pointee: 1259 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1266 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 867
+      ID: 874
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 919712
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 875 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1263
+      ID: 1270
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1651744
       GoKind: 22
-      Pointee: 1264 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1271 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1136
+      ID: 1143
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1433536
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1144 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1150
+      ID: 1157
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2053216
       GoKind: 22
-      Pointee: 1151 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1158 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 929312
       GoKind: 22
-      Pointee: 940 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 947 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 928832
       GoKind: 22
-      Pointee: 934 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 941 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 928928
       GoKind: 22
-      Pointee: 936 StructureType crypto/x509.HostnameError
+      Pointee: 943 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 928736
       GoKind: 22
-      Pointee: 765 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 772 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1044
+      ID: 1051
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1057216
       GoKind: 22
-      Pointee: 1045 StructureType crypto/x509.SystemRootsError
+      Pointee: 1052 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 929408
       GoKind: 22
-      Pointee: 942 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 949 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 929216
       GoKind: 22
-      Pointee: 938 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 945 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 957
+      ID: 964
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 936224
       GoKind: 22
-      Pointee: 958 StructureType encoding/asn1.StructuralError
+      Pointee: 965 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 936416
       GoKind: 22
-      Pointee: 962 StructureType encoding/asn1.SyntaxError
+      Pointee: 969 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 936320
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 967 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 915488
       GoKind: 22
-      Pointee: 747 BaseType encoding/base64.CorruptInputError
+      Pointee: 754 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1216
+      ID: 1223
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1046208
       GoKind: 22
-      Pointee: 1217 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1224 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 916352
       GoKind: 22
-      Pointee: 748 BaseType encoding/hex.InvalidByteError
+      Pointee: 755 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 910304
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 831 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1042368
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1036 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 909920
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 823 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 910208
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 829 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 827 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 910016
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 825 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1359
+      ID: 1366
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2304128
       GoKind: 22
-      Pointee: 1360 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1367 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 826 StructureType encoding/json.jsonError
+      Pointee: 833 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1224
+      ID: 1231
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1060032
       GoKind: 22
-      Pointee: 1225 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1232 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 935 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 927680
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 933 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927872
       GoKind: 22
-      Pointee: 762 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 769 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 763 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 770 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 927968
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 938 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1337
+      ID: 1344
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2170720
       GoKind: 22
-      Pointee: 1338 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1345 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -12517,19 +12517,19 @@ Types:
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType errors.errorString
+      Pointee: 799 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 995
+      ID: 1002
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1028160
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType errors.joinError
+      Pointee: 1003 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -12545,625 +12545,625 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 1347
+      ID: 1354
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2270912
       GoKind: 22
-      Pointee: 1348 UnresolvedPointeeType fmt.pp
+      Pointee: 1355 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1028288
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType fmt.wrapError
+      Pointee: 1005 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 999
+      ID: 1006
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1028416
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 1007 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915872
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 861 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 913088
       GoKind: 22
-      Pointee: 835 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 842 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 913184
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 844 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1162
+      ID: 1169
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 912896
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1170 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 840
+      ID: 847
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 913472
       GoKind: 22
-      Pointee: 841 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 848 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1164
+      ID: 1171
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 912992
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1172 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 913280
       GoKind: 22
-      Pointee: 741 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 748 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 742 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 912800
       GoKind: 22
-      Pointee: 738 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 745 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 740
+      ID: 747
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 739 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 746 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 913376
       GoKind: 22
-      Pointee: 744 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 751 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 745 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1236
+      ID: 1243
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1214656
       GoKind: 22
-      Pointee: 1237 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1244 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1323
+      ID: 1330
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2067904
       GoKind: 22
-      Pointee: 1324 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1331 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 951
+      ID: 958
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 934688
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 959 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 390
+      ID: 395
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2289344
       GoKind: 22
-      Pointee: 391 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 365 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 416
+      ID: 393
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2018080
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 394 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 411
+      ID: 388
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1197632
       GoKind: 22
-      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 389 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 414
+      ID: 391
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1197760
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 392 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1428
+      ID: 1435
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1198400
       GoKind: 22
-      Pointee: 1429 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1436 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1198528
       GoKind: 22
-      Pointee: 713 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 720 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 418
+      ID: 396
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2236224
       GoKind: 22
-      Pointee: 419 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 397 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1104
+      ID: 1111
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1218240
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1112 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1355
+      ID: 1362
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2280640
       GoKind: 22
-      Pointee: 1356 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1363 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1431
+      ID: 404
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1427296
       GoKind: 22
-      Pointee: 1432 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 405 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 923264
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 884 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 924320
       GoKind: 22
-      Pointee: 884 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 891 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 761 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 768 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 924224
       GoKind: 22
-      Pointee: 882 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 889 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 924128
       GoKind: 22
-      Pointee: 880 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 887 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 926240
       GoKind: 22
-      Pointee: 900 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 907 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 926432
       GoKind: 22
-      Pointee: 904 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 911 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 926336
       GoKind: 22
-      Pointee: 902 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 909 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 926144
       GoKind: 22
-      Pointee: 898 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 905 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1187
+      ID: 1194
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1186 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1193 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 926816
       GoKind: 22
-      Pointee: 912 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 919 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 926528
       GoKind: 22
-      Pointee: 906 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 913 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 926720
       GoKind: 22
-      Pointee: 910 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 917 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 926624
       GoKind: 22
-      Pointee: 908 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 915 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 926912
       GoKind: 22
-      Pointee: 914 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 921 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 927200
       GoKind: 22
-      Pointee: 920 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 927 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 927296
       GoKind: 22
-      Pointee: 922 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 929 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 927104
       GoKind: 22
-      Pointee: 918 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 925 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 927008
       GoKind: 22
-      Pointee: 916 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 923 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 927488
       GoKind: 22
-      Pointee: 924 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 931 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 914624
       GoKind: 22
-      Pointee: 843 StructureType github.com/cihub/seelog.baseError
+      Pointee: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1276
+      ID: 1283
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1812992
       GoKind: 22
-      Pointee: 1277 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1284 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 914720
       GoKind: 22
-      Pointee: 845 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 852 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1256
+      ID: 1263
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1566560
       GoKind: 22
-      Pointee: 1257 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1264 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1212
+      ID: 1219
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1045056
       GoKind: 22
-      Pointee: 1213 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1220 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1246
+      ID: 1253
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1430976
       GoKind: 22
-      Pointee: 1247 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1254 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 914912
       GoKind: 22
-      Pointee: 849 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 856 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1311
+      ID: 1318
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1985696
       GoKind: 22
-      Pointee: 1312 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1319 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1330
+      ID: 1337
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2143520
       GoKind: 22
-      Pointee: 1325 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1332 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1329
+      ID: 1336
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2143136
       GoKind: 22
-      Pointee: 1328 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1335 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1214
+      ID: 1221
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1045184
       GoKind: 22
-      Pointee: 1215 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1222 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 914816
       GoKind: 22
-      Pointee: 847 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 854 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 915008
       GoKind: 22
-      Pointee: 851 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 858 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1278
+      ID: 1285
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1814784
       GoKind: 22
-      Pointee: 1279 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1286 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1319
+      ID: 1326
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2022400
       GoKind: 22
-      Pointee: 1320 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1327 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1321
+      ID: 1328
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2052896
       GoKind: 22
-      Pointee: 1322 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1329 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1138
+      ID: 1145
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1445856
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1146 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1071680
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1062 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1071552
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1060 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1075648
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1064 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1075776
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1066 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1267
+      ID: 1274
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1679392
       GoKind: 22
-      Pointee: 1268 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1275 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1046
+      ID: 1053
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1057856
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1054 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 916544
       GoKind: 22
-      Pointee: 857 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 864 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1371
+      ID: 1378
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2366560
       GoKind: 22
-      Pointee: 1372 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1379 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1112
+      ID: 1119
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1227712
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1120 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1081
+      ID: 1088
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1205824
       GoKind: 22
-      Pointee: 1082 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1089 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1075
+      ID: 1082
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1205440
       GoKind: 22
-      Pointee: 1076 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1083 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1014
+      ID: 1021
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1036608
       GoKind: 22
-      Pointee: 1015 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1022 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1087
+      ID: 1094
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1206208
       GoKind: 22
-      Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1095 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1036480
       GoKind: 22
-      Pointee: 992 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 999 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1079
+      ID: 1086
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1205696
       GoKind: 22
-      Pointee: 1080 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1087 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1077
+      ID: 1084
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1205568
       GoKind: 22
-      Pointee: 1078 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1085 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1206080
       GoKind: 22
-      Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1093 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1205952
       GoKind: 22
-      Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1091 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1375
+      ID: 1382
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2379168
       GoKind: 22
-      Pointee: 1376 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1383 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1206592
       GoKind: 22
-      Pointee: 1092 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1099 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1018
+      ID: 1025
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1036864
       GoKind: 22
-      Pointee: 1019 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1026 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1016
+      ID: 1023
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1036736
       GoKind: 22
-      Pointee: 1017 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1024 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1089
+      ID: 1096
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1206464
       GoKind: 22
-      Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1097 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 949184
       GoKind: 22
-      Pointee: 774 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 781 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 775 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 782 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
       ID: 361
       Name: '*go.shape.float64'
@@ -13186,10 +13186,10 @@ Types:
       GoKind: 22
       Pointee: 334 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 650
+      ID: 657
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 649 GoStringDataType go.shape.string.str
+      Pointee: 656 GoStringDataType go.shape.string.str
     - __kind: PointerType
       ID: 340
       Name: '*go.shape.struct { Name string }'
@@ -13209,249 +13209,249 @@ Types:
       GoKind: 22
       Pointee: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1153
+      ID: 1160
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1677856
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1161 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1090496
       GoKind: 22
-      Pointee: 1063 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1070 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1242
+      ID: 1249
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1267648
       GoKind: 22
-      Pointee: 1243 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1250 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1335
+      ID: 1342
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2158880
       GoKind: 22
-      Pointee: 1336 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1343 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1230
+      ID: 1237
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1092800
       GoKind: 22
-      Pointee: 1231 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1238 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 950432
       GoKind: 22
-      Pointee: 777 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 784 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1120
+      ID: 1127
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1269312
       GoKind: 22
-      Pointee: 1121 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1128 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 950720
       GoKind: 22
-      Pointee: 978 StructureType golang.org/x/net/http2.connError
+      Pointee: 985 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 950624
       GoKind: 22
-      Pointee: 781 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 788 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 782 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 789 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 950912
       GoKind: 22
-      Pointee: 787 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 794 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 788 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 795 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 950816
       GoKind: 22
-      Pointee: 784 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 791 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 785 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 792 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 950528
       GoKind: 22
-      Pointee: 778 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 785 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 779 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 786 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1333
+      ID: 1340
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2156960
       GoKind: 22
-      Pointee: 1334 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1341 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 981
+      ID: 988
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 951008
       GoKind: 22
-      Pointee: 982 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 989 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 951104
       GoKind: 22
-      Pointee: 790 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 797 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 944384
       GoKind: 22
-      Pointee: 970 StructureType google.golang.org/grpc.dropError
+      Pointee: 977 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1118
+      ID: 1125
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1266368
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1126 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1140
+      ID: 1147
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1453216
       GoKind: 22
-      Pointee: 1141 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1148 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 947456
       GoKind: 22
-      Pointee: 972 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 979 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1282
+      ID: 1289
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1820608
       GoKind: 22
-      Pointee: 1283 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1290 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1240
+      ID: 1247
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1262912
       GoKind: 22
-      Pointee: 1241 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1248 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1084736
       GoKind: 22
-      Pointee: 1061 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1068 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1202
+      ID: 1209
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 947552
       GoKind: 22
-      Pointee: 1203 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1210 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 949
+      ID: 956
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 932576
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 957 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1048
+      ID: 1055
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1061440
       GoKind: 22
-      Pointee: 1049 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1056 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1116
+      ID: 1123
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1234240
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1124 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1233984
       GoKind: 22
-      Pointee: 1115 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1122 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 937280
       GoKind: 22
-      Pointee: 964 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 971 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 937376
       GoKind: 22
-      Pointee: 966 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 973 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 899 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1290
+      ID: 1297
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1911232
       GoKind: 22
-      Pointee: 1291 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1298 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 984
+      ID: 991
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 951872
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType html/template.Error
+      Pointee: 992 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -13495,115 +13495,115 @@ Types:
       GoKind: 22
       Pointee: 164 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 1142
+      ID: 1149
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2223232
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType internal/abi.Type
+      Pointee: 1150 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 929984
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 951 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 917792
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 867 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1192
+      ID: 1199
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 916928
       GoKind: 22
-      Pointee: 1193 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1200 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1110
+      ID: 1117
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1219520
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1118 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1377
+      ID: 1384
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2384832
       GoKind: 22
-      Pointee: 1378 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1385 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1108
+      ID: 1115
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1219392
       GoKind: 22
-      Pointee: 1109 StructureType internal/poll.errNetClosing
+      Pointee: 1116 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 905408
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 806 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 749 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 756 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 757 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 1032
+      ID: 1039
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1048384
       GoKind: 22
-      Pointee: 1033 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 1040 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1234
+      ID: 1241
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1197120
       GoKind: 22
-      Pointee: 1235 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1242 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1232
+      ID: 1239
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1196736
       GoKind: 22
-      Pointee: 1233 StructureType io.discard
+      Pointee: 1240 StructureType io.discard
     - __kind: PointerType
-      ID: 1206
+      ID: 1213
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1029184
       GoKind: 22
-      Pointee: 1207 UnresolvedPointeeType io.multiWriter
+      Pointee: 1214 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1106
+      ID: 1113
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1218880
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1114 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1280
+      ID: 1287
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1815008
       GoKind: 22
-      Pointee: 1281 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1288 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 347
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
@@ -13623,19 +13623,19 @@ Types:
       GoKind: 22
       Pointee: 324 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 441
+      ID: 448
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 388160
       GoKind: 22
-      Pointee: 442 StructureType main.deepMap2
+      Pointee: 449 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1423
+      ID: 1430
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 388096
       GoKind: 22
-      Pointee: 1424 UnresolvedPointeeType main.deepMap3
+      Pointee: 1431 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 151
       Name: '*main.deepMap7'
@@ -13665,12 +13665,12 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1381
+      ID: 1388
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 388672
       GoKind: 22
-      Pointee: 1382 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1389 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 137
       Name: '*main.deepPtr7'
@@ -13698,14 +13698,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 389312
       GoKind: 22
-      Pointee: 432 StructureType main.deepSlice2
+      Pointee: 439 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1408
+      ID: 1415
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 389248
       GoKind: 22
-      Pointee: 1409 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1416 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepSlice7'
@@ -13741,7 +13741,7 @@ Types:
       GoKind: 22
       Pointee: 167 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1394
+      ID: 1401
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 900704
@@ -13774,19 +13774,19 @@ Types:
       GoKind: 22
       Pointee: 160 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1395
+      ID: 1402
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 900800
       GoKind: 22
-      Pointee: 1396 StructureType main.secondBehavior
+      Pointee: 1403 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1387
+      ID: 1394
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 900896
       GoKind: 22
-      Pointee: 1388 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1395 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 153
       Name: '*main.stringType1'
@@ -13794,16 +13794,16 @@ Types:
       GoKind: 22
       Pointee: 154 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1384
+      ID: 1391
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1383 GoStringDataType main.stringType1.str
+      Pointee: 1390 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 156
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1385 GoStringHeaderType main.stringType2
+      Pointee: 1392 GoStringHeaderType main.stringType2
     - __kind: PointerType
       ID: 1501
       Name: '*main.stringType2.str'
@@ -13815,7 +13815,7 @@ Types:
       ByteSize: 8
       Pointee: 278 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 495
+      ID: 502
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 387648
@@ -13839,10 +13839,10 @@ Types:
       GoKind: 22
       Pointee: 256 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1399
+      ID: 1406
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1398 GoSliceDataType main.t.array
+      Pointee: 1405 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 275
       Name: '*main.threeStringStruct'
@@ -13870,20 +13870,20 @@ Types:
       ByteSize: 8
       Pointee: 207 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 382
+      ID: 420
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 383 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 421 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 147
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 148 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1413
+      ID: 1420
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1414 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1421 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1457
       Name: '*map<int,*main.deepMap8>'
@@ -13915,10 +13915,10 @@ Types:
       ByteSize: 8
       Pointee: 212 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 693
+      ID: 691
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 694 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 692 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 201
       Name: '*map<string,[]main.structWithMap>'
@@ -13930,35 +13930,35 @@ Types:
       ByteSize: 8
       Pointee: 190 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 406
+      ID: 383
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 407 GoSwissMapHeaderType map<string,float64>
+      Pointee: 384 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1146
+      ID: 1153
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1147 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1154 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 184
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 185 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 401
+      ID: 378
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 402 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 379 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 179
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 180 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 396
+      ID: 373
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 397 GoSwissMapHeaderType map<string,string>
+      Pointee: 374 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 236
       Name: '*map<struct {},int>'
@@ -14016,493 +14016,493 @@ Types:
       GoKind: 22
       Pointee: 183 GoMapType map[string]int
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 896 StructureType math/big.ErrNaN
+      Pointee: 903 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1196
+      ID: 1203
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 1197 StructureType mime/multipart.writerOnly·1
+      Pointee: 1204 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1098
+      ID: 1105
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1212480
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType net.AddrError
+      Pointee: 1106 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1429216
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType net.DNSError
+      Pointee: 1137 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1341
+      ID: 1348
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2243104
       GoKind: 22
-      Pointee: 1342 UnresolvedPointeeType net.IPConn
+      Pointee: 1349 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1127
+      ID: 1134
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1428896
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType net.OpError
+      Pointee: 1135 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1100
+      ID: 1107
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1212608
       GoKind: 22
-      Pointee: 1101 UnresolvedPointeeType net.ParseError
+      Pointee: 1108 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1351
+      ID: 1358
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2271936
       GoKind: 22
-      Pointee: 1352 UnresolvedPointeeType net.TCPConn
+      Pointee: 1359 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1361
+      ID: 1368
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2317440
       GoKind: 22
-      Pointee: 1362 UnresolvedPointeeType net.UDPConn
+      Pointee: 1369 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1349
+      ID: 1356
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2271424
       GoKind: 22
-      Pointee: 1350 UnresolvedPointeeType net.UnixConn
+      Pointee: 1357 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1097
+      ID: 1104
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1211712
       GoKind: 22
-      Pointee: 1066 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1073 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1068
+      ID: 1075
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1067 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1074 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1030
+      ID: 1037
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1043264
       GoKind: 22
-      Pointee: 1031 StructureType net.canceledError
+      Pointee: 1038 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1317
+      ID: 1324
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2019808
       GoKind: 22
-      Pointee: 1318 UnresolvedPointeeType net.conn
+      Pointee: 1325 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1171
+      ID: 1178
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1857120
       GoKind: 22
-      Pointee: 1172 StructureType net.dialResult·1
+      Pointee: 1179 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1363
+      ID: 1370
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2321696
       GoKind: 22
-      Pointee: 1364 UnresolvedPointeeType net.netFD
+      Pointee: 1371 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 911648
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net.notFoundError
+      Pointee: 835 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1433
+      ID: 406
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1429056
       GoKind: 22
-      Pointee: 1434 StructureType net.onlyValuesCtx
+      Pointee: 407 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 912320
       GoKind: 22
-      Pointee: 830 StructureType net.result·2
+      Pointee: 837 StructureType net.result·2
     - __kind: PointerType
-      ID: 1345
+      ID: 1352
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2257952
       GoKind: 22
-      Pointee: 1346 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1353 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1343
+      ID: 1350
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2257472
       GoKind: 22
-      Pointee: 1344 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1351 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1102
+      ID: 1109
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1213248
       GoKind: 22
-      Pointee: 1103 UnresolvedPointeeType net.temporaryError
+      Pointee: 1110 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1131
+      ID: 1138
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1429376
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType net.timeoutError
+      Pointee: 1139 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1020
+      ID: 1027
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1039296
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1028 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1188
+      ID: 1195
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 907424
       GoKind: 22
-      Pointee: 1189 StructureType net/http.bufioFlushWriter
+      Pointee: 1196 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 908096
       GoKind: 22
-      Pointee: 719 BaseType net/http.http2ConnectionError
+      Pointee: 726 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 908192
       GoKind: 22
-      Pointee: 806 StructureType net/http.http2GoAwayError
+      Pointee: 813 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1123
+      ID: 1130
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1425216
       GoKind: 22
-      Pointee: 1124 StructureType net/http.http2StreamError
+      Pointee: 1131 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 908768
       GoKind: 22
-      Pointee: 810 StructureType net/http.http2connError
+      Pointee: 817 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1252
+      ID: 1259
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1563680
       GoKind: 22
-      Pointee: 1253 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1260 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908672
       GoKind: 22
-      Pointee: 723 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 730 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 725
+      ID: 732
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 724 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 731 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 908960
       GoKind: 22
-      Pointee: 729 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 736 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 730 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 737 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 908864
       GoKind: 22
-      Pointee: 726 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 733 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 727 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 734 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1208512
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1103 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1039936
       GoKind: 22
-      Pointee: 1027 StructureType net/http.http2noCachedConnError
+      Pointee: 1034 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1306
+      ID: 1313
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1961856
       GoKind: 22
-      Pointee: 1307 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1314 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908576
       GoKind: 22
-      Pointee: 720 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 727 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 721 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 728 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1190
+      ID: 1197
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 909056
       GoKind: 22
-      Pointee: 1191 StructureType net/http.http2stickyErrWriter
+      Pointee: 1198 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1022
+      ID: 1029
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1039552
       GoKind: 22
-      Pointee: 1023 StructureType net/http.nothingWrittenError
+      Pointee: 1030 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1254
+      ID: 1261
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2186976
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1262 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1210
+      ID: 1217
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1039424
       GoKind: 22
-      Pointee: 1211 StructureType net/http.persistConnWriter
+      Pointee: 1218 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1244
+      ID: 1251
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1425376
       GoKind: 22
-      Pointee: 1245 StructureType net/http.readWriteCloserBody
+      Pointee: 1252 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 909152
       GoKind: 22
-      Pointee: 814 StructureType net/http.requestBodyReadError
+      Pointee: 821 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1125
+      ID: 1132
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1426496
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1133 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1208384
       GoKind: 22
-      Pointee: 1094 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1101 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1039680
       GoKind: 22
-      Pointee: 1025 StructureType net/http.transportReadFromServerError
+      Pointee: 1032 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1286
+      ID: 1293
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1853984
       GoKind: 22
-      Pointee: 1287 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1294 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 907328
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 810 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1308
+      ID: 1315
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1963904
       GoKind: 22
-      Pointee: 1309 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1316 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1220
+      ID: 1227
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1052608
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1228 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 924512
       GoKind: 22
-      Pointee: 888 StructureType net/netip.parseAddrError
+      Pointee: 895 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 886 StructureType net/netip.parsePrefixError
+      Pointee: 893 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1260
+      ID: 1267
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2129472
       GoKind: 22
-      Pointee: 1261 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1268 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1222
+      ID: 1229
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1057472
       GoKind: 22
-      Pointee: 1223 StructureType net/smtp.dataCloser
+      Pointee: 1230 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 920576
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType net/textproto.Error
+      Pointee: 879 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 920480
       GoKind: 22
-      Pointee: 757 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 764 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 758 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 765 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1218
+      ID: 1225
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1051840
       GoKind: 22
-      Pointee: 1219 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1226 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1133
+      ID: 1140
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1429696
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType net/url.Error
+      Pointee: 1141 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 912416
       GoKind: 22
-      Pointee: 732 GoStringHeaderType net/url.EscapeError
+      Pointee: 739 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 733 GoStringDataType net/url.EscapeError.str
+      Pointee: 740 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 912512
       GoKind: 22
-      Pointee: 735 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 742 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 736 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 743 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 541
+      ID: 548
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 542 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 549 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 533
+      ID: 540
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 534 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 541 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 481
+      ID: 488
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 482 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 489 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 500
+      ID: 507
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 501 StructureType noalg.map.group[bool]main.node
+      Pointee: 508 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 659
+      ID: 700
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 660 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 701 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 437
+      ID: 444
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 438 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 445 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1419
+      ID: 1426
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1420 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1427 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1463
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -14514,230 +14514,230 @@ Types:
       ByteSize: 8
       Pointee: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 449
+      ID: 456
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 450 StructureType noalg.map.group[int]int
+      Pointee: 457 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 1493
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 557
+      ID: 564
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 558 StructureType noalg.map.group[int]struct {}
+      Pointee: 565 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 508
+      ID: 515
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 509 StructureType noalg.map.group[int]uint8
+      Pointee: 516 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 708
+      ID: 715
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 716 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 490
+      ID: 497
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 491 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 498 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 473
+      ID: 480
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 474 StructureType noalg.map.group[string][]string
+      Pointee: 481 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 684
+      ID: 682
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 685 StructureType noalg.map.group[string]float64
+      Pointee: 683 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1178
+      ID: 1185
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1186 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 465
+      ID: 472
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 466 StructureType noalg.map.group[string]int
+      Pointee: 473 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 676
+      ID: 674
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 677 StructureType noalg.map.group[string]interface {}
+      Pointee: 675 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 457
+      ID: 464
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 458 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 465 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 668
+      ID: 666
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 669 StructureType noalg.map.group[string]string
+      Pointee: 667 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 549
+      ID: 556
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 550 StructureType noalg.map.group[struct {}]int
+      Pointee: 557 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 597
+      ID: 604
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 605 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 605
+      ID: 612
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 613 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 613
+      ID: 620
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 621
+      ID: 628
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 645 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 565
+      ID: 572
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 566 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 573 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 524
+      ID: 531
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 525 StructureType noalg.map.group[uint8][4]int
+      Pointee: 532 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 516
+      ID: 523
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 517 StructureType noalg.map.group[uint8]uint8
+      Pointee: 524 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1369
+      ID: 1376
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2361184
       GoKind: 22
-      Pointee: 1370 UnresolvedPointeeType os.File
+      Pointee: 1377 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1032896
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType os.LinkError
+      Pointee: 1011 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1071
+      ID: 1078
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1201600
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType os.SyscallError
+      Pointee: 1079 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1367
+      ID: 1374
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2359712
       GoKind: 22
-      Pointee: 1368 StructureType os.fileWithoutReadFrom
+      Pointee: 1375 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1365
+      ID: 1372
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2358976
       GoKind: 22
-      Pointee: 1366 StructureType os.fileWithoutWriteTo
+      Pointee: 1373 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1034
+      ID: 1041
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1048512
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType os/exec.Error
+      Pointee: 1042 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1174
+      ID: 1181
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2100032
       GoKind: 22
-      Pointee: 1175 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1182 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1238
+      ID: 1245
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1220416
       GoKind: 22
-      Pointee: 1239 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1246 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1036
+      ID: 1043
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1048640
       GoKind: 22
-      Pointee: 1037 StructureType os/exec.wrappedError
+      Pointee: 1044 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 942464
       GoKind: 22
-      Pointee: 771 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 778 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 772 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 779 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 942368
       GoKind: 22
-      Pointee: 770 BaseType os/user.UnknownUserIdError
+      Pointee: 777 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 906080
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType reflect.ValueError
+      Pointee: 808 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 925184
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 901 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1033920
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1015 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1035712
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1019 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14753,12 +14753,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1034048
       GoKind: 22
-      Pointee: 1010 StructureType runtime.boundsError
+      Pointee: 1017 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -14774,24 +14774,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1073
+      ID: 1080
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1204032
       GoKind: 22
-      Pointee: 1074 StructureType runtime.errorAddressString
+      Pointee: 1081 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 1005
+      ID: 1012
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1033536
       GoKind: 22
-      Pointee: 986 GoStringHeaderType runtime.errorString
+      Pointee: 993 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 988
+      ID: 995
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 987 GoStringDataType runtime.errorString.str
+      Pointee: 994 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -14812,19 +14812,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1035072
       GoKind: 22
-      Pointee: 427 UnresolvedPointeeType runtime.p
+      Pointee: 434 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 1006
+      ID: 1013
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1033664
       GoKind: 22
-      Pointee: 989 GoStringHeaderType runtime.plainError
+      Pointee: 996 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 990 GoStringDataType runtime.plainError.str
+      Pointee: 997 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14840,12 +14840,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 22
-      Pointee: 797 StructureType runtime.synctestDeadlockError
+      Pointee: 804 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -14861,12 +14861,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1031744
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType strconv.NumError
+      Pointee: 1009 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -14875,31 +14875,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 422
+      ID: 429
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 421 GoStringDataType string.str
+      Pointee: 428 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1302
+      ID: 1309
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1960064
       GoKind: 22
-      Pointee: 1303 UnresolvedPointeeType strings.Builder
+      Pointee: 1310 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1208
+      ID: 1215
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1031872
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1216 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1204
+      ID: 1211
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 976416
       GoKind: 22
-      Pointee: 1205 StructureType struct { io.Writer }
+      Pointee: 1212 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 273
       Name: '*struct {}'
@@ -14908,47 +14908,47 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType struct {}
     - __kind: PointerType
-      ID: 1135
+      ID: 1142
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1431936
       GoKind: 22
-      Pointee: 1122 BaseType syscall.Errno
+      Pointee: 1129 BaseType syscall.Errno
     - __kind: PointerType
       ID: 234
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 539 StructureType table<[4]int,[4]int>
+      Pointee: 546 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 229
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 531 StructureType table<[4]int,uint8>
+      Pointee: 538 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 197
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 479 StructureType table<[4]string,[2]int>
+      Pointee: 486 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 209
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 498 StructureType table<bool,main.node>
+      Pointee: 505 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 385
+      ID: 423
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 657 StructureType table<context.canceler,struct {}>
+      Pointee: 698 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 150
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 435 StructureType table<int,*main.deepMap2>
+      Pointee: 442 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1416
+      ID: 1423
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1417 StructureType table<int,*main.deepMap3>
+      Pointee: 1424 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1460
       Name: '*table<int,*main.deepMap8>'
@@ -14963,7 +14963,7 @@ Types:
       ID: 177
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 447 StructureType table<int,int>
+      Pointee: 454 StructureType table<int,int>
     - __kind: PointerType
       ID: 1490
       Name: '*table<int,interface {}>'
@@ -14973,121 +14973,121 @@ Types:
       ID: 244
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 555 StructureType table<int,struct {}>
+      Pointee: 562 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 214
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 506 StructureType table<int,uint8>
+      Pointee: 513 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 696
+      ID: 694
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 706 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 713 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 204
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 488 StructureType table<string,[]main.structWithMap>
+      Pointee: 495 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 192
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 471 StructureType table<string,[]string>
+      Pointee: 478 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 409
+      ID: 386
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 682 StructureType table<string,float64>
+      Pointee: 680 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1149
+      ID: 1156
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1176 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1183 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 187
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 463 StructureType table<string,int>
+      Pointee: 470 StructureType table<string,int>
     - __kind: PointerType
-      ID: 404
+      ID: 381
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 674 StructureType table<string,interface {}>
+      Pointee: 672 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 182
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 455 StructureType table<string,main.nestedStruct>
+      Pointee: 462 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 399
+      ID: 376
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 666 StructureType table<string,string>
+      Pointee: 664 StructureType table<string,string>
     - __kind: PointerType
       ID: 239
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 547 StructureType table<struct {},int>
+      Pointee: 554 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 296
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 595 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 602 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 301
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 603 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 610 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 306
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 611 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 618 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 311
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 619 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 626 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 316
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 627 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 634 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 321
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 635 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 642 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 249
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 563 StructureType table<struct {},struct {}>
+      Pointee: 570 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 224
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 522 StructureType table<uint8,[4]int>
+      Pointee: 529 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 219
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 514 StructureType table<uint8,uint8>
+      Pointee: 521 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1339
+      ID: 1346
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2171104
       GoKind: 22
-      Pointee: 1340 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1347 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1094336
       GoKind: 22
-      Pointee: 1065 StructureType text/template.ExecError
+      Pointee: 1072 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 329
       Name: '*time.Location'
@@ -15096,45 +15096,45 @@ Types:
       GoKind: 22
       Pointee: 330 StructureType time.Location
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 903392
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType time.ParseError
+      Pointee: 802 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 387
+      ID: 426
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1033280
       GoKind: 22
-      Pointee: 388 StructureType time.Timer
+      Pointee: 427 StructureType time.Timer
     - __kind: PointerType
-      ID: 793
+      ID: 800
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 903296
       GoKind: 22
-      Pointee: 716 GoStringHeaderType time.fileSizeError
+      Pointee: 723 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 717 GoStringDataType time.fileSizeError.str
+      Pointee: 724 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 644
+      ID: 651
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394880
       GoKind: 22
-      Pointee: 645 StructureType time.zone
+      Pointee: 652 StructureType time.zone
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394944
       GoKind: 22
-      Pointee: 648 StructureType time.zoneTrans
+      Pointee: 655 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -15178,49 +15178,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 924608
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 897 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1331
+      ID: 1338
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2146592
       GoKind: 22
-      Pointee: 1332 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1339 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 920768
       GoKind: 22
-      Pointee: 874 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 881 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 875
+      ID: 882
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 760 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 767 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1041
+      ID: 1048
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1052352
       GoKind: 22
-      Pointee: 1042 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1049 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1043
+      ID: 1050
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1052480
       GoKind: 22
-      Pointee: 994 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 1001 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1400
+      ID: 1412
       Name: <-chan time.Time
       GoRuntimeType: 600352
       GoKind: 18
@@ -25941,7 +25941,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 528
+      ID: 535
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 686816
@@ -25950,7 +25950,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 485
+      ID: 492
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 687104
@@ -25976,7 +25976,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1166
+      ID: 1173
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 688640
@@ -25985,7 +25985,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1386
+      ID: 1393
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -26011,7 +26011,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1401
+      ID: 1407
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 484288
@@ -26019,20 +26019,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1402 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1408 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1404 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1410 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1404
+      ID: 1410
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 395 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 140
       Name: '[]*main.deepSlice2'
@@ -26049,15 +26049,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 433 GoSliceDataType []*main.deepSlice2.array
+      Data: 440 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 433
+      ID: 440
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 142 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1406
+      ID: 1413
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 480192
@@ -26065,20 +26065,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1407 PointerType **main.deepSlice3
+          Type: 1414 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1410 GoSliceDataType []*main.deepSlice3.array
+      Data: 1417 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1410
+      ID: 1417
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1408 PointerType *main.deepSlice3
+      Element: 1415 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1441
       Name: '[]*main.deepSlice8'
@@ -26141,9 +26141,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 428 GoSliceDataType []*runtime.p.array
+      Data: 435 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 428
+      ID: 435
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26164,55 +26164,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 430 GoSliceDataType []*string.array
+      Data: 437 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 430
+      ID: 437
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 97 PointerType *string
     - __kind: GoSliceDataType
-      ID: 545
+      ID: 552
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 234 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 537
+      ID: 544
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 229 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 493
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 197 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 504
+      ID: 511
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 209 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 664
+      ID: 705
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 385 PointerType *table<context.canceler,struct {}>
+      Element: 423 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 450
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 150 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1425
+      ID: 1432
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1416 PointerType *table<int,*main.deepMap3>
+      Element: 1423 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1469
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -26226,7 +26226,7 @@ Types:
       ByteSize: 8
       Element: 1475 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 460
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26238,127 +26238,127 @@ Types:
       ByteSize: 8
       Element: 1490 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 561
+      ID: 568
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 244 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 512
+      ID: 519
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 214 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 721
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 696 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 694 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 503
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 204 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 484
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 192 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 688
+      ID: 686
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 409 PointerType *table<string,float64>
+      Element: 386 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1182
+      ID: 1189
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1149 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1156 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 476
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 187 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 680
+      ID: 678
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 404 PointerType *table<string,interface {}>
+      Element: 381 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 468
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 182 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 672
+      ID: 670
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 399 PointerType *table<string,string>
+      Element: 376 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 553
+      ID: 560
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 239 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 601
+      ID: 608
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 296 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 609
+      ID: 616
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 301 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 617
+      ID: 624
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 306 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 625
+      ID: 632
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 311 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 633
+      ID: 640
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 316 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 641
+      ID: 648
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 321 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 569
+      ID: 576
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 249 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 536
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 224 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 527
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26378,9 +26378,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 593 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 600 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 593
+      ID: 600
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26400,9 +26400,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 591 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 598 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 591
+      ID: 598
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26422,9 +26422,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 589 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 596 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 589
+      ID: 596
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26444,9 +26444,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 587 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 594 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 587
+      ID: 594
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26466,9 +26466,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 585 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 592 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 585
+      ID: 592
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26488,9 +26488,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 573 GoSliceDataType [][]uint.array
+      Data: 580 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 573
+      ID: 580
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26511,15 +26511,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 577 GoSliceDataType []bool.array
+      Data: 584 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 577
+      ID: 584
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1161
+      ID: 1168
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 490560
@@ -26534,15 +26534,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1184 GoSliceDataType []float64.array
+      Data: 1191 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1184
+      ID: 1191
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 410
+      ID: 387
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 483840
@@ -26550,22 +26550,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 690 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 688 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 690
+      ID: 688
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 389 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 413
+      ID: 390
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 484032
@@ -26573,20 +26573,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 414 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 391 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 696 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 698
+      ID: 696
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 392 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
       ID: 360
       Name: '[]go.shape.float64'
@@ -26603,9 +26603,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 655 GoSliceDataType []go.shape.float64.array
+      Data: 662 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 655
+      ID: 662
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26625,9 +26625,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 651 GoSliceDataType []go.shape.int.array
+      Data: 658 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 651
+      ID: 658
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26647,9 +26647,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 653 GoSliceDataType []go.shape.string.array
+      Data: 660 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 653
+      ID: 660
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26692,15 +26692,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 583 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 590 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 583
+      ID: 590
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 278 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 494
+      ID: 501
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 480832
@@ -26708,16 +26708,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 495 PointerType *main.structWithMap
+          Type: 502 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 700 GoSliceDataType []main.structWithMap.array
+      Data: 707 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 700
+      ID: 707
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26737,55 +26737,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 575 GoSliceDataType []main.structWithNoStrings.array
+      Data: 582 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 575
+      ID: 582
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 269 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 546
+      ID: 553
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 542 StructureType noalg.map.group[[4]int][4]int
+      Element: 549 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 538
+      ID: 545
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 534 StructureType noalg.map.group[[4]int]uint8
+      Element: 541 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 494
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 482 StructureType noalg.map.group[[4]string][2]int
+      Element: 489 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 505
+      ID: 512
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 501 StructureType noalg.map.group[bool]main.node
+      Element: 508 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 706
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 660 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 701 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 444
+      ID: 451
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 438 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 445 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1426
+      ID: 1433
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1420 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1427 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1470
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -26799,11 +26799,11 @@ Types:
       ByteSize: 136
       Element: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 461
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 450 StructureType noalg.map.group[int]int
+      Element: 457 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 1498
       Name: '[]noalg.map.group[int]interface {}.array'
@@ -26811,131 +26811,131 @@ Types:
       ByteSize: 200
       Element: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 562
+      ID: 569
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 558 StructureType noalg.map.group[int]struct {}
+      Element: 565 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 513
+      ID: 520
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 509 StructureType noalg.map.group[int]uint8
+      Element: 516 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 715
+      ID: 722
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 716 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 504
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 491 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 498 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 485
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 474 StructureType noalg.map.group[string][]string
+      Element: 481 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 689
+      ID: 687
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 685 StructureType noalg.map.group[string]float64
+      Element: 683 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1183
+      ID: 1190
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1186 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 477
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 466 StructureType noalg.map.group[string]int
+      Element: 473 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 681
+      ID: 679
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 677 StructureType noalg.map.group[string]interface {}
+      Element: 675 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 462
+      ID: 469
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 458 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 465 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 673
+      ID: 671
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 669 StructureType noalg.map.group[string]string
+      Element: 667 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 554
+      ID: 561
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 550 StructureType noalg.map.group[struct {}]int
+      Element: 557 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 602
+      ID: 609
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 605 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 610
+      ID: 617
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 613 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 618
+      ID: 625
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 626
+      ID: 633
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 634
+      ID: 641
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 642
+      ID: 649
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 645 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 570
+      ID: 577
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 566 StructureType noalg.map.group[struct {}]struct {}
+      Element: 573 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 537
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 525 StructureType noalg.map.group[uint8][4]int
+      Element: 532 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 521
+      ID: 528
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 517 StructureType noalg.map.group[uint8]uint8
+      Element: 524 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -26956,9 +26956,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 445 GoSliceDataType []string.array
+      Data: 452 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 445
+      ID: 452
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26978,14 +26978,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 581 GoSliceDataType []struct {}.array
+      Data: 588 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 581
+      ID: 588
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 127 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 643
+      ID: 650
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489216
@@ -26993,22 +26993,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 644 PointerType *time.zone
+          Type: 651 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 702 GoSliceDataType []time.zone.array
+      Data: 709 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 702
+      ID: 709
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 645 StructureType time.zone
+      Element: 652 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 646
+      ID: 653
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489280
@@ -27016,20 +27016,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 647 PointerType *time.zoneTrans
+          Type: 654 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 704 GoSliceDataType []time.zoneTrans.array
+      Data: 711 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 704
+      ID: 711
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 648 StructureType time.zoneTrans
+      Element: 655 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 264
       Name: '[]uint'
@@ -27046,9 +27046,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 571 GoSliceDataType []uint.array
+      Data: 578 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 571
+      ID: 578
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -27069,9 +27069,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 579 GoSliceDataType []uint16.array
+      Data: 586 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 579
+      ID: 586
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -27092,9 +27092,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 423 GoSliceDataType []uint8.array
+      Data: 430 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 423
+      ID: 430
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -27115,19 +27115,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 425 GoSliceDataType []uintptr.array
+      Data: 432 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 425
+      ID: 432
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1316
+      ID: 1323
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 954
+      ID: 961
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 935840
@@ -27142,33 +27142,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 955 GoSliceDataType archive/tar.headerError.array
+      Data: 962 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 955
+      ID: 962
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1251
+      ID: 1258
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1206
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1201
+      ID: 1208
       Name: archive/zip.dirWriter
       GoRuntimeType: 1126528
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1295
+      ID: 1302
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1227
+      ID: 1234
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1574400
@@ -27178,7 +27178,7 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1229
+      ID: 1236
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -27188,15 +27188,15 @@ Types:
       GoRuntimeType: 588320
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1274
+      ID: 1281
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1305
+      ID: 1312
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1354
+      ID: 1361
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -27222,13 +27222,13 @@ Types:
       GoRuntimeType: 588064
       GoKind: 15
     - __kind: BaseType
-      ID: 752
+      ID: 759
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 838720
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 753
+      ID: 760
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 838816
@@ -27236,26 +27236,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 755 PointerType *compress/flate.InternalError.str
+          Type: 762 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 754 GoStringDataType compress/flate.InternalError.str
+      Data: 761 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 754
+      ID: 761
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1249
+      ID: 1256
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1195
+      ID: 1202
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1271
+      ID: 1278
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27272,19 +27272,19 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 375
+      ID: 413
       Name: context.backgroundCtx
       GoRuntimeType: 1809184
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 376 StructureType context.emptyCtx
+          Type: 400 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 417
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1976192
@@ -27295,23 +27295,23 @@ Types:
           Type: 157 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 377 StructureType sync.Mutex
+          Type: 367 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 380 StructureType sync/atomic.Value
+          Type: 418 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 381 GoMapType map[context.canceler]struct {}
+          Type: 419 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 380 StructureType sync/atomic.Value
+          Type: 418 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 15 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 663
+      ID: 704
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1117184
@@ -27324,13 +27324,13 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1070
+      ID: 1077
       Name: context.deadlineExceededError
       GoRuntimeType: 1472640
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 376
+      ID: 400
       Name: context.emptyCtx
       GoRuntimeType: 1604192
       GoKind: 25
@@ -27339,7 +27339,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 402
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1834432
@@ -27350,11 +27350,11 @@ Types:
           Type: 157 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 386 GoSubroutineType func() bool
+          Type: 403 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 425
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1622944
@@ -27362,29 +27362,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 366 StructureType context.cancelCtx
+          Type: 417 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 387 PointerType *time.Timer
+          Type: 426 PointerType *time.Timer
         - Name: deadline
           Offset: 88
           Type: 328 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 389
+      ID: 415
       Name: context.todoCtx
       GoRuntimeType: 1809408
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 376 StructureType context.emptyCtx
+          Type: 400 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 409
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1846816
@@ -27402,7 +27402,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 374
+      ID: 411
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1808960
@@ -27414,87 +27414,87 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 766
+      ID: 773
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 841312
       GoKind: 2
     - __kind: BaseType
-      ID: 767
+      ID: 774
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 841408
       GoKind: 2
     - __kind: BaseType
-      ID: 768
+      ID: 775
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 841504
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1266
+      ID: 1273
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 1051
+      ID: 1058
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1296384
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1304
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1327
+      ID: 1334
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1301
+      ID: 1308
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1299
+      ID: 1306
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1293
+      ID: 1300
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 769
+      ID: 776
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 841600
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1314
+      ID: 1321
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1289
+      ID: 1296
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 756
+      ID: 763
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 839296
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1047
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1380
+      ID: 1387
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 873
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 871
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1740960
@@ -27505,38 +27505,38 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1166 ArrayType [5]uint8
+          Type: 1173 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 993
+      ID: 1000
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 998784
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1259
+      ID: 1266
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 875
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1264
+      ID: 1271
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1144
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1151
+      ID: 1158
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 940
+      ID: 947
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1743840
@@ -27544,21 +27544,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1150 PointerType *crypto/x509.Certificate
+          Type: 1157 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1169 BaseType crypto/x509.InvalidReason
+          Type: 1176 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 934
+      ID: 941
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1124096
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 936
+      ID: 943
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1608512
@@ -27566,24 +27566,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1150 PointerType *crypto/x509.Certificate
+          Type: 1157 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 765
+      ID: 772
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 840928
       GoKind: 2
     - __kind: BaseType
-      ID: 1169
+      ID: 1176
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 593504
       GoKind: 2
     - __kind: StructureType
-      ID: 1045
+      ID: 1052
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1570400
@@ -27593,13 +27593,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 942
+      ID: 949
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1124352
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 938
+      ID: 945
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1743648
@@ -27607,15 +27607,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1150 PointerType *crypto/x509.Certificate
+          Type: 1157 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 15 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1150 PointerType *crypto/x509.Certificate
+          Type: 1157 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 958
+      ID: 965
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1444096
@@ -27625,7 +27625,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 962
+      ID: 969
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1444256
@@ -27635,55 +27635,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 967
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 747
+      ID: 754
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 838240
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1217
+      ID: 1224
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 748
+      ID: 755
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 838432
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1036
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1360
+      ID: 1367
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 826
+      ID: 833
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1427936
@@ -27693,19 +27693,19 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1225
+      ID: 1232
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 933
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 762
+      ID: 769
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 840832
@@ -27713,22 +27713,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 764 PointerType *encoding/xml.UnmarshalError.str
+          Type: 771 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 763 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 770 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 763
+      ID: 770
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1338
+      ID: 1345
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27745,11 +27745,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 799
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 1003
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27765,15 +27765,15 @@ Types:
       GoRuntimeType: 588256
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1348
+      ID: 1355
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1005
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1007
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27783,7 +27783,7 @@ Types:
       GoRuntimeType: 478272
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 386
+      ID: 403
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 599200
@@ -27828,11 +27828,11 @@ Types:
           Offset: 0
           Type: 334 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 861
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1739808
@@ -27840,7 +27840,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1159 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1166 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -27848,25 +27848,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 844
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1170
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1119872
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1172
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 741
+      ID: 748
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 837664
@@ -27874,18 +27874,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 743 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 750 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 742 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 742
+      ID: 749
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1159
+      ID: 1166
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2230400
@@ -27893,7 +27893,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1160 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1167 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27908,7 +27908,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1161 GoSliceHeaderType []float64
+          Type: 1168 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -27917,10 +27917,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1162 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1169 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1164 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1171 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 161 GoSliceHeaderType []string
@@ -27934,13 +27934,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 1160
+      ID: 1167
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 589920
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 738
+      ID: 745
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 837568
@@ -27948,18 +27948,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 740 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 747 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 739 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 746 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 739
+      ID: 746
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 744
+      ID: 751
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 837760
@@ -27967,30 +27967,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 746 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 753 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 745 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 745
+      ID: 752
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1237
+      ID: 1244
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1324
+      ID: 1331
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 959
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 391
+      ID: 365
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2351072
@@ -27998,7 +27998,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 392 StructureType sync.RWMutex
+          Type: 366 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -28019,13 +28019,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 400 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 377 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 405 GoMapType map[string]float64
+          Type: 382 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -28040,10 +28040,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 387 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 413 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 390 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -28055,7 +28055,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -28078,7 +28078,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 417
+      ID: 394
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2228160
@@ -28089,13 +28089,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 418 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 396 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 395 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 393 StructureType sync/atomic.Int32
+          Type: 370 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28104,16 +28104,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 420 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 398 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 392 StructureType sync.RWMutex
+          Type: 366 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -28122,12 +28122,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 387 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 412
+      ID: 389
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1922432
@@ -28144,7 +28144,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28152,20 +28152,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 400
+      ID: 377
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1289600
       GoKind: 21
-      HeaderType: 402 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 379 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1403
+      ID: 1409
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 587104
       GoKind: 10
     - __kind: StructureType
-      ID: 415
+      ID: 392
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1759744
@@ -28179,16 +28179,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 692 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 690 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 697 GoMapType map[string]interface {}
+          Type: 695 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1429
+      ID: 1436
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 713
+      ID: 720
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1922688
@@ -28196,7 +28196,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1427 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1434 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28211,15 +28211,15 @@ Types:
           Type: 17 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1428 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1435 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1427
+      ID: 1434
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 993696
       GoKind: 5
     - __kind: StructureType
-      ID: 419
+      ID: 397
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2115424
@@ -28227,16 +28227,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 392 StructureType sync.RWMutex
+          Type: 366 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1401 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1407 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -28251,12 +28251,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1403 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1409 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 395 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 420
+      ID: 398
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 901952
@@ -28265,15 +28265,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1112
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1356
+      ID: 1363
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1432
+    - __kind: GoContextImplementationType
+      ID: 405
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1636960
@@ -28282,30 +28282,32 @@ Types:
         - Name: Context
           Offset: 0
           Type: 157 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1123328
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 761
+      ID: 768
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 839968
       GoKind: 2
     - __kind: StructureType
-      ID: 882
+      ID: 889
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1123200
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 880
+      ID: 887
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1606592
@@ -28318,7 +28320,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 907
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1607392
@@ -28331,7 +28333,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1743072
@@ -28347,7 +28349,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 902
+      ID: 909
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1438016
@@ -28357,7 +28359,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 898
+      ID: 905
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1437696
@@ -28367,14 +28369,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1145
+      ID: 1152
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1509280
       GoKind: 21
-      HeaderType: 1147 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1154 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1168
+      ID: 1175
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1055936
@@ -28389,15 +28391,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1186 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1193 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1186
+      ID: 1193
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 912
+      ID: 919
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1607712
@@ -28405,12 +28407,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1145 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1152 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1145 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1152 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1438176
@@ -28420,7 +28422,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1743264
@@ -28431,12 +28433,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1175 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1175 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 908
+      ID: 915
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1607552
@@ -28449,7 +28451,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 914
+      ID: 921
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1438336
@@ -28459,7 +28461,7 @@ Types:
           Offset: 0
           Type: 328 GoTimeType time.Time
     - __kind: StructureType
-      ID: 920
+      ID: 927
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1608032
@@ -28472,7 +28474,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 922
+      ID: 929
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1438656
@@ -28482,7 +28484,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 918
+      ID: 925
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1607872
@@ -28495,7 +28497,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 916
+      ID: 923
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1438496
@@ -28505,7 +28507,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 924
+      ID: 931
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1608192
@@ -28518,7 +28520,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 843
+      ID: 850
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1430176
@@ -28528,11 +28530,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1277
+      ID: 1284
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 852
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1430336
@@ -28540,21 +28542,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 843 StructureType github.com/cihub/seelog.baseError
+          Type: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1257
+      ID: 1264
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1213
+      ID: 1220
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1247
+      ID: 1254
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 849
+      ID: 856
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1430656
@@ -28562,13 +28564,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 843 StructureType github.com/cihub/seelog.baseError
+          Type: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1312
+      ID: 1319
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1325
+      ID: 1332
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2117888
@@ -28576,12 +28578,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1311 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 1328
+      ID: 1335
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2142752
@@ -28589,7 +28591,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1311 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28597,11 +28599,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1215
+      ID: 1222
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 847
+      ID: 854
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1430496
@@ -28609,9 +28611,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 843 StructureType github.com/cihub/seelog.baseError
+          Type: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 851
+      ID: 858
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1430816
@@ -28619,64 +28621,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 843 StructureType github.com/cihub/seelog.baseError
+          Type: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1279
+      ID: 1286
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1320
+      ID: 1327
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1322
+      ID: 1329
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1146
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1060
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1064
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1268
+      ID: 1275
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1054
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1431776
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1372
+      ID: 1379
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1120
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1082
+      ID: 1089
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1852192
@@ -28692,11 +28694,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1076
+      ID: 1083
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1015
+      ID: 1022
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1712512
@@ -28709,7 +28711,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 1088
+      ID: 1095
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1852640
@@ -28725,13 +28727,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 992
+      ID: 999
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 995616
       GoKind: 8
     - __kind: StructureType
-      ID: 1080
+      ID: 1087
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1851968
@@ -28747,13 +28749,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1170
+      ID: 1177
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 835936
       GoKind: 8
     - __kind: StructureType
-      ID: 1078
+      ID: 1085
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1851744
@@ -28761,15 +28763,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1170 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1177 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1170 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1177 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1086
+      ID: 1093
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1765504
@@ -28782,7 +28784,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1084
+      ID: 1091
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1852416
@@ -28798,11 +28800,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1376
+      ID: 1383
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1092
+      ID: 1099
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1632736
@@ -28812,19 +28814,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1019
+      ID: 1026
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1290112
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1017
+      ID: 1024
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1289984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1090
+      ID: 1097
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1765696
@@ -28837,7 +28839,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 774
+      ID: 781
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 843424
@@ -28845,13 +28847,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 776 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 783 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 775 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 782 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 775
+      ID: 782
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -28882,13 +28884,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 650 PointerType *go.shape.string.str
+          Type: 657 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 649 GoStringDataType go.shape.string.str
+      Data: 656 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 649
+      ID: 656
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -28944,11 +28946,11 @@ Types:
           Offset: 32
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1161
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1063
+      ID: 1070
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1455936
@@ -28958,7 +28960,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1243
+      ID: 1250
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1688224
@@ -28966,13 +28968,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1269 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1276 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1336
+      ID: 1343
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1269
+      ID: 1276
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1134080
@@ -28985,7 +28987,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1231
+      ID: 1238
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1579200
@@ -28995,19 +28997,19 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 777
+      ID: 784
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 844000
       GoKind: 10
     - __kind: BaseType
-      ID: 1152
+      ID: 1159
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1009248
       GoKind: 10
     - __kind: StructureType
-      ID: 1121
+      ID: 1128
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1891392
@@ -29018,12 +29020,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1152 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1159 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1615232
@@ -29031,12 +29033,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1152 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1159 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 781
+      ID: 788
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 844192
@@ -29044,18 +29046,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 783 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 790 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 782 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 789 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 782
+      ID: 789
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 787
+      ID: 794
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 844384
@@ -29063,18 +29065,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 789 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 796 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 788 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 795 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 788
+      ID: 795
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 784
+      ID: 791
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 844288
@@ -29082,18 +29084,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 786 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 793 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 785 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 792 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 785
+      ID: 792
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 778
+      ID: 785
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 844096
@@ -29101,22 +29103,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 780 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 787 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 779 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 786 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 779
+      ID: 786
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1334
+      ID: 1341
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 982
+      ID: 989
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1456576
@@ -29126,13 +29128,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 790
+      ID: 797
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 844480
       GoKind: 2
     - __kind: StructureType
-      ID: 970
+      ID: 977
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1451616
@@ -29142,11 +29144,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1126
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1141
+      ID: 1148
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1919168
@@ -29162,7 +29164,7 @@ Types:
           Offset: 24
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 972
+      ID: 979
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1614752
@@ -29175,7 +29177,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1283
+      ID: 1290
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1977216
@@ -29183,16 +29185,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1310 GoInterfaceType io.Reader
+          Type: 1317 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1241
+      ID: 1248
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1061
+      ID: 1068
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1576800
@@ -29202,29 +29204,29 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1203
+      ID: 1210
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 957
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1049
+      ID: 1056
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1124
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1115
+      ID: 1122
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1520000
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 964
+      ID: 971
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1444896
@@ -29234,7 +29236,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 966
+      ID: 973
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1445056
@@ -29244,107 +29246,107 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 899
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 540
+      ID: 547
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 541 PointerType *noalg.map.group[[4]int][4]int
+          Type: 548 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 542 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 546 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 549 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 553 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 532
+      ID: 539
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 533 PointerType *noalg.map.group[[4]int]uint8
+          Type: 540 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 534 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 538 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 541 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 545 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 480
+      ID: 487
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 481 PointerType *noalg.map.group[[4]string][2]int
+          Type: 488 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 482 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 487 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 489 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 494 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 499
+      ID: 506
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 500 PointerType *noalg.map.group[bool]main.node
+          Type: 507 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 501 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 505 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 508 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 512 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 658
+      ID: 699
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 659 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 700 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 660 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 665 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 701 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 706 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 436
+      ID: 443
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 437 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 444 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 438 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 444 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 445 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 451 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1418
+      ID: 1425
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1419 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1426 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1420 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1426 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1427 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1433 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1462
       Name: groupReference<int,*main.deepMap8>
@@ -29374,19 +29376,19 @@ Types:
       GroupType: 1479 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 1485 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 448
+      ID: 455
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 449 PointerType *noalg.map.group[int]int
+          Type: 456 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 450 StructureType noalg.map.group[int]int
-      GroupSliceType: 454 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 457 StructureType noalg.map.group[int]int
+      GroupSliceType: 461 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 1492
       Name: groupReference<int,interface {}>
@@ -29402,305 +29404,305 @@ Types:
       GroupType: 1494 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 1498 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 556
+      ID: 563
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 557 PointerType *noalg.map.group[int]struct {}
+          Type: 564 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 558 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 562 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 565 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 569 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 507
+      ID: 514
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 508 PointerType *noalg.map.group[int]uint8
+          Type: 515 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 509 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 513 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 516 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 520 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 707
+      ID: 714
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 708 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 715 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 715 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 716 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 722 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 489
+      ID: 496
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 490 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 497 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 491 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 497 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 498 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 504 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 472
+      ID: 479
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 473 PointerType *noalg.map.group[string][]string
+          Type: 480 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 474 StructureType noalg.map.group[string][]string
-      GroupSliceType: 478 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 481 StructureType noalg.map.group[string][]string
+      GroupSliceType: 485 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 683
+      ID: 681
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 684 PointerType *noalg.map.group[string]float64
+          Type: 682 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 685 StructureType noalg.map.group[string]float64
-      GroupSliceType: 689 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 683 StructureType noalg.map.group[string]float64
+      GroupSliceType: 687 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1177
+      ID: 1184
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1178 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1185 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1183 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1186 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1190 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 464
+      ID: 471
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 465 PointerType *noalg.map.group[string]int
+          Type: 472 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 466 StructureType noalg.map.group[string]int
-      GroupSliceType: 470 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 473 StructureType noalg.map.group[string]int
+      GroupSliceType: 477 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 675
+      ID: 673
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 676 PointerType *noalg.map.group[string]interface {}
+          Type: 674 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 677 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 681 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 675 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 679 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 456
+      ID: 463
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 457 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 464 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 458 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 462 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 465 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 469 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 667
+      ID: 665
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 668 PointerType *noalg.map.group[string]string
+          Type: 666 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 669 StructureType noalg.map.group[string]string
-      GroupSliceType: 673 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 667 StructureType noalg.map.group[string]string
+      GroupSliceType: 671 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 548
+      ID: 555
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 549 PointerType *noalg.map.group[struct {}]int
+          Type: 556 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 550 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 554 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 557 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 561 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 596
+      ID: 603
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 597 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 604 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 602 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 605 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 609 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 604
+      ID: 611
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 605 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 612 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 610 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 613 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 617 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 612
+      ID: 619
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 613 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 620 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 618 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 625 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 620
+      ID: 627
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 621 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 628 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 626 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 633 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 628
+      ID: 635
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 629 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 636 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 634 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 641 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 636
+      ID: 643
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 637 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 644 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 642 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 645 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 649 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 564
+      ID: 571
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 565 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 572 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 566 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 570 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 573 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 577 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 523
+      ID: 530
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 524 PointerType *noalg.map.group[uint8][4]int
+          Type: 531 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 525 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 530 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 532 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 537 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 515
+      ID: 522
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 516 PointerType *noalg.map.group[uint8]uint8
+          Type: 523 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 517 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 521 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 524 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 528 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1291
+      ID: 1298
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 992
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29747,11 +29749,11 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1150
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 951
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29777,29 +29779,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1193
+      ID: 1200
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1118
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1378
+      ID: 1385
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1109
+      ID: 1116
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1498880
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 806
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29880,7 +29882,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 756
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 838624
@@ -29888,18 +29890,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 758 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 750 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 757 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 757
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1033
+      ID: 1040
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1568160
@@ -29907,9 +29909,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 1142 PointerType *internal/abi.Type
+          Type: 1149 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 379
+      ID: 369
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1496320
@@ -29922,11 +29924,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1235
+      ID: 1242
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1275
+      ID: 1282
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1196864
@@ -29939,7 +29941,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1310
+      ID: 1317
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1029312
@@ -29952,7 +29954,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1262
+      ID: 1269
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1116672
@@ -29978,21 +29980,21 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1233
+      ID: 1240
       Name: io.discard
       GoRuntimeType: 1472320
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1207
+      ID: 1214
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1114
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1281
+      ID: 1288
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -30086,7 +30088,7 @@ Types:
           Offset: 0
           Type: 146 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 442
+      ID: 449
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1193024
@@ -30094,9 +30096,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1412 GoMapType map[int]*main.deepMap3
+          Type: 1419 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1424
+      ID: 1431
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -30148,9 +30150,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1381 PointerType *main.deepPtr3
+          Type: 1388 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1382
+      ID: 1389
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -30194,7 +30196,7 @@ Types:
           Offset: 0
           Type: 140 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 432
+      ID: 439
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1195328
@@ -30202,9 +30204,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1406 GoSliceHeaderType []*main.deepSlice3
+          Type: 1413 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1409
+      ID: 1416
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -30254,16 +30256,16 @@ Types:
           Type: 162 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 377 StructureType sync.Mutex
+          Type: 367 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1389 StructureType sync.Once
+          Type: 1396 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1391 StructureType sync.WaitGroup
+          Type: 1398 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 393 StructureType sync/atomic.Int32
+          Type: 370 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 162
       Name: main.esotericStack
@@ -30681,9 +30683,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1386 ArrayType [63]uint64
+          Type: 1393 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1396
+      ID: 1403
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1420736
@@ -30703,7 +30705,7 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1388
+      ID: 1395
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30714,18 +30716,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1384 PointerType *main.stringType1.str
+          Type: 1391 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1383 GoStringDataType main.stringType1.str
+      Data: 1390 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1383
+      ID: 1390
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1385
+      ID: 1392
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
@@ -30854,16 +30856,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1397 PointerType **main.t
+          Type: 1404 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1398 GoSliceDataType main.t.array
+      Data: 1405 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1398
+      ID: 1405
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -31023,8 +31025,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 545 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 542 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 552 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 549 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 227
       Name: map<[4]int,uint8>
@@ -31058,8 +31060,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 537 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 534 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 544 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 541 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 195
       Name: map<[4]string,[2]int>
@@ -31093,8 +31095,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 486 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 482 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 493 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 489 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 207
       Name: map<bool,main.node>
@@ -31128,10 +31130,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 504 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 501 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 511 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 508 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 383
+      ID: 421
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -31144,7 +31146,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 384 PointerType **table<context.canceler,struct {}>
+          Type: 422 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31163,8 +31165,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 664 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 660 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 705 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 701 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 148
       Name: map<int,*main.deepMap2>
@@ -31198,10 +31200,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 443 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 438 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 450 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 445 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1414
+      ID: 1421
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -31214,7 +31216,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1415 PointerType **table<int,*main.deepMap3>
+          Type: 1422 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31233,8 +31235,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1425 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1420 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1432 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1427 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1458
       Name: map<int,*main.deepMap8>
@@ -31338,8 +31340,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 453 GoSliceDataType []*table<int,int>.array
-      GroupType: 450 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 460 GoSliceDataType []*table<int,int>.array
+      GroupType: 457 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 1488
       Name: map<int,interface {}>
@@ -31408,8 +31410,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 561 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 558 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 568 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 565 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 212
       Name: map<int,uint8>
@@ -31443,10 +31445,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 512 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 509 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 519 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 516 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 694
+      ID: 692
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -31459,7 +31461,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 695 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 693 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31478,8 +31480,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 714 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 721 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 716 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 202
       Name: map<string,[]main.structWithMap>
@@ -31513,8 +31515,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 496 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 491 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 503 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 498 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 190
       Name: map<string,[]string>
@@ -31548,10 +31550,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 477 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 474 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 484 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 481 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 407
+      ID: 384
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -31564,7 +31566,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 408 PointerType **table<string,float64>
+          Type: 385 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31583,10 +31585,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 688 GoSliceDataType []*table<string,float64>.array
-      GroupType: 685 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 686 GoSliceDataType []*table<string,float64>.array
+      GroupType: 683 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1147
+      ID: 1154
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31599,7 +31601,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1148 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1155 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31618,8 +31620,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1182 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1189 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1186 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 185
       Name: map<string,int>
@@ -31653,10 +31655,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 469 GoSliceDataType []*table<string,int>.array
-      GroupType: 466 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 476 GoSliceDataType []*table<string,int>.array
+      GroupType: 473 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 402
+      ID: 379
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31669,7 +31671,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 403 PointerType **table<string,interface {}>
+          Type: 380 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31688,8 +31690,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 680 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 677 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 678 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 675 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 180
       Name: map<string,main.nestedStruct>
@@ -31723,10 +31725,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 461 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 458 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 468 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 465 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 397
+      ID: 374
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -31739,7 +31741,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 398 PointerType **table<string,string>
+          Type: 375 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31758,8 +31760,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 672 GoSliceDataType []*table<string,string>.array
-      GroupType: 669 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 670 GoSliceDataType []*table<string,string>.array
+      GroupType: 667 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 237
       Name: map<struct {},int>
@@ -31793,8 +31795,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 553 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 550 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 560 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 557 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 294
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31828,8 +31830,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 601 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 608 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 605 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 299
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31863,8 +31865,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 609 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 616 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 613 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 304
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31898,8 +31900,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 617 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 624 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 309
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31933,8 +31935,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 625 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 632 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 314
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31968,8 +31970,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 633 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 640 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 319
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32003,8 +32005,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 641 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 648 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 645 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 247
       Name: map<struct {},struct {}>
@@ -32038,8 +32040,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 569 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 566 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 576 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 573 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 222
       Name: map<uint8,[4]int>
@@ -32073,8 +32075,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 529 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 525 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 536 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 532 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 217
       Name: map<uint8,uint8>
@@ -32108,8 +32110,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 520 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 517 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 527 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 524 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 230
       Name: map[[4]int][4]int
@@ -32139,12 +32141,12 @@ Types:
       GoKind: 21
       HeaderType: 207 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 381
+      ID: 419
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1138304
       GoKind: 21
-      HeaderType: 383 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 421 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 146
       Name: map[int]*main.deepMap2
@@ -32153,12 +32155,12 @@ Types:
       GoKind: 21
       HeaderType: 148 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1412
+      ID: 1419
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1135872
       GoKind: 21
-      HeaderType: 1414 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1421 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1456
       Name: map[int]*main.deepMap8
@@ -32202,12 +32204,12 @@ Types:
       GoKind: 21
       HeaderType: 212 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 692
+      ID: 690
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1138560
       GoKind: 21
-      HeaderType: 694 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 692 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 200
       Name: map[string][]main.structWithMap
@@ -32223,12 +32225,12 @@ Types:
       GoKind: 21
       HeaderType: 190 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 405
+      ID: 382
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1138432
       GoKind: 21
-      HeaderType: 407 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 384 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 183
       Name: map[string]int
@@ -32237,12 +32239,12 @@ Types:
       GoKind: 21
       HeaderType: 185 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 697
+      ID: 695
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1134848
       GoKind: 21
-      HeaderType: 402 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 379 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 178
       Name: map[string]main.nestedStruct
@@ -32251,12 +32253,12 @@ Types:
       GoKind: 21
       HeaderType: 180 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 395
+      ID: 372
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1138176
       GoKind: 21
-      HeaderType: 397 GoSwissMapHeaderType map<string,string>
+      HeaderType: 374 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 235
       Name: map[struct {}]int
@@ -32322,7 +32324,7 @@ Types:
       GoKind: 21
       HeaderType: 217 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 896
+      ID: 903
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1437216
@@ -32332,7 +32334,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1197
+      ID: 1204
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1434016
@@ -32342,11 +32344,11 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1106
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1167
+      ID: 1174
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1605312
@@ -32359,35 +32361,35 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1137
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1342
+      ID: 1349
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1135
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1101
+      ID: 1108
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1352
+      ID: 1359
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1362
+      ID: 1369
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1350
+      ID: 1357
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1066
+      ID: 1073
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1119488
@@ -32395,28 +32397,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1068 PointerType *net.UnknownNetworkError.str
+          Type: 1075 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1067 GoStringDataType net.UnknownNetworkError.str
+      Data: 1074 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1067
+      ID: 1074
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1031
+      ID: 1038
       Name: net.canceledError
       GoRuntimeType: 1291008
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1318
+      ID: 1325
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1172
+      ID: 1179
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2117184
@@ -32424,7 +32426,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 15 GoInterfaceType error
@@ -32435,27 +32437,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1364
+      ID: 1371
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1358
+      ID: 1365
       Name: net.noReadFrom
       GoRuntimeType: 1119744
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1357
+      ID: 1364
       Name: net.noWriteTo
       GoRuntimeType: 1119616
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1434
+    - __kind: GoContextImplementationType
+      ID: 407
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1770496
@@ -32467,8 +32469,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 157 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 830
+      ID: 837
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1739616
@@ -32476,7 +32480,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1155 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1162 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -32484,7 +32488,7 @@ Types:
           Offset: 96
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1346
+      ID: 1353
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2300192
@@ -32492,12 +32496,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1358 StructureType net.noReadFrom
+          Type: 1365 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1351 PointerType *net.TCPConn
+          Type: 1358 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1344
+      ID: 1351
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2299648
@@ -32505,24 +32509,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1357 StructureType net.noWriteTo
+          Type: 1364 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1351 PointerType *net.TCPConn
+          Type: 1358 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1103
+      ID: 1110
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1139
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1028
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1189
+      ID: 1196
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1425696
@@ -32532,19 +32536,19 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 719
+      ID: 726
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 836416
       GoKind: 10
     - __kind: BaseType
-      ID: 1144
+      ID: 1151
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 995712
       GoKind: 10
     - __kind: StructureType
-      ID: 806
+      ID: 813
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1738272
@@ -32555,12 +32559,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1144 BaseType net/http.http2ErrCode
+          Type: 1151 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1124
+      ID: 1131
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1909696
@@ -32571,12 +32575,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1144 BaseType net/http.http2ErrCode
+          Type: 1151 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1604992
@@ -32584,16 +32588,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1144 BaseType net/http.http2ErrCode
+          Type: 1151 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1253
+      ID: 1260
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 723
+      ID: 730
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836608
@@ -32601,18 +32605,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 725 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 732 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 724 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 731 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 724
+      ID: 731
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 729
+      ID: 736
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836800
@@ -32620,18 +32624,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 731 PointerType *net/http.http2headerFieldNameError.str
+          Type: 738 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 730 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 737 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 730
+      ID: 737
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 726
+      ID: 733
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836704
@@ -32639,32 +32643,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 728 PointerType *net/http.http2headerFieldValueError.str
+          Type: 735 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 727 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 734 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 727
+      ID: 734
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1103
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1027
+      ID: 1034
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1290368
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1307
+      ID: 1314
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 720
+      ID: 727
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836512
@@ -32672,18 +32676,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 722 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 729 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 721 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 728 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 721
+      ID: 728
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1191
+      ID: 1198
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1835552
@@ -32691,18 +32695,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1284 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1291 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1285 BaseType time.Duration
+          Type: 1292 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 108 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1284
+      ID: 1291
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1424896
@@ -32715,14 +32719,14 @@ Types:
           Offset: 8
           Type: 16 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1272
+      ID: 1279
       Name: net/http.incomparable
       GoRuntimeType: 907136
       GoKind: 17
       HasCount: true
       Element: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1023
+      ID: 1030
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1564320
@@ -32732,11 +32736,11 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1262
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1211
+      ID: 1218
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1564160
@@ -32744,9 +32748,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1254 PointerType *net/http.persistConn
+          Type: 1261 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1245
+      ID: 1252
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1810976
@@ -32754,15 +32758,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1272 ArrayType net/http.incomparable
+          Type: 1279 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1273 PointerType *bufio.Reader
+          Type: 1280 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1275 GoInterfaceType io.ReadWriteCloser
+          Type: 1282 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 814
+      ID: 821
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1426656
@@ -32772,17 +32776,17 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1133
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1094
+      ID: 1101
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1485440
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1025
+      ID: 1032
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1564480
@@ -32792,7 +32796,7 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: StructureType
-      ID: 1287
+      ID: 1294
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2036192
@@ -32800,16 +32804,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1309
+      ID: 1316
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2051936
@@ -32817,13 +32821,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1304 PointerType *bufio.Writer
+          Type: 1311 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1228
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 895
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1742688
@@ -32839,7 +32843,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 886
+      ID: 893
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1606752
@@ -32852,11 +32856,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1261
+      ID: 1268
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1223
+      ID: 1230
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1608672
@@ -32864,16 +32868,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1260 PointerType *net/smtp.Client
+          Type: 1267 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1262 GoInterfaceType io.WriteCloser
+          Type: 1269 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 879
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 757
+      ID: 764
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 839392
@@ -32881,26 +32885,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 759 PointerType *net/textproto.ProtocolError.str
+          Type: 766 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 758 GoStringDataType net/textproto.ProtocolError.str
+      Data: 765 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 758
+      ID: 765
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1219
+      ID: 1226
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1141
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 732
+      ID: 739
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 837280
@@ -32908,18 +32912,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 734 PointerType *net/url.EscapeError.str
+          Type: 741 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 733 GoStringDataType net/url.EscapeError.str
+      Data: 740 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 733
+      ID: 740
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 735
+      ID: 742
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 837376
@@ -32927,79 +32931,79 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 737 PointerType *net/url.InvalidHostError.str
+          Type: 744 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 736 GoStringDataType net/url.InvalidHostError.str
+      Data: 743 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 736
+      ID: 743
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 543
+      ID: 550
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 686912
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 544 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 551 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 535
+      ID: 542
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 687008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 536 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 543 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 483
+      ID: 490
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 687296
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 484 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 491 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 502
+      ID: 509
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 687392
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 503 StructureType noalg.struct { key bool; elem main.node }
+      Element: 510 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 661
+      ID: 702
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 692864
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 662 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 703 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 439
+      ID: 446
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 686144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 440 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 447 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1421
+      ID: 1428
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 686048
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1422 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1429 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1465
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -33019,14 +33023,14 @@ Types:
       HasCount: true
       Element: 1481 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 451
+      ID: 458
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 684224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 452 StructureType noalg.struct { key int; elem int }
+      Element: 459 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 1495
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -33037,189 +33041,189 @@ Types:
       HasCount: true
       Element: 1496 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 559
+      ID: 566
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 687488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 560 StructureType noalg.struct { key int; elem struct {} }
+      Element: 567 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 510
+      ID: 517
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 687584
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 511 StructureType noalg.struct { key int; elem uint8 }
+      Element: 518 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 710
+      ID: 717
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 693504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 711 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 718 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 492
+      ID: 499
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 687680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 493 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 500 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 475
+      ID: 482
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 687776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 476 StructureType noalg.struct { key string; elem []string }
+      Element: 483 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 686
+      ID: 684
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 687 StructureType noalg.struct { key string; elem float64 }
+      Element: 685 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1180
+      ID: 1187
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 763232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1181 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1188 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 467
+      ID: 474
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 687872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 468 StructureType noalg.struct { key string; elem int }
+      Element: 475 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 678
+      ID: 676
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 684992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 679 StructureType noalg.struct { key string; elem interface {} }
+      Element: 677 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 459
+      ID: 466
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 687968
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 460 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 467 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 670
+      ID: 668
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 691136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 671 StructureType noalg.struct { key string; elem string }
+      Element: 669 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 551
+      ID: 558
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 688064
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 552 StructureType noalg.struct { key struct {}; elem int }
+      Element: 559 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 599
+      ID: 606
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 600 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 607 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 607
+      ID: 614
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 608 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 615 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 615
+      ID: 622
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 616 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 623 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 623
+      ID: 630
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 624 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 631 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 631
+      ID: 638
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 632 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 639 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 639
+      ID: 646
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 640 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 647 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 567
+      ID: 574
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 568 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 575 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 526
+      ID: 533
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 688256
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 527 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 534 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 518
+      ID: 525
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 688352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 519 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 526 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 542
+      ID: 549
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1302656
@@ -33230,9 +33234,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 543 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 550 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 534
+      ID: 541
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1302912
@@ -33243,9 +33247,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 535 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 542 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 482
+      ID: 489
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1303168
@@ -33256,9 +33260,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 483 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 490 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 501
+      ID: 508
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1303424
@@ -33269,9 +33273,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 502 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 509 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 660
+      ID: 701
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1307520
@@ -33282,9 +33286,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 661 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 702 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 438
+      ID: 445
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1302400
@@ -33295,9 +33299,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 439 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 446 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1420
+      ID: 1427
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1302144
@@ -33308,7 +33312,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1421 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1428 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1464
       Name: noalg.map.group[int]*main.deepMap8
@@ -33336,7 +33340,7 @@ Types:
           Offset: 8
           Type: 1480 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 450
+      ID: 457
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1299328
@@ -33347,7 +33351,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 451 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 458 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 1494
       Name: noalg.map.group[int]interface {}
@@ -33362,7 +33366,7 @@ Types:
           Offset: 8
           Type: 1495 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 558
+      ID: 565
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1303680
@@ -33373,9 +33377,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 559 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 566 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 509
+      ID: 516
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1303936
@@ -33386,9 +33390,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 510 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 517 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 709
+      ID: 716
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1308416
@@ -33399,9 +33403,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 710 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 717 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 491
+      ID: 498
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1304192
@@ -33412,9 +33416,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 492 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 499 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 474
+      ID: 481
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1304448
@@ -33425,9 +33429,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 475 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 482 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 685
+      ID: 683
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1308160
@@ -33438,9 +33442,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 686 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 684 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1179
+      ID: 1186
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1366144
@@ -33451,9 +33455,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1180 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1187 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 466
+      ID: 473
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1304704
@@ -33464,9 +33468,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 467 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 474 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 677
+      ID: 675
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1300096
@@ -33477,9 +33481,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 678 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 676 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 458
+      ID: 465
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1304960
@@ -33490,9 +33494,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 459 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 466 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 669
+      ID: 667
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1306752
@@ -33503,9 +33507,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 670 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 668 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 550
+      ID: 557
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1305216
@@ -33516,9 +33520,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 551 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 558 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 598
+      ID: 605
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -33528,9 +33532,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 599 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 606 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 606
+      ID: 613
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33540,9 +33544,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 607 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 614 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 614
+      ID: 621
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33552,9 +33556,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 615 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 622 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 622
+      ID: 629
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33564,9 +33568,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 623 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 630 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 630
+      ID: 637
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33576,9 +33580,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 631 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 638 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 638
+      ID: 645
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33588,9 +33592,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 639 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 646 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 566
+      ID: 573
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1305472
@@ -33601,9 +33605,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 567 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 574 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 525
+      ID: 532
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1305728
@@ -33614,9 +33618,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 526 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 533 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 517
+      ID: 524
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1305984
@@ -33627,9 +33631,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 518 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 525 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 544
+      ID: 551
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1302528
@@ -33637,12 +33641,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 528 ArrayType [4]int
+          Type: 535 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 528 ArrayType [4]int
+          Type: 535 ArrayType [4]int
     - __kind: StructureType
-      ID: 536
+      ID: 543
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1302784
@@ -33650,12 +33654,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 528 ArrayType [4]int
+          Type: 535 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 484
+      ID: 491
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1303040
@@ -33663,12 +33667,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 485 ArrayType [4]string
+          Type: 492 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 115 ArrayType [2]int
     - __kind: StructureType
-      ID: 503
+      ID: 510
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1303296
@@ -33681,7 +33685,7 @@ Types:
           Offset: 8
           Type: 253 StructureType main.node
     - __kind: StructureType
-      ID: 662
+      ID: 703
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1307392
@@ -33689,12 +33693,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 663 GoInterfaceType context.canceler
+          Type: 704 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 440
+      ID: 447
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1302272
@@ -33705,9 +33709,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 441 PointerType *main.deepMap2
+          Type: 448 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1422
+      ID: 1429
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1302016
@@ -33718,7 +33722,7 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1423 PointerType *main.deepMap3
+          Type: 1430 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1466
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -33746,7 +33750,7 @@ Types:
           Offset: 8
           Type: 1482 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 452
+      ID: 459
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1299200
@@ -33772,7 +33776,7 @@ Types:
           Offset: 8
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 560
+      ID: 567
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1303552
@@ -33785,7 +33789,7 @@ Types:
           Offset: 8
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 511
+      ID: 518
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1303808
@@ -33798,7 +33802,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 711
+      ID: 718
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1308288
@@ -33809,9 +33813,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 712 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 719 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 493
+      ID: 500
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1304064
@@ -33822,9 +33826,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 494 GoSliceHeaderType []main.structWithMap
+          Type: 501 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 476
+      ID: 483
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1304320
@@ -33837,7 +33841,7 @@ Types:
           Offset: 16
           Type: 161 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 687
+      ID: 685
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1308032
@@ -33850,7 +33854,7 @@ Types:
           Offset: 16
           Type: 17 BaseType float64
     - __kind: StructureType
-      ID: 1181
+      ID: 1188
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1366016
@@ -33861,9 +33865,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1175 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 468
+      ID: 475
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1304576
@@ -33876,7 +33880,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 679
+      ID: 677
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1299968
@@ -33889,7 +33893,7 @@ Types:
           Offset: 16
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 460
+      ID: 467
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1304832
@@ -33902,7 +33906,7 @@ Types:
           Offset: 16
           Type: 125 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 671
+      ID: 669
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1306624
@@ -33915,7 +33919,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 552
+      ID: 559
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1305088
@@ -33928,7 +33932,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 600
+      ID: 607
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -33940,7 +33944,7 @@ Types:
           Offset: 0
           Type: 291 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 608
+      ID: 615
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33952,7 +33956,7 @@ Types:
           Offset: 0
           Type: 292 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 616
+      ID: 623
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33964,7 +33968,7 @@ Types:
           Offset: 0
           Type: 297 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 624
+      ID: 631
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33976,7 +33980,7 @@ Types:
           Offset: 0
           Type: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 632
+      ID: 639
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33988,7 +33992,7 @@ Types:
           Offset: 0
           Type: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34000,7 +34004,7 @@ Types:
           Offset: 0
           Type: 312 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 568
+      ID: 575
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1305344
       GoKind: 25
@@ -34012,7 +34016,7 @@ Types:
           Offset: 0
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 527
+      ID: 534
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1305600
@@ -34023,9 +34027,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 528 ArrayType [4]int
+          Type: 535 ArrayType [4]int
     - __kind: StructureType
-      ID: 519
+      ID: 526
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1305856
@@ -34038,19 +34042,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1370
+      ID: 1377
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1011
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1079
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1368
+      ID: 1375
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2370560
@@ -34058,12 +34062,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1374 StructureType os.noReadFrom
+          Type: 1381 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1369 PointerType *os.File
+          Type: 1376 PointerType *os.File
     - __kind: StructureType
-      ID: 1366
+      ID: 1373
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2369760
@@ -34071,36 +34075,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1373 StructureType os.noWriteTo
+          Type: 1380 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1369 PointerType *os.File
+          Type: 1376 PointerType *os.File
     - __kind: StructureType
-      ID: 1374
+      ID: 1381
       Name: os.noReadFrom
       GoRuntimeType: 1117952
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1373
+      ID: 1380
       Name: os.noWriteTo
       GoRuntimeType: 1117824
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1042
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1175
+      ID: 1182
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1239
+      ID: 1246
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1037
+      ID: 1044
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1713088
@@ -34113,7 +34117,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 771
+      ID: 778
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 842656
@@ -34121,36 +34125,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 773 PointerType *os/user.UnknownGroupIdError.str
+          Type: 780 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 772 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 779 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 772
+      ID: 779
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 770
+      ID: 777
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 842560
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 901
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1015
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1019
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34162,7 +34166,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 1010
+      ID: 1017
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1898560
@@ -34179,9 +34183,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1173 BaseType runtime.boundsErrorCode
+          Type: 1180 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1173
+      ID: 1180
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 588448
@@ -34201,7 +34205,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1074
+      ID: 1081
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1763584
@@ -34214,7 +34218,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 986
+      ID: 993
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 994752
@@ -34222,13 +34226,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 988 PointerType *runtime.errorString.str
+          Type: 995 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 987 GoStringDataType runtime.errorString.str
+      Data: 994 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 987
+      ID: 994
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34855,7 +34859,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 427
+      ID: 434
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -34891,7 +34895,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 989
+      ID: 996
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 994848
@@ -34899,13 +34903,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 991 PointerType *runtime.plainError.str
+          Type: 998 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 990 GoStringDataType runtime.plainError.str
+      Data: 997 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 990
+      ID: 997
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34946,7 +34950,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 797
+      ID: 804
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1604672
@@ -35004,7 +35008,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1009
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -35016,26 +35020,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 422 PointerType *string.str
+          Type: 429 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 421 GoStringDataType string.str
+      Data: 428 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 421
+      ID: 428
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1303
+      ID: 1310
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1216
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1205
+      ID: 1212
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1463936
@@ -35051,7 +35055,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 377
+      ID: 367
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1475360
@@ -35059,12 +35063,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 378 StructureType sync.noCopy
+          Type: 368 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 379 StructureType internal/sync.Mutex
+          Type: 369 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1389
+      ID: 1396
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1625440
@@ -35072,15 +35076,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 378 StructureType sync.noCopy
+          Type: 368 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1390 StructureType sync/atomic.Bool
+          Type: 1397 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 377 StructureType sync.Mutex
+          Type: 367 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 392
+      ID: 366
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1849504
@@ -35088,7 +35092,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 377 StructureType sync.Mutex
+          Type: 367 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -35097,12 +35101,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 393 StructureType sync/atomic.Int32
+          Type: 370 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 393 StructureType sync/atomic.Int32
+          Type: 370 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1391
+      ID: 1398
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1625248
@@ -35110,21 +35114,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 378 StructureType sync.noCopy
+          Type: 368 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1392 StructureType sync/atomic.Uint64
+          Type: 1399 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 378
+      ID: 368
       Name: sync.noCopy
       GoRuntimeType: 994368
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1390
+      ID: 1397
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1476480
@@ -35132,12 +35136,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 371 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 393
+      ID: 370
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1476640
@@ -35145,12 +35149,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 371 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1392
+      ID: 1399
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1625824
@@ -35158,15 +35162,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 371 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1393 StructureType sync/atomic.align64
+          Type: 1400 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 380
+      ID: 418
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1201088
@@ -35176,25 +35180,25 @@ Types:
           Offset: 0
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1393
+      ID: 1400
       Name: sync/atomic.align64
       GoRuntimeType: 994560
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 394
+      ID: 371
       Name: sync/atomic.noCopy
       GoRuntimeType: 994464
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1122
+      ID: 1129
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1292416
       GoKind: 12
     - __kind: StructureType
-      ID: 539
+      ID: 546
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35216,9 +35220,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 540 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 547 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 531
+      ID: 538
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35240,9 +35244,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 532 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 539 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 479
+      ID: 486
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -35264,9 +35268,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 480 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 487 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 498
+      ID: 505
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -35288,9 +35292,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 499 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 506 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 657
+      ID: 698
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35312,9 +35316,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 658 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 699 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 435
+      ID: 442
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -35336,9 +35340,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 436 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 443 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1417
+      ID: 1424
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -35360,7 +35364,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1418 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1425 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1461
       Name: table<int,*main.deepMap8>
@@ -35410,7 +35414,7 @@ Types:
           Offset: 16
           Type: 1477 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 447
+      ID: 454
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -35432,7 +35436,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 448 GoSwissMapGroupsType groupReference<int,int>
+          Type: 455 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 1491
       Name: table<int,interface {}>
@@ -35458,7 +35462,7 @@ Types:
           Offset: 16
           Type: 1492 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 555
+      ID: 562
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35480,9 +35484,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 556 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 563 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 506
+      ID: 513
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35504,9 +35508,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 507 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 514 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 706
+      ID: 713
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -35528,9 +35532,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 707 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 714 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 488
+      ID: 495
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -35552,9 +35556,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 489 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 496 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 471
+      ID: 478
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35576,9 +35580,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 472 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 479 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 682
+      ID: 680
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35600,9 +35604,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 683 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 681 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1176
+      ID: 1183
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35624,9 +35628,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1177 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1184 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 463
+      ID: 470
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35648,9 +35652,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 464 GoSwissMapGroupsType groupReference<string,int>
+          Type: 471 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 674
+      ID: 672
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35672,9 +35676,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 675 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 673 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 455
+      ID: 462
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -35696,9 +35700,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 456 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 463 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 666
+      ID: 664
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -35720,9 +35724,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 667 GoSwissMapGroupsType groupReference<string,string>
+          Type: 665 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 547
+      ID: 554
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -35744,9 +35748,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 548 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 555 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 595
+      ID: 602
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35768,9 +35772,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 596 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 603 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 603
+      ID: 610
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35792,9 +35796,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 604 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 611 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 611
+      ID: 618
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35816,9 +35820,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 612 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 619 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 619
+      ID: 626
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35840,9 +35844,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 620 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 627 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 627
+      ID: 634
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35864,9 +35868,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 628 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 635 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 635
+      ID: 642
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35888,9 +35892,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 636 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 643 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 563
+      ID: 570
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35912,9 +35916,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 564 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 571 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 522
+      ID: 529
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35936,9 +35940,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 523 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 530 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 514
+      ID: 521
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35960,13 +35964,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 515 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 522 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1340
+      ID: 1347
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1065
+      ID: 1072
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1717504
@@ -35979,7 +35983,7 @@ Types:
           Offset: 16
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 1285
+      ID: 1292
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1924224
@@ -35996,10 +36000,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 643 GoSliceHeaderType []time.zone
+          Type: 650 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 646 GoSliceHeaderType []time.zoneTrans
+          Type: 653 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -36011,9 +36015,9 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 644 PointerType *time.zone
+          Type: 651 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 802
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
@@ -36041,7 +36045,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 388
+      ID: 427
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1477600
@@ -36049,12 +36053,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1400 GoChannelType <-chan time.Time
+          Type: 1412 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 716
+      ID: 723
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 834880
@@ -36062,18 +36066,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 718 PointerType *time.fileSizeError.str
+          Type: 725 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 717 GoStringDataType time.fileSizeError.str
+      Data: 724 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 717
+      ID: 724
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 645
+      ID: 652
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1626784
@@ -36089,7 +36093,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 648
+      ID: 655
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1762240
@@ -36150,7 +36154,7 @@ Types:
       GoRuntimeType: 588384
       GoKind: 26
     - __kind: StructureType
-      ID: 1155
+      ID: 1162
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2073664
@@ -36161,10 +36165,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1156 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1163 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1157 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1164 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -36179,18 +36183,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1158 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1165 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1158
+      ID: 1165
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1000416
       GoKind: 9
     - __kind: StructureType
-      ID: 1156
+      ID: 1163
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1937024
@@ -36215,21 +36219,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1157
+      ID: 1164
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 592032
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1332
+      ID: 1339
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 874
+      ID: 881
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1434336
@@ -36239,13 +36243,13 @@ Types:
           Offset: 0
           Type: 15 GoInterfaceType error
     - __kind: BaseType
-      ID: 760
+      ID: 767
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 839488
       GoKind: 2
     - __kind: StructureType
-      ID: 1042
+      ID: 1049
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1713280
@@ -36258,7 +36262,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 994
+      ID: 1001
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 999264

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -11543,7 +11543,7 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1405
+      ID: 1411
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
@@ -11554,10 +11554,10 @@ Types:
       ByteSize: 8
       Pointee: 148 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1410
+      ID: 1417
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1411 PointerType *main.deepSlice3
+      Pointee: 1418 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1445
       Name: '**main.deepSlice8'
@@ -11575,7 +11575,7 @@ Types:
       GoKind: 22
       Pointee: 162 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1400
+      ID: 1407
       Name: '**main.t'
       ByteSize: 8
       Pointee: 261 PointerType *main.t
@@ -11613,20 +11613,20 @@ Types:
       ByteSize: 8
       Pointee: 215 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 390
+      ID: 428
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 391 PointerType *table<context.canceler,struct {}>
+      Pointee: 429 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 155
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 156 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1418
+      ID: 1425
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1419 PointerType *table<int,*main.deepMap3>
+      Pointee: 1426 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1462
       Name: '**table<int,*main.deepMap8>'
@@ -11658,10 +11658,10 @@ Types:
       ByteSize: 8
       Pointee: 220 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 705
+      ID: 703
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 706 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 704 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 209
       Name: '**table<string,[]main.structWithMap>'
@@ -11673,35 +11673,35 @@ Types:
       ByteSize: 8
       Pointee: 198 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 418
+      ID: 391
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 419 PointerType *table<string,float64>
+      Pointee: 392 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1154
+      ID: 1161
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1155 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1162 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 192
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 193 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 413
+      ID: 386
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 414 PointerType *table<string,interface {}>
+      Pointee: 387 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 187
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 188 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 408
+      ID: 381
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 409 PointerType *table<string,string>
+      Pointee: 382 PointerType *table<string,string>
     - __kind: PointerType
       ID: 244
       Name: '**table<struct {},int>'
@@ -11753,20 +11753,20 @@ Types:
       ByteSize: 8
       Pointee: 225 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1408
+      ID: 1414
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1407 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1413 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 444
+      ID: 451
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 443 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 450 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1414
+      ID: 1421
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1413 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1420 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1449
       Name: '*[]*main.deepSlice8.array'
@@ -11778,100 +11778,100 @@ Types:
       ByteSize: 8
       Pointee: 1454 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 439
+      ID: 446
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 438 GoSliceDataType []*runtime.p.array
+      Pointee: 445 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 441
+      ID: 448
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 440 GoSliceDataType []*string.array
+      Pointee: 447 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 604
+      ID: 611
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 603 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 610 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 296
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 293 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 602
+      ID: 609
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 601 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 608 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 294
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 291 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 600
+      ID: 607
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 599 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 606 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 292
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 289 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 598
+      ID: 605
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 597 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 604 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 596
+      ID: 603
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 595 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 602 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 584
+      ID: 591
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 583 GoSliceDataType [][]uint.array
+      Pointee: 590 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 588
+      ID: 595
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 587 GoSliceDataType []bool.array
+      Pointee: 594 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1191
+      ID: 1198
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1190 GoSliceDataType []float64.array
+      Pointee: 1197 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 701
+      ID: 699
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 700 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 709
+      ID: 707
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 708 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 706 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 666
+      ID: 673
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 665 GoSliceDataType []go.shape.float64.array
+      Pointee: 672 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 661 GoSliceDataType []go.shape.int.array
+      Pointee: 668 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 664
+      ID: 671
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 663 GoSliceDataType []go.shape.string.array
+      Pointee: 670 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
       ID: 1458
       Name: '*[]interface {}.array'
@@ -11883,20 +11883,20 @@ Types:
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 594
+      ID: 601
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 593 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 600 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 711
+      ID: 718
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 710 GoSliceDataType []main.structWithMap.array
+      Pointee: 717 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 586
+      ID: 593
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 585 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 592 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -11905,111 +11905,111 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 456
+      ID: 463
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 455 GoSliceDataType []string.array
+      Pointee: 462 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 591 GoSliceDataType []struct {}.array
+      Pointee: 598 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 713
+      ID: 720
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 712 GoSliceDataType []time.zone.array
+      Pointee: 719 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 715
+      ID: 722
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 714 GoSliceDataType []time.zoneTrans.array
+      Pointee: 721 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 272
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 270 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 582
+      ID: 589
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 581 GoSliceDataType []uint.array
+      Pointee: 588 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 590
+      ID: 597
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 589 GoSliceDataType []uint16.array
+      Pointee: 596 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 434
+      ID: 441
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 433 GoSliceDataType []uint8.array
+      Pointee: 440 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 436
+      ID: 443
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 435 GoSliceDataType []uintptr.array
+      Pointee: 442 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1322
+      ID: 1329
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2017920
       GoKind: 22
-      Pointee: 1323 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1330 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 944704
       GoKind: 22
-      Pointee: 960 GoSliceHeaderType archive/tar.headerError
+      Pointee: 967 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 961 GoSliceDataType archive/tar.headerError.array
+      Pointee: 968 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1256
+      ID: 1263
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1454592
       GoKind: 22
-      Pointee: 1257 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1264 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1204
+      ID: 1211
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 944896
       GoKind: 22
-      Pointee: 1205 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1212 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1206
+      ID: 1213
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 944992
       GoKind: 22
-      Pointee: 1207 StructureType archive/zip.dirWriter
+      Pointee: 1214 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1299
+      ID: 1306
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1933952
       GoKind: 22
-      Pointee: 1300 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1307 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1232
+      ID: 1239
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1071584
       GoKind: 22
-      Pointee: 1233 StructureType archive/zip.nopCloser
+      Pointee: 1240 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1234
+      ID: 1241
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1071840
       GoKind: 22
-      Pointee: 1235 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1242 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -12018,26 +12018,26 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1280
+      ID: 1287
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2208000
       GoKind: 22
-      Pointee: 1281 UnresolvedPointeeType bufio.Reader
+      Pointee: 1288 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1311
+      ID: 1318
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1980736
       GoKind: 22
-      Pointee: 1312 UnresolvedPointeeType bufio.Writer
+      Pointee: 1319 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1358
+      ID: 1365
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2309984
       GoKind: 22
-      Pointee: 1359 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1366 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 116
       Name: '*complex128'
@@ -12046,451 +12046,451 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 926752
       GoKind: 22
-      Pointee: 763 BaseType compress/flate.CorruptInputError
+      Pointee: 770 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 926848
       GoKind: 22
-      Pointee: 764 GoStringHeaderType compress/flate.InternalError
+      Pointee: 771 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 765 GoStringDataType compress/flate.InternalError.str
+      Pointee: 772 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1254
+      ID: 1261
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1443392
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1262 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1200
+      ID: 1207
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 926944
       GoKind: 22
-      Pointee: 1201 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1208 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1276
+      ID: 1283
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1753856
       GoKind: 22
-      Pointee: 1277 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1284 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 371
+      ID: 434
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 1751744
       GoKind: 22
-      Pointee: 372 StructureType context.afterFuncCtx
+      Pointee: 435 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 1438
+      ID: 418
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1573184
       GoKind: 22
-      Pointee: 395 StructureType context.backgroundCtx
+      Pointee: 419 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 373
+      ID: 422
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1751168
       GoKind: 22
-      Pointee: 374 StructureType context.cancelCtx
+      Pointee: 423 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1075
+      ID: 1082
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1205216
       GoKind: 22
-      Pointee: 1076 StructureType context.deadlineExceededError
+      Pointee: 1083 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1433
+      ID: 405
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1431712
       GoKind: 22
-      Pointee: 396 StructureType context.emptyCtx
+      Pointee: 406 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 375
+      ID: 407
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1431872
       GoKind: 22
-      Pointee: 376 StructureType context.stopCtx
+      Pointee: 408 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 377
+      ID: 430
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1751360
       GoKind: 22
-      Pointee: 378 StructureType context.timerCtx
+      Pointee: 431 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1439
+      ID: 420
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1573344
       GoKind: 22
-      Pointee: 400 StructureType context.todoCtx
+      Pointee: 421 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 379
+      ID: 414
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1572864
       GoKind: 22
-      Pointee: 380 StructureType context.valueCtx
+      Pointee: 415 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 381
+      ID: 416
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1573024
       GoKind: 22
-      Pointee: 382 StructureType context.withoutCancelCtx
+      Pointee: 417 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 951
+      ID: 958
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 774 BaseType crypto/aes.KeySizeError
+      Pointee: 781 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939520
       GoKind: 22
-      Pointee: 775 BaseType crypto/des.KeySizeError
+      Pointee: 782 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939808
       GoKind: 22
-      Pointee: 776 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 783 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1271
+      ID: 1278
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1693632
       GoKind: 22
-      Pointee: 1272 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1279 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1079392
       GoKind: 22
-      Pointee: 1057 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 1064 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1301
+      ID: 1308
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1934464
       GoKind: 22
-      Pointee: 1302 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1309 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1333
+      ID: 1340
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2152000
       GoKind: 22
-      Pointee: 1334 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1341 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1307
+      ID: 1314
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1935232
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1315 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1303
+      ID: 1310
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1934720
       GoKind: 22
-      Pointee: 1304 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1311 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1297
+      ID: 1304
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1931904
       GoKind: 22
-      Pointee: 1298 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1305 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 940096
       GoKind: 22
-      Pointee: 777 BaseType crypto/rc4.KeySizeError
+      Pointee: 784 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1320
+      ID: 1327
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 2015616
       GoKind: 22
-      Pointee: 1321 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1328 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1305
+      ID: 1312
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1934976
       GoKind: 22
-      Pointee: 1306 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1313 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 1289
+      ID: 1296
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1836640
       GoKind: 22
-      Pointee: 1290 UnresolvedPointeeType crypto/sha3.SHAKE
+      Pointee: 1297 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 928288
       GoKind: 22
-      Pointee: 767 BaseType crypto/tls.AlertError
+      Pointee: 774 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1045
+      ID: 1052
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1060576
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1053 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1384
+      ID: 1391
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2412704
       GoKind: 22
-      Pointee: 1385 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1392 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 928384
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 885 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 928192
       GoKind: 22
-      Pointee: 875 StructureType crypto/tls.RecordHeaderError
+      Pointee: 882 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1044
+      ID: 1051
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1058912
       GoKind: 22
-      Pointee: 999 BaseType crypto/tls.alert
+      Pointee: 1006 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1264
+      ID: 1271
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1582464
       GoKind: 22
-      Pointee: 1265 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1272 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 928480
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 887 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1269
+      ID: 1276
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1667328
       GoKind: 22
-      Pointee: 1270 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1277 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1142
+      ID: 1149
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1443872
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1150 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1156
+      ID: 1163
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2044256
       GoKind: 22
-      Pointee: 1157 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1164 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 938080
       GoKind: 22
-      Pointee: 946 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 953 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 937120
       GoKind: 22
-      Pointee: 940 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 947 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 937600
       GoKind: 22
-      Pointee: 942 StructureType crypto/x509.HostnameError
+      Pointee: 949 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 937024
       GoKind: 22
-      Pointee: 773 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 780 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1050
+      ID: 1057
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1065824
       GoKind: 22
-      Pointee: 1051 StructureType crypto/x509.SystemRootsError
+      Pointee: 1058 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 947
+      ID: 954
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 938176
       GoKind: 22
-      Pointee: 948 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 955 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 937984
       GoKind: 22
-      Pointee: 944 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 951 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 945184
       GoKind: 22
-      Pointee: 964 StructureType encoding/asn1.StructuralError
+      Pointee: 971 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 945376
       GoKind: 22
-      Pointee: 968 StructureType encoding/asn1.SyntaxError
+      Pointee: 975 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 945280
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 973 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 924064
       GoKind: 22
-      Pointee: 757 BaseType encoding/base64.CorruptInputError
+      Pointee: 764 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1222
+      ID: 1229
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1055328
       GoKind: 22
-      Pointee: 1223 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1230 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 924928
       GoKind: 22
-      Pointee: 758 BaseType encoding/hex.InvalidByteError
+      Pointee: 765 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918880
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 841 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1034
+      ID: 1041
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1051488
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1042 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 833 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 918784
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 839 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918688
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 837 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 835 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1364
+      ID: 1371
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2331104
       GoKind: 22
-      Pointee: 1365 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1372 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 836 StructureType encoding/json.jsonError
+      Pointee: 843 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1230
+      ID: 1237
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1068384
       GoKind: 22
-      Pointee: 1231 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1238 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 936256
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 944 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -12499,19 +12499,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 800 UnresolvedPointeeType errors.errorString
+      Pointee: 807 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1037024
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType errors.joinError
+      Pointee: 1009 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -12527,625 +12527,625 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 1352
+      ID: 1359
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2292544
       GoKind: 22
-      Pointee: 1353 UnresolvedPointeeType fmt.pp
+      Pointee: 1360 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1037152
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType fmt.wrapError
+      Pointee: 1011 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 1005
+      ID: 1012
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1037280
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 1013 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 871 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 921664
       GoKind: 22
-      Pointee: 845 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 852 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 921760
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 854 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1168
+      ID: 1175
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 921472
       GoKind: 22
-      Pointee: 1169 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1176 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 922048
       GoKind: 22
-      Pointee: 851 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 858 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1170
+      ID: 1177
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 921568
       GoKind: 22
-      Pointee: 1171 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1178 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 921856
       GoKind: 22
-      Pointee: 751 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 758 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 753
+      ID: 760
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 759 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 748 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 755 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 756 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 921952
       GoKind: 22
-      Pointee: 754 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 761 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 755 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 762 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1242
+      ID: 1249
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1222880
       GoKind: 22
-      Pointee: 1243 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1250 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1330
+      ID: 1337
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2089088
       GoKind: 22
-      Pointee: 1331 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1338 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 957
+      ID: 964
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 943648
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 965 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 401
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2309440
       GoKind: 22
-      Pointee: 402 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 371 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 426
+      ID: 399
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2039072
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 400 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 421
+      ID: 394
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1205472
       GoKind: 22
-      Pointee: 422 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 395 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 424
+      ID: 397
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1205600
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 398 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1431
+      ID: 1438
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1206240
       GoKind: 22
-      Pointee: 1432 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1439 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1206368
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 730 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 428
+      ID: 402
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2258400
       GoKind: 22
-      Pointee: 429 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 403 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1110
+      ID: 1117
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1226336
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1118 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1360
+      ID: 1367
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2310528
       GoKind: 22
-      Pointee: 1361 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1368 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1434
+      ID: 410
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1437632
       GoKind: 22
-      Pointee: 1435 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 411 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 931936
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 895 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 932992
       GoKind: 22
-      Pointee: 895 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 902 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 932704
       GoKind: 22
-      Pointee: 772 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 779 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 932896
       GoKind: 22
-      Pointee: 893 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 900 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 932800
       GoKind: 22
-      Pointee: 891 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 898 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 910
+      ID: 917
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 934912
       GoKind: 22
-      Pointee: 911 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 918 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 935104
       GoKind: 22
-      Pointee: 915 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 922 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 935008
       GoKind: 22
-      Pointee: 913 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 920 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 934816
       GoKind: 22
-      Pointee: 909 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 916 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1193
+      ID: 1200
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1192 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1199 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 922
+      ID: 929
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 935488
       GoKind: 22
-      Pointee: 923 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 930 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 916
+      ID: 923
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 935200
       GoKind: 22
-      Pointee: 917 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 924 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 920
+      ID: 927
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 935392
       GoKind: 22
-      Pointee: 921 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 928 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 918
+      ID: 925
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 935296
       GoKind: 22
-      Pointee: 919 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 926 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 935584
       GoKind: 22
-      Pointee: 925 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 932 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 935872
       GoKind: 22
-      Pointee: 931 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 938 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 935968
       GoKind: 22
-      Pointee: 933 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 940 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 935776
       GoKind: 22
-      Pointee: 929 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 936 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 935680
       GoKind: 22
-      Pointee: 927 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 934 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 936160
       GoKind: 22
-      Pointee: 935 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 942 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 923200
       GoKind: 22
-      Pointee: 853 StructureType github.com/cihub/seelog.baseError
+      Pointee: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1283
+      ID: 1290
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1831040
       GoKind: 22
-      Pointee: 1284 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1291 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 923296
       GoKind: 22
-      Pointee: 855 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 862 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1262
+      ID: 1269
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1580544
       GoKind: 22
-      Pointee: 1263 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1270 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1218
+      ID: 1225
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1054176
       GoKind: 22
-      Pointee: 1219 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1226 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1252
+      ID: 1259
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1441312
       GoKind: 22
-      Pointee: 1253 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1260 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 923488
       GoKind: 22
-      Pointee: 859 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 866 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1318
+      ID: 1325
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 2006976
       GoKind: 22
-      Pointee: 1319 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1326 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1337
+      ID: 1344
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2165792
       GoKind: 22
-      Pointee: 1332 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1339 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1336
+      ID: 1343
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2165408
       GoKind: 22
-      Pointee: 1335 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1342 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1220
+      ID: 1227
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1054304
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1228 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 923392
       GoKind: 22
-      Pointee: 857 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 864 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 923584
       GoKind: 22
-      Pointee: 861 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 868 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1285
+      ID: 1292
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1832832
       GoKind: 22
-      Pointee: 1286 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1293 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1326
+      ID: 1333
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2043968
       GoKind: 22
-      Pointee: 1327 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1334 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1328
+      ID: 1335
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2075040
       GoKind: 22
-      Pointee: 1329 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1336 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1144
+      ID: 1151
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1456992
       GoKind: 22
-      Pointee: 1145 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1152 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1080160
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1068 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1080032
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1066 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1084128
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1070 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1084256
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1072 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1273
+      ID: 1280
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1696512
       GoKind: 22
-      Pointee: 1274 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1281 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1066336
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1060 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 925120
       GoKind: 22
-      Pointee: 867 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 874 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1376
+      ID: 1383
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2386432
       GoKind: 22
-      Pointee: 1377 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1384 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1118
+      ID: 1125
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1236320
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1126 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1087
+      ID: 1094
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1214048
       GoKind: 22
-      Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1095 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1081
+      ID: 1088
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1213664
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1089 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1020
+      ID: 1027
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1045600
       GoKind: 22
-      Pointee: 1021 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1028 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1214432
       GoKind: 22
-      Pointee: 1094 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1101 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1045472
       GoKind: 22
-      Pointee: 998 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 1005 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1213920
       GoKind: 22
-      Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1093 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1213792
       GoKind: 22
-      Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1091 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1214304
       GoKind: 22
-      Pointee: 1092 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1099 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1089
+      ID: 1096
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1214176
       GoKind: 22
-      Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1097 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1380
+      ID: 1387
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2400672
       GoKind: 22
-      Pointee: 1381 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1388 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1097
+      ID: 1104
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1214816
       GoKind: 22
-      Pointee: 1098 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1105 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1045856
       GoKind: 22
-      Pointee: 1025 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1032 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1022
+      ID: 1029
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1045728
       GoKind: 22
-      Pointee: 1023 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1030 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1214688
       GoKind: 22
-      Pointee: 1096 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1103 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 958432
       GoKind: 22
-      Pointee: 782 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 789 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 784
+      ID: 791
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 783 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 790 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
       ID: 367
       Name: '*go.shape.float64'
@@ -13168,10 +13168,10 @@ Types:
       GoKind: 22
       Pointee: 340 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 660
+      ID: 667
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 659 GoStringDataType go.shape.string.str
+      Pointee: 666 GoStringDataType go.shape.string.str
     - __kind: PointerType
       ID: 346
       Name: '*go.shape.struct { Name string }'
@@ -13191,249 +13191,249 @@ Types:
       GoKind: 22
       Pointee: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1159
+      ID: 1166
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1694976
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1167 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1068
+      ID: 1075
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1098976
       GoKind: 22
-      Pointee: 1069 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1076 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1248
+      ID: 1255
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1277280
       GoKind: 22
-      Pointee: 1249 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1256 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1342
+      ID: 1349
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2180768
       GoKind: 22
-      Pointee: 1343 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1350 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1236
+      ID: 1243
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1101280
       GoKind: 22
-      Pointee: 1237 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1244 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 959680
       GoKind: 22
-      Pointee: 785 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 792 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1126
+      ID: 1133
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1278944
       GoKind: 22
-      Pointee: 1127 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1134 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 959968
       GoKind: 22
-      Pointee: 984 StructureType golang.org/x/net/http2.connError
+      Pointee: 991 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 982
+      ID: 989
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 959872
       GoKind: 22
-      Pointee: 789 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 796 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 790 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 797 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 960160
       GoKind: 22
-      Pointee: 795 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 802 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 796 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 803 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 960064
       GoKind: 22
-      Pointee: 792 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 799 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 793 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 800 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 981
+      ID: 988
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 959776
       GoKind: 22
-      Pointee: 786 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 793 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 787 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 794 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1340
+      ID: 1347
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2178848
       GoKind: 22
-      Pointee: 1341 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1348 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 960256
       GoKind: 22
-      Pointee: 988 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 995 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 960352
       GoKind: 22
-      Pointee: 798 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 805 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 953632
       GoKind: 22
-      Pointee: 976 StructureType google.golang.org/grpc.dropError
+      Pointee: 983 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1124
+      ID: 1131
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1276000
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1132 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1146
+      ID: 1153
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1464352
       GoKind: 22
-      Pointee: 1147 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1154 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 956704
       GoKind: 22
-      Pointee: 978 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 985 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1291
+      ID: 1298
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1838880
       GoKind: 22
-      Pointee: 1292 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1299 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1246
+      ID: 1253
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1272544
       GoKind: 22
-      Pointee: 1247 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1254 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1066
+      ID: 1073
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1093216
       GoKind: 22
-      Pointee: 1067 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1074 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1208
+      ID: 1215
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 956800
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1216 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 955
+      ID: 962
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 941536
       GoKind: 22
-      Pointee: 956 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 963 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1069920
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1062 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1122
+      ID: 1129
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1243232
       GoKind: 22
-      Pointee: 1123 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1130 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1120
+      ID: 1127
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1242976
       GoKind: 22
-      Pointee: 1121 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1128 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 946240
       GoKind: 22
-      Pointee: 970 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 977 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 946336
       GoKind: 22
-      Pointee: 972 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 979 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 933376
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 910 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1295
+      ID: 1302
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1929856
       GoKind: 22
-      Pointee: 1296 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1303 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 990
+      ID: 997
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 961120
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType html/template.Error
+      Pointee: 998 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 106
       Name: '*int'
@@ -13477,61 +13477,61 @@ Types:
       GoKind: 22
       Pointee: 170 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 1148
+      ID: 1155
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2231264
       GoKind: 22
-      Pointee: 1149 UnresolvedPointeeType internal/abi.Type
+      Pointee: 1156 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 949
+      ID: 956
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 938944
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 957 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 926464
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 878 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1198
+      ID: 1205
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 925600
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1206 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1116
+      ID: 1123
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1227616
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1124 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1382
+      ID: 1389
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2406336
       GoKind: 22
-      Pointee: 1383 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1390 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1227488
       GoKind: 22
-      Pointee: 1115 StructureType internal/poll.errNetClosing
+      Pointee: 1122 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 913984
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 816 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -13540,66 +13540,66 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 869
+      ID: 876
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 926272
       GoKind: 22
-      Pointee: 760 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 767 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 761 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 768 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1057504
       GoKind: 22
-      Pointee: 1039 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 1046 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 925216
       GoKind: 22
-      Pointee: 759 BaseType internal/strconv.Error
+      Pointee: 766 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 1240
+      ID: 1247
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1204960
       GoKind: 22
-      Pointee: 1241 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1248 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1238
+      ID: 1245
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1204576
       GoKind: 22
-      Pointee: 1239 StructureType io.discard
+      Pointee: 1246 StructureType io.discard
     - __kind: PointerType
-      ID: 1212
+      ID: 1219
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1038048
       GoKind: 22
-      Pointee: 1213 UnresolvedPointeeType io.multiWriter
+      Pointee: 1220 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1112
+      ID: 1119
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1226976
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1120 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1287
+      ID: 1294
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1833056
       GoKind: 22
-      Pointee: 1288 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1295 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 353
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
@@ -13619,19 +13619,19 @@ Types:
       GoKind: 22
       Pointee: 330 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 451
+      ID: 458
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 393184
       GoKind: 22
-      Pointee: 452 StructureType main.deepMap2
+      Pointee: 459 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1426
+      ID: 1433
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 393120
       GoKind: 22
-      Pointee: 1427 UnresolvedPointeeType main.deepMap3
+      Pointee: 1434 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 157
       Name: '*main.deepMap7'
@@ -13661,12 +13661,12 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1386
+      ID: 1393
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 393696
       GoKind: 22
-      Pointee: 1387 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1394 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepPtr7'
@@ -13694,14 +13694,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 394336
       GoKind: 22
-      Pointee: 442 StructureType main.deepSlice2
+      Pointee: 449 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1411
+      ID: 1418
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 394272
       GoKind: 22
-      Pointee: 1412 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1419 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepSlice7'
@@ -13737,7 +13737,7 @@ Types:
       GoKind: 22
       Pointee: 173 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1397
+      ID: 1404
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 908992
@@ -13770,19 +13770,19 @@ Types:
       GoKind: 22
       Pointee: 166 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1398
+      ID: 1405
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 909088
       GoKind: 22
-      Pointee: 1399 StructureType main.secondBehavior
+      Pointee: 1406 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1392
+      ID: 1399
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 909184
       GoKind: 22
-      Pointee: 1393 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1400 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 159
       Name: '*main.stringType1'
@@ -13790,16 +13790,16 @@ Types:
       GoKind: 22
       Pointee: 160 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1389
+      ID: 1396
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1388 GoStringDataType main.stringType1.str
+      Pointee: 1395 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 162
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1390 GoStringHeaderType main.stringType2
+      Pointee: 1397 GoStringHeaderType main.stringType2
     - __kind: PointerType
       ID: 1504
       Name: '*main.stringType2.str'
@@ -13811,7 +13811,7 @@ Types:
       ByteSize: 8
       Pointee: 284 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 505
+      ID: 512
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 392672
@@ -13835,10 +13835,10 @@ Types:
       GoKind: 22
       Pointee: 262 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1402
+      ID: 1409
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1401 GoSliceDataType main.t.array
+      Pointee: 1408 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 281
       Name: '*main.threeStringStruct'
@@ -13866,20 +13866,20 @@ Types:
       ByteSize: 8
       Pointee: 213 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 388
+      ID: 426
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 389 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 427 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 153
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 154 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1416
+      ID: 1423
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1417 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1424 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1460
       Name: '*map<int,*main.deepMap8>'
@@ -13911,10 +13911,10 @@ Types:
       ByteSize: 8
       Pointee: 218 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 703
+      ID: 701
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 704 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 702 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 207
       Name: '*map<string,[]main.structWithMap>'
@@ -13926,35 +13926,35 @@ Types:
       ByteSize: 8
       Pointee: 196 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 416
+      ID: 389
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 417 GoSwissMapHeaderType map<string,float64>
+      Pointee: 390 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1152
+      ID: 1159
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1153 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1160 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 190
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 191 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 411
+      ID: 384
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 412 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 385 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 185
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 186 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 406
+      ID: 379
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 407 GoSwissMapHeaderType map<string,string>
+      Pointee: 380 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 242
       Name: '*map<struct {},int>'
@@ -14012,493 +14012,493 @@ Types:
       GoKind: 22
       Pointee: 189 GoMapType map[string]int
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 934240
       GoKind: 22
-      Pointee: 907 StructureType math/big.ErrNaN
+      Pointee: 914 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1202
+      ID: 1209
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 929056
       GoKind: 22
-      Pointee: 1203 StructureType mime/multipart.writerOnly·1
+      Pointee: 1210 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1104
+      ID: 1111
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1220704
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType net.AddrError
+      Pointee: 1112 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1135
+      ID: 1142
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1439552
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType net.DNSError
+      Pointee: 1143 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1346
+      ID: 1353
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2266176
       GoKind: 22
-      Pointee: 1347 UnresolvedPointeeType net.IPConn
+      Pointee: 1354 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1133
+      ID: 1140
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1439232
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType net.OpError
+      Pointee: 1141 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1106
+      ID: 1113
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1220832
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType net.ParseError
+      Pointee: 1114 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1356
+      ID: 1363
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2293568
       GoKind: 22
-      Pointee: 1357 UnresolvedPointeeType net.TCPConn
+      Pointee: 1364 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1366
+      ID: 1373
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2338688
       GoKind: 22
-      Pointee: 1367 UnresolvedPointeeType net.UDPConn
+      Pointee: 1374 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1354
+      ID: 1361
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2293056
       GoKind: 22
-      Pointee: 1355 UnresolvedPointeeType net.UnixConn
+      Pointee: 1362 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1103
+      ID: 1110
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1219936
       GoKind: 22
-      Pointee: 1072 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1079 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1074
+      ID: 1081
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1073 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1080 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1036
+      ID: 1043
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1052384
       GoKind: 22
-      Pointee: 1037 StructureType net.canceledError
+      Pointee: 1044 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1324
+      ID: 1331
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2041088
       GoKind: 22
-      Pointee: 1325 UnresolvedPointeeType net.conn
+      Pointee: 1332 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1177
+      ID: 1184
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1875616
       GoKind: 22
-      Pointee: 1178 StructureType net.dialResult·1
+      Pointee: 1185 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1368
+      ID: 1375
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2342944
       GoKind: 22
-      Pointee: 1369 UnresolvedPointeeType net.netFD
+      Pointee: 1376 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType net.notFoundError
+      Pointee: 845 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1436
+      ID: 412
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1439392
       GoKind: 22
-      Pointee: 1437 StructureType net.onlyValuesCtx
+      Pointee: 413 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 920896
       GoKind: 22
-      Pointee: 840 StructureType net.result·2
+      Pointee: 847 StructureType net.result·2
     - __kind: PointerType
-      ID: 1350
+      ID: 1357
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2279584
       GoKind: 22
-      Pointee: 1351 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1358 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1348
+      ID: 1355
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2279104
       GoKind: 22
-      Pointee: 1349 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1356 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1108
+      ID: 1115
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1221472
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType net.temporaryError
+      Pointee: 1116 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1137
+      ID: 1144
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1439712
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType net.timeoutError
+      Pointee: 1145 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1048416
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1034 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1194
+      ID: 1201
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 1195 StructureType net/http.bufioFlushWriter
+      Pointee: 1202 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 916672
       GoKind: 22
-      Pointee: 729 BaseType net/http.http2ConnectionError
+      Pointee: 736 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 916768
       GoKind: 22
-      Pointee: 816 StructureType net/http.http2GoAwayError
+      Pointee: 823 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1435552
       GoKind: 22
-      Pointee: 1130 StructureType net/http.http2StreamError
+      Pointee: 1137 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 917344
       GoKind: 22
-      Pointee: 820 StructureType net/http.http2connError
+      Pointee: 827 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1258
+      ID: 1265
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1577344
       GoKind: 22
-      Pointee: 1259 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1266 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 917248
       GoKind: 22
-      Pointee: 733 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 740 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 734 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 741 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 739 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 746 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 740 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 747 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 917440
       GoKind: 22
-      Pointee: 736 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 743 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 737 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 744 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1101
+      ID: 1108
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1216736
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1109 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1032
+      ID: 1039
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1048928
       GoKind: 22
-      Pointee: 1033 StructureType net/http.http2noCachedConnError
+      Pointee: 1040 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1313
+      ID: 1320
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1982016
       GoKind: 22
-      Pointee: 1314 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1321 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 917152
       GoKind: 22
-      Pointee: 730 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 737 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 731 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 738 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1196
+      ID: 1203
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 917632
       GoKind: 22
-      Pointee: 1197 StructureType net/http.http2stickyErrWriter
+      Pointee: 1204 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1048672
       GoKind: 22
-      Pointee: 1029 StructureType net/http.nothingWrittenError
+      Pointee: 1036 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1260
+      ID: 1267
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2227520
       GoKind: 22
-      Pointee: 1261 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1268 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1216
+      ID: 1223
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1048544
       GoKind: 22
-      Pointee: 1217 StructureType net/http.persistConnWriter
+      Pointee: 1224 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1250
+      ID: 1257
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1435712
       GoKind: 22
-      Pointee: 1251 StructureType net/http.readWriteCloserBody
+      Pointee: 1258 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 917728
       GoKind: 22
-      Pointee: 824 StructureType net/http.requestBodyReadError
+      Pointee: 831 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1131
+      ID: 1138
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1436832
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1139 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1099
+      ID: 1106
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1216608
       GoKind: 22
-      Pointee: 1100 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1107 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1030
+      ID: 1037
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1048800
       GoKind: 22
-      Pointee: 1031 StructureType net/http.transportReadFromServerError
+      Pointee: 1038 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1293
+      ID: 1300
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1872032
       GoKind: 22
-      Pointee: 1294 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1301 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 820 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1315
+      ID: 1322
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1984064
       GoKind: 22
-      Pointee: 1316 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1323 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1226
+      ID: 1233
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1061600
       GoKind: 22
-      Pointee: 1227 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1234 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 933184
       GoKind: 22
-      Pointee: 899 StructureType net/netip.parseAddrError
+      Pointee: 906 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 933088
       GoKind: 22
-      Pointee: 897 StructureType net/netip.parsePrefixError
+      Pointee: 904 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1266
+      ID: 1273
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2150592
       GoKind: 22
-      Pointee: 1267 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1274 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1228
+      ID: 1235
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1065952
       GoKind: 22
-      Pointee: 1229 StructureType net/smtp.dataCloser
+      Pointee: 1236 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 929248
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType net/textproto.Error
+      Pointee: 890 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 929152
       GoKind: 22
-      Pointee: 768 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 775 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 769 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 776 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1224
+      ID: 1231
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1061088
       GoKind: 22
-      Pointee: 1225 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1232 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1139
+      ID: 1146
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1440032
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType net/url.Error
+      Pointee: 1147 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 920992
       GoKind: 22
-      Pointee: 742 GoStringHeaderType net/url.EscapeError
+      Pointee: 749 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 743 GoStringDataType net/url.EscapeError.str
+      Pointee: 750 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 921088
       GoKind: 22
-      Pointee: 745 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 752 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 746 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 753 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 551
+      ID: 558
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 552 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 559 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 543
+      ID: 550
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 544 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 551 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 491
+      ID: 498
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 492 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 499 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 510
+      ID: 517
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 511 StructureType noalg.map.group[bool]main.node
+      Pointee: 518 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 669
+      ID: 710
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 670 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 711 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 447
+      ID: 454
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 448 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 455 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1422
+      ID: 1429
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1423 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1430 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1466
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -14510,230 +14510,230 @@ Types:
       ByteSize: 8
       Pointee: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 459
+      ID: 466
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 460 StructureType noalg.map.group[int]int
+      Pointee: 467 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 1496
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 567
+      ID: 574
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 568 StructureType noalg.map.group[int]struct {}
+      Pointee: 575 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 518
+      ID: 525
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 519 StructureType noalg.map.group[int]uint8
+      Pointee: 526 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 726 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 500
+      ID: 507
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 501 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 508 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 483
+      ID: 490
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 484 StructureType noalg.map.group[string][]string
+      Pointee: 491 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 694
+      ID: 692
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 695 StructureType noalg.map.group[string]float64
+      Pointee: 693 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1184
+      ID: 1191
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1192 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 475
+      ID: 482
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 476 StructureType noalg.map.group[string]int
+      Pointee: 483 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 686
+      ID: 684
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 687 StructureType noalg.map.group[string]interface {}
+      Pointee: 685 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 467
+      ID: 474
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 468 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 475 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 678
+      ID: 676
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 679 StructureType noalg.map.group[string]string
+      Pointee: 677 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 559
+      ID: 566
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 560 StructureType noalg.map.group[struct {}]int
+      Pointee: 567 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 607
+      ID: 614
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 615 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 615
+      ID: 622
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 623 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 623
+      ID: 630
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 655 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 575
+      ID: 582
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 576 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 583 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 534
+      ID: 541
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 535 StructureType noalg.map.group[uint8][4]int
+      Pointee: 542 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 526
+      ID: 533
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 527 StructureType noalg.map.group[uint8]uint8
+      Pointee: 534 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1374
+      ID: 1381
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2381056
       GoKind: 22
-      Pointee: 1375 UnresolvedPointeeType os.File
+      Pointee: 1382 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1041760
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType os.LinkError
+      Pointee: 1017 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1077
+      ID: 1084
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1209440
       GoKind: 22
-      Pointee: 1078 UnresolvedPointeeType os.SyscallError
+      Pointee: 1085 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1372
+      ID: 1379
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2380320
       GoKind: 22
-      Pointee: 1373 StructureType os.fileWithoutReadFrom
+      Pointee: 1380 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1370
+      ID: 1377
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2379584
       GoKind: 22
-      Pointee: 1371 StructureType os.fileWithoutWriteTo
+      Pointee: 1378 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1040
+      ID: 1047
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1057632
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType os/exec.Error
+      Pointee: 1048 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1180
+      ID: 1187
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2121504
       GoKind: 22
-      Pointee: 1181 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1188 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1244
+      ID: 1251
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1228640
       GoKind: 22
-      Pointee: 1245 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1252 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1042
+      ID: 1049
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1057760
       GoKind: 22
-      Pointee: 1043 StructureType os/exec.wrappedError
+      Pointee: 1050 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 951712
       GoKind: 22
-      Pointee: 779 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 786 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 780 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 787 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 951616
       GoKind: 22
-      Pointee: 778 BaseType os/user.UnknownUserIdError
+      Pointee: 785 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 914656
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType reflect.ValueError
+      Pointee: 818 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 933856
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 912 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1044064
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1021 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1044704
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1025 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -14749,12 +14749,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1044192
       GoKind: 22
-      Pointee: 1016 StructureType runtime.boundsError
+      Pointee: 1023 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -14770,24 +14770,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1079
+      ID: 1086
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1212256
       GoKind: 22
-      Pointee: 1080 StructureType runtime.errorAddressString
+      Pointee: 1087 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1042400
       GoKind: 22
-      Pointee: 992 GoStringHeaderType runtime.errorString
+      Pointee: 999 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 993 GoStringDataType runtime.errorString.str
+      Pointee: 1000 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -14808,19 +14808,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1043808
       GoKind: 22
-      Pointee: 437 UnresolvedPointeeType runtime.p
+      Pointee: 444 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 1012
+      ID: 1019
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1042528
       GoKind: 22
-      Pointee: 995 GoStringHeaderType runtime.plainError
+      Pointee: 1002 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 996 GoStringDataType runtime.plainError.str
+      Pointee: 1003 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -14836,12 +14836,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 913696
       GoKind: 22
-      Pointee: 807 StructureType runtime.synctestDeadlockError
+      Pointee: 814 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -14864,12 +14864,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1040608
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType strconv.NumError
+      Pointee: 1015 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -14878,31 +14878,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 432
+      ID: 439
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 431 GoStringDataType string.str
+      Pointee: 438 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1309
+      ID: 1316
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1980224
       GoKind: 22
-      Pointee: 1310 UnresolvedPointeeType strings.Builder
+      Pointee: 1317 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1214
+      ID: 1221
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1040736
       GoKind: 22
-      Pointee: 1215 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1222 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1210
+      ID: 1217
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 986144
       GoKind: 22
-      Pointee: 1211 StructureType struct { io.Writer }
+      Pointee: 1218 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 279
       Name: '*struct {}'
@@ -14911,47 +14911,47 @@ Types:
       GoKind: 22
       Pointee: 133 StructureType struct {}
     - __kind: PointerType
-      ID: 1141
+      ID: 1148
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1442272
       GoKind: 22
-      Pointee: 1128 BaseType syscall.Errno
+      Pointee: 1135 BaseType syscall.Errno
     - __kind: PointerType
       ID: 240
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 549 StructureType table<[4]int,[4]int>
+      Pointee: 556 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 235
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 541 StructureType table<[4]int,uint8>
+      Pointee: 548 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 203
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 489 StructureType table<[4]string,[2]int>
+      Pointee: 496 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 215
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 508 StructureType table<bool,main.node>
+      Pointee: 515 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 391
+      ID: 429
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 667 StructureType table<context.canceler,struct {}>
+      Pointee: 708 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 156
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 445 StructureType table<int,*main.deepMap2>
+      Pointee: 452 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1419
+      ID: 1426
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1420 StructureType table<int,*main.deepMap3>
+      Pointee: 1427 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1463
       Name: '*table<int,*main.deepMap8>'
@@ -14966,7 +14966,7 @@ Types:
       ID: 183
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 457 StructureType table<int,int>
+      Pointee: 464 StructureType table<int,int>
     - __kind: PointerType
       ID: 1493
       Name: '*table<int,interface {}>'
@@ -14976,121 +14976,121 @@ Types:
       ID: 250
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 565 StructureType table<int,struct {}>
+      Pointee: 572 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 220
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 516 StructureType table<int,uint8>
+      Pointee: 523 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 706
+      ID: 704
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 716 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 723 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 210
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 498 StructureType table<string,[]main.structWithMap>
+      Pointee: 505 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 198
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 481 StructureType table<string,[]string>
+      Pointee: 488 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 419
+      ID: 392
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 692 StructureType table<string,float64>
+      Pointee: 690 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1155
+      ID: 1162
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1182 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1189 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 193
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 473 StructureType table<string,int>
+      Pointee: 480 StructureType table<string,int>
     - __kind: PointerType
-      ID: 414
+      ID: 387
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 684 StructureType table<string,interface {}>
+      Pointee: 682 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 188
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 465 StructureType table<string,main.nestedStruct>
+      Pointee: 472 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 409
+      ID: 382
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 676 StructureType table<string,string>
+      Pointee: 674 StructureType table<string,string>
     - __kind: PointerType
       ID: 245
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 557 StructureType table<struct {},int>
+      Pointee: 564 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 302
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 605 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 612 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 307
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 613 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 620 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 312
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 621 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 628 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 317
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 629 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 636 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 322
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 637 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 644 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 327
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 645 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 652 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 255
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 573 StructureType table<struct {},struct {}>
+      Pointee: 580 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 230
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 532 StructureType table<uint8,[4]int>
+      Pointee: 539 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 225
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 524 StructureType table<uint8,uint8>
+      Pointee: 531 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1344
+      ID: 1351
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2192992
       GoKind: 22
-      Pointee: 1345 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1352 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1070
+      ID: 1077
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1102816
       GoKind: 22
-      Pointee: 1071 StructureType text/template.ExecError
+      Pointee: 1078 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 335
       Name: '*time.Location'
@@ -15099,52 +15099,52 @@ Types:
       GoKind: 22
       Pointee: 336 StructureType time.Location
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 911776
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType time.ParseError
+      Pointee: 812 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 398
+      ID: 432
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1042144
       GoKind: 22
-      Pointee: 399 StructureType time.Timer
+      Pointee: 433 StructureType time.Timer
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 911584
       GoKind: 22
-      Pointee: 726 GoStringHeaderType time.fileSizeError
+      Pointee: 733 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 727 GoStringDataType time.fileSizeError.str
+      Pointee: 734 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 911680
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType time.parseDurationError
+      Pointee: 810 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399904
       GoKind: 22
-      Pointee: 655 StructureType time.zone
+      Pointee: 662 StructureType time.zone
     - __kind: PointerType
-      ID: 657
+      ID: 664
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399968
       GoKind: 22
-      Pointee: 658 StructureType time.zoneTrans
+      Pointee: 665 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -15188,49 +15188,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 933280
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 908 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1338
+      ID: 1345
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2168480
       GoKind: 22
-      Pointee: 1339 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1346 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 929440
       GoKind: 22
-      Pointee: 885 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 892 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 929536
       GoKind: 22
-      Pointee: 771 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 778 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1047
+      ID: 1054
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1061344
       GoKind: 22
-      Pointee: 1048 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1055 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1049
+      ID: 1056
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1061472
       GoKind: 22
-      Pointee: 1000 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 1007 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1403
+      ID: 1415
       Name: <-chan time.Time
       GoRuntimeType: 606528
       GoKind: 18
@@ -25959,7 +25959,7 @@ Types:
       HasCount: true
       Element: 35 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 538
+      ID: 545
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 693120
@@ -25968,7 +25968,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 495
+      ID: 502
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 693408
@@ -25994,7 +25994,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1172
+      ID: 1179
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 694944
@@ -26003,7 +26003,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1391
+      ID: 1398
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -26029,7 +26029,7 @@ Types:
       HasCount: true
       Element: 91 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1404
+      ID: 1410
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 490016
@@ -26037,16 +26037,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1405 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1411 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1407 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1413 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1407
+      ID: 1413
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26067,15 +26067,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 443 GoSliceDataType []*main.deepSlice2.array
+      Data: 450 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 450
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 148 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1409
+      ID: 1416
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -26083,20 +26083,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1410 PointerType **main.deepSlice3
+          Type: 1417 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1413 GoSliceDataType []*main.deepSlice3.array
+      Data: 1420 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1413
+      ID: 1420
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1411 PointerType *main.deepSlice3
+      Element: 1418 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1444
       Name: '[]*main.deepSlice8'
@@ -26159,9 +26159,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 438 GoSliceDataType []*runtime.p.array
+      Data: 445 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 445
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26182,55 +26182,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 440 GoSliceDataType []*string.array
+      Data: 447 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 440
+      ID: 447
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 103 PointerType *string
     - __kind: GoSliceDataType
-      ID: 555
+      ID: 562
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 240 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 547
+      ID: 554
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 235 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 503
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 203 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 521
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 215 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 674
+      ID: 715
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 391 PointerType *table<context.canceler,struct {}>
+      Element: 429 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 460
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 156 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1428
+      ID: 1435
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1419 PointerType *table<int,*main.deepMap3>
+      Element: 1426 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1472
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -26244,7 +26244,7 @@ Types:
       ByteSize: 8
       Element: 1478 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 470
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26256,127 +26256,127 @@ Types:
       ByteSize: 8
       Element: 1493 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 571
+      ID: 578
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 250 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 522
+      ID: 529
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 220 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 724
+      ID: 731
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 706 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 704 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 513
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 210 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 494
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 198 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 698
+      ID: 696
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 419 PointerType *table<string,float64>
+      Element: 392 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1188
+      ID: 1195
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1155 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1162 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 486
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 193 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 690
+      ID: 688
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 414 PointerType *table<string,interface {}>
+      Element: 387 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 478
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 188 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 682
+      ID: 680
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 409 PointerType *table<string,string>
+      Element: 382 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 563
+      ID: 570
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 245 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 611
+      ID: 618
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 302 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 619
+      ID: 626
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 307 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 627
+      ID: 634
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 312 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 635
+      ID: 642
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 317 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 643
+      ID: 650
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 322 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 651
+      ID: 658
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 327 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 579
+      ID: 586
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 255 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 539
+      ID: 546
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 230 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 537
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26396,9 +26396,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 603 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 610 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 603
+      ID: 610
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26418,9 +26418,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 601 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 608 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 601
+      ID: 608
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26440,9 +26440,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 599 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 606 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 599
+      ID: 606
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26462,9 +26462,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 597 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 604 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 597
+      ID: 604
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26484,9 +26484,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 595 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 602 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 595
+      ID: 602
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26506,9 +26506,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 583 GoSliceDataType [][]uint.array
+      Data: 590 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 583
+      ID: 590
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26529,15 +26529,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 587 GoSliceDataType []bool.array
+      Data: 594 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 587
+      ID: 594
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1167
+      ID: 1174
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -26552,15 +26552,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1190 GoSliceDataType []float64.array
+      Data: 1197 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1190
+      ID: 1197
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 15 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 420
+      ID: 393
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 489568
@@ -26568,22 +26568,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 421 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 394 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 700 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 700
+      ID: 698
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 422 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 395 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 423
+      ID: 396
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 489760
@@ -26591,20 +26591,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 424 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 397 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 708 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 706 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 708
+      ID: 706
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 425 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 398 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
       ID: 366
       Name: '[]go.shape.float64'
@@ -26621,9 +26621,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 665 GoSliceDataType []go.shape.float64.array
+      Data: 672 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 672
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26643,9 +26643,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 661 GoSliceDataType []go.shape.int.array
+      Data: 668 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 661
+      ID: 668
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26665,9 +26665,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 663 GoSliceDataType []go.shape.string.array
+      Data: 670 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 663
+      ID: 670
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26710,15 +26710,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 593 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 600 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 593
+      ID: 600
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 284 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 504
+      ID: 511
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 486432
@@ -26726,16 +26726,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 505 PointerType *main.structWithMap
+          Type: 512 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 710 GoSliceDataType []main.structWithMap.array
+      Data: 717 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 710
+      ID: 717
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26755,55 +26755,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 585 GoSliceDataType []main.structWithNoStrings.array
+      Data: 592 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 585
+      ID: 592
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 275 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 556
+      ID: 563
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 552 StructureType noalg.map.group[[4]int][4]int
+      Element: 559 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 548
+      ID: 555
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 544 StructureType noalg.map.group[[4]int]uint8
+      Element: 551 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 504
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 492 StructureType noalg.map.group[[4]string][2]int
+      Element: 499 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 515
+      ID: 522
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 511 StructureType noalg.map.group[bool]main.node
+      Element: 518 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 675
+      ID: 716
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 670 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 711 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 461
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 448 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 455 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1429
+      ID: 1436
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1423 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1430 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1473
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -26817,11 +26817,11 @@ Types:
       ByteSize: 136
       Element: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 471
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 460 StructureType noalg.map.group[int]int
+      Element: 467 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 1501
       Name: '[]noalg.map.group[int]interface {}.array'
@@ -26829,131 +26829,131 @@ Types:
       ByteSize: 200
       Element: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 572
+      ID: 579
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 568 StructureType noalg.map.group[int]struct {}
+      Element: 575 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 523
+      ID: 530
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 519 StructureType noalg.map.group[int]uint8
+      Element: 526 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 725
+      ID: 732
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 726 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 507
+      ID: 514
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 501 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 508 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 495
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 484 StructureType noalg.map.group[string][]string
+      Element: 491 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 699
+      ID: 697
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 695 StructureType noalg.map.group[string]float64
+      Element: 693 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1189
+      ID: 1196
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1192 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 487
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 476 StructureType noalg.map.group[string]int
+      Element: 483 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 691
+      ID: 689
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 687 StructureType noalg.map.group[string]interface {}
+      Element: 685 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 479
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 468 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 475 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 681
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 679 StructureType noalg.map.group[string]string
+      Element: 677 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 564
+      ID: 571
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 560 StructureType noalg.map.group[struct {}]int
+      Element: 567 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 612
+      ID: 619
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 615 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 620
+      ID: 627
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 623 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 628
+      ID: 635
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 636
+      ID: 643
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 644
+      ID: 651
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 652
+      ID: 659
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 655 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 580
+      ID: 587
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 576 StructureType noalg.map.group[struct {}]struct {}
+      Element: 583 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 547
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 535 StructureType noalg.map.group[uint8][4]int
+      Element: 542 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 531
+      ID: 538
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 527 StructureType noalg.map.group[uint8]uint8
+      Element: 534 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 43
       Name: '[]runtime.ancestorInfo'
@@ -26974,9 +26974,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 455 GoSliceDataType []string.array
+      Data: 462 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 462
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26996,14 +26996,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 591 GoSliceDataType []struct {}.array
+      Data: 598 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 591
+      ID: 598
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 133 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 653
+      ID: 660
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494944
@@ -27011,22 +27011,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 654 PointerType *time.zone
+          Type: 661 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 712 GoSliceDataType []time.zone.array
+      Data: 719 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 712
+      ID: 719
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 655 StructureType time.zone
+      Element: 662 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 656
+      ID: 663
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 495008
@@ -27034,20 +27034,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 657 PointerType *time.zoneTrans
+          Type: 664 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 714 GoSliceDataType []time.zoneTrans.array
+      Data: 721 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 721
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 658 StructureType time.zoneTrans
+      Element: 665 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 270
       Name: '[]uint'
@@ -27064,9 +27064,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 581 GoSliceDataType []uint.array
+      Data: 588 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 581
+      ID: 588
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -27087,9 +27087,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 589 GoSliceDataType []uint16.array
+      Data: 596 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 589
+      ID: 596
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -27110,9 +27110,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 433 GoSliceDataType []uint8.array
+      Data: 440 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 433
+      ID: 440
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -27133,19 +27133,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 435 GoSliceDataType []uintptr.array
+      Data: 442 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 435
+      ID: 442
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1323
+      ID: 1330
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 960
+      ID: 967
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 944800
@@ -27160,33 +27160,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 961 GoSliceDataType archive/tar.headerError.array
+      Data: 968 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 961
+      ID: 968
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1257
+      ID: 1264
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1205
+      ID: 1212
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1207
+      ID: 1214
       Name: archive/zip.dirWriter
       GoRuntimeType: 1134944
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1300
+      ID: 1307
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1233
+      ID: 1240
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1588544
@@ -27196,7 +27196,7 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1235
+      ID: 1242
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -27206,15 +27206,15 @@ Types:
       GoRuntimeType: 594048
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1281
+      ID: 1288
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1312
+      ID: 1319
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1359
+      ID: 1366
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -27240,13 +27240,13 @@ Types:
       GoRuntimeType: 593792
       GoKind: 15
     - __kind: BaseType
-      ID: 763
+      ID: 770
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 764
+      ID: 771
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 845760
@@ -27254,26 +27254,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 766 PointerType *compress/flate.InternalError.str
+          Type: 773 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 765 GoStringDataType compress/flate.InternalError.str
+      Data: 772 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 765
+      ID: 772
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1262
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1201
+      ID: 1208
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1277
+      ID: 1284
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27290,7 +27290,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 435
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 1751552
@@ -27298,29 +27298,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 374 StructureType context.cancelCtx
+          Type: 423 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 392 StructureType sync.Once
+          Type: 436 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 395
+      ID: 419
       Name: context.backgroundCtx
       GoRuntimeType: 1827232
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 396 StructureType context.emptyCtx
+          Type: 406 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 374
+      ID: 423
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1996608
@@ -27331,23 +27331,23 @@ Types:
           Type: 163 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 383 StructureType sync.Mutex
+          Type: 373 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 386 StructureType sync/atomic.Value
+          Type: 424 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 387 GoMapType map[context.canceler]struct {}
+          Type: 425 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 386 StructureType sync/atomic.Value
+          Type: 424 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 17 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 673
+      ID: 714
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1125472
@@ -27360,13 +27360,13 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1076
+      ID: 1083
       Name: context.deadlineExceededError
       GoRuntimeType: 1483904
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 396
+      ID: 406
       Name: context.emptyCtx
       GoRuntimeType: 1619136
       GoKind: 25
@@ -27375,7 +27375,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 376
+      ID: 408
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1852704
@@ -27386,11 +27386,11 @@ Types:
           Type: 163 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 397 GoSubroutineType func() bool
+          Type: 409 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 378
+      ID: 431
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1638528
@@ -27398,29 +27398,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 374 StructureType context.cancelCtx
+          Type: 423 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 398 PointerType *time.Timer
+          Type: 432 PointerType *time.Timer
         - Name: deadline
           Offset: 88
           Type: 334 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 400
+      ID: 421
       Name: context.todoCtx
       GoRuntimeType: 1827456
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 396 StructureType context.emptyCtx
+          Type: 406 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 380
+      ID: 415
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1864864
@@ -27438,7 +27438,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 382
+      ID: 417
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1827008
@@ -27450,91 +27450,91 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 774
+      ID: 781
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 848256
       GoKind: 2
     - __kind: BaseType
-      ID: 775
+      ID: 782
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 848352
       GoKind: 2
     - __kind: BaseType
-      ID: 776
+      ID: 783
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 848448
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1272
+      ID: 1279
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 1057
+      ID: 1064
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1306912
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1302
+      ID: 1309
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1334
+      ID: 1341
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1315
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1304
+      ID: 1311
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1298
+      ID: 1305
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 777
+      ID: 784
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 848544
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1321
+      ID: 1328
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1306
+      ID: 1313
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1290
+      ID: 1297
       Name: crypto/sha3.SHAKE
       ByteSize: 8
     - __kind: BaseType
-      ID: 767
+      ID: 774
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 846240
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1053
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1385
+      ID: 1392
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 885
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1758464
@@ -27545,38 +27545,38 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1172 ArrayType [5]uint8
+          Type: 1179 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 999
+      ID: 1006
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1007840
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1265
+      ID: 1272
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 887
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1270
+      ID: 1277
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1150
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1157
+      ID: 1164
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 946
+      ID: 953
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1761344
@@ -27584,21 +27584,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1156 PointerType *crypto/x509.Certificate
+          Type: 1163 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1175 BaseType crypto/x509.InvalidReason
+          Type: 1182 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 940
+      ID: 947
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1132384
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 942
+      ID: 949
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1623776
@@ -27606,24 +27606,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1156 PointerType *crypto/x509.Certificate
+          Type: 1163 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 773
+      ID: 780
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 847776
       GoKind: 2
     - __kind: BaseType
-      ID: 1175
+      ID: 1182
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 599104
       GoKind: 2
     - __kind: StructureType
-      ID: 1051
+      ID: 1058
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1584384
@@ -27633,13 +27633,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 948
+      ID: 955
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1132640
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 944
+      ID: 951
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1761152
@@ -27647,15 +27647,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1156 PointerType *crypto/x509.Certificate
+          Type: 1163 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1156 PointerType *crypto/x509.Certificate
+          Type: 1163 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 964
+      ID: 971
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1455232
@@ -27665,7 +27665,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 968
+      ID: 975
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1455392
@@ -27675,55 +27675,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 973
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 757
+      ID: 764
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 845088
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1223
+      ID: 1230
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 758
+      ID: 765
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 845280
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 841
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1042
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 839
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1365
+      ID: 1372
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 836
+      ID: 843
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1438272
@@ -27733,11 +27733,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1231
+      ID: 1238
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27754,11 +27754,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 800
+      ID: 807
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1009
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27774,15 +27774,15 @@ Types:
       GoRuntimeType: 593984
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1353
+      ID: 1360
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1011
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1013
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27792,7 +27792,7 @@ Types:
       GoRuntimeType: 483872
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 397
+      ID: 409
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 604800
@@ -27837,11 +27837,11 @@ Types:
           Offset: 0
           Type: 340 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 871
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 852
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1757312
@@ -27849,7 +27849,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1165 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1172 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -27857,25 +27857,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 854
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1169
+      ID: 1176
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 851
+      ID: 858
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1128160
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1171
+      ID: 1178
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 751
+      ID: 758
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 844512
@@ -27883,18 +27883,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 753 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 760 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 759 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 752
+      ID: 759
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1165
+      ID: 1172
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2253024
@@ -27902,7 +27902,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1166 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1173 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -27917,7 +27917,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1167 GoSliceHeaderType []float64
+          Type: 1174 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -27926,10 +27926,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1168 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1175 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1170 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1177 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 167 GoSliceHeaderType []string
@@ -27943,13 +27943,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 1166
+      ID: 1173
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 595584
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 748
+      ID: 755
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 844416
@@ -27957,18 +27957,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 750 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 757 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 756 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 749
+      ID: 756
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 754
+      ID: 761
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 844608
@@ -27976,30 +27976,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 756 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 763 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 755 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 762 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 755
+      ID: 762
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1243
+      ID: 1250
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1331
+      ID: 1338
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 965
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 402
+      ID: 371
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2371648
@@ -28007,7 +28007,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 403 StructureType sync.RWMutex
+          Type: 372 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -28028,13 +28028,13 @@ Types:
           Type: 14 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 410 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 383 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 415 GoMapType map[string]float64
+          Type: 388 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -28049,10 +28049,10 @@ Types:
           Type: 12 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 420 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 393 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 423 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 396 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -28064,7 +28064,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 426 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 399 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -28087,7 +28087,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 427
+      ID: 400
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2250784
@@ -28098,13 +28098,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 428 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 402 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 404 StructureType sync/atomic.Int32
+          Type: 376 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28113,16 +28113,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 430 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 404 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 403 StructureType sync.RWMutex
+          Type: 372 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -28131,12 +28131,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 420 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 393 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 422
+      ID: 395
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1941312
@@ -28153,7 +28153,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28161,20 +28161,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 410
+      ID: 383
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1299744
       GoKind: 21
-      HeaderType: 412 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 385 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1406
+      ID: 1412
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 592832
       GoKind: 10
     - __kind: StructureType
-      ID: 425
+      ID: 398
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1777792
@@ -28188,16 +28188,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 702 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 700 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 707 GoMapType map[string]interface {}
+          Type: 705 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1432
+      ID: 1439
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 723
+      ID: 730
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1941568
@@ -28205,7 +28205,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1430 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1437 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28220,15 +28220,15 @@ Types:
           Type: 15 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1431 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1438 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1430
+      ID: 1437
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1002752
       GoKind: 5
     - __kind: StructureType
-      ID: 429
+      ID: 403
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2136896
@@ -28236,16 +28236,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 403 StructureType sync.RWMutex
+          Type: 372 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1404 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1410 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -28260,12 +28260,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1406 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1412 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 430
+      ID: 404
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 910240
@@ -28274,15 +28274,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1118
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1361
+      ID: 1368
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1435
+    - __kind: GoContextImplementationType
+      ID: 411
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1652736
@@ -28291,30 +28291,32 @@ Types:
         - Name: Context
           Offset: 0
           Type: 163 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1131616
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 772
+      ID: 779
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 846912
       GoKind: 2
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1131488
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1621696
@@ -28327,7 +28329,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 911
+      ID: 918
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1622496
@@ -28340,7 +28342,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 915
+      ID: 922
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1760576
@@ -28356,7 +28358,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 913
+      ID: 920
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1448192
@@ -28366,7 +28368,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 909
+      ID: 916
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1447872
@@ -28376,14 +28378,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1151
+      ID: 1158
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1521824
       GoKind: 21
-      HeaderType: 1153 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1160 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1174
+      ID: 1181
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1064928
@@ -28398,15 +28400,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1192 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1199 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1192
+      ID: 1199
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 923
+      ID: 930
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1622816
@@ -28414,12 +28416,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1151 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1158 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1151 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1158 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 917
+      ID: 924
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1448352
@@ -28429,7 +28431,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 921
+      ID: 928
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1760768
@@ -28440,12 +28442,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1181 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1181 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 919
+      ID: 926
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1622656
@@ -28458,7 +28460,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 925
+      ID: 932
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1448512
@@ -28468,7 +28470,7 @@ Types:
           Offset: 0
           Type: 334 GoTimeType time.Time
     - __kind: StructureType
-      ID: 931
+      ID: 938
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1623136
@@ -28481,7 +28483,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 933
+      ID: 940
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1448832
@@ -28491,7 +28493,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 929
+      ID: 936
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1622976
@@ -28504,7 +28506,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 927
+      ID: 934
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1448672
@@ -28514,7 +28516,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 935
+      ID: 942
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1623296
@@ -28527,7 +28529,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1440512
@@ -28537,11 +28539,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1284
+      ID: 1291
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 855
+      ID: 862
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1440672
@@ -28549,21 +28551,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 853 StructureType github.com/cihub/seelog.baseError
+          Type: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1263
+      ID: 1270
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1219
+      ID: 1226
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1253
+      ID: 1260
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 859
+      ID: 866
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1440992
@@ -28571,13 +28573,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 853 StructureType github.com/cihub/seelog.baseError
+          Type: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1319
+      ID: 1326
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1332
+      ID: 1339
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2139360
@@ -28585,12 +28587,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1325 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 1335
+      ID: 1342
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2165024
@@ -28598,7 +28600,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1325 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28606,11 +28608,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1228
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1440832
@@ -28618,9 +28620,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 853 StructureType github.com/cihub/seelog.baseError
+          Type: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 861
+      ID: 868
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1441152
@@ -28628,64 +28630,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 853 StructureType github.com/cihub/seelog.baseError
+          Type: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1286
+      ID: 1293
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1327
+      ID: 1334
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1329
+      ID: 1336
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1145
+      ID: 1152
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1068
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1070
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1072
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1274
+      ID: 1281
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1060
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 867
+      ID: 874
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1442112
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1377
+      ID: 1384
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1126
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1088
+      ID: 1095
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1870240
@@ -28701,11 +28703,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1089
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1021
+      ID: 1028
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1730016
@@ -28718,7 +28720,7 @@ Types:
           Offset: 1
           Type: 22 BaseType int8
     - __kind: StructureType
-      ID: 1094
+      ID: 1101
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1870688
@@ -28734,13 +28736,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 998
+      ID: 1005
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1004672
       GoKind: 8
     - __kind: StructureType
-      ID: 1086
+      ID: 1093
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1870016
@@ -28756,13 +28758,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1176
+      ID: 1183
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 842784
       GoKind: 8
     - __kind: StructureType
-      ID: 1084
+      ID: 1091
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1869792
@@ -28770,15 +28772,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1176 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1183 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1176 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1183 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1092
+      ID: 1099
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1783744
@@ -28791,7 +28793,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1090
+      ID: 1097
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1870464
@@ -28807,11 +28809,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1381
+      ID: 1388
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1098
+      ID: 1105
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1648704
@@ -28821,19 +28823,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1025
+      ID: 1032
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1300128
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1023
+      ID: 1030
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1300000
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1096
+      ID: 1103
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1783936
@@ -28846,7 +28848,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 782
+      ID: 789
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 850368
@@ -28854,13 +28856,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 784 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 791 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 783 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 790 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 783
+      ID: 790
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -28891,13 +28893,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 660 PointerType *go.shape.string.str
+          Type: 667 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 659 GoStringDataType go.shape.string.str
+      Data: 666 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 659
+      ID: 666
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -28953,11 +28955,11 @@ Types:
           Offset: 32
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1167
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1069
+      ID: 1076
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1467072
@@ -28967,7 +28969,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1249
+      ID: 1256
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1705344
@@ -28975,13 +28977,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1275 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1282 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1343
+      ID: 1350
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1275
+      ID: 1282
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1142496
@@ -28994,7 +28996,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1237
+      ID: 1244
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1593664
@@ -29004,19 +29006,19 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 785
+      ID: 792
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 850944
       GoKind: 10
     - __kind: BaseType
-      ID: 1158
+      ID: 1165
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1018400
       GoKind: 10
     - __kind: StructureType
-      ID: 1127
+      ID: 1134
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1909440
@@ -29027,12 +29029,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1158 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1165 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 984
+      ID: 991
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1630816
@@ -29040,12 +29042,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1158 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1165 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 789
+      ID: 796
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 851136
@@ -29053,18 +29055,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 791 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 798 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 790 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 797 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 790
+      ID: 797
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 795
+      ID: 802
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 851328
@@ -29072,18 +29074,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 797 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 804 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 796 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 803 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 796
+      ID: 803
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 792
+      ID: 799
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 851232
@@ -29091,18 +29093,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 794 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 801 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 793 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 800 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 793
+      ID: 800
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 786
+      ID: 793
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 851040
@@ -29110,22 +29112,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 788 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 795 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 787 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 794 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 787
+      ID: 794
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1341
+      ID: 1348
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 988
+      ID: 995
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1467712
@@ -29135,13 +29137,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 798
+      ID: 805
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 851424
       GoKind: 2
     - __kind: StructureType
-      ID: 976
+      ID: 983
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1462752
@@ -29151,11 +29153,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1132
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1147
+      ID: 1154
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1938304
@@ -29171,7 +29173,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1630336
@@ -29184,7 +29186,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1292
+      ID: 1299
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1997632
@@ -29192,16 +29194,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1317 GoInterfaceType io.Reader
+          Type: 1324 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1247
+      ID: 1254
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1067
+      ID: 1074
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1591264
@@ -29211,29 +29213,29 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1216
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 956
+      ID: 963
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1123
+      ID: 1130
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1121
+      ID: 1128
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1533344
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 970
+      ID: 977
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1456032
@@ -29243,7 +29245,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 972
+      ID: 979
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1456192
@@ -29253,107 +29255,107 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 550
+      ID: 557
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 551 PointerType *noalg.map.group[[4]int][4]int
+          Type: 558 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 552 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 556 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 559 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 563 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 542
+      ID: 549
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 543 PointerType *noalg.map.group[[4]int]uint8
+          Type: 550 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 544 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 548 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 551 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 555 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 490
+      ID: 497
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 491 PointerType *noalg.map.group[[4]string][2]int
+          Type: 498 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 492 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 497 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 499 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 504 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 509
+      ID: 516
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 510 PointerType *noalg.map.group[bool]main.node
+          Type: 517 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 511 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 515 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 518 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 522 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 668
+      ID: 709
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 669 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 710 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 670 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 675 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 711 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 716 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 446
+      ID: 453
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 447 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 454 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 448 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 454 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 455 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 461 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1421
+      ID: 1428
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1422 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1429 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1423 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1429 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1430 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1436 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1465
       Name: groupReference<int,*main.deepMap8>
@@ -29383,19 +29385,19 @@ Types:
       GroupType: 1482 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 1488 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 458
+      ID: 465
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 459 PointerType *noalg.map.group[int]int
+          Type: 466 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 460 StructureType noalg.map.group[int]int
-      GroupSliceType: 464 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 467 StructureType noalg.map.group[int]int
+      GroupSliceType: 471 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 1495
       Name: groupReference<int,interface {}>
@@ -29411,305 +29413,305 @@ Types:
       GroupType: 1497 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 1501 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 566
+      ID: 573
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 567 PointerType *noalg.map.group[int]struct {}
+          Type: 574 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 568 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 572 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 575 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 579 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 517
+      ID: 524
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 518 PointerType *noalg.map.group[int]uint8
+          Type: 525 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 519 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 523 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 526 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 530 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 717
+      ID: 724
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 718 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 725 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 725 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 726 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 732 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 499
+      ID: 506
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 500 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 507 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 501 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 507 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 508 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 514 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 482
+      ID: 489
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 483 PointerType *noalg.map.group[string][]string
+          Type: 490 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 484 StructureType noalg.map.group[string][]string
-      GroupSliceType: 488 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 491 StructureType noalg.map.group[string][]string
+      GroupSliceType: 495 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 693
+      ID: 691
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 694 PointerType *noalg.map.group[string]float64
+          Type: 692 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 695 StructureType noalg.map.group[string]float64
-      GroupSliceType: 699 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 693 StructureType noalg.map.group[string]float64
+      GroupSliceType: 697 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1183
+      ID: 1190
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1184 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1191 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1189 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1192 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1196 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 474
+      ID: 481
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 475 PointerType *noalg.map.group[string]int
+          Type: 482 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 476 StructureType noalg.map.group[string]int
-      GroupSliceType: 480 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 483 StructureType noalg.map.group[string]int
+      GroupSliceType: 487 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 685
+      ID: 683
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 686 PointerType *noalg.map.group[string]interface {}
+          Type: 684 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 687 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 691 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 685 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 689 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 466
+      ID: 473
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 467 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 474 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 468 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 472 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 475 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 479 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 677
+      ID: 675
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 678 PointerType *noalg.map.group[string]string
+          Type: 676 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 679 StructureType noalg.map.group[string]string
-      GroupSliceType: 683 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 677 StructureType noalg.map.group[string]string
+      GroupSliceType: 681 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 558
+      ID: 565
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 559 PointerType *noalg.map.group[struct {}]int
+          Type: 566 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 560 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 564 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 567 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 571 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 606
+      ID: 613
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 607 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 614 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 612 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 615 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 619 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 614
+      ID: 621
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 615 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 622 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 620 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 623 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 627 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 622
+      ID: 629
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 623 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 630 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 628 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 635 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 630
+      ID: 637
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 631 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 638 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 636 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 643 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 638
+      ID: 645
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 639 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 646 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 644 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 651 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 646
+      ID: 653
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 647 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 654 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 652 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 655 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 659 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 574
+      ID: 581
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 575 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 582 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 576 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 580 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 583 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 587 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 533
+      ID: 540
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 534 PointerType *noalg.map.group[uint8][4]int
+          Type: 541 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 535 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 540 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 542 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 547 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 525
+      ID: 532
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 526 PointerType *noalg.map.group[uint8]uint8
+          Type: 533 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 527 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 531 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 534 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 538 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1296
+      ID: 1303
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 998
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29756,17 +29758,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 1179
+      ID: 1186
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 596480
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1149
+      ID: 1156
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 957
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29792,29 +29794,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 878
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1206
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1124
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1383
+      ID: 1390
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1115
+      ID: 1122
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1510944
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 816
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -29886,7 +29888,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 760
+      ID: 767
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 845568
@@ -29894,18 +29896,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 762 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 769 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 761 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 768 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 761
+      ID: 768
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1039
+      ID: 1046
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1582144
@@ -29913,15 +29915,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 1148 PointerType *internal/abi.Type
+          Type: 1155 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 759
+      ID: 766
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 845376
       GoKind: 2
     - __kind: StructureType
-      ID: 385
+      ID: 375
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1508384
@@ -29934,11 +29936,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1241
+      ID: 1248
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1282
+      ID: 1289
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1204704
@@ -29951,7 +29953,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1317
+      ID: 1324
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1038176
@@ -29964,7 +29966,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1268
+      ID: 1275
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1124960
@@ -29990,21 +29992,21 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1239
+      ID: 1246
       Name: io.discard
       GoRuntimeType: 1483584
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1213
+      ID: 1220
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1120
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1288
+      ID: 1295
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -30098,7 +30100,7 @@ Types:
           Offset: 0
           Type: 152 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 452
+      ID: 459
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1200864
@@ -30106,9 +30108,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1415 GoMapType map[int]*main.deepMap3
+          Type: 1422 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1427
+      ID: 1434
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -30160,9 +30162,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1386 PointerType *main.deepPtr3
+          Type: 1393 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1387
+      ID: 1394
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -30206,7 +30208,7 @@ Types:
           Offset: 0
           Type: 146 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 442
+      ID: 449
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1203168
@@ -30214,9 +30216,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1409 GoSliceHeaderType []*main.deepSlice3
+          Type: 1416 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1412
+      ID: 1419
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -30266,16 +30268,16 @@ Types:
           Type: 168 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 383 StructureType sync.Mutex
+          Type: 373 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 392 StructureType sync.Once
+          Type: 436 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1394 StructureType sync.WaitGroup
+          Type: 1401 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 404 StructureType sync/atomic.Int32
+          Type: 376 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 168
       Name: main.esotericStack
@@ -30693,9 +30695,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1391 ArrayType [63]uint64
+          Type: 1398 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1399
+      ID: 1406
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1431392
@@ -30715,7 +30717,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1393
+      ID: 1400
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30726,18 +30728,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1389 PointerType *main.stringType1.str
+          Type: 1396 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1388 GoStringDataType main.stringType1.str
+      Data: 1395 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1388
+      ID: 1395
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1390
+      ID: 1397
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
@@ -30866,16 +30868,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1400 PointerType **main.t
+          Type: 1407 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1401 GoSliceDataType main.t.array
+      Data: 1408 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1401
+      ID: 1408
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -31035,8 +31037,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 555 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 552 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 562 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 559 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 233
       Name: map<[4]int,uint8>
@@ -31070,8 +31072,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 547 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 544 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 554 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 551 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 201
       Name: map<[4]string,[2]int>
@@ -31105,8 +31107,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 496 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 492 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 503 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 499 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 213
       Name: map<bool,main.node>
@@ -31140,10 +31142,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 514 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 511 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 521 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 518 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 389
+      ID: 427
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -31156,7 +31158,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 390 PointerType **table<context.canceler,struct {}>
+          Type: 428 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31175,8 +31177,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 674 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 670 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 715 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 711 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 154
       Name: map<int,*main.deepMap2>
@@ -31210,10 +31212,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 453 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 448 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 460 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 455 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1417
+      ID: 1424
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -31226,7 +31228,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1418 PointerType **table<int,*main.deepMap3>
+          Type: 1425 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31245,8 +31247,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1428 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1423 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1435 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1430 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1461
       Name: map<int,*main.deepMap8>
@@ -31350,8 +31352,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 463 GoSliceDataType []*table<int,int>.array
-      GroupType: 460 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 470 GoSliceDataType []*table<int,int>.array
+      GroupType: 467 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 1491
       Name: map<int,interface {}>
@@ -31420,8 +31422,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 571 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 568 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 578 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 575 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 218
       Name: map<int,uint8>
@@ -31455,10 +31457,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 522 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 519 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 529 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 526 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 704
+      ID: 702
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -31471,7 +31473,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 705 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 703 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31490,8 +31492,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 724 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 731 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 726 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 208
       Name: map<string,[]main.structWithMap>
@@ -31525,8 +31527,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 506 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 501 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 513 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 508 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 196
       Name: map<string,[]string>
@@ -31560,10 +31562,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 487 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 484 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 494 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 491 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 417
+      ID: 390
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -31576,7 +31578,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 418 PointerType **table<string,float64>
+          Type: 391 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31595,10 +31597,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 698 GoSliceDataType []*table<string,float64>.array
-      GroupType: 695 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 696 GoSliceDataType []*table<string,float64>.array
+      GroupType: 693 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1153
+      ID: 1160
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31611,7 +31613,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1154 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1161 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31630,8 +31632,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1188 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1195 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1192 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 191
       Name: map<string,int>
@@ -31665,10 +31667,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 479 GoSliceDataType []*table<string,int>.array
-      GroupType: 476 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 486 GoSliceDataType []*table<string,int>.array
+      GroupType: 483 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 412
+      ID: 385
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31681,7 +31683,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 413 PointerType **table<string,interface {}>
+          Type: 386 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31700,8 +31702,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 690 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 687 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 688 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 685 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 186
       Name: map<string,main.nestedStruct>
@@ -31735,10 +31737,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 471 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 468 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 478 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 475 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 407
+      ID: 380
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -31751,7 +31753,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 408 PointerType **table<string,string>
+          Type: 381 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31770,8 +31772,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 682 GoSliceDataType []*table<string,string>.array
-      GroupType: 679 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 680 GoSliceDataType []*table<string,string>.array
+      GroupType: 677 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 243
       Name: map<struct {},int>
@@ -31805,8 +31807,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 563 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 560 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 570 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 567 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 300
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31840,8 +31842,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 611 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 618 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 615 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 305
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31875,8 +31877,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 619 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 626 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 623 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 310
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31910,8 +31912,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 627 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 634 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 315
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31945,8 +31947,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 635 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 642 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 320
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31980,8 +31982,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 643 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 650 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 325
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32015,8 +32017,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 651 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 658 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 655 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 253
       Name: map<struct {},struct {}>
@@ -32050,8 +32052,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 579 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 576 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 586 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 583 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 228
       Name: map<uint8,[4]int>
@@ -32085,8 +32087,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 539 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 535 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 546 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 542 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 223
       Name: map<uint8,uint8>
@@ -32120,8 +32122,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 530 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 527 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 537 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 534 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 236
       Name: map[[4]int][4]int
@@ -32151,12 +32153,12 @@ Types:
       GoKind: 21
       HeaderType: 213 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 387
+      ID: 425
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1146720
       GoKind: 21
-      HeaderType: 389 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 427 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 152
       Name: map[int]*main.deepMap2
@@ -32165,12 +32167,12 @@ Types:
       GoKind: 21
       HeaderType: 154 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1415
+      ID: 1422
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1144288
       GoKind: 21
-      HeaderType: 1417 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1424 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1459
       Name: map[int]*main.deepMap8
@@ -32214,12 +32216,12 @@ Types:
       GoKind: 21
       HeaderType: 218 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 702
+      ID: 700
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1146976
       GoKind: 21
-      HeaderType: 704 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 702 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 206
       Name: map[string][]main.structWithMap
@@ -32235,12 +32237,12 @@ Types:
       GoKind: 21
       HeaderType: 196 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 415
+      ID: 388
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1146848
       GoKind: 21
-      HeaderType: 417 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 390 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 189
       Name: map[string]int
@@ -32249,12 +32251,12 @@ Types:
       GoKind: 21
       HeaderType: 191 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 707
+      ID: 705
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1143264
       GoKind: 21
-      HeaderType: 412 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 385 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 184
       Name: map[string]main.nestedStruct
@@ -32263,12 +32265,12 @@ Types:
       GoKind: 21
       HeaderType: 186 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 405
+      ID: 378
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1146592
       GoKind: 21
-      HeaderType: 407 GoSwissMapHeaderType map<string,string>
+      HeaderType: 380 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 241
       Name: map[struct {}]int
@@ -32334,7 +32336,7 @@ Types:
       GoKind: 21
       HeaderType: 223 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 907
+      ID: 914
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1447392
@@ -32344,7 +32346,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1203
+      ID: 1210
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1444352
@@ -32354,11 +32356,11 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1112
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1173
+      ID: 1180
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1620416
@@ -32371,35 +32373,35 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1143
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1347
+      ID: 1354
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1141
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1114
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1357
+      ID: 1364
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1367
+      ID: 1374
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1355
+      ID: 1362
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1072
+      ID: 1079
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1127776
@@ -32407,28 +32409,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1074 PointerType *net.UnknownNetworkError.str
+          Type: 1081 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1073 GoStringDataType net.UnknownNetworkError.str
+      Data: 1080 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1073
+      ID: 1080
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1037
+      ID: 1044
       Name: net.canceledError
       GoRuntimeType: 1301280
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1325
+      ID: 1332
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1178
+      ID: 1185
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2138656
@@ -32436,7 +32438,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -32447,27 +32449,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1369
+      ID: 1376
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1363
+      ID: 1370
       Name: net.noReadFrom
       GoRuntimeType: 1128032
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1362
+      ID: 1369
       Name: net.noWriteTo
       GoRuntimeType: 1127904
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 845
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1437
+    - __kind: GoContextImplementationType
+      ID: 413
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1788352
@@ -32479,8 +32481,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 163 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1757120
@@ -32488,7 +32492,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1161 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1168 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -32496,7 +32500,7 @@ Types:
           Offset: 96
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1351
+      ID: 1358
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2320832
@@ -32504,12 +32508,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1363 StructureType net.noReadFrom
+          Type: 1370 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1356 PointerType *net.TCPConn
+          Type: 1363 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1349
+      ID: 1356
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2320288
@@ -32517,24 +32521,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1362 StructureType net.noWriteTo
+          Type: 1369 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1356 PointerType *net.TCPConn
+          Type: 1363 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1116
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1145
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1034
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1195
+      ID: 1202
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1436032
@@ -32544,19 +32548,19 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 729
+      ID: 736
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 843264
       GoKind: 10
     - __kind: BaseType
-      ID: 1150
+      ID: 1157
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1004768
       GoKind: 10
     - __kind: StructureType
-      ID: 816
+      ID: 823
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1755392
@@ -32567,12 +32571,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1150 BaseType net/http.http2ErrCode
+          Type: 1157 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1130
+      ID: 1137
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1927552
@@ -32583,12 +32587,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1150 BaseType net/http.http2ErrCode
+          Type: 1157 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 820
+      ID: 827
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1620096
@@ -32596,16 +32600,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1150 BaseType net/http.http2ErrCode
+          Type: 1157 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1259
+      ID: 1266
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 733
+      ID: 740
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 843456
@@ -32613,18 +32617,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 735 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 742 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 734 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 741 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 734
+      ID: 741
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 739
+      ID: 746
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 843648
@@ -32632,18 +32636,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 741 PointerType *net/http.http2headerFieldNameError.str
+          Type: 748 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 740 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 747 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 740
+      ID: 747
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 736
+      ID: 743
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 843552
@@ -32651,32 +32655,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 738 PointerType *net/http.http2headerFieldValueError.str
+          Type: 745 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 737 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 744 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 737
+      ID: 744
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1109
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1033
+      ID: 1040
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1300640
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1314
+      ID: 1321
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 730
+      ID: 737
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 843360
@@ -32684,18 +32688,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 732 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 739 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 731 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 738 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 731
+      ID: 738
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1197
+      ID: 1204
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1756160
@@ -32703,22 +32707,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1278 BaseType time.Duration
+          Type: 1285 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 113 PointerType *error
     - __kind: ArrayType
-      ID: 1279
+      ID: 1286
       Name: net/http.incomparable
       GoRuntimeType: 915712
       GoKind: 17
       HasCount: true
       Element: 65 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1029
+      ID: 1036
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1578144
@@ -32728,11 +32732,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1261
+      ID: 1268
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1217
+      ID: 1224
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1577984
@@ -32740,9 +32744,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1260 PointerType *net/http.persistConn
+          Type: 1267 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1251
+      ID: 1258
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1829248
@@ -32750,15 +32754,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1279 ArrayType net/http.incomparable
+          Type: 1286 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1280 PointerType *bufio.Reader
+          Type: 1287 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1282 GoInterfaceType io.ReadWriteCloser
+          Type: 1289 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 824
+      ID: 831
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1436992
@@ -32768,17 +32772,17 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1139
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1100
+      ID: 1107
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1497504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1031
+      ID: 1038
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1578304
@@ -32788,7 +32792,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1294
+      ID: 1301
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2058336
@@ -32796,16 +32800,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1316
+      ID: 1323
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2074080
@@ -32813,13 +32817,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1311 PointerType *bufio.Writer
+          Type: 1318 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1227
+      ID: 1234
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1760192
@@ -32835,7 +32839,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1621856
@@ -32848,11 +32852,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1267
+      ID: 1274
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1229
+      ID: 1236
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1624096
@@ -32860,16 +32864,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1266 PointerType *net/smtp.Client
+          Type: 1273 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1268 GoInterfaceType io.WriteCloser
+          Type: 1275 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 890
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 768
+      ID: 775
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 846336
@@ -32877,26 +32881,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 770 PointerType *net/textproto.ProtocolError.str
+          Type: 777 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 769 GoStringDataType net/textproto.ProtocolError.str
+      Data: 776 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 769
+      ID: 776
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1225
+      ID: 1232
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1147
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 742
+      ID: 749
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 844128
@@ -32904,18 +32908,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 744 PointerType *net/url.EscapeError.str
+          Type: 751 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 743 GoStringDataType net/url.EscapeError.str
+      Data: 750 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 743
+      ID: 750
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 745
+      ID: 752
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 844224
@@ -32923,79 +32927,79 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 747 PointerType *net/url.InvalidHostError.str
+          Type: 754 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 746 GoStringDataType net/url.InvalidHostError.str
+      Data: 753 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 746
+      ID: 753
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 553
+      ID: 560
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 693216
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 554 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 561 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 545
+      ID: 552
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 693312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 546 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 553 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 493
+      ID: 500
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 693600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 494 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 501 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 512
+      ID: 519
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 693696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 513 StructureType noalg.struct { key bool; elem main.node }
+      Element: 520 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 671
+      ID: 712
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 700032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 672 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 713 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 449
+      ID: 456
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 692448
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 450 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 457 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1424
+      ID: 1431
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 692352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1425 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1432 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1468
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -33015,14 +33019,14 @@ Types:
       HasCount: true
       Element: 1484 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 461
+      ID: 468
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 690528
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 462 StructureType noalg.struct { key int; elem int }
+      Element: 469 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 1498
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -33033,189 +33037,189 @@ Types:
       HasCount: true
       Element: 1499 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 569
+      ID: 576
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 693792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 570 StructureType noalg.struct { key int; elem struct {} }
+      Element: 577 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 520
+      ID: 527
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 521 StructureType noalg.struct { key int; elem uint8 }
+      Element: 528 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 720
+      ID: 727
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 700672
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 721 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 728 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 502
+      ID: 509
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 693984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 503 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 510 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 485
+      ID: 492
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 694080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 486 StructureType noalg.struct { key string; elem []string }
+      Element: 493 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 696
+      ID: 694
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 700576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 697 StructureType noalg.struct { key string; elem float64 }
+      Element: 695 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1186
+      ID: 1193
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 769984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1187 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1194 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 477
+      ID: 484
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 694176
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 478 StructureType noalg.struct { key string; elem int }
+      Element: 485 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 688
+      ID: 686
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 691296
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 689 StructureType noalg.struct { key string; elem interface {} }
+      Element: 687 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 469
+      ID: 476
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 694272
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 470 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 477 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 680
+      ID: 678
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 698304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 681 StructureType noalg.struct { key string; elem string }
+      Element: 679 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 561
+      ID: 568
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 694368
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 562 StructureType noalg.struct { key struct {}; elem int }
+      Element: 569 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 609
+      ID: 616
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 610 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 617 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 617
+      ID: 624
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 618 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 625 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 625
+      ID: 632
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 626 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 633 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 633
+      ID: 640
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 634 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 641 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 641
+      ID: 648
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 642 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 649 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 649
+      ID: 656
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 650 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 657 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 577
+      ID: 584
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 694464
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 578 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 585 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 536
+      ID: 543
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 694560
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 537 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 544 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 528
+      ID: 535
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 694656
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 529 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 536 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 552
+      ID: 559
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1313184
@@ -33226,9 +33230,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 553 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 560 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 544
+      ID: 551
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1313440
@@ -33239,9 +33243,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 545 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 552 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 492
+      ID: 499
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1313696
@@ -33252,9 +33256,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 493 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 500 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 511
+      ID: 518
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1313952
@@ -33265,9 +33269,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 512 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 519 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 670
+      ID: 711
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1318048
@@ -33278,9 +33282,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 671 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 712 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 448
+      ID: 455
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1312928
@@ -33291,9 +33295,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 449 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 456 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1423
+      ID: 1430
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1312672
@@ -33304,7 +33308,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1424 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1431 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1467
       Name: noalg.map.group[int]*main.deepMap8
@@ -33332,7 +33336,7 @@ Types:
           Offset: 8
           Type: 1483 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 460
+      ID: 467
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1309856
@@ -33343,7 +33347,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 461 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 468 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 1497
       Name: noalg.map.group[int]interface {}
@@ -33358,7 +33362,7 @@ Types:
           Offset: 8
           Type: 1498 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 568
+      ID: 575
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1314208
@@ -33369,9 +33373,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 569 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 576 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 519
+      ID: 526
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1314464
@@ -33382,9 +33386,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 520 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 527 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1319072
@@ -33395,9 +33399,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 720 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 727 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 501
+      ID: 508
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1314720
@@ -33408,9 +33412,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 502 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 509 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 484
+      ID: 491
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1314976
@@ -33421,9 +33425,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 485 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 492 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 695
+      ID: 693
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1318816
@@ -33434,9 +33438,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 696 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 694 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1185
+      ID: 1192
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1376672
@@ -33447,9 +33451,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1186 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1193 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 476
+      ID: 483
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1315232
@@ -33460,9 +33464,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 477 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 484 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 687
+      ID: 685
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1310624
@@ -33473,9 +33477,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 688 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 686 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 468
+      ID: 475
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1315488
@@ -33486,9 +33490,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 469 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 476 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 679
+      ID: 677
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1317280
@@ -33499,9 +33503,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 680 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 678 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 560
+      ID: 567
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1315744
@@ -33512,9 +33516,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 561 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 568 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 608
+      ID: 615
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -33524,9 +33528,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 609 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 616 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 616
+      ID: 623
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33536,9 +33540,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 617 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 624 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 624
+      ID: 631
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33548,9 +33552,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 625 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 632 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 632
+      ID: 639
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33560,9 +33564,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 633 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 640 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33572,9 +33576,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 641 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 648 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 648
+      ID: 655
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33584,9 +33588,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 649 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 656 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 576
+      ID: 583
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1316000
@@ -33597,9 +33601,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 577 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 584 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 535
+      ID: 542
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1316256
@@ -33610,9 +33614,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 536 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 543 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 527
+      ID: 534
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1316512
@@ -33623,9 +33627,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 528 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 535 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 554
+      ID: 561
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1313056
@@ -33633,12 +33637,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 538 ArrayType [4]int
+          Type: 545 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 538 ArrayType [4]int
+          Type: 545 ArrayType [4]int
     - __kind: StructureType
-      ID: 546
+      ID: 553
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1313312
@@ -33646,12 +33650,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 538 ArrayType [4]int
+          Type: 545 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 494
+      ID: 501
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1313568
@@ -33659,12 +33663,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 495 ArrayType [4]string
+          Type: 502 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 121 ArrayType [2]int
     - __kind: StructureType
-      ID: 513
+      ID: 520
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1313824
@@ -33677,7 +33681,7 @@ Types:
           Offset: 8
           Type: 259 StructureType main.node
     - __kind: StructureType
-      ID: 672
+      ID: 713
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1317920
@@ -33685,12 +33689,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 673 GoInterfaceType context.canceler
+          Type: 714 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 450
+      ID: 457
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1312800
@@ -33701,9 +33705,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 451 PointerType *main.deepMap2
+          Type: 458 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1425
+      ID: 1432
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1312544
@@ -33714,7 +33718,7 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1426 PointerType *main.deepMap3
+          Type: 1433 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1469
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -33742,7 +33746,7 @@ Types:
           Offset: 8
           Type: 1485 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 462
+      ID: 469
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1309728
@@ -33768,7 +33772,7 @@ Types:
           Offset: 8
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 570
+      ID: 577
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1314080
@@ -33781,7 +33785,7 @@ Types:
           Offset: 8
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 521
+      ID: 528
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1314336
@@ -33794,7 +33798,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 721
+      ID: 728
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1318944
@@ -33805,9 +33809,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 722 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 729 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 503
+      ID: 510
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1314592
@@ -33818,9 +33822,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 504 GoSliceHeaderType []main.structWithMap
+          Type: 511 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1314848
@@ -33833,7 +33837,7 @@ Types:
           Offset: 16
           Type: 167 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 697
+      ID: 695
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1318688
@@ -33846,7 +33850,7 @@ Types:
           Offset: 16
           Type: 15 BaseType float64
     - __kind: StructureType
-      ID: 1187
+      ID: 1194
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1376544
@@ -33857,9 +33861,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1181 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 478
+      ID: 485
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1315104
@@ -33872,7 +33876,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 689
+      ID: 687
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1310496
@@ -33885,7 +33889,7 @@ Types:
           Offset: 16
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 470
+      ID: 477
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1315360
@@ -33898,7 +33902,7 @@ Types:
           Offset: 16
           Type: 131 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 681
+      ID: 679
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1317152
@@ -33911,7 +33915,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 562
+      ID: 569
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1315616
@@ -33924,7 +33928,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 610
+      ID: 617
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -33936,7 +33940,7 @@ Types:
           Offset: 0
           Type: 297 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 618
+      ID: 625
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33948,7 +33952,7 @@ Types:
           Offset: 0
           Type: 298 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 626
+      ID: 633
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33960,7 +33964,7 @@ Types:
           Offset: 0
           Type: 303 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 634
+      ID: 641
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33972,7 +33976,7 @@ Types:
           Offset: 0
           Type: 308 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 642
+      ID: 649
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33984,7 +33988,7 @@ Types:
           Offset: 0
           Type: 313 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -33996,7 +34000,7 @@ Types:
           Offset: 0
           Type: 318 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 578
+      ID: 585
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1315872
       GoKind: 25
@@ -34008,7 +34012,7 @@ Types:
           Offset: 0
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 537
+      ID: 544
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1316128
@@ -34019,9 +34023,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 538 ArrayType [4]int
+          Type: 545 ArrayType [4]int
     - __kind: StructureType
-      ID: 529
+      ID: 536
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1316384
@@ -34034,19 +34038,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1375
+      ID: 1382
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1017
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1078
+      ID: 1085
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1373
+      ID: 1380
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2391232
@@ -34054,12 +34058,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1379 StructureType os.noReadFrom
+          Type: 1386 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1374 PointerType *os.File
+          Type: 1381 PointerType *os.File
     - __kind: StructureType
-      ID: 1371
+      ID: 1378
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2390432
@@ -34067,36 +34071,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1378 StructureType os.noWriteTo
+          Type: 1385 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1374 PointerType *os.File
+          Type: 1381 PointerType *os.File
     - __kind: StructureType
-      ID: 1379
+      ID: 1386
       Name: os.noReadFrom
       GoRuntimeType: 1126240
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1378
+      ID: 1385
       Name: os.noWriteTo
       GoRuntimeType: 1126112
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1048
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1181
+      ID: 1188
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1245
+      ID: 1252
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1043
+      ID: 1050
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1730592
@@ -34109,7 +34113,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 779
+      ID: 786
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 849600
@@ -34117,36 +34121,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 781 PointerType *os/user.UnknownGroupIdError.str
+          Type: 788 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 780 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 787 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 780
+      ID: 787
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 778
+      ID: 785
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 849504
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 818
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 912
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1021
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1025
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34158,7 +34162,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 1016
+      ID: 1023
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1916608
@@ -34175,7 +34179,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1179 BaseType internal/abi.BoundsErrorCode
+          Type: 1186 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -34191,7 +34195,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1080
+      ID: 1087
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1781632
@@ -34204,7 +34208,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 992
+      ID: 999
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1003808
@@ -34212,13 +34216,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 994 PointerType *runtime.errorString.str
+          Type: 1001 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 993 GoStringDataType runtime.errorString.str
+      Data: 1000 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 993
+      ID: 1000
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34867,7 +34871,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 437
+      ID: 444
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -34903,7 +34907,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 995
+      ID: 1002
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1003904
@@ -34911,13 +34915,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 997 PointerType *runtime.plainError.str
+          Type: 1004 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 996 GoStringDataType runtime.plainError.str
+      Data: 1003 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 996
+      ID: 1003
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34958,7 +34962,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 807
+      ID: 814
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1619776
@@ -35030,7 +35034,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1015
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -35042,26 +35046,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 432 PointerType *string.str
+          Type: 439 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 431 GoStringDataType string.str
+      Data: 438 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 431
+      ID: 438
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1310
+      ID: 1317
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1215
+      ID: 1222
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1211
+      ID: 1218
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1475072
@@ -35077,7 +35081,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 383
+      ID: 373
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1486624
@@ -35085,12 +35089,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 384 StructureType sync.noCopy
+          Type: 374 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 385 StructureType internal/sync.Mutex
+          Type: 375 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 392
+      ID: 436
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1641024
@@ -35098,15 +35102,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 384 StructureType sync.noCopy
+          Type: 374 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 393 StructureType sync/atomic.Bool
+          Type: 437 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 383 StructureType sync.Mutex
+          Type: 373 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 403
+      ID: 372
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1867552
@@ -35114,7 +35118,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 383 StructureType sync.Mutex
+          Type: 373 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -35123,12 +35127,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 404 StructureType sync/atomic.Int32
+          Type: 376 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 404 StructureType sync/atomic.Int32
+          Type: 376 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1394
+      ID: 1401
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1640832
@@ -35136,21 +35140,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 384 StructureType sync.noCopy
+          Type: 374 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1395 StructureType sync/atomic.Uint64
+          Type: 1402 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 384
+      ID: 374
       Name: sync.noCopy
       GoRuntimeType: 1003424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 393
+      ID: 437
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1487744
@@ -35158,12 +35162,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 377 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 404
+      ID: 376
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1487904
@@ -35171,12 +35175,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 377 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1395
+      ID: 1402
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1641408
@@ -35184,15 +35188,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 377 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1396 StructureType sync/atomic.align64
+          Type: 1403 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 386
+      ID: 424
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1208928
@@ -35202,25 +35206,25 @@ Types:
           Offset: 0
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1396
+      ID: 1403
       Name: sync/atomic.align64
       GoRuntimeType: 1003616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 394
+      ID: 377
       Name: sync/atomic.noCopy
       GoRuntimeType: 1003520
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1128
+      ID: 1135
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1302688
       GoKind: 12
     - __kind: StructureType
-      ID: 549
+      ID: 556
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35242,9 +35246,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 550 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 557 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 541
+      ID: 548
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35266,9 +35270,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 542 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 549 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 489
+      ID: 496
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -35290,9 +35294,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 490 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 497 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 508
+      ID: 515
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -35314,9 +35318,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 509 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 516 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 667
+      ID: 708
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35338,9 +35342,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 668 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 709 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 445
+      ID: 452
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -35362,9 +35366,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 446 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 453 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1420
+      ID: 1427
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -35386,7 +35390,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1421 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1428 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1464
       Name: table<int,*main.deepMap8>
@@ -35436,7 +35440,7 @@ Types:
           Offset: 16
           Type: 1480 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 457
+      ID: 464
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -35458,7 +35462,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 458 GoSwissMapGroupsType groupReference<int,int>
+          Type: 465 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 1494
       Name: table<int,interface {}>
@@ -35484,7 +35488,7 @@ Types:
           Offset: 16
           Type: 1495 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 565
+      ID: 572
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35506,9 +35510,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 566 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 573 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 516
+      ID: 523
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35530,9 +35534,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 517 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 524 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 716
+      ID: 723
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -35554,9 +35558,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 717 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 724 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 498
+      ID: 505
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -35578,9 +35582,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 499 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 506 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 481
+      ID: 488
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35602,9 +35606,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 482 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 489 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 692
+      ID: 690
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35626,9 +35630,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 693 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 691 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1182
+      ID: 1189
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35650,9 +35654,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1183 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1190 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 473
+      ID: 480
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35674,9 +35678,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 474 GoSwissMapGroupsType groupReference<string,int>
+          Type: 481 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 684
+      ID: 682
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35698,9 +35702,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 685 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 683 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 465
+      ID: 472
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -35722,9 +35726,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 466 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 473 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 676
+      ID: 674
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -35746,9 +35750,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 677 GoSwissMapGroupsType groupReference<string,string>
+          Type: 675 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 557
+      ID: 564
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -35770,9 +35774,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 558 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 565 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 605
+      ID: 612
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35794,9 +35798,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 606 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 613 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 613
+      ID: 620
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35818,9 +35822,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 614 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 621 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 621
+      ID: 628
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35842,9 +35846,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 622 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 629 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 629
+      ID: 636
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35866,9 +35870,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 630 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 637 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 637
+      ID: 644
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35890,9 +35894,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 638 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 645 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 645
+      ID: 652
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35914,9 +35918,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 646 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 653 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 573
+      ID: 580
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35938,9 +35942,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 574 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 581 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 532
+      ID: 539
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35962,9 +35966,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 533 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 540 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 524
+      ID: 531
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35986,13 +35990,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 525 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 532 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1345
+      ID: 1352
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1071
+      ID: 1078
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1735008
@@ -36005,7 +36009,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 1278
+      ID: 1285
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1943104
@@ -36022,10 +36026,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 653 GoSliceHeaderType []time.zone
+          Type: 660 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 656 GoSliceHeaderType []time.zoneTrans
+          Type: 663 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -36037,9 +36041,9 @@ Types:
           Type: 14 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 654 PointerType *time.zone
+          Type: 661 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
@@ -36067,7 +36071,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 399
+      ID: 433
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1489024
@@ -36075,12 +36079,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1403 GoChannelType <-chan time.Time
+          Type: 1415 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 726
+      ID: 733
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 841728
@@ -36088,22 +36092,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 728 PointerType *time.fileSizeError.str
+          Type: 735 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 727 GoStringDataType time.fileSizeError.str
+      Data: 734 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 727
+      ID: 734
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 662
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1642368
@@ -36119,7 +36123,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 658
+      ID: 665
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1780288
@@ -36180,7 +36184,7 @@ Types:
       GoRuntimeType: 594112
       GoKind: 26
     - __kind: StructureType
-      ID: 1161
+      ID: 1168
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2094848
@@ -36191,10 +36195,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1162 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1169 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1163 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1170 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -36209,18 +36213,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1164 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1171 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1164
+      ID: 1171
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1009472
       GoKind: 9
     - __kind: StructureType
-      ID: 1162
+      ID: 1169
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1956160
@@ -36245,21 +36249,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 908
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1163
+      ID: 1170
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 597824
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1339
+      ID: 1346
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1444512
@@ -36269,13 +36273,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 771
+      ID: 778
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 846432
       GoKind: 2
     - __kind: StructureType
-      ID: 1048
+      ID: 1055
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1730784
@@ -36288,7 +36292,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1000
+      ID: 1007
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1008320

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -11845,21 +11845,21 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1202
+      ID: 1208
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 134
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 135 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1207
+      ID: 1214
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1208 PointerType *main.deepSlice3
+      Pointee: 1215 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1236
       Name: '**main.deepSlice8'
@@ -11877,7 +11877,7 @@ Types:
       GoKind: 22
       Pointee: 151 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1197
+      ID: 1204
       Name: '**main.t'
       ByteSize: 8
       Pointee: 250 PointerType *main.t
@@ -11889,20 +11889,20 @@ Types:
       GoKind: 22
       Pointee: 90 PointerType *string
     - __kind: PointerType
-      ID: 1205
+      ID: 1211
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1204 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1210 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 424
+      ID: 431
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 423 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 430 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1211
+      ID: 1218
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1210 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1217 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1240
       Name: '*[]*main.deepSlice8.array'
@@ -11914,95 +11914,95 @@ Types:
       ByteSize: 8
       Pointee: 1245 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 421
+      ID: 428
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 420 GoSliceDataType []*string.array
+      Pointee: 427 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 490
+      ID: 497
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 496 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 285
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 282 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 488
+      ID: 495
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 494 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 283
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 280 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 486
+      ID: 493
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 492 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 281
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 278 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 484
+      ID: 491
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 490 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 279
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 276 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 482
+      ID: 489
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 488 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 470
+      ID: 477
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 469 GoSliceDataType [][]uint.array
+      Pointee: 476 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 474
+      ID: 481
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 473 GoSliceDataType []bool.array
+      Pointee: 480 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 990 GoSliceDataType []float64.array
+      Pointee: 997 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 527
+      ID: 531
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 526 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 530 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 535
+      ID: 539
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 534 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 538 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 516
+      ID: 523
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 515 GoSliceDataType []go.shape.float64.array
+      Pointee: 522 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 512
+      ID: 519
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 511 GoSliceDataType []go.shape.int.array
+      Pointee: 518 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 514
+      ID: 521
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 513 GoSliceDataType []go.shape.string.array
+      Pointee: 520 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
       ID: 1249
       Name: '*[]interface {}.array'
@@ -12014,20 +12014,20 @@ Types:
       ByteSize: 8
       Pointee: 274 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 480
+      ID: 487
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 479 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 486 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 537
+      ID: 544
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 536 GoSliceDataType []main.structWithMap.array
+      Pointee: 543 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 472
+      ID: 479
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 471 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 478 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -12036,111 +12036,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 432
+      ID: 439
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 431 GoSliceDataType []string.array
+      Pointee: 438 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 478
+      ID: 485
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 477 GoSliceDataType []struct {}.array
+      Pointee: 484 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 539
+      ID: 546
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 538 GoSliceDataType []time.zone.array
+      Pointee: 545 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 541
+      ID: 548
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 540 GoSliceDataType []time.zoneTrans.array
+      Pointee: 547 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 261
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 259 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 468
+      ID: 475
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 467 GoSliceDataType []uint.array
+      Pointee: 474 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 476
+      ID: 483
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 475 GoSliceDataType []uint16.array
+      Pointee: 482 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 417
+      ID: 424
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 416 GoSliceDataType []uint8.array
+      Pointee: 423 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 419
+      ID: 426
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 418 GoSliceDataType []uintptr.array
+      Pointee: 425 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1116
+      ID: 1123
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1858656
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1124 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 861920
       GoKind: 22
-      Pointee: 772 GoSliceHeaderType archive/tar.headerError
+      Pointee: 779 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 774
+      ID: 781
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 773 GoSliceDataType archive/tar.headerError.array
+      Pointee: 780 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1259488
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1064 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1004
+      ID: 1011
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 862112
       GoKind: 22
-      Pointee: 1005 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1012 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1006
+      ID: 1013
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 862208
       GoKind: 22
-      Pointee: 1007 StructureType archive/zip.dirWriter
+      Pointee: 1014 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1103
+      ID: 1110
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1782944
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1111 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1032
+      ID: 1039
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1021472
       GoKind: 22
-      Pointee: 1033 StructureType archive/zip.nopCloser
+      Pointee: 1040 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1034
+      ID: 1041
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1021728
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1042 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 7
       Name: '*bool'
@@ -12169,20 +12169,20 @@ Types:
       ByteSize: 8
       Pointee: 204 GoHMapBucketType bucket<bool,main.node>
     - __kind: PointerType
-      ID: 377
+      ID: 415
       Name: '*bucket<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 378 GoHMapBucketType bucket<context.canceler,struct {}>
+      Pointee: 416 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: PointerType
       ID: 142
       Name: '*bucket<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 143 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1215
+      ID: 1222
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1223 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1253
       Name: '*bucket<int,*main.deepMap8>'
@@ -12214,10 +12214,10 @@ Types:
       ByteSize: 8
       Pointee: 209 GoHMapBucketType bucket<int,uint8>
     - __kind: PointerType
-      ID: 531
+      ID: 535
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 536 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 198
       Name: '*bucket<string,[]main.structWithMap>'
@@ -12229,35 +12229,35 @@ Types:
       ByteSize: 8
       Pointee: 187 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 401
+      ID: 378
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 402 GoHMapBucketType bucket<string,float64>
+      Pointee: 379 GoHMapBucketType bucket<string,float64>
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 968 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 181
       Name: '*bucket<string,int>'
       ByteSize: 8
       Pointee: 182 GoHMapBucketType bucket<string,int>
     - __kind: PointerType
-      ID: 396
+      ID: 373
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 397 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 374 GoHMapBucketType bucket<string,interface {}>
     - __kind: PointerType
       ID: 176
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 177 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 391
+      ID: 368
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 392 GoHMapBucketType bucket<string,string>
+      Pointee: 369 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
       ID: 233
       Name: '*bucket<struct {},int>'
@@ -12309,449 +12309,449 @@ Types:
       ByteSize: 8
       Pointee: 214 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 1080
+      ID: 1087
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2039840
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType bufio.Reader
+      Pointee: 1088 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1107
+      ID: 1114
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1825152
       GoKind: 22
-      Pointee: 1108 UnresolvedPointeeType bufio.Writer
+      Pointee: 1115 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1152
+      ID: 1159
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2132800
       GoKind: 22
-      Pointee: 1153 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1160 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 682
+      ID: 689
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 844448
       GoKind: 22
-      Pointee: 579 BaseType compress/flate.CorruptInputError
+      Pointee: 586 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 844544
       GoKind: 22
-      Pointee: 580 GoStringHeaderType compress/flate.InternalError
+      Pointee: 587 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 582
+      ID: 589
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 581 GoStringDataType compress/flate.InternalError.str
+      Pointee: 588 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1249728
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1062 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1000
+      ID: 1007
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 844640
       GoKind: 22
-      Pointee: 1001 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1008 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1076
+      ID: 1083
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1609952
       GoKind: 22
-      Pointee: 1077 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1084 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1229
+      ID: 405
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1370400
       GoKind: 22
-      Pointee: 370 StructureType context.backgroundCtx
+      Pointee: 406 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 360
+      ID: 409
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1607456
       GoKind: 22
-      Pointee: 361 StructureType context.cancelCtx
+      Pointee: 410 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1110208
       GoKind: 22
-      Pointee: 884 StructureType context.deadlineExceededError
+      Pointee: 891 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1224
+      ID: 392
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1238528
       GoKind: 22
-      Pointee: 371 StructureType context.emptyCtx
+      Pointee: 393 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 362
+      ID: 394
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1238688
       GoKind: 22
-      Pointee: 363 StructureType context.stopCtx
+      Pointee: 395 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 364
+      ID: 417
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1607648
       GoKind: 22
-      Pointee: 365 StructureType context.timerCtx
+      Pointee: 418 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1230
+      ID: 407
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1370560
       GoKind: 22
-      Pointee: 382 StructureType context.todoCtx
+      Pointee: 408 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 366
+      ID: 401
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1370080
       GoKind: 22
-      Pointee: 367 StructureType context.valueCtx
+      Pointee: 402 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 368
+      ID: 403
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1370240
       GoKind: 22
-      Pointee: 369 StructureType context.withoutCancelCtx
+      Pointee: 404 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 856832
       GoKind: 22
-      Pointee: 593 BaseType crypto/aes.KeySizeError
+      Pointee: 600 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 857024
       GoKind: 22
-      Pointee: 594 BaseType crypto/des.KeySizeError
+      Pointee: 601 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 1066
+      ID: 1073
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1381280
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 1074 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1688352
       GoKind: 22
-      Pointee: 1092 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1099 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 857312
       GoKind: 22
-      Pointee: 595 BaseType crypto/rc4.KeySizeError
+      Pointee: 602 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1099
+      ID: 1106
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1780128
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1107 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1689024
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 1101 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1689472
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 1103 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 846080
       GoKind: 22
-      Pointee: 583 BaseType crypto/tls.AlertError
+      Pointee: 590 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1009056
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 863 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1178
+      ID: 1185
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2241920
       GoKind: 22
-      Pointee: 1179 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1186 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 686
+      ID: 693
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 845888
       GoKind: 22
-      Pointee: 687 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 694 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 845792
       GoKind: 22
-      Pointee: 685 StructureType crypto/tls.RecordHeaderError
+      Pointee: 692 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1007392
       GoKind: 22
-      Pointee: 811 BaseType crypto/tls.alert
+      Pointee: 818 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1378400
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1072 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1071
+      ID: 1078
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1458560
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1079 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1250048
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 958 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1915808
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 970 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 855680
       GoKind: 22
-      Pointee: 759 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 766 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 855200
       GoKind: 22
-      Pointee: 753 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 760 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 855296
       GoKind: 22
-      Pointee: 755 StructureType crypto/x509.HostnameError
+      Pointee: 762 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 855104
       GoKind: 22
-      Pointee: 592 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 599 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1014944
       GoKind: 22
-      Pointee: 861 StructureType crypto/x509.SystemRootsError
+      Pointee: 868 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 855776
       GoKind: 22
-      Pointee: 761 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 768 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 855584
       GoKind: 22
-      Pointee: 757 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 764 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 862400
       GoKind: 22
-      Pointee: 776 StructureType encoding/asn1.StructuralError
+      Pointee: 783 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 862592
       GoKind: 22
-      Pointee: 780 StructureType encoding/asn1.SyntaxError
+      Pointee: 787 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 862496
       GoKind: 22
-      Pointee: 778 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 785 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 676
+      ID: 683
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 842144
       GoKind: 22
-      Pointee: 577 BaseType encoding/base64.CorruptInputError
+      Pointee: 584 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1022
+      ID: 1029
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1003552
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1030 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 843008
       GoKind: 22
-      Pointee: 578 BaseType encoding/hex.InvalidByteError
+      Pointee: 585 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 836864
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 655 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 999200
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 854 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 836480
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 647 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 836768
       GoKind: 22
-      Pointee: 646 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 653 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 836672
       GoKind: 22
-      Pointee: 644 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 651 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 641
+      ID: 648
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 836576
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 649 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1158
+      ID: 1165
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2158368
       GoKind: 22
-      Pointee: 1159 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1166 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 837248
       GoKind: 22
-      Pointee: 650 StructureType encoding/json.jsonError
+      Pointee: 657 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1030
+      ID: 1037
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1018016
       GoKind: 22
-      Pointee: 1031 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1038 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 854144
       GoKind: 22
-      Pointee: 747 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 754 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 854048
       GoKind: 22
-      Pointee: 745 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 752 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 854240
       GoKind: 22
-      Pointee: 589 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 596 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 591
+      ID: 598
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 590 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 597 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 854336
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 757 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1136
+      ID: 1143
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2028320
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1144 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 101
       Name: '*error'
@@ -12760,19 +12760,19 @@ Types:
       GoKind: 22
       Pointee: 20 GoInterfaceType error
     - __kind: PointerType
-      ID: 617
+      ID: 624
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 827840
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType errors.errorString
+      Pointee: 625 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 984736
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType errors.joinError
+      Pointee: 821 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 103
       Name: '*float32'
@@ -12788,625 +12788,625 @@ Types:
       GoKind: 22
       Pointee: 19 BaseType float64
     - __kind: PointerType
-      ID: 1146
+      ID: 1153
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2124096
       GoKind: 22
-      Pointee: 1147 UnresolvedPointeeType fmt.pp
+      Pointee: 1154 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 984864
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType fmt.wrapError
+      Pointee: 823 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 984992
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 825 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 677
+      ID: 684
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 842528
       GoKind: 22
-      Pointee: 678 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 685 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 658
+      ID: 665
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 839648
       GoKind: 22
-      Pointee: 659 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 666 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 660
+      ID: 667
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 839744
       GoKind: 22
-      Pointee: 661 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 668 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 839456
       GoKind: 22
-      Pointee: 975 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 982 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 664
+      ID: 671
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 840032
       GoKind: 22
-      Pointee: 665 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 672 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 839552
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 984 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 839840
       GoKind: 22
-      Pointee: 571 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 578 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 573
+      ID: 580
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 579 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 657
+      ID: 664
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 839360
       GoKind: 22
-      Pointee: 568 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 575 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 570
+      ID: 577
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 576 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 663
+      ID: 670
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 839936
       GoKind: 22
-      Pointee: 574 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 581 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 576
+      ID: 583
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 582 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1044
+      ID: 1051
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1128512
       GoKind: 22
-      Pointee: 1045 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1052 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1124
+      ID: 1131
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1930496
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1132 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 860864
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 777 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 383
+      ID: 388
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2143040
       GoKind: 22
-      Pointee: 384 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 360 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 409
+      ID: 386
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1880416
       GoKind: 22
-      Pointee: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 387 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 404
+      ID: 381
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1110464
       GoKind: 22
-      Pointee: 405 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 382 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 407
+      ID: 384
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1110592
       GoKind: 22
-      Pointee: 408 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 385 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1222
+      ID: 1229
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1111232
       GoKind: 22
-      Pointee: 1223 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1230 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 543
+      ID: 550
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1111360
       GoKind: 22
-      Pointee: 544 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 551 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 411
+      ID: 389
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2089920
       GoKind: 22
-      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 390 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 918
+      ID: 925
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1131840
       GoKind: 22
-      Pointee: 919 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 926 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1154
+      ID: 1161
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2134336
       GoKind: 22
-      Pointee: 1155 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1162 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1225
+      ID: 397
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1243968
       GoKind: 22
-      Pointee: 1226 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 398 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 695
+      ID: 702
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 849632
       GoKind: 22
-      Pointee: 696 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 703 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 850688
       GoKind: 22
-      Pointee: 703 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 710 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 697
+      ID: 704
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 850400
       GoKind: 22
-      Pointee: 588 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 595 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 850592
       GoKind: 22
-      Pointee: 701 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 708 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 850496
       GoKind: 22
-      Pointee: 699 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 706 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 852608
       GoKind: 22
-      Pointee: 719 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 726 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 852800
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 730 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 852704
       GoKind: 22
-      Pointee: 721 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 728 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 852512
       GoKind: 22
-      Pointee: 717 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 724 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 992 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 999 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 730
+      ID: 737
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 853184
       GoKind: 22
-      Pointee: 731 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 738 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 724
+      ID: 731
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 852896
       GoKind: 22
-      Pointee: 725 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 732 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 853088
       GoKind: 22
-      Pointee: 729 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 736 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 852992
       GoKind: 22
-      Pointee: 727 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 734 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 853280
       GoKind: 22
-      Pointee: 733 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 740 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 853568
       GoKind: 22
-      Pointee: 739 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 746 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 740
+      ID: 747
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 853664
       GoKind: 22
-      Pointee: 741 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 748 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 736
+      ID: 743
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 853472
       GoKind: 22
-      Pointee: 737 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 744 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 853376
       GoKind: 22
-      Pointee: 735 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 742 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 742
+      ID: 749
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 743 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 750 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 666
+      ID: 673
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 841184
       GoKind: 22
-      Pointee: 667 StructureType github.com/cihub/seelog.baseError
+      Pointee: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1685440
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1091 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 668
+      ID: 675
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 841280
       GoKind: 22
-      Pointee: 669 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 676 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1376800
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1070 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1018
+      ID: 1025
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1002528
       GoKind: 22
-      Pointee: 1019 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1026 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1247648
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1060 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 672
+      ID: 679
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 841472
       GoKind: 22
-      Pointee: 673 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 680 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1848288
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1122 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2002976
       GoKind: 22
-      Pointee: 1126 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1133 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1128
+      ID: 1135
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2002592
       GoKind: 22
-      Pointee: 1127 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1134 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1020
+      ID: 1027
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1002656
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1028 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 670
+      ID: 677
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 841376
       GoKind: 22
-      Pointee: 671 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 678 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 674
+      ID: 681
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 841568
       GoKind: 22
-      Pointee: 675 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 682 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1087
+      ID: 1094
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1687008
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1095 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1120
+      ID: 1127
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1884736
       GoKind: 22
-      Pointee: 1121 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1128 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1122
+      ID: 1129
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1915488
       GoKind: 22
-      Pointee: 1123 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1130 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1261888
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 960 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1029408
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 876 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1029280
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 874 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1033376
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 878 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1033504
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 880 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1073
+      ID: 1080
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1486592
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1081 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1015712
       GoKind: 22
-      Pointee: 863 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 870 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 680
+      ID: 687
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 843200
       GoKind: 22
-      Pointee: 681 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 688 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1170
+      ID: 1177
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2221024
       GoKind: 22
-      Pointee: 1171 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1178 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1140800
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 934 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1119040
       GoKind: 22
-      Pointee: 896 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 903 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1118656
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 897 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 993312
       GoKind: 22
-      Pointee: 833 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 840 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1119424
       GoKind: 22
-      Pointee: 902 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 909 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 993184
       GoKind: 22
-      Pointee: 810 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 817 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1118912
       GoKind: 22
-      Pointee: 894 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 901 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1118784
       GoKind: 22
-      Pointee: 892 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 899 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1119296
       GoKind: 22
-      Pointee: 900 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 907 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1119168
       GoKind: 22
-      Pointee: 898 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 905 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1174
+      ID: 1181
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2232064
       GoKind: 22
-      Pointee: 1175 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1182 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1119808
       GoKind: 22
-      Pointee: 906 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 913 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 993568
       GoKind: 22
-      Pointee: 837 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 844 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 993440
       GoKind: 22
-      Pointee: 835 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 842 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1119680
       GoKind: 22
-      Pointee: 904 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 911 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 874496
       GoKind: 22
-      Pointee: 600 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 607 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 602
+      ID: 609
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 601 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 608 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
       ID: 356
       Name: '*go.shape.float64'
@@ -13429,10 +13429,10 @@ Types:
       GoKind: 22
       Pointee: 329 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 510
+      ID: 517
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 509 GoStringDataType go.shape.string.str
+      Pointee: 516 GoStringDataType go.shape.string.str
     - __kind: PointerType
       ID: 335
       Name: '*go.shape.struct { Name string }'
@@ -13452,242 +13452,242 @@ Types:
       GoKind: 22
       Pointee: 351 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1485056
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 973 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1048352
       GoKind: 22
-      Pointee: 877 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 884 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1050
+      ID: 1057
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1179840
       GoKind: 22
-      Pointee: 1051 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1058 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1134
+      ID: 1141
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2017952
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1142 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1036
+      ID: 1043
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1050656
       GoKind: 22
-      Pointee: 1037 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1044 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 875744
       GoKind: 22
-      Pointee: 603 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 610 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1181504
       GoKind: 22
-      Pointee: 935 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 942 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 876032
       GoKind: 22
-      Pointee: 796 StructureType golang.org/x/net/http2.connError
+      Pointee: 803 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 875936
       GoKind: 22
-      Pointee: 607 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 614 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 609
+      ID: 616
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 608 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 615 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 876224
       GoKind: 22
-      Pointee: 613 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 620 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 615
+      ID: 622
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 614 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 621 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 876128
       GoKind: 22
-      Pointee: 610 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 617 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 612
+      ID: 619
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 611 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 618 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 793
+      ID: 800
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 875840
       GoKind: 22
-      Pointee: 604 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 611 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 606
+      ID: 613
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 605 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 612 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1132
+      ID: 1139
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2016032
       GoKind: 22
-      Pointee: 1133 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1140 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 876320
       GoKind: 22
-      Pointee: 800 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 807 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 876416
       GoKind: 22
-      Pointee: 616 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 623 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 869888
       GoKind: 22
-      Pointee: 788 StructureType google.golang.org/grpc.dropError
+      Pointee: 795 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1178432
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 940 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1269248
       GoKind: 22
-      Pointee: 955 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 962 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 872768
       GoKind: 22
-      Pointee: 790 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 797 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1097
+      ID: 1104
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1693952
       GoKind: 22
-      Pointee: 1098 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1105 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1048
+      ID: 1055
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1174976
       GoKind: 22
-      Pointee: 1049 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1056 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1042592
       GoKind: 22
-      Pointee: 875 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 882 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 872864
       GoKind: 22
-      Pointee: 1009 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1016 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 858752
       GoKind: 22
-      Pointee: 768 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 775 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1019424
       GoKind: 22
-      Pointee: 865 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 872 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1146688
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 938 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1146432
       GoKind: 22
-      Pointee: 929 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 936 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 863456
       GoKind: 22
-      Pointee: 782 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 789 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 863552
       GoKind: 22
-      Pointee: 784 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 791 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 710
+      ID: 717
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 851072
       GoKind: 22
-      Pointee: 711 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 718 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1686112
       GoKind: 22
-      Pointee: 1086 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1093 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 226
       Name: '*hash<[4]int,[4]int>'
@@ -13709,20 +13709,20 @@ Types:
       ByteSize: 8
       Pointee: 202 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 375
+      ID: 413
       Name: '*hash<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 376 GoHMapHeaderType hash<context.canceler,struct {}>
+      Pointee: 414 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: PointerType
       ID: 140
       Name: '*hash<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 141 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1213
+      ID: 1220
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1214 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1221 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1251
       Name: '*hash<int,*main.deepMap8>'
@@ -13754,10 +13754,10 @@ Types:
       ByteSize: 8
       Pointee: 207 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 529
+      ID: 533
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 530 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 534 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 196
       Name: '*hash<string,[]main.structWithMap>'
@@ -13769,35 +13769,35 @@ Types:
       ByteSize: 8
       Pointee: 185 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 399
+      ID: 376
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 400 GoHMapHeaderType hash<string,float64>
+      Pointee: 377 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 959 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 966 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 179
       Name: '*hash<string,int>'
       ByteSize: 8
       Pointee: 180 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 394
+      ID: 371
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 395 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 372 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
       ID: 174
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 175 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 389
+      ID: 366
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 390 GoHMapHeaderType hash<string,string>
+      Pointee: 367 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 231
       Name: '*hash<struct {},int>'
@@ -13849,12 +13849,12 @@ Types:
       ByteSize: 8
       Pointee: 212 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 877184
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType html/template.Error
+      Pointee: 810 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 96
       Name: '*int'
@@ -13898,82 +13898,82 @@ Types:
       GoKind: 22
       Pointee: 159 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 856352
       GoKind: 22
-      Pointee: 763 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 770 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 843584
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1006 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1132992
       GoKind: 22
-      Pointee: 925 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 932 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1176
+      ID: 1183
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2236736
       GoKind: 22
-      Pointee: 1177 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1184 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 922
+      ID: 929
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1132864
       GoKind: 22
-      Pointee: 923 StructureType internal/poll.errNetClosing
+      Pointee: 930 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 622
+      ID: 629
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 831968
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 630 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1040
+      ID: 1047
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1109952
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1048 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1109568
       GoKind: 22
-      Pointee: 1039 StructureType io.discard
+      Pointee: 1046 StructureType io.discard
     - __kind: PointerType
-      ID: 1012
+      ID: 1019
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 985760
       GoKind: 22
-      Pointee: 1013 UnresolvedPointeeType io.multiWriter
+      Pointee: 1020 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 920
+      ID: 927
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1132608
       GoKind: 22
-      Pointee: 921 UnresolvedPointeeType io/fs.PathError
+      Pointee: 928 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1089
+      ID: 1096
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1687232
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1097 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 342
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
@@ -13993,19 +13993,19 @@ Types:
       GoKind: 22
       Pointee: 319 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 428
+      ID: 435
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 358048
       GoKind: 22
-      Pointee: 429 StructureType main.deepMap2
+      Pointee: 436 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1218
+      ID: 1225
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 357984
       GoKind: 22
-      Pointee: 1219 UnresolvedPointeeType main.deepMap3
+      Pointee: 1226 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 146
       Name: '*main.deepMap7'
@@ -14035,12 +14035,12 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1180
+      ID: 1187
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 358560
       GoKind: 22
-      Pointee: 1181 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1188 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 130
       Name: '*main.deepPtr7'
@@ -14068,14 +14068,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 359200
       GoKind: 22
-      Pointee: 422 StructureType main.deepSlice2
+      Pointee: 429 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1208
+      ID: 1215
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 359136
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1216 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 136
       Name: '*main.deepSlice7'
@@ -14111,7 +14111,7 @@ Types:
       GoKind: 22
       Pointee: 162 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1194
+      ID: 1201
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 827552
@@ -14144,19 +14144,19 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1195
+      ID: 1202
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 827648
       GoKind: 22
-      Pointee: 1196 StructureType main.secondBehavior
+      Pointee: 1203 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1186
+      ID: 1193
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 827744
       GoKind: 22
-      Pointee: 1187 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1194 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 148
       Name: '*main.stringType1'
@@ -14164,16 +14164,16 @@ Types:
       GoKind: 22
       Pointee: 149 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1183
+      ID: 1190
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1182 GoStringDataType main.stringType1.str
+      Pointee: 1189 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1184 GoStringHeaderType main.stringType2
+      Pointee: 1191 GoStringHeaderType main.stringType2
     - __kind: PointerType
       ID: 1276
       Name: '*main.stringType2.str'
@@ -14185,7 +14185,7 @@ Types:
       ByteSize: 8
       Pointee: 273 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 447
+      ID: 454
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 357536
@@ -14209,10 +14209,10 @@ Types:
       GoKind: 22
       Pointee: 251 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1199
+      ID: 1206
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1198 GoSliceDataType main.t.array
+      Pointee: 1205 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 270
       Name: '*main.threeStringStruct'
@@ -14226,561 +14226,561 @@ Types:
       GoKind: 22
       Pointee: 178 GoMapType map[string]int
     - __kind: PointerType
-      ID: 714
+      ID: 721
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 851936
       GoKind: 22
-      Pointee: 715 StructureType math/big.ErrNaN
+      Pointee: 722 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1002
+      ID: 1009
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 846560
       GoKind: 22
-      Pointee: 1003 StructureType mime/multipart.writerOnly·1
+      Pointee: 1010 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1126080
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType net.AddrError
+      Pointee: 920 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1245888
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType net.DNSError
+      Pointee: 951 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1140
+      ID: 1147
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2096288
       GoKind: 22
-      Pointee: 1141 UnresolvedPointeeType net.IPConn
+      Pointee: 1148 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1245568
       GoKind: 22
-      Pointee: 942 UnresolvedPointeeType net.OpError
+      Pointee: 949 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1126208
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType net.ParseError
+      Pointee: 922 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1150
+      ID: 1157
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2126144
       GoKind: 22
-      Pointee: 1151 UnresolvedPointeeType net.TCPConn
+      Pointee: 1158 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1160
+      ID: 1167
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2171104
       GoKind: 22
-      Pointee: 1161 UnresolvedPointeeType net.UDPConn
+      Pointee: 1168 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1148
+      ID: 1155
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2125632
       GoKind: 22
-      Pointee: 1149 UnresolvedPointeeType net.UnixConn
+      Pointee: 1156 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1125312
       GoKind: 22
-      Pointee: 880 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 887 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 881 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 888 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 999968
       GoKind: 22
-      Pointee: 849 StructureType net.canceledError
+      Pointee: 856 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1118
+      ID: 1125
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1882432
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType net.conn
+      Pointee: 1126 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1725760
       GoKind: 22
-      Pointee: 984 StructureType net.dialResult·1
+      Pointee: 991 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1162
+      ID: 1169
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2175360
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType net.netFD
+      Pointee: 1170 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 651
+      ID: 658
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 838208
       GoKind: 22
-      Pointee: 652 UnresolvedPointeeType net.notFoundError
+      Pointee: 659 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1227
+      ID: 399
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1245728
       GoKind: 22
-      Pointee: 1228 StructureType net.onlyValuesCtx
+      Pointee: 400 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 653
+      ID: 660
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 838880
       GoKind: 22
-      Pointee: 654 StructureType net.result·2
+      Pointee: 661 StructureType net.result·2
     - __kind: PointerType
-      ID: 1144
+      ID: 1151
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2110176
       GoKind: 22
-      Pointee: 1145 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1152 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1142
+      ID: 1149
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2109696
       GoKind: 22
-      Pointee: 1143 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1150 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 916
+      ID: 923
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1126848
       GoKind: 22
-      Pointee: 917 UnresolvedPointeeType net.temporaryError
+      Pointee: 924 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1246048
       GoKind: 22
-      Pointee: 946 UnresolvedPointeeType net.timeoutError
+      Pointee: 953 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 996000
       GoKind: 22
-      Pointee: 839 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 846 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 834080
       GoKind: 22
-      Pointee: 995 StructureType net/http.bufioFlushWriter
+      Pointee: 1002 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 628
+      ID: 635
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 834752
       GoKind: 22
-      Pointee: 549 BaseType net/http.http2ConnectionError
+      Pointee: 556 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 834848
       GoKind: 22
-      Pointee: 630 StructureType net/http.http2GoAwayError
+      Pointee: 637 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1242048
       GoKind: 22
-      Pointee: 938 StructureType net/http.http2StreamError
+      Pointee: 945 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 633
+      ID: 640
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 835328
       GoKind: 22
-      Pointee: 634 StructureType net/http.http2connError
+      Pointee: 641 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1374080
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1066 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 632
+      ID: 639
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 835232
       GoKind: 22
-      Pointee: 553 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 560 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 555
+      ID: 562
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 561 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 636
+      ID: 643
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 835520
       GoKind: 22
-      Pointee: 559 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 566 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 561
+      ID: 568
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 560 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 567 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 635
+      ID: 642
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 835424
       GoKind: 22
-      Pointee: 556 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 563 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 558
+      ID: 565
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 557 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 564 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1121984
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 917 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 996640
       GoKind: 22
-      Pointee: 845 StructureType net/http.http2noCachedConnError
+      Pointee: 852 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1109
+      ID: 1116
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1826176
       GoKind: 22
-      Pointee: 1110 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1117 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 835136
       GoKind: 22
-      Pointee: 550 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 557 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 552
+      ID: 559
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 551 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 558 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 835616
       GoKind: 22
-      Pointee: 997 StructureType net/http.http2stickyErrWriter
+      Pointee: 1004 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 840
+      ID: 847
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 996256
       GoKind: 22
-      Pointee: 841 StructureType net/http.nothingWrittenError
+      Pointee: 848 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2041088
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1068 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1016
+      ID: 1023
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 996128
       GoKind: 22
-      Pointee: 1017 StructureType net/http.persistConnWriter
+      Pointee: 1024 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1042
+      ID: 1049
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1120960
       GoKind: 22
-      Pointee: 1043 StructureType net/http.readWriteCloserBody
+      Pointee: 1050 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 835712
       GoKind: 22
-      Pointee: 638 StructureType net/http.requestBodyReadError
+      Pointee: 645 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1243168
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 947 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1121856
       GoKind: 22
-      Pointee: 908 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 915 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 996384
       GoKind: 22
-      Pointee: 843 StructureType net/http.transportReadFromServerError
+      Pointee: 850 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 626
+      ID: 633
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 833984
       GoKind: 22
-      Pointee: 627 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 634 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1111
+      ID: 1118
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1827968
       GoKind: 22
-      Pointee: 1112 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1119 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1010080
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1034 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 706
+      ID: 713
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 850880
       GoKind: 22
-      Pointee: 707 StructureType net/netip.parseAddrError
+      Pointee: 714 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 850784
       GoKind: 22
-      Pointee: 705 StructureType net/netip.parsePrefixError
+      Pointee: 712 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1068
+      ID: 1075
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1990752
       GoKind: 22
-      Pointee: 1069 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1076 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1015200
       GoKind: 22
-      Pointee: 1029 StructureType net/smtp.dataCloser
+      Pointee: 1036 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 690
+      ID: 697
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 846752
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType net/textproto.Error
+      Pointee: 698 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 846656
       GoKind: 22
-      Pointee: 584 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 591 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 586
+      ID: 593
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 585 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 592 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1009440
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1032 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 947
+      ID: 954
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1246368
       GoKind: 22
-      Pointee: 948 UnresolvedPointeeType net/url.Error
+      Pointee: 955 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 655
+      ID: 662
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 838976
       GoKind: 22
-      Pointee: 562 GoStringHeaderType net/url.EscapeError
+      Pointee: 569 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 564
+      ID: 571
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 563 GoStringDataType net/url.EscapeError.str
+      Pointee: 570 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 839072
       GoKind: 22
-      Pointee: 565 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 572 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 567
+      ID: 574
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 566 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 573 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 1168
+      ID: 1175
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2212608
       GoKind: 22
-      Pointee: 1169 UnresolvedPointeeType os.File
+      Pointee: 1176 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 989600
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType os.LinkError
+      Pointee: 829 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1114560
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType os.SyscallError
+      Pointee: 893 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1166
+      ID: 1173
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2209664
       GoKind: 22
-      Pointee: 1167 StructureType os.fileWithoutReadFrom
+      Pointee: 1174 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1164
+      ID: 1171
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2208928
       GoKind: 22
-      Pointee: 1165 StructureType os.fileWithoutWriteTo
+      Pointee: 1172 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1006112
       GoKind: 22
-      Pointee: 851 UnresolvedPointeeType os/exec.Error
+      Pointee: 858 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1962016
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 994 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1046
+      ID: 1053
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1133632
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1054 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1006240
       GoKind: 22
-      Pointee: 853 StructureType os/exec.wrappedError
+      Pointee: 860 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 867968
       GoKind: 22
-      Pointee: 597 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 604 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 599
+      ID: 606
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 598 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 605 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 867872
       GoKind: 22
-      Pointee: 596 BaseType os/user.UnknownUserIdError
+      Pointee: 603 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 624
+      ID: 631
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 832736
       GoKind: 22
-      Pointee: 625 UnresolvedPointeeType reflect.ValueError
+      Pointee: 632 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 851552
       GoKind: 22
-      Pointee: 713 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 720 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 824
+      ID: 831
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 990496
       GoKind: 22
-      Pointee: 825 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 832 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 992416
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 837 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14796,12 +14796,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 826
+      ID: 833
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 990624
       GoKind: 22
-      Pointee: 827 StructureType runtime.boundsError
+      Pointee: 834 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -14817,24 +14817,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1116864
       GoKind: 22
-      Pointee: 888 StructureType runtime.errorAddressString
+      Pointee: 895 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 990240
       GoKind: 22
-      Pointee: 804 GoStringHeaderType runtime.errorString
+      Pointee: 811 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 805 GoStringDataType runtime.errorString.str
+      Pointee: 812 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -14857,17 +14857,17 @@ Types:
       GoKind: 22
       Pointee: 145 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 828
+      ID: 835
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 992160
       GoKind: 22
-      Pointee: 807 GoStringHeaderType runtime.plainError
+      Pointee: 814 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 808 GoStringDataType runtime.plainError.str
+      Pointee: 815 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -14890,12 +14890,12 @@ Types:
       GoKind: 22
       Pointee: 75 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 988448
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType strconv.NumError
+      Pointee: 827 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 90
       Name: '*string'
@@ -14904,57 +14904,57 @@ Types:
       GoKind: 22
       Pointee: 13 GoStringHeaderType string
     - __kind: PointerType
-      ID: 415
+      ID: 422
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 414 GoStringDataType string.str
+      Pointee: 421 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1105
+      ID: 1112
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1824640
       GoKind: 22
-      Pointee: 1106 UnresolvedPointeeType strings.Builder
+      Pointee: 1113 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1014
+      ID: 1021
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 988576
       GoKind: 22
-      Pointee: 1015 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1022 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1010
+      ID: 1017
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 924832
       GoKind: 22
-      Pointee: 1011 StructureType struct { io.Writer }
+      Pointee: 1018 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 268
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 120 StructureType struct {}
     - __kind: PointerType
-      ID: 949
+      ID: 956
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1248608
       GoKind: 22
-      Pointee: 936 BaseType syscall.Errno
+      Pointee: 943 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 1138
+      ID: 1145
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2028704
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1146 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1052192
       GoKind: 22
-      Pointee: 879 StructureType text/template.ExecError
+      Pointee: 886 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 324
       Name: '*time.Location'
@@ -14963,45 +14963,45 @@ Types:
       GoKind: 22
       Pointee: 325 StructureType time.Location
     - __kind: PointerType
-      ID: 620
+      ID: 627
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 830240
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType time.ParseError
+      Pointee: 628 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 380
+      ID: 419
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 989984
       GoKind: 22
-      Pointee: 381 StructureType time.Timer
+      Pointee: 420 StructureType time.Timer
     - __kind: PointerType
-      ID: 619
+      ID: 626
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 830144
       GoKind: 22
-      Pointee: 546 GoStringHeaderType time.fileSizeError
+      Pointee: 553 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 548
+      ID: 555
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 547 GoStringDataType time.fileSizeError.str
+      Pointee: 554 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 504
+      ID: 511
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 364896
       GoKind: 22
-      Pointee: 505 StructureType time.zone
+      Pointee: 512 StructureType time.zone
     - __kind: PointerType
-      ID: 507
+      ID: 514
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 364960
       GoKind: 22
-      Pointee: 508 StructureType time.zoneTrans
+      Pointee: 515 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 102
       Name: '*uint'
@@ -15045,56 +15045,56 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 1101
+      ID: 1108
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1781408
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 1109 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 708
+      ID: 715
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 850976
       GoKind: 22
-      Pointee: 709 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 716 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1130
+      ID: 1137
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2005280
       GoKind: 22
-      Pointee: 1131 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1138 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 847136
       GoKind: 22
-      Pointee: 693 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 700 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 847232
       GoKind: 22
-      Pointee: 587 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 594 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1009824
       GoKind: 22
-      Pointee: 858 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 865 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1009952
       GoKind: 22
-      Pointee: 812 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 819 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1200
+      ID: 1212
       Name: <-chan time.Time
       GoRuntimeType: 547008
       GoKind: 18
@@ -25806,7 +25806,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 457
+      ID: 464
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 626080
@@ -25815,7 +25815,7 @@ Types:
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 442
+      ID: 449
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 626368
@@ -25841,7 +25841,7 @@ Types:
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 978
+      ID: 985
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 627424
@@ -25850,7 +25850,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1185
+      ID: 1192
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -25876,7 +25876,7 @@ Types:
       HasCount: true
       Element: 81 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 425
+      ID: 432
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 623296
@@ -25885,7 +25885,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 1201
+      ID: 1207
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 452384
@@ -25893,20 +25893,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1202 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1208 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1204 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1210 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1204
+      ID: 1210
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 133
       Name: '[]*main.deepSlice2'
@@ -25923,15 +25923,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 423 GoSliceDataType []*main.deepSlice2.array
+      Data: 430 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 423
+      ID: 430
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 135 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1206
+      ID: 1213
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 448864
@@ -25939,20 +25939,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1207 PointerType **main.deepSlice3
+          Type: 1214 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1210 GoSliceDataType []*main.deepSlice3.array
+      Data: 1217 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1210
+      ID: 1217
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1208 PointerType *main.deepSlice3
+      Element: 1215 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1235
       Name: '[]*main.deepSlice8'
@@ -26015,9 +26015,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 420 GoSliceDataType []*string.array
+      Data: 427 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 420
+      ID: 427
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26037,9 +26037,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 489 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 496 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 489
+      ID: 496
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26059,9 +26059,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 487 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 494 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 494
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26081,9 +26081,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 485 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 492 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 485
+      ID: 492
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26103,9 +26103,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 483 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 490 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 483
+      ID: 490
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26125,9 +26125,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 481 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 488 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 481
+      ID: 488
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26147,9 +26147,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 469 GoSliceDataType [][]uint.array
+      Data: 476 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 476
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26170,55 +26170,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 473 GoSliceDataType []bool.array
+      Data: 480 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 473
+      ID: 480
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 468
       Name: '[]bucket<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 528
       Element: 229 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 467
       Name: '[]bucket<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 224 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 444
+      ID: 451
       Name: '[]bucket<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 656
       Element: 192 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 451
+      ID: 458
       Name: '[]bucket<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 152
       Element: 204 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 542
       Name: '[]bucket<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 378 GoHMapBucketType bucket<context.canceler,struct {}>
+      Element: 416 GoHMapBucketType bucket<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 430
+      ID: 437
       Name: '[]bucket<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 143 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1220
+      ID: 1227
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1223 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1258
       Name: '[]bucket<int,*main.deepMap8>.array'
@@ -26232,7 +26232,7 @@ Types:
       ByteSize: 144
       Element: 1263 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 434
+      ID: 441
       Name: '[]bucket<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
@@ -26244,133 +26244,133 @@ Types:
       ByteSize: 208
       Element: 1272 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 472
       Name: '[]bucket<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 239 GoHMapBucketType bucket<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 460
       Name: '[]bucket<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
       Element: 209 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 545
+      ID: 552
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 536 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 448
+      ID: 455
       Name: '[]bucket<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 199 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 440
+      ID: 447
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 187 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 525
+      ID: 529
       Name: '[]bucket<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 402 GoHMapBucketType bucket<string,float64>
+      Element: 379 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 989
+      ID: 996
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 968 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 445
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 182 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 523
+      ID: 527
       Name: '[]bucket<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 397 GoHMapBucketType bucket<string,interface {}>
+      Element: 374 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 444
       Name: '[]bucket<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 177 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 521
+      ID: 525
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 392 GoHMapBucketType bucket<string,string>
+      Element: 369 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 470
       Name: '[]bucket<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 234 GoHMapBucketType bucket<struct {},int>
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 499
       Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 400
       Element: 291 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 494
+      ID: 501
       Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 296 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 503
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 301 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 498
+      ID: 505
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 306 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 507
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 311 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 502
+      ID: 509
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 316 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 466
+      ID: 473
       Name: '[]bucket<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
       Element: 244 GoHMapBucketType bucket<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 458
+      ID: 465
       Name: '[]bucket<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 219 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 462
       Name: '[]bucket<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
       Element: 214 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 973
+      ID: 980
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 456864
@@ -26385,15 +26385,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 990 GoSliceDataType []float64.array
+      Data: 997 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 990
+      ID: 997
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 19 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 403
+      ID: 380
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 451936
@@ -26401,22 +26401,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 404 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 381 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 526 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 530 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 526
+      ID: 530
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 405 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 382 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 406
+      ID: 383
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 452128
@@ -26424,20 +26424,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 407 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 384 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 534 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 538 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 534
+      ID: 538
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 408 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 385 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
       ID: 355
       Name: '[]go.shape.float64'
@@ -26454,9 +26454,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 515 GoSliceDataType []go.shape.float64.array
+      Data: 522 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 515
+      ID: 522
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26476,9 +26476,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 511 GoSliceDataType []go.shape.int.array
+      Data: 518 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 511
+      ID: 518
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26499,9 +26499,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 513 GoSliceDataType []go.shape.string.array
+      Data: 520 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 513
+      ID: 520
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26530,55 +26530,55 @@ Types:
       ByteSize: 16
       Element: 159 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 459
+      ID: 466
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 457 ArrayType [4]int
+      Element: 464 ArrayType [4]int
     - __kind: ArrayType
-      ID: 441
+      ID: 448
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 442 ArrayType [4]string
+      Element: 449 ArrayType [4]string
     - __kind: ArrayType
-      ID: 449
+      ID: 456
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 6 BaseType bool
     - __kind: ArrayType
-      ID: 517
+      ID: 540
       Name: '[]key<context.canceler>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 518 GoInterfaceType context.canceler
+      Element: 541 GoInterfaceType context.canceler
     - __kind: ArrayType
-      ID: 426
+      ID: 433
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 435
+      ID: 442
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 462
+      ID: 469
       Name: '[]key<struct {}>'
       Count: 8
       HasCount: true
       Element: 120 StructureType struct {}
     - __kind: ArrayType
-      ID: 454
+      ID: 461
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -26599,15 +26599,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 479 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 486 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 486
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 273 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 446
+      ID: 453
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 449504
@@ -26615,16 +26615,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 447 PointerType *main.structWithMap
+          Type: 454 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 536 GoSliceDataType []main.structWithMap.array
+      Data: 543 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 536
+      ID: 543
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26644,9 +26644,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 471 GoSliceDataType []main.structWithNoStrings.array
+      Data: 478 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 478
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26671,9 +26671,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 431 GoSliceDataType []string.array
+      Data: 438 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 431
+      ID: 438
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26694,14 +26694,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 477 GoSliceDataType []struct {}.array
+      Data: 484 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 484
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 120 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 503
+      ID: 510
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 455584
@@ -26709,22 +26709,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 504 PointerType *time.zone
+          Type: 511 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 538 GoSliceDataType []time.zone.array
+      Data: 545 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 538
+      ID: 545
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 505 StructureType time.zone
+      Element: 512 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 506
+      ID: 513
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 455648
@@ -26732,20 +26732,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 507 PointerType *time.zoneTrans
+          Type: 514 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 540 GoSliceDataType []time.zoneTrans.array
+      Data: 547 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 547
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 508 StructureType time.zoneTrans
+      Element: 515 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 259
       Name: '[]uint'
@@ -26762,9 +26762,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 467 GoSliceDataType []uint.array
+      Data: 474 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 467
+      ID: 474
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26785,9 +26785,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 475 GoSliceDataType []uint16.array
+      Data: 482 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 475
+      ID: 482
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -26808,9 +26808,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 416 GoSliceDataType []uint8.array
+      Data: 423 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 416
+      ID: 423
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -26831,34 +26831,34 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 418 GoSliceDataType []uintptr.array
+      Data: 425 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 418
+      ID: 425
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: ArrayType
-      ID: 542
+      ID: 549
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 543 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 550 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 427
+      ID: 434
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 428 PointerType *main.deepMap2
+      Element: 435 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1217
+      ID: 1224
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1218 PointerType *main.deepMap3
+      Element: 1225 PointerType *main.deepMap3
     - __kind: ArrayType
       ID: 1255
       Name: '[]val<*main.deepMap8>'
@@ -26874,143 +26874,143 @@ Types:
       HasCount: true
       Element: 1265 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 443
+      ID: 450
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 108 ArrayType [2]int
     - __kind: ArrayType
-      ID: 456
+      ID: 463
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 457 ArrayType [4]int
+      Element: 464 ArrayType [4]int
     - __kind: ArrayType
-      ID: 445
+      ID: 452
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 446 GoSliceHeaderType []main.structWithMap
+      Element: 453 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 439
+      ID: 446
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 156 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 524
+      ID: 528
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 19 BaseType float64
     - __kind: ArrayType
-      ID: 988
+      ID: 995
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 987 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 433
+      ID: 440
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 11 BaseType int
     - __kind: ArrayType
-      ID: 522
+      ID: 526
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 159 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 436
+      ID: 443
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 118 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 450
+      ID: 457
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 248 StructureType main.node
     - __kind: ArrayType
-      ID: 491
+      ID: 498
       Name: '[]val<main.structWithCyclicMaps>'
       ByteSize: 384
       Count: 8
       HasCount: true
       Element: 286 StructureType main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 493
+      ID: 500
       Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 287 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 495
+      ID: 502
       Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 292 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 497
+      ID: 504
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 297 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 499
+      ID: 506
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 501
+      ID: 508
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 520
+      ID: 524
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 13 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 464
+      ID: 471
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
       Element: 120 StructureType struct {}
     - __kind: ArrayType
-      ID: 452
+      ID: 459
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1124
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 772
+      ID: 779
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 862016
@@ -27025,33 +27025,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 773 GoSliceDataType archive/tar.headerError.array
+      Data: 780 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 773
+      ID: 780
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1064
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1005
+      ID: 1012
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1007
+      ID: 1014
       Name: archive/zip.dirWriter
       GoRuntimeType: 1084192
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1111
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1033
+      ID: 1040
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1384000
@@ -27061,7 +27061,7 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1042
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -27077,18 +27077,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 459 ArrayType []key<[4]int>
+          Type: 466 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 456 ArrayType []val<[4]int>
+          Type: 463 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 228 PointerType *bucket<[4]int,[4]int>
-      KeyType: 457 ArrayType [4]int
-      ValueType: 457 ArrayType [4]int
+      KeyType: 464 ArrayType [4]int
+      ValueType: 464 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 224
       Name: bucket<[4]int,uint8>
@@ -27096,17 +27096,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 459 ArrayType []key<[4]int>
+          Type: 466 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 452 ArrayType []val<uint8>
+          Type: 459 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 223 PointerType *bucket<[4]int,uint8>
-      KeyType: 457 ArrayType [4]int
+      KeyType: 464 ArrayType [4]int
       ValueType: 5 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 192
@@ -27115,17 +27115,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 441 ArrayType []key<[4]string>
+          Type: 448 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 443 ArrayType []val<[2]int>
+          Type: 450 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 191 PointerType *bucket<[4]string,[2]int>
-      KeyType: 442 ArrayType [4]string
+      KeyType: 449 ArrayType [4]string
       ValueType: 108 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 204
@@ -27134,36 +27134,36 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 449 ArrayType []key<bool>
+          Type: 456 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 450 ArrayType []val<main.node>
+          Type: 457 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 203 PointerType *bucket<bool,main.node>
       KeyType: 6 BaseType bool
       ValueType: 248 StructureType main.node
     - __kind: GoHMapBucketType
-      ID: 378
+      ID: 416
       Name: bucket<context.canceler,struct {}>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 517 ArrayType []key<context.canceler>
+          Type: 540 ArrayType []key<context.canceler>
         - Name: values
           Offset: 136
-          Type: 464 ArrayType []val<struct {}>
+          Type: 471 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 136
-          Type: 377 PointerType *bucket<context.canceler,struct {}>
-      KeyType: 518 GoInterfaceType context.canceler
+          Type: 415 PointerType *bucket<context.canceler,struct {}>
+      KeyType: 541 GoInterfaceType context.canceler
       ValueType: 120 StructureType struct {}
     - __kind: GoHMapBucketType
       ID: 143
@@ -27172,37 +27172,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 427 ArrayType []val<*main.deepMap2>
+          Type: 434 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 142 PointerType *bucket<int,*main.deepMap2>
       KeyType: 11 BaseType int
-      ValueType: 428 PointerType *main.deepMap2
+      ValueType: 435 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1216
+      ID: 1223
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1217 ArrayType []val<*main.deepMap3>
+          Type: 1224 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1215 PointerType *bucket<int,*main.deepMap3>
+          Type: 1222 PointerType *bucket<int,*main.deepMap3>
       KeyType: 11 BaseType int
-      ValueType: 1218 PointerType *main.deepMap3
+      ValueType: 1225 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
       ID: 1254
       Name: bucket<int,*main.deepMap8>
@@ -27210,10 +27210,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 1255 ArrayType []val<*main.deepMap8>
@@ -27229,10 +27229,10 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
           Type: 1264 ArrayType []val<*main.deepMap9>
@@ -27248,13 +27248,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 433 ArrayType []val<int>
+          Type: 440 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 171 PointerType *bucket<int,int>
@@ -27267,13 +27267,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 522 ArrayType []val<interface {}>
+          Type: 526 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
           Type: 1271 PointerType *bucket<int,interface {}>
@@ -27286,13 +27286,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 464 ArrayType []val<struct {}>
+          Type: 471 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 238 PointerType *bucket<int,struct {}>
@@ -27305,37 +27305,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 426 ArrayType []key<int>
+          Type: 433 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 452 ArrayType []val<uint8>
+          Type: 459 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 208 PointerType *bucket<int,uint8>
       KeyType: 11 BaseType int
       ValueType: 5 BaseType uint8
     - __kind: GoHMapBucketType
-      ID: 532
+      ID: 536
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 542 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 549 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 535 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 543 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ValueType: 550 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoHMapBucketType
       ID: 199
       Name: bucket<string,[]main.structWithMap>
@@ -27343,18 +27343,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 445 ArrayType []val<[]main.structWithMap>
+          Type: 452 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 198 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 446 GoSliceHeaderType []main.structWithMap
+      ValueType: 453 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 187
       Name: bucket<string,[]string>
@@ -27362,56 +27362,56 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 439 ArrayType []val<[]string>
+          Type: 446 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 186 PointerType *bucket<string,[]string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 156 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 402
+      ID: 379
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 524 ArrayType []val<float64>
+          Type: 528 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 401 PointerType *bucket<string,float64>
+          Type: 378 PointerType *bucket<string,float64>
       KeyType: 13 GoStringHeaderType string
       ValueType: 19 BaseType float64
     - __kind: GoHMapBucketType
-      ID: 961
+      ID: 968
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 988 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 995 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 967 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 13 GoStringHeaderType string
-      ValueType: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 987 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 182
       Name: bucket<string,int>
@@ -27419,35 +27419,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 433 ArrayType []val<int>
+          Type: 440 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 181 PointerType *bucket<string,int>
       KeyType: 13 GoStringHeaderType string
       ValueType: 11 BaseType int
     - __kind: GoHMapBucketType
-      ID: 397
+      ID: 374
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 522 ArrayType []val<interface {}>
+          Type: 526 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 396 PointerType *bucket<string,interface {}>
+          Type: 373 PointerType *bucket<string,interface {}>
       KeyType: 13 GoStringHeaderType string
       ValueType: 159 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -27457,35 +27457,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 436 ArrayType []val<main.nestedStruct>
+          Type: 443 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 176 PointerType *bucket<string,main.nestedStruct>
       KeyType: 13 GoStringHeaderType string
       ValueType: 118 StructureType main.nestedStruct
     - __kind: GoHMapBucketType
-      ID: 392
+      ID: 369
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 435 ArrayType []key<string>
+          Type: 442 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 520 ArrayType []val<string>
+          Type: 524 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 391 PointerType *bucket<string,string>
+          Type: 368 PointerType *bucket<string,string>
       KeyType: 13 GoStringHeaderType string
       ValueType: 13 GoStringHeaderType string
     - __kind: GoHMapBucketType
@@ -27495,13 +27495,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 433 ArrayType []val<int>
+          Type: 440 ArrayType []val<int>
         - Name: overflow
           Offset: 72
           Type: 233 PointerType *bucket<struct {},int>
@@ -27514,13 +27514,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 491 ArrayType []val<main.structWithCyclicMaps>
+          Type: 498 ArrayType []val<main.structWithCyclicMaps>
         - Name: overflow
           Offset: 392
           Type: 290 PointerType *bucket<struct {},main.structWithCyclicMaps>
@@ -27533,13 +27533,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 493 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+          Type: 500 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 295 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -27552,13 +27552,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 495 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 502 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 300 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27571,13 +27571,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 497 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 504 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 305 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27590,13 +27590,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 499 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 506 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 310 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27609,13 +27609,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 501 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 508 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
           Type: 315 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -27628,13 +27628,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 462 ArrayType []key<struct {}>
+          Type: 469 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 464 ArrayType []val<struct {}>
+          Type: 471 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 8
           Type: 243 PointerType *bucket<struct {},struct {}>
@@ -27647,18 +27647,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 454 ArrayType []key<uint8>
+          Type: 461 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 456 ArrayType []val<[4]int>
+          Type: 463 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 218 PointerType *bucket<uint8,[4]int>
       KeyType: 5 BaseType uint8
-      ValueType: 457 ArrayType [4]int
+      ValueType: 464 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 214
       Name: bucket<uint8,uint8>
@@ -27666,28 +27666,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 425 ArrayType [8]uint8
+          Type: 432 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 454 ArrayType []key<uint8>
+          Type: 461 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 452 ArrayType []val<uint8>
+          Type: 459 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 213 PointerType *bucket<uint8,uint8>
       KeyType: 5 BaseType uint8
       ValueType: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1088
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1108
+      ID: 1115
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1153
+      ID: 1160
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -27713,13 +27713,13 @@ Types:
       GoRuntimeType: 534784
       GoKind: 15
     - __kind: BaseType
-      ID: 579
+      ID: 586
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 767840
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 580
+      ID: 587
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 767936
@@ -27727,26 +27727,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 582 PointerType *compress/flate.InternalError.str
+          Type: 589 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 581 GoStringDataType compress/flate.InternalError.str
+      Data: 588 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 581
+      ID: 588
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1001
+      ID: 1008
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1077
+      ID: 1084
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27763,19 +27763,19 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 406
       Name: context.backgroundCtx
       GoRuntimeType: 1681632
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 371 StructureType context.emptyCtx
+          Type: 393 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 361
+      ID: 410
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1838464
@@ -27786,13 +27786,13 @@ Types:
           Type: 152 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 372 StructureType sync.Mutex
+          Type: 362 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 373 StructureType sync/atomic.Value
+          Type: 411 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 374 GoMapType map[context.canceler]struct {}
+          Type: 412 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 20 GoInterfaceType error
@@ -27802,7 +27802,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 518
+      ID: 541
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1074848
@@ -27815,13 +27815,13 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: context.deadlineExceededError
       GoRuntimeType: 1288576
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 371
+      ID: 393
       Name: context.emptyCtx
       GoRuntimeType: 1412512
       GoKind: 25
@@ -27830,7 +27830,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 363
+      ID: 395
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1704192
@@ -27841,11 +27841,11 @@ Types:
           Type: 152 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 379 GoSubroutineType func() bool
+          Type: 396 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 365
+      ID: 418
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1430144
@@ -27853,29 +27853,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 361 StructureType context.cancelCtx
+          Type: 410 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 380 PointerType *time.Timer
+          Type: 419 PointerType *time.Timer
         - Name: deadline
           Offset: 88
           Type: 323 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 382
+      ID: 408
       Name: context.todoCtx
       GoRuntimeType: 1681856
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 371 StructureType context.emptyCtx
+          Type: 393 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 367
+      ID: 402
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1715680
@@ -27893,7 +27893,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 369
+      ID: 404
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1681408
@@ -27905,63 +27905,63 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 593
+      ID: 600
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770432
       GoKind: 2
     - __kind: BaseType
-      ID: 594
+      ID: 601
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770528
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1074
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1092
+      ID: 1099
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 595
+      ID: 602
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 770624
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1107
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1101
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1103
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 583
+      ID: 590
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 768416
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1179
+      ID: 1186
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 687
+      ID: 694
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 685
+      ID: 692
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1614752
@@ -27972,34 +27972,34 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 978 ArrayType [5]uint8
+          Type: 985 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 979 GoInterfaceType net.Conn
+          Type: 986 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 811
+      ID: 818
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 956320
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1072
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1079
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 970
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 759
+      ID: 766
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1617824
@@ -28007,21 +28007,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 962 PointerType *crypto/x509.Certificate
+          Type: 969 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 981 BaseType crypto/x509.InvalidReason
+          Type: 988 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 753
+      ID: 760
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1081504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 755
+      ID: 762
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1416352
@@ -28029,24 +28029,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 962 PointerType *crypto/x509.Certificate
+          Type: 969 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 592
+      ID: 599
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 770048
       GoKind: 2
     - __kind: BaseType
-      ID: 981
+      ID: 988
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 540288
       GoKind: 2
     - __kind: StructureType
-      ID: 861
+      ID: 868
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1380320
@@ -28056,13 +28056,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 761
+      ID: 768
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1081760
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 757
+      ID: 764
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1617632
@@ -28070,15 +28070,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 962 PointerType *crypto/x509.Certificate
+          Type: 969 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 20 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 962 PointerType *crypto/x509.Certificate
+          Type: 969 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 776
+      ID: 783
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1260128
@@ -28088,7 +28088,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 780
+      ID: 787
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1260288
@@ -28098,55 +28098,55 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 778
+      ID: 785
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 577
+      ID: 584
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 767456
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1030
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 578
+      ID: 585
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 767648
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 655
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 854
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 647
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 646
+      ID: 653
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 644
+      ID: 651
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 649
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1159
+      ID: 1166
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1244608
@@ -28156,19 +28156,19 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1031
+      ID: 1038
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 747
+      ID: 754
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 745
+      ID: 752
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 589
+      ID: 596
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 769952
@@ -28176,22 +28176,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 591 PointerType *encoding/xml.UnmarshalError.str
+          Type: 598 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 590 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 597 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 590
+      ID: 597
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 757
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1144
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -28208,11 +28208,11 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 625
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 821
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -28228,15 +28228,15 @@ Types:
       GoRuntimeType: 534976
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1147
+      ID: 1154
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -28246,7 +28246,7 @@ Types:
       GoRuntimeType: 447200
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 379
+      ID: 396
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 545856
@@ -28291,11 +28291,11 @@ Types:
           Offset: 0
           Type: 329 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 678
+      ID: 685
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 659
+      ID: 666
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1613024
@@ -28303,7 +28303,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 971 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 978 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 11 BaseType int
@@ -28311,25 +28311,25 @@ Types:
           Offset: 200
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 661
+      ID: 668
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 975
+      ID: 982
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 672
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1077664
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 984
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 571
+      ID: 578
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 766880
@@ -28337,18 +28337,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 573 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 580 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 579 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 572
+      ID: 579
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 971
+      ID: 978
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2084544
@@ -28356,7 +28356,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 972 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 979 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -28371,7 +28371,7 @@ Types:
           Type: 19 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 973 GoSliceHeaderType []float64
+          Type: 980 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 16 BaseType int64
@@ -28380,10 +28380,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 974 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 981 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 976 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 983 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 156 GoSliceHeaderType []string
@@ -28397,13 +28397,13 @@ Types:
           Offset: 184
           Type: 16 BaseType int64
     - __kind: BaseType
-      ID: 972
+      ID: 979
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 536640
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 568
+      ID: 575
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 766784
@@ -28411,18 +28411,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 570 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 577 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 576 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 569
+      ID: 576
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 574
+      ID: 581
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 766976
@@ -28430,30 +28430,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 576 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 583 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 575 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 582 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 575
+      ID: 582
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1045
+      ID: 1052
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1132
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 777
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 384
+      ID: 360
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2204704
@@ -28461,7 +28461,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 385 StructureType sync.RWMutex
+          Type: 361 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 13 GoStringHeaderType string
@@ -28482,13 +28482,13 @@ Types:
           Type: 16 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 393 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 370 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 398 GoMapType map[string]float64
+          Type: 375 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 12 BaseType uint64
@@ -28503,10 +28503,10 @@ Types:
           Type: 15 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 403 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 380 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 406 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 383 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -28518,7 +28518,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 386 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 13 GoStringHeaderType string
@@ -28541,7 +28541,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 410
+      ID: 387
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2081856
@@ -28552,13 +28552,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 386 StructureType sync/atomic.Int32
+          Type: 363 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -28567,16 +28567,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 413 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 391 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 12 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 385 StructureType sync.RWMutex
+          Type: 361 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -28585,12 +28585,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 403 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 380 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 405
+      ID: 382
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1788800
@@ -28607,7 +28607,7 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 13 GoStringHeaderType string
@@ -28615,20 +28615,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 393
+      ID: 370
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 987552
       GoKind: 21
-      HeaderType: 395 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 372 GoHMapHeaderType hash<string,interface {}>
     - __kind: BaseType
-      ID: 1203
+      ID: 1209
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 533760
       GoKind: 10
     - __kind: StructureType
-      ID: 408
+      ID: 385
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1633152
@@ -28642,16 +28642,16 @@ Types:
           Type: 12 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 528 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 532 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 533 GoMapType map[string]interface {}
+          Type: 537 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1223
+      ID: 1230
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 544
+      ID: 551
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1789056
@@ -28659,7 +28659,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1221 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1228 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -28674,15 +28674,15 @@ Types:
           Type: 19 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1229 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1221
+      ID: 1228
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 951616
       GoKind: 5
     - __kind: StructureType
-      ID: 412
+      ID: 390
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 1976704
@@ -28690,16 +28690,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 385 StructureType sync.RWMutex
+          Type: 361 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1201 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1207 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 388 GoMapType map[string]string
+          Type: 365 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 11 BaseType int
@@ -28714,12 +28714,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1203 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1209 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 383 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 413
+      ID: 391
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 828800
@@ -28728,15 +28728,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 919
+      ID: 926
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1155
+      ID: 1162
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1226
+    - __kind: GoContextImplementationType
+      ID: 398
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1444352
@@ -28745,30 +28745,32 @@ Types:
         - Name: Context
           Offset: 0
           Type: 152 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 696
+      ID: 703
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 703
+      ID: 710
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1080736
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 588
+      ID: 595
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 769088
       GoKind: 2
     - __kind: StructureType
-      ID: 701
+      ID: 708
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1080608
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 699
+      ID: 706
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1414432
@@ -28781,7 +28783,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1415232
@@ -28794,7 +28796,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 723
+      ID: 730
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1617056
@@ -28810,7 +28812,7 @@ Types:
           Offset: 24
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 721
+      ID: 728
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1254528
@@ -28820,7 +28822,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 717
+      ID: 724
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1254208
@@ -28830,14 +28832,14 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 957
+      ID: 964
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1141056
       GoKind: 21
-      HeaderType: 959 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 966 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 980
+      ID: 987
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1013536
@@ -28852,15 +28854,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 992 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 999 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 992
+      ID: 999
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 731
+      ID: 738
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1415552
@@ -28868,12 +28870,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 957 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 964 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 957 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 964 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 725
+      ID: 732
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1254688
@@ -28883,7 +28885,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 729
+      ID: 736
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1617248
@@ -28894,12 +28896,12 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 987 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 980 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 987 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 727
+      ID: 734
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1415392
@@ -28912,7 +28914,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 733
+      ID: 740
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1254848
@@ -28922,7 +28924,7 @@ Types:
           Offset: 0
           Type: 323 GoTimeType time.Time
     - __kind: StructureType
-      ID: 739
+      ID: 746
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1415872
@@ -28935,7 +28937,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 741
+      ID: 748
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1255168
@@ -28945,7 +28947,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 737
+      ID: 744
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1415712
@@ -28958,7 +28960,7 @@ Types:
           Offset: 8
           Type: 11 BaseType int
     - __kind: StructureType
-      ID: 735
+      ID: 742
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1255008
@@ -28968,7 +28970,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 743
+      ID: 750
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1416032
@@ -28981,7 +28983,7 @@ Types:
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1246848
@@ -28991,11 +28993,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1091
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 676
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1247008
@@ -29003,21 +29005,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 667 StructureType github.com/cihub/seelog.baseError
+          Type: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1070
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1019
+      ID: 1026
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1060
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 673
+      ID: 680
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1247328
@@ -29025,13 +29027,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 667 StructureType github.com/cihub/seelog.baseError
+          Type: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1122
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1126
+      ID: 1133
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1978816
@@ -29039,12 +29041,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1114 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1121 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 16 BaseType int64
     - __kind: StructureType
-      ID: 1127
+      ID: 1134
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2002208
@@ -29052,7 +29054,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1114 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1121 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 13 GoStringHeaderType string
@@ -29060,11 +29062,11 @@ Types:
           Offset: 24
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1028
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 671
+      ID: 678
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1247168
@@ -29072,9 +29074,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 667 StructureType github.com/cihub/seelog.baseError
+          Type: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 675
+      ID: 682
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1247488
@@ -29082,64 +29084,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 667 StructureType github.com/cihub/seelog.baseError
+          Type: 674 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1095
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1121
+      ID: 1128
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1123
+      ID: 1130
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 960
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 876
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 878
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1081
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 863
+      ID: 870
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 681
+      ID: 688
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1248448
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 11 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1171
+      ID: 1178
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 934
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 896
+      ID: 903
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1721056
@@ -29155,11 +29157,11 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 833
+      ID: 840
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1518560
@@ -29172,7 +29174,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 902
+      ID: 909
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1721504
@@ -29188,13 +29190,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 810
+      ID: 817
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 953440
       GoKind: 8
     - __kind: StructureType
-      ID: 894
+      ID: 901
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1720832
@@ -29210,13 +29212,13 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 982
+      ID: 989
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 765152
       GoKind: 8
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1720608
@@ -29224,15 +29226,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 982 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 989 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 982 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 989 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 907
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1638912
@@ -29245,7 +29247,7 @@ Types:
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 898
+      ID: 905
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1721280
@@ -29261,11 +29263,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1175
+      ID: 1182
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1440128
@@ -29275,19 +29277,19 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 837
+      ID: 844
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1200896
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1200768
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1639104
@@ -29300,7 +29302,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 600
+      ID: 607
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 772448
@@ -29308,13 +29310,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 602 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 609 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 601 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 608 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 601
+      ID: 608
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29345,13 +29347,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 510 PointerType *go.shape.string.str
+          Type: 517 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 509 GoStringDataType go.shape.string.str
+      Data: 516 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 509
+      ID: 516
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29407,11 +29409,11 @@ Types:
           Offset: 32
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 973
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 877
+      ID: 884
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1271968
@@ -29421,7 +29423,7 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 1051
+      ID: 1058
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1495424
@@ -29429,13 +29431,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1075 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1082 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1142
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1075
+      ID: 1082
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1091616
@@ -29448,7 +29450,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1037
+      ID: 1044
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1388800
@@ -29458,19 +29460,19 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 603
+      ID: 610
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 773024
       GoKind: 10
     - __kind: BaseType
-      ID: 964
+      ID: 971
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 966976
       GoKind: 10
     - __kind: StructureType
-      ID: 935
+      ID: 942
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1760256
@@ -29481,12 +29483,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 964 BaseType golang.org/x/net/http2.ErrCode
+          Type: 971 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 796
+      ID: 803
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1423232
@@ -29494,12 +29496,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 964 BaseType golang.org/x/net/http2.ErrCode
+          Type: 971 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 607
+      ID: 614
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 773216
@@ -29507,18 +29509,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 609 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 616 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 608 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 615 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 608
+      ID: 615
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 613
+      ID: 620
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 773408
@@ -29526,18 +29528,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 615 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 622 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 614 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 621 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 614
+      ID: 621
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 610
+      ID: 617
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 773312
@@ -29545,18 +29547,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 612 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 619 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 611 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 618 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 611
+      ID: 618
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 604
+      ID: 611
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 773120
@@ -29564,22 +29566,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 606 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 613 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 605 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 612 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 605
+      ID: 612
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1133
+      ID: 1140
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 800
+      ID: 807
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1272608
@@ -29589,13 +29591,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 616
+      ID: 623
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 773504
       GoKind: 2
     - __kind: StructureType
-      ID: 788
+      ID: 795
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1267648
@@ -29605,11 +29607,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 940
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 955
+      ID: 962
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1786016
@@ -29625,7 +29627,7 @@ Types:
           Offset: 24
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1422752
@@ -29638,7 +29640,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1098
+      ID: 1105
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1839488
@@ -29646,16 +29648,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 979 GoInterfaceType net.Conn
+          Type: 986 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1113 GoInterfaceType io.Reader
+          Type: 1120 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1049
+      ID: 1056
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1386400
@@ -29665,29 +29667,29 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1009
+      ID: 1016
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 768
+      ID: 775
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 865
+      ID: 872
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 929
+      ID: 936
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1333216
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1260928
@@ -29697,7 +29699,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 784
+      ID: 791
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1261088
@@ -29707,11 +29709,11 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 711
+      ID: 718
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1086
+      ID: 1093
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -29747,7 +29749,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 229 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 461 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 468 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 222
       Name: hash<[4]int,uint8>
@@ -29781,7 +29783,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 224 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 460 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 467 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 190
       Name: hash<[4]string,[2]int>
@@ -29815,7 +29817,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 192 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 444 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 451 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 202
       Name: hash<bool,main.node>
@@ -29849,9 +29851,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 204 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 451 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 458 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
-      ID: 376
+      ID: 414
       Name: hash<context.canceler,struct {}>
       ByteSize: 48
       RawFields:
@@ -29872,18 +29874,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 377 PointerType *bucket<context.canceler,struct {}>
+          Type: 415 PointerType *bucket<context.canceler,struct {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 377 PointerType *bucket<context.canceler,struct {}>
+          Type: 415 PointerType *bucket<context.canceler,struct {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 378 GoHMapBucketType bucket<context.canceler,struct {}>
-      BucketsType: 519 GoSliceDataType []bucket<context.canceler,struct {}>.array
+      BucketType: 416 GoHMapBucketType bucket<context.canceler,struct {}>
+      BucketsType: 542 GoSliceDataType []bucket<context.canceler,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 141
       Name: hash<int,*main.deepMap2>
@@ -29917,9 +29919,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 143 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 430 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 437 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1214
+      ID: 1221
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -29940,18 +29942,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1215 PointerType *bucket<int,*main.deepMap3>
+          Type: 1222 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1215 PointerType *bucket<int,*main.deepMap3>
+          Type: 1222 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 1216 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1220 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1223 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1227 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
       ID: 1252
       Name: hash<int,*main.deepMap8>
@@ -30053,7 +30055,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 172 GoHMapBucketType bucket<int,int>
-      BucketsType: 434 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 441 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
       ID: 1270
       Name: hash<int,interface {}>
@@ -30121,7 +30123,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 239 GoHMapBucketType bucket<int,struct {}>
-      BucketsType: 465 GoSliceDataType []bucket<int,struct {}>.array
+      BucketsType: 472 GoSliceDataType []bucket<int,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 207
       Name: hash<int,uint8>
@@ -30155,9 +30157,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 209 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 453 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 460 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
-      ID: 530
+      ID: 534
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
@@ -30178,18 +30180,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 535 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 531 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 535 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 532 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 545 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketType: 536 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 552 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: GoHMapHeaderType
       ID: 197
       Name: hash<string,[]main.structWithMap>
@@ -30223,7 +30225,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 199 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 448 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 455 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 185
       Name: hash<string,[]string>
@@ -30257,9 +30259,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 187 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 440 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 447 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 400
+      ID: 377
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
@@ -30280,20 +30282,20 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 401 PointerType *bucket<string,float64>
+          Type: 378 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 401 PointerType *bucket<string,float64>
+          Type: 378 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 402 GoHMapBucketType bucket<string,float64>
-      BucketsType: 525 GoSliceDataType []bucket<string,float64>.array
+      BucketType: 379 GoHMapBucketType bucket<string,float64>
+      BucketsType: 529 GoSliceDataType []bucket<string,float64>.array
     - __kind: GoHMapHeaderType
-      ID: 959
+      ID: 966
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -30314,18 +30316,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 967 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 960 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 967 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 961 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 989 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 968 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 996 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 180
       Name: hash<string,int>
@@ -30359,9 +30361,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 182 GoHMapBucketType bucket<string,int>
-      BucketsType: 438 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 445 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
-      ID: 395
+      ID: 372
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
@@ -30382,18 +30384,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 396 PointerType *bucket<string,interface {}>
+          Type: 373 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 396 PointerType *bucket<string,interface {}>
+          Type: 373 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 397 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 523 GoSliceDataType []bucket<string,interface {}>.array
+      BucketType: 374 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 527 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 175
       Name: hash<string,main.nestedStruct>
@@ -30427,9 +30429,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 177 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 437 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 444 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 390
+      ID: 367
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -30450,18 +30452,18 @@ Types:
           Type: 4 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 391 PointerType *bucket<string,string>
+          Type: 368 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 391 PointerType *bucket<string,string>
+          Type: 368 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 3 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
-      BucketType: 392 GoHMapBucketType bucket<string,string>
-      BucketsType: 521 GoSliceDataType []bucket<string,string>.array
+      BucketType: 369 GoHMapBucketType bucket<string,string>
+      BucketsType: 525 GoSliceDataType []bucket<string,string>.array
     - __kind: GoHMapHeaderType
       ID: 232
       Name: hash<struct {},int>
@@ -30495,7 +30497,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 234 GoHMapBucketType bucket<struct {},int>
-      BucketsType: 463 GoSliceDataType []bucket<struct {},int>.array
+      BucketsType: 470 GoSliceDataType []bucket<struct {},int>.array
     - __kind: GoHMapHeaderType
       ID: 289
       Name: hash<struct {},main.structWithCyclicMaps>
@@ -30529,7 +30531,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 291 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
-      BucketsType: 492 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+      BucketsType: 499 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 294
       Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -30563,7 +30565,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 296 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 494 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 501 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 299
       Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30597,7 +30599,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 301 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 496 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 503 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 304
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30631,7 +30633,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 306 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 498 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 505 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 309
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30665,7 +30667,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 311 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 500 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 507 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 314
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -30699,7 +30701,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 316 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 502 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketsType: 509 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 242
       Name: hash<struct {},struct {}>
@@ -30733,7 +30735,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 244 GoHMapBucketType bucket<struct {},struct {}>
-      BucketsType: 466 GoSliceDataType []bucket<struct {},struct {}>.array
+      BucketsType: 473 GoSliceDataType []bucket<struct {},struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 217
       Name: hash<uint8,[4]int>
@@ -30767,7 +30769,7 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 219 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 458 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 465 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 212
       Name: hash<uint8,uint8>
@@ -30801,9 +30803,9 @@ Types:
           Offset: 40
           Type: 144 PointerType *runtime.mapextra
       BucketType: 214 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 455 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 462 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -30850,7 +30852,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 763
+      ID: 770
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -30876,25 +30878,25 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1006
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 925
+      ID: 932
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1177
+      ID: 1184
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 923
+      ID: 930
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1313536
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 630
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -30975,11 +30977,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1048
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1082
+      ID: 1089
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1109696
@@ -30992,7 +30994,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1113
+      ID: 1120
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 985888
@@ -31005,7 +31007,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1070
+      ID: 1077
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1074336
@@ -31031,21 +31033,21 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1039
+      ID: 1046
       Name: io.discard
       GoRuntimeType: 1288256
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1013
+      ID: 1020
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 921
+      ID: 928
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1097
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -31139,7 +31141,7 @@ Types:
           Offset: 0
           Type: 139 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 429
+      ID: 436
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1105856
@@ -31147,9 +31149,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1212 GoMapType map[int]*main.deepMap3
+          Type: 1219 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1219
+      ID: 1226
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -31201,9 +31203,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1180 PointerType *main.deepPtr3
+          Type: 1187 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1181
+      ID: 1188
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -31247,7 +31249,7 @@ Types:
           Offset: 0
           Type: 133 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 422
+      ID: 429
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1108160
@@ -31255,9 +31257,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1206 GoSliceHeaderType []*main.deepSlice3
+          Type: 1213 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1216
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -31307,16 +31309,16 @@ Types:
           Type: 157 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 372 StructureType sync.Mutex
+          Type: 362 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1188 StructureType sync.Once
+          Type: 1195 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1190 StructureType sync.WaitGroup
+          Type: 1197 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 386 StructureType sync/atomic.Int32
+          Type: 363 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 157
       Name: main.esotericStack
@@ -31734,9 +31736,9 @@ Types:
           Type: 11 BaseType int
         - Name: data
           Offset: 8
-          Type: 1185 ArrayType [63]uint64
+          Type: 1192 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1196
+      ID: 1203
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1238208
@@ -31756,7 +31758,7 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1187
+      ID: 1194
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -31767,18 +31769,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1183 PointerType *main.stringType1.str
+          Type: 1190 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 1182 GoStringDataType main.stringType1.str
+      Data: 1189 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1182
+      ID: 1189
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1184
+      ID: 1191
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
@@ -31907,16 +31909,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1197 PointerType **main.t
+          Type: 1204 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 11 BaseType int
         - Name: cap
           Offset: 16
           Type: 11 BaseType int
-      Data: 1198 GoSliceDataType main.t.array
+      Data: 1205 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1198
+      ID: 1205
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -32072,12 +32074,12 @@ Types:
       GoKind: 21
       HeaderType: 202 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoMapType
-      ID: 374
+      ID: 412
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 886688
       GoKind: 21
-      HeaderType: 376 GoHMapHeaderType hash<context.canceler,struct {}>
+      HeaderType: 414 GoHMapHeaderType hash<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 139
       Name: map[int]*main.deepMap2
@@ -32086,12 +32088,12 @@ Types:
       GoKind: 21
       HeaderType: 141 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1212
+      ID: 1219
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 884192
       GoKind: 21
-      HeaderType: 1214 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1221 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1250
       Name: map[int]*main.deepMap8
@@ -32135,12 +32137,12 @@ Types:
       GoKind: 21
       HeaderType: 207 GoHMapHeaderType hash<int,uint8>
     - __kind: GoMapType
-      ID: 528
+      ID: 532
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 886880
       GoKind: 21
-      HeaderType: 530 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 534 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 195
       Name: map[string][]main.structWithMap
@@ -32156,12 +32158,12 @@ Types:
       GoKind: 21
       HeaderType: 185 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 398
+      ID: 375
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 886784
       GoKind: 21
-      HeaderType: 400 GoHMapHeaderType hash<string,float64>
+      HeaderType: 377 GoHMapHeaderType hash<string,float64>
     - __kind: GoMapType
       ID: 178
       Name: map[string]int
@@ -32170,12 +32172,12 @@ Types:
       GoKind: 21
       HeaderType: 180 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
-      ID: 533
+      ID: 537
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 882944
       GoKind: 21
-      HeaderType: 395 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 372 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoMapType
       ID: 173
       Name: map[string]main.nestedStruct
@@ -32184,12 +32186,12 @@ Types:
       GoKind: 21
       HeaderType: 175 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 388
+      ID: 365
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 885920
       GoKind: 21
-      HeaderType: 390 GoHMapHeaderType hash<string,string>
+      HeaderType: 367 GoHMapHeaderType hash<string,string>
     - __kind: GoMapType
       ID: 230
       Name: map[struct {}]int
@@ -32255,7 +32257,7 @@ Types:
       GoKind: 21
       HeaderType: 212 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 715
+      ID: 722
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1253888
@@ -32265,7 +32267,7 @@ Types:
           Offset: 0
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1003
+      ID: 1010
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1250688
@@ -32275,11 +32277,11 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 920
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 979
+      ID: 986
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1413152
@@ -32292,35 +32294,35 @@ Types:
           Offset: 8
           Type: 21 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 951
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1141
+      ID: 1148
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 942
+      ID: 949
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 922
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1151
+      ID: 1158
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1161
+      ID: 1168
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1149
+      ID: 1156
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 880
+      ID: 887
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1077280
@@ -32328,28 +32330,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 882 PointerType *net.UnknownNetworkError.str
+          Type: 889 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 881 GoStringDataType net.UnknownNetworkError.str
+      Data: 888 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 881
+      ID: 888
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 849
+      ID: 856
       Name: net.canceledError
       GoRuntimeType: 1201664
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1126
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 984
+      ID: 991
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1978112
@@ -32357,7 +32359,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 979 GoInterfaceType net.Conn
+          Type: 986 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 20 GoInterfaceType error
@@ -32368,27 +32370,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1170
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1157
+      ID: 1164
       Name: net.noReadFrom
       GoRuntimeType: 1077536
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1156
+      ID: 1163
       Name: net.noWriteTo
       GoRuntimeType: 1077408
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 652
+      ID: 659
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1228
+    - __kind: GoContextImplementationType
+      ID: 400
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1643904
@@ -32400,8 +32402,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 152 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 654
+      ID: 661
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1612832
@@ -32409,7 +32413,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 967 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 974 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 13 GoStringHeaderType string
@@ -32417,7 +32421,7 @@ Types:
           Offset: 96
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 1145
+      ID: 1152
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2154432
@@ -32425,12 +32429,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1157 StructureType net.noReadFrom
+          Type: 1164 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1150 PointerType *net.TCPConn
+          Type: 1157 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1143
+      ID: 1150
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2153888
@@ -32438,24 +32442,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1156 StructureType net.noWriteTo
+          Type: 1163 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1150 PointerType *net.TCPConn
+          Type: 1157 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 917
+      ID: 924
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 946
+      ID: 953
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 839
+      ID: 846
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 995
+      ID: 1002
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1242368
@@ -32465,19 +32469,19 @@ Types:
           Offset: 0
           Type: 126 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 549
+      ID: 556
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 765632
       GoKind: 10
     - __kind: BaseType
-      ID: 956
+      ID: 963
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 953536
       GoKind: 10
     - __kind: StructureType
-      ID: 630
+      ID: 637
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1611296
@@ -32488,12 +32492,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 956 BaseType net/http.http2ErrCode
+          Type: 963 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 938
+      ID: 945
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1776288
@@ -32504,12 +32508,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 956 BaseType net/http.http2ErrCode
+          Type: 963 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 20 GoInterfaceType error
     - __kind: StructureType
-      ID: 634
+      ID: 641
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1412832
@@ -32517,16 +32521,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 956 BaseType net/http.http2ErrCode
+          Type: 963 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 553
+      ID: 560
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 765824
@@ -32534,18 +32538,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 555 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 562 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 554 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 561 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 554
+      ID: 561
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 559
+      ID: 566
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 766016
@@ -32553,18 +32557,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 561 PointerType *net/http.http2headerFieldNameError.str
+          Type: 568 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 560 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 567 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 560
+      ID: 567
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 556
+      ID: 563
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 765920
@@ -32572,32 +32576,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 558 PointerType *net/http.http2headerFieldValueError.str
+          Type: 565 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 557 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 564 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 557
+      ID: 564
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 917
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 852
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1201152
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1110
+      ID: 1117
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 550
+      ID: 557
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 765728
@@ -32605,18 +32609,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 552 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 559 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 551 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 558 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 551
+      ID: 558
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 997
+      ID: 1004
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1612064
@@ -32624,22 +32628,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 979 GoInterfaceType net.Conn
+          Type: 986 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1078 BaseType time.Duration
+          Type: 1085 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 101 PointerType *error
     - __kind: ArrayType
-      ID: 1079
+      ID: 1086
       Name: net/http.incomparable
       GoRuntimeType: 833792
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1374720
@@ -32649,11 +32653,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1068
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1017
+      ID: 1024
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1374560
@@ -32661,9 +32665,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1060 PointerType *net/http.persistConn
+          Type: 1067 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1043
+      ID: 1050
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1683424
@@ -32671,15 +32675,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1079 ArrayType net/http.incomparable
+          Type: 1086 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1080 PointerType *bufio.Reader
+          Type: 1087 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1082 GoInterfaceType io.ReadWriteCloser
+          Type: 1089 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 638
+      ID: 645
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1243328
@@ -32689,17 +32693,17 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 947
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 908
+      ID: 915
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1300576
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 843
+      ID: 850
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1374880
@@ -32709,11 +32713,11 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 627
+      ID: 634
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1112
+      ID: 1119
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1914528
@@ -32721,13 +32725,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1107 PointerType *bufio.Writer
+          Type: 1114 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1034
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 707
+      ID: 714
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1616672
@@ -32743,7 +32747,7 @@ Types:
           Offset: 32
           Type: 13 GoStringHeaderType string
     - __kind: StructureType
-      ID: 705
+      ID: 712
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1414592
@@ -32756,11 +32760,11 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1069
+      ID: 1076
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1029
+      ID: 1036
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1416512
@@ -32768,16 +32772,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1068 PointerType *net/smtp.Client
+          Type: 1075 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1070 GoInterfaceType io.WriteCloser
+          Type: 1077 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 698
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 584
+      ID: 591
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 768512
@@ -32785,26 +32789,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 586 PointerType *net/textproto.ProtocolError.str
+          Type: 593 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 585 GoStringDataType net/textproto.ProtocolError.str
+      Data: 592 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 585
+      ID: 592
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1032
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 948
+      ID: 955
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 562
+      ID: 569
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 766496
@@ -32812,18 +32816,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 564 PointerType *net/url.EscapeError.str
+          Type: 571 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 563 GoStringDataType net/url.EscapeError.str
+      Data: 570 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 563
+      ID: 570
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 565
+      ID: 572
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 766592
@@ -32831,30 +32835,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 567 PointerType *net/url.InvalidHostError.str
+          Type: 574 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 566 GoStringDataType net/url.InvalidHostError.str
+      Data: 573 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 566
+      ID: 573
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1169
+      ID: 1176
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1167
+      ID: 1174
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2222624
@@ -32862,12 +32866,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1173 StructureType os.noReadFrom
+          Type: 1180 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1168 PointerType *os.File
+          Type: 1175 PointerType *os.File
     - __kind: StructureType
-      ID: 1165
+      ID: 1172
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2221824
@@ -32875,36 +32879,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1172 StructureType os.noWriteTo
+          Type: 1179 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1168 PointerType *os.File
+          Type: 1175 PointerType *os.File
     - __kind: StructureType
-      ID: 1173
+      ID: 1180
       Name: os.noReadFrom
       GoRuntimeType: 1075616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1172
+      ID: 1179
       Name: os.noWriteTo
       GoRuntimeType: 1075488
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 851
+      ID: 858
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 994
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1054
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1519136
@@ -32917,7 +32921,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 597
+      ID: 604
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 771680
@@ -32925,36 +32929,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 599 PointerType *os/user.UnknownGroupIdError.str
+          Type: 606 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 598 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 605 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 598
+      ID: 605
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 596
+      ID: 603
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 771584
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 625
+      ID: 632
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 713
+      ID: 720
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 825
+      ID: 832
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -32966,7 +32970,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 827
+      ID: 834
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1765856
@@ -32983,9 +32987,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 985 BaseType runtime.boundsErrorCode
+          Type: 992 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 985
+      ID: 992
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 535168
@@ -33005,7 +33009,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 888
+      ID: 895
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1636992
@@ -33018,7 +33022,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 804
+      ID: 811
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 952672
@@ -33026,13 +33030,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 806 PointerType *runtime.errorString.str
+          Type: 813 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 805 GoStringDataType runtime.errorString.str
+      Data: 812 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 805
+      ID: 812
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -33658,7 +33662,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 807
+      ID: 814
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 953248
@@ -33666,13 +33670,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 809 PointerType *runtime.plainError.str
+          Type: 816 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 808 GoStringDataType runtime.plainError.str
+      Data: 815 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 808
+      ID: 815
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -33754,7 +33758,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -33766,26 +33770,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 415 PointerType *string.str
+          Type: 422 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 414 GoStringDataType string.str
+      Data: 421 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 414
+      ID: 421
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1106
+      ID: 1113
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1015
+      ID: 1022
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1011
+      ID: 1018
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1279776
@@ -33801,7 +33805,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 372
+      ID: 362
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1291296
@@ -33814,7 +33818,7 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1188
+      ID: 1195
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1292416
@@ -33822,12 +33826,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1189 StructureType sync/atomic.Uint32
+          Type: 1196 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 372 StructureType sync.Mutex
+          Type: 362 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 385
+      ID: 361
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1718368
@@ -33835,7 +33839,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 372 StructureType sync.Mutex
+          Type: 362 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -33844,12 +33848,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 386 StructureType sync/atomic.Int32
+          Type: 363 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 386 StructureType sync/atomic.Int32
+          Type: 363 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1190
+      ID: 1197
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1432448
@@ -33857,21 +33861,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1191 StructureType sync.noCopy
+          Type: 1198 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1192 StructureType sync/atomic.Uint64
+          Type: 1199 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1191
+      ID: 1198
       Name: sync.noCopy
       GoRuntimeType: 952288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 386
+      ID: 363
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1292736
@@ -33879,12 +33883,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 387 StructureType sync/atomic.noCopy
+          Type: 364 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 15 BaseType int32
     - __kind: StructureType
-      ID: 1189
+      ID: 1196
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1292896
@@ -33892,12 +33896,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 387 StructureType sync/atomic.noCopy
+          Type: 364 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1192
+      ID: 1199
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1432832
@@ -33905,15 +33909,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 387 StructureType sync/atomic.noCopy
+          Type: 364 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1193 StructureType sync/atomic.align64
+          Type: 1200 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 12 BaseType uint64
     - __kind: StructureType
-      ID: 373
+      ID: 411
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1114048
@@ -33923,29 +33927,29 @@ Types:
           Offset: 0
           Type: 159 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1193
+      ID: 1200
       Name: sync/atomic.align64
       GoRuntimeType: 952480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 387
+      ID: 364
       Name: sync/atomic.noCopy
       GoRuntimeType: 952384
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 936
+      ID: 943
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1202432
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1146
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 879
+      ID: 886
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1523552
@@ -33958,7 +33962,7 @@ Types:
           Offset: 16
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 1078
+      ID: 1085
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1790592
@@ -33975,10 +33979,10 @@ Types:
           Type: 13 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 503 GoSliceHeaderType []time.zone
+          Type: 510 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 506 GoSliceHeaderType []time.zoneTrans
+          Type: 513 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 13 GoStringHeaderType string
@@ -33990,9 +33994,9 @@ Types:
           Type: 16 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 504 PointerType *time.zone
+          Type: 511 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 628
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
@@ -34020,7 +34024,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 381
+      ID: 420
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1293536
@@ -34028,12 +34032,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1200 GoChannelType <-chan time.Time
+          Type: 1212 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 546
+      ID: 553
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 764096
@@ -34041,18 +34045,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 548 PointerType *time.fileSizeError.str
+          Type: 555 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 11 BaseType int
-      Data: 547 GoStringDataType time.fileSizeError.str
+      Data: 554 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 547
+      ID: 554
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 505
+      ID: 512
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1433792
@@ -34068,7 +34072,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 508
+      ID: 515
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1635840
@@ -34129,11 +34133,11 @@ Types:
       GoRuntimeType: 535104
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1109
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 967
+      ID: 974
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1936256
@@ -34144,10 +34148,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 968 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 975 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 969 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 976 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 11 BaseType int
@@ -34162,18 +34166,18 @@ Types:
           Type: 11 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 970 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 977 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 9 BaseType uint16
     - __kind: BaseType
-      ID: 970
+      ID: 977
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 957952
       GoKind: 9
     - __kind: StructureType
-      ID: 968
+      ID: 975
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1802624
@@ -34198,21 +34202,21 @@ Types:
           Offset: 10
           Type: 9 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 709
+      ID: 716
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 969
+      ID: 976
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 538752
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1131
+      ID: 1138
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 693
+      ID: 700
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1251008
@@ -34222,13 +34226,13 @@ Types:
           Offset: 0
           Type: 20 GoInterfaceType error
     - __kind: BaseType
-      ID: 587
+      ID: 594
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 768608
       GoKind: 2
     - __kind: StructureType
-      ID: 858
+      ID: 865
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1519328
@@ -34241,7 +34245,7 @@ Types:
           Offset: 16
           Type: 13 GoStringHeaderType string
     - __kind: BaseType
-      ID: 812
+      ID: 819
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 956800

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -11845,21 +11845,21 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1383
+      ID: 1389
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 139
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 140 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1388
+      ID: 1395
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1389 PointerType *main.deepSlice3
+      Pointee: 1396 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1423
       Name: '**main.deepSlice8'
@@ -11877,7 +11877,7 @@ Types:
       GoKind: 22
       Pointee: 154 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1378
+      ID: 1385
       Name: '**main.t'
       ByteSize: 8
       Pointee: 253 PointerType *main.t
@@ -11909,20 +11909,20 @@ Types:
       ByteSize: 8
       Pointee: 207 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 382
+      ID: 420
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 383 PointerType *table<context.canceler,struct {}>
+      Pointee: 421 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 147
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 148 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1396
+      ID: 1403
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1397 PointerType *table<int,*main.deepMap3>
+      Pointee: 1404 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1440
       Name: '**table<int,*main.deepMap8>'
@@ -11954,10 +11954,10 @@ Types:
       ByteSize: 8
       Pointee: 212 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 690
+      ID: 688
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 691 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 689 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 201
       Name: '**table<string,[]main.structWithMap>'
@@ -11969,35 +11969,35 @@ Types:
       ByteSize: 8
       Pointee: 190 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 406
+      ID: 383
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 407 PointerType *table<string,float64>
+      Pointee: 384 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1130 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1137 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 184
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 185 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 401
+      ID: 378
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 402 PointerType *table<string,interface {}>
+      Pointee: 379 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 179
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 180 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 396
+      ID: 373
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 397 PointerType *table<string,string>
+      Pointee: 374 PointerType *table<string,string>
     - __kind: PointerType
       ID: 236
       Name: '**table<struct {},int>'
@@ -12049,20 +12049,20 @@ Types:
       ByteSize: 8
       Pointee: 217 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1386
+      ID: 1392
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1385 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1391 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 429
+      ID: 436
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 428 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 435 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1392
+      ID: 1399
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1391 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1398 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1427
       Name: '*[]*main.deepSlice8.array'
@@ -12074,95 +12074,95 @@ Types:
       ByteSize: 8
       Pointee: 1432 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 426
+      ID: 433
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 425 GoSliceDataType []*string.array
+      Pointee: 432 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 589
+      ID: 596
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 588 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 595 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 587
+      ID: 594
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 586 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 593 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 585
+      ID: 592
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 584 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 591 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 583
+      ID: 590
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 582 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 589 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 282
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 581
+      ID: 588
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 580 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 587 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 569
+      ID: 576
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 568 GoSliceDataType [][]uint.array
+      Pointee: 575 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 573
+      ID: 580
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 572 GoSliceDataType []bool.array
+      Pointee: 579 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1166
+      ID: 1173
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1165 GoSliceDataType []float64.array
+      Pointee: 1172 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 686
+      ID: 684
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 685 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 683 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 694
+      ID: 692
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 691 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 651
+      ID: 658
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 650 GoSliceDataType []go.shape.float64.array
+      Pointee: 657 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 646 GoSliceDataType []go.shape.int.array
+      Pointee: 653 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 648 GoSliceDataType []go.shape.string.array
+      Pointee: 655 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
       ID: 1436
       Name: '*[]interface {}.array'
@@ -12174,20 +12174,20 @@ Types:
       ByteSize: 8
       Pointee: 277 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 579
+      ID: 586
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 578 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 585 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 695 GoSliceDataType []main.structWithMap.array
+      Pointee: 702 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 571
+      ID: 578
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 570 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 577 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -12196,111 +12196,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 441
+      ID: 448
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 440 GoSliceDataType []string.array
+      Pointee: 447 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 577
+      ID: 584
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 576 GoSliceDataType []struct {}.array
+      Pointee: 583 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 697 GoSliceDataType []time.zone.array
+      Pointee: 704 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 699 GoSliceDataType []time.zoneTrans.array
+      Pointee: 706 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 264
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 262 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 567
+      ID: 574
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 566 GoSliceDataType []uint.array
+      Pointee: 573 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 575
+      ID: 582
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 574 GoSliceDataType []uint16.array
+      Pointee: 581 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 422
+      ID: 429
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 421 GoSliceDataType []uint8.array
+      Pointee: 428 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 424
+      ID: 431
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 423 GoSliceDataType []uintptr.array
+      Pointee: 430 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1296
+      ID: 1303
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1987168
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1304 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 930336
       GoKind: 22
-      Pointee: 941 GoSliceHeaderType archive/tar.headerError
+      Pointee: 948 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 942 GoSliceDataType archive/tar.headerError.array
+      Pointee: 949 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1231
+      ID: 1238
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1438464
       GoKind: 22
-      Pointee: 1232 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1239 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1179
+      ID: 1186
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 930528
       GoKind: 22
-      Pointee: 1180 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1187 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1181
+      ID: 1188
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 930624
       GoKind: 22
-      Pointee: 1182 StructureType archive/zip.dirWriter
+      Pointee: 1189 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1279
+      ID: 1286
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1906848
       GoKind: 22
-      Pointee: 1280 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1287 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1207
+      ID: 1214
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1057920
       GoKind: 22
-      Pointee: 1208 StructureType archive/zip.nopCloser
+      Pointee: 1215 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1209
+      ID: 1216
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1058176
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1217 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -12309,477 +12309,477 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1254
+      ID: 1261
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2176000
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType bufio.Reader
+      Pointee: 1262 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1285
+      ID: 1292
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1952128
       GoKind: 22
-      Pointee: 1286 UnresolvedPointeeType bufio.Writer
+      Pointee: 1293 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1334
+      ID: 1341
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2273280
       GoKind: 22
-      Pointee: 1335 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1342 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 912864
       GoKind: 22
-      Pointee: 744 BaseType compress/flate.CorruptInputError
+      Pointee: 751 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 912960
       GoKind: 22
-      Pointee: 745 GoStringHeaderType compress/flate.InternalError
+      Pointee: 752 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 746 GoStringDataType compress/flate.InternalError.str
+      Pointee: 753 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1229
+      ID: 1236
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1427904
       GoKind: 22
-      Pointee: 1230 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1237 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1175
+      ID: 1182
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 913056
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1183 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1251
+      ID: 1258
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1729216
       GoKind: 22
-      Pointee: 1252 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1259 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1416
+      ID: 410
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1554304
       GoKind: 22
-      Pointee: 373 StructureType context.backgroundCtx
+      Pointee: 411 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 363
+      ID: 414
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1726912
       GoKind: 22
-      Pointee: 364 StructureType context.cancelCtx
+      Pointee: 415 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1192736
       GoKind: 22
-      Pointee: 1053 StructureType context.deadlineExceededError
+      Pointee: 1060 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1411
+      ID: 397
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1416544
       GoKind: 22
-      Pointee: 374 StructureType context.emptyCtx
+      Pointee: 398 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 365
+      ID: 399
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1416704
       GoKind: 22
-      Pointee: 366 StructureType context.stopCtx
+      Pointee: 400 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 367
+      ID: 422
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1727104
       GoKind: 22
-      Pointee: 368 StructureType context.timerCtx
+      Pointee: 423 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1417
+      ID: 412
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1554464
       GoKind: 22
-      Pointee: 387 StructureType context.todoCtx
+      Pointee: 413 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 369
+      ID: 406
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1553984
       GoKind: 22
-      Pointee: 370 StructureType context.valueCtx
+      Pointee: 407 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 371
+      ID: 408
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1554144
       GoKind: 22
-      Pointee: 372 StructureType context.withoutCancelCtx
+      Pointee: 409 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 758 BaseType crypto/aes.KeySizeError
+      Pointee: 765 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925152
       GoKind: 22
-      Pointee: 759 BaseType crypto/des.KeySizeError
+      Pointee: 766 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 760 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 767 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1241
+      ID: 1248
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1569664
       GoKind: 22
-      Pointee: 1242 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1249 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1275
+      ID: 1282
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1865504
       GoKind: 22
-      Pointee: 1276 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1283 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1307
+      ID: 1314
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2123328
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1315 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1281
+      ID: 1288
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1907360
       GoKind: 22
-      Pointee: 1282 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1289 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1277
+      ID: 1284
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1865952
       GoKind: 22
-      Pointee: 1278 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1285 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1273
+      ID: 1280
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1858112
       GoKind: 22
-      Pointee: 1274 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1281 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 925728
       GoKind: 22
-      Pointee: 761 BaseType crypto/rc4.KeySizeError
+      Pointee: 768 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1291
+      ID: 1298
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1956736
       GoKind: 22
-      Pointee: 1292 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1299 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1263
+      ID: 1270
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1812320
       GoKind: 22
-      Pointee: 1264 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1271 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 914496
       GoKind: 22
-      Pointee: 748 BaseType crypto/tls.AlertError
+      Pointee: 755 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1046272
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1032 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1360
+      ID: 1367
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2385152
       GoKind: 22
-      Pointee: 1361 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1368 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 862 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 914208
       GoKind: 22
-      Pointee: 853 StructureType crypto/tls.RecordHeaderError
+      Pointee: 860 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1023
+      ID: 1030
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1044608
       GoKind: 22
-      Pointee: 980 BaseType crypto/tls.alert
+      Pointee: 987 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1239
+      ID: 1246
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1562624
       GoKind: 22
-      Pointee: 1240 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1247 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1246
+      ID: 1253
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1646144
       GoKind: 22
-      Pointee: 1247 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1254 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1119
+      ID: 1126
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1428224
       GoKind: 22
-      Pointee: 1120 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1127 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1131
+      ID: 1138
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2045216
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1139 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 923904
       GoKind: 22
-      Pointee: 927 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 934 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 920
+      ID: 927
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 921 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 928 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 922
+      ID: 929
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 923 StructureType crypto/x509.HostnameError
+      Pointee: 930 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 923328
       GoKind: 22
-      Pointee: 757 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 764 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1029
+      ID: 1036
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1052032
       GoKind: 22
-      Pointee: 1030 StructureType crypto/x509.SystemRootsError
+      Pointee: 1037 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 924000
       GoKind: 22
-      Pointee: 929 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 936 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 923808
       GoKind: 22
-      Pointee: 925 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 932 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 930816
       GoKind: 22
-      Pointee: 945 StructureType encoding/asn1.StructuralError
+      Pointee: 952 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 931008
       GoKind: 22
-      Pointee: 949 StructureType encoding/asn1.SyntaxError
+      Pointee: 956 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 930912
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 954 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 910368
       GoKind: 22
-      Pointee: 742 BaseType encoding/base64.CorruptInputError
+      Pointee: 749 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1197
+      ID: 1204
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1041152
       GoKind: 22
-      Pointee: 1198 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1205 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 845
+      ID: 852
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 911232
       GoKind: 22
-      Pointee: 743 BaseType encoding/hex.InvalidByteError
+      Pointee: 750 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 905088
       GoKind: 22
-      Pointee: 814 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 821 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1037440
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1023 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 904704
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 813 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 22
-      Pointee: 812 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 819 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 810 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 817 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 904800
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 815 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1340
+      ID: 1347
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2298304
       GoKind: 22
-      Pointee: 1341 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1348 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 816 StructureType encoding/json.jsonError
+      Pointee: 823 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1205
+      ID: 1212
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1054848
       GoKind: 22
-      Pointee: 1206 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1213 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 922368
       GoKind: 22
-      Pointee: 915 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 922 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 922272
       GoKind: 22
-      Pointee: 913 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 920 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 916
+      ID: 923
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 922464
       GoKind: 22
-      Pointee: 754 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 761 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 755 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 762 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 925 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1318
+      ID: 1325
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2161760
       GoKind: 22
-      Pointee: 1319 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1326 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -12788,19 +12788,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 896064
       GoKind: 22
-      Pointee: 784 UnresolvedPointeeType errors.errorString
+      Pointee: 791 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 982
+      ID: 989
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1023232
       GoKind: 22
-      Pointee: 983 UnresolvedPointeeType errors.joinError
+      Pointee: 990 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -12816,625 +12816,625 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType float64
     - __kind: PointerType
-      ID: 1328
+      ID: 1335
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2265600
       GoKind: 22
-      Pointee: 1329 UnresolvedPointeeType fmt.pp
+      Pointee: 1336 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 984
+      ID: 991
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1023360
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType fmt.wrapError
+      Pointee: 992 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1023488
       GoKind: 22
-      Pointee: 987 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 994 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 910752
       GoKind: 22
-      Pointee: 844 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 851 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 824
+      ID: 831
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 907872
       GoKind: 22
-      Pointee: 825 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 832 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 826
+      ID: 833
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 907968
       GoKind: 22
-      Pointee: 827 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 834 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1143
+      ID: 1150
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 907680
       GoKind: 22
-      Pointee: 1144 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1151 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 830
+      ID: 837
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 831 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 838 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1145
+      ID: 1152
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 907776
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1153 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 828
+      ID: 835
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 908064
       GoKind: 22
-      Pointee: 736 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 743 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 737 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 744 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 907584
       GoKind: 22
-      Pointee: 733 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 740 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 741 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 908160
       GoKind: 22
-      Pointee: 739 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 746 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 740 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 747 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1219
+      ID: 1226
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1210272
       GoKind: 22
-      Pointee: 1220 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1227 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1304
+      ID: 1311
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2059904
       GoKind: 22
-      Pointee: 1305 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1312 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 929280
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 946 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 388
+      ID: 393
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2283520
       GoKind: 22
-      Pointee: 389 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 363 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 414
+      ID: 391
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2009216
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 392 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 409
+      ID: 386
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1192992
       GoKind: 22
-      Pointee: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 387 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 412
+      ID: 389
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1193120
       GoKind: 22
-      Pointee: 413 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 390 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1409
+      ID: 1416
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1193760
       GoKind: 22
-      Pointee: 1410 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1417 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 707
+      ID: 714
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1193888
       GoKind: 22
-      Pointee: 708 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 715 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 416
+      ID: 394
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2228192
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 395 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1087
+      ID: 1094
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1213856
       GoKind: 22
-      Pointee: 1088 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1095 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1336
+      ID: 1343
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2275328
       GoKind: 22
-      Pointee: 1337 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1344 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1412
+      ID: 402
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1422144
       GoKind: 22
-      Pointee: 1413 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 403 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 917856
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 871 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 918912
       GoKind: 22
-      Pointee: 871 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 878 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 918624
       GoKind: 22
-      Pointee: 753 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 760 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 918816
       GoKind: 22
-      Pointee: 869 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 876 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 918720
       GoKind: 22
-      Pointee: 867 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 874 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 920832
       GoKind: 22
-      Pointee: 887 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 894 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 921024
       GoKind: 22
-      Pointee: 891 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 898 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 920928
       GoKind: 22
-      Pointee: 889 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 896 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 885 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 892 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1168
+      ID: 1175
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1167 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1174 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 921408
       GoKind: 22
-      Pointee: 899 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 906 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 921120
       GoKind: 22
-      Pointee: 893 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 900 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 921312
       GoKind: 22
-      Pointee: 897 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 904 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 921216
       GoKind: 22
-      Pointee: 895 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 902 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 921504
       GoKind: 22
-      Pointee: 901 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 908 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 921792
       GoKind: 22
-      Pointee: 907 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 914 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 921888
       GoKind: 22
-      Pointee: 909 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 916 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 921696
       GoKind: 22
-      Pointee: 905 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 912 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 921600
       GoKind: 22
-      Pointee: 903 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 910 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 910
+      ID: 917
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 922080
       GoKind: 22
-      Pointee: 911 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 918 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 909408
       GoKind: 22
-      Pointee: 833 StructureType github.com/cihub/seelog.baseError
+      Pointee: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1257
+      ID: 1264
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1804704
       GoKind: 22
-      Pointee: 1258 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1265 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 835 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 842 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1237
+      ID: 1244
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1560864
       GoKind: 22
-      Pointee: 1238 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1245 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1193
+      ID: 1200
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1040128
       GoKind: 22
-      Pointee: 1194 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1201 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1227
+      ID: 1234
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1425824
       GoKind: 22
-      Pointee: 1228 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1235 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 839 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 846 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1294
+      ID: 1301
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1976512
       GoKind: 22
-      Pointee: 1295 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1302 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1311
+      ID: 1318
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2134912
       GoKind: 22
-      Pointee: 1306 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1313 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1310
+      ID: 1317
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2134528
       GoKind: 22
-      Pointee: 1309 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1316 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1195
+      ID: 1202
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1040256
       GoKind: 22
-      Pointee: 1196 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1203 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 837 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 844 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 840
+      ID: 847
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 909792
       GoKind: 22
-      Pointee: 841 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 848 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1259
+      ID: 1266
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1806496
       GoKind: 22
-      Pointee: 1260 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1267 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1300
+      ID: 1307
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2013824
       GoKind: 22
-      Pointee: 1301 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1308 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1302
+      ID: 1309
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2044896
       GoKind: 22
-      Pointee: 1303 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1310 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1121
+      ID: 1128
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1440864
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1129 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1037
+      ID: 1044
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1066368
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1045 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1035
+      ID: 1042
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1066240
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1043 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1039
+      ID: 1046
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1070336
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1047 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1041
+      ID: 1048
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1070464
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1049 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1248
+      ID: 1255
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1673600
       GoKind: 22
-      Pointee: 1249 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1256 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1031
+      ID: 1038
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1052672
       GoKind: 22
-      Pointee: 1032 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1039 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 911424
       GoKind: 22
-      Pointee: 847 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 854 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1352
+      ID: 1359
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2361376
       GoKind: 22
-      Pointee: 1353 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1360 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1223072
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1103 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1201184
       GoKind: 22
-      Pointee: 1065 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1072 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1200800
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1066 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1031680
       GoKind: 22
-      Pointee: 1002 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1009 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1070
+      ID: 1077
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1201568
       GoKind: 22
-      Pointee: 1071 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1078 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1000
+      ID: 1007
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1031552
       GoKind: 22
-      Pointee: 979 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 986 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1201056
       GoKind: 22
-      Pointee: 1063 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1070 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1200928
       GoKind: 22
-      Pointee: 1061 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1068 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1068
+      ID: 1075
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1201440
       GoKind: 22
-      Pointee: 1069 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1076 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1066
+      ID: 1073
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1201312
       GoKind: 22
-      Pointee: 1067 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1074 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1356
+      ID: 1363
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2373184
       GoKind: 22
-      Pointee: 1357 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1364 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1074
+      ID: 1081
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1201952
       GoKind: 22
-      Pointee: 1075 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1082 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1005
+      ID: 1012
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1031936
       GoKind: 22
-      Pointee: 1006 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1013 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1031808
       GoKind: 22
-      Pointee: 1004 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1011 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1072
+      ID: 1079
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1201824
       GoKind: 22
-      Pointee: 1073 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1080 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 943776
       GoKind: 22
-      Pointee: 766 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 773 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 767 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 774 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
       ID: 359
       Name: '*go.shape.float64'
@@ -13457,10 +13457,10 @@ Types:
       GoKind: 22
       Pointee: 332 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 644 GoStringDataType go.shape.string.str
+      Pointee: 651 GoStringDataType go.shape.string.str
     - __kind: PointerType
       ID: 338
       Name: '*go.shape.struct { Name string }'
@@ -13480,249 +13480,249 @@ Types:
       GoKind: 22
       Pointee: 354 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1134
+      ID: 1141
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1672064
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1142 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1045
+      ID: 1052
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1085184
       GoKind: 22
-      Pointee: 1046 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1053 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1225
+      ID: 1232
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1262752
       GoKind: 22
-      Pointee: 1226 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1233 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1316
+      ID: 1323
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2149888
       GoKind: 22
-      Pointee: 1317 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1324 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1211
+      ID: 1218
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1087488
       GoKind: 22
-      Pointee: 1212 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1219 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 945024
       GoKind: 22
-      Pointee: 769 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 776 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1103
+      ID: 1110
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1264416
       GoKind: 22
-      Pointee: 1104 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1111 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 945312
       GoKind: 22
-      Pointee: 965 StructureType golang.org/x/net/http2.connError
+      Pointee: 972 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945216
       GoKind: 22
-      Pointee: 773 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 780 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 774 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 781 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 945504
       GoKind: 22
-      Pointee: 779 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 786 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 780 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 787 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 945408
       GoKind: 22
-      Pointee: 776 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 783 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 778
+      ID: 785
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 777 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 784 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 945120
       GoKind: 22
-      Pointee: 770 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 777 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 771 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 778 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1314
+      ID: 1321
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2147968
       GoKind: 22
-      Pointee: 1315 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1322 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 945600
       GoKind: 22
-      Pointee: 969 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 976 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 970
+      ID: 977
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 945696
       GoKind: 22
-      Pointee: 782 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 789 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 938976
       GoKind: 22
-      Pointee: 957 StructureType google.golang.org/grpc.dropError
+      Pointee: 964 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1101
+      ID: 1108
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1261472
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1109 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1123
+      ID: 1130
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1448224
       GoKind: 22
-      Pointee: 1124 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1131 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 942048
       GoKind: 22
-      Pointee: 959 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 966 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1265
+      ID: 1272
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1812768
       GoKind: 22
-      Pointee: 1266 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1273 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1223
+      ID: 1230
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1258016
       GoKind: 22
-      Pointee: 1224 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1231 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1043
+      ID: 1050
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1079424
       GoKind: 22
-      Pointee: 1044 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1051 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1183
+      ID: 1190
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 942144
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1191 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 927168
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 944 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1033
+      ID: 1040
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1056256
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1041 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1099
+      ID: 1106
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1229472
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1107 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1097
+      ID: 1104
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1229216
       GoKind: 22
-      Pointee: 1098 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1105 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 951 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 958 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 931968
       GoKind: 22
-      Pointee: 953 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 960 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 919296
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 886 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1271
+      ID: 1278
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1853184
       GoKind: 22
-      Pointee: 1272 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1279 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 946464
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType html/template.Error
+      Pointee: 979 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 101
       Name: '*int'
@@ -13766,89 +13766,89 @@ Types:
       GoKind: 22
       Pointee: 162 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 924576
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 938 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 856 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1173
+      ID: 1180
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 911808
       GoKind: 22
-      Pointee: 1174 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1181 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1215008
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1101 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1358
+      ID: 1365
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2378816
       GoKind: 22
-      Pointee: 1359 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1366 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1214880
       GoKind: 22
-      Pointee: 1092 StructureType internal/poll.errNetClosing
+      Pointee: 1099 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 900192
       GoKind: 22
-      Pointee: 789 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 796 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1215
+      ID: 1222
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1192480
       GoKind: 22
-      Pointee: 1216 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1223 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1213
+      ID: 1220
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1192096
       GoKind: 22
-      Pointee: 1214 StructureType io.discard
+      Pointee: 1221 StructureType io.discard
     - __kind: PointerType
-      ID: 1187
+      ID: 1194
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1024256
       GoKind: 22
-      Pointee: 1188 UnresolvedPointeeType io.multiWriter
+      Pointee: 1195 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1089
+      ID: 1096
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1214624
       GoKind: 22
-      Pointee: 1090 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1097 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1261
+      ID: 1268
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1806720
       GoKind: 22
-      Pointee: 1262 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1269 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 345
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
@@ -13868,19 +13868,19 @@ Types:
       GoKind: 22
       Pointee: 322 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 436
+      ID: 443
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 385280
       GoKind: 22
-      Pointee: 437 StructureType main.deepMap2
+      Pointee: 444 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1404
+      ID: 1411
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 385216
       GoKind: 22
-      Pointee: 1405 UnresolvedPointeeType main.deepMap3
+      Pointee: 1412 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepMap7'
@@ -13910,12 +13910,12 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1362
+      ID: 1369
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 385792
       GoKind: 22
-      Pointee: 1363 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1370 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr7'
@@ -13943,14 +13943,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 386432
       GoKind: 22
-      Pointee: 427 StructureType main.deepSlice2
+      Pointee: 434 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1389
+      ID: 1396
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 386368
       GoKind: 22
-      Pointee: 1390 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1397 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepSlice7'
@@ -13986,7 +13986,7 @@ Types:
       GoKind: 22
       Pointee: 165 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1375
+      ID: 1382
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 895776
@@ -14019,19 +14019,19 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1376
+      ID: 1383
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 895872
       GoKind: 22
-      Pointee: 1377 StructureType main.secondBehavior
+      Pointee: 1384 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1368
+      ID: 1375
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 895968
       GoKind: 22
-      Pointee: 1369 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1376 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType1'
@@ -14039,16 +14039,16 @@ Types:
       GoKind: 22
       Pointee: 152 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1365
+      ID: 1372
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1364 GoStringDataType main.stringType1.str
+      Pointee: 1371 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 154
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1366 GoStringHeaderType main.stringType2
+      Pointee: 1373 GoStringHeaderType main.stringType2
     - __kind: PointerType
       ID: 1482
       Name: '*main.stringType2.str'
@@ -14060,7 +14060,7 @@ Types:
       ByteSize: 8
       Pointee: 276 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 490
+      ID: 497
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 384768
@@ -14084,10 +14084,10 @@ Types:
       GoKind: 22
       Pointee: 254 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1380
+      ID: 1387
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1379 GoSliceDataType main.t.array
+      Pointee: 1386 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 273
       Name: '*main.threeStringStruct'
@@ -14115,20 +14115,20 @@ Types:
       ByteSize: 8
       Pointee: 205 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 380
+      ID: 418
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 381 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 419 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 145
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1394
+      ID: 1401
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1395 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1402 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1438
       Name: '*map<int,*main.deepMap8>'
@@ -14160,10 +14160,10 @@ Types:
       ByteSize: 8
       Pointee: 210 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 688
+      ID: 686
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 689 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 687 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 199
       Name: '*map<string,[]main.structWithMap>'
@@ -14175,35 +14175,35 @@ Types:
       ByteSize: 8
       Pointee: 188 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 404
+      ID: 381
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 405 GoSwissMapHeaderType map<string,float64>
+      Pointee: 382 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1127
+      ID: 1134
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1128 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1135 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 182
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 183 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 399
+      ID: 376
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 400 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 377 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 177
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 178 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 394
+      ID: 371
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 395 GoSwissMapHeaderType map<string,string>
+      Pointee: 372 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 234
       Name: '*map<struct {},int>'
@@ -14261,493 +14261,493 @@ Types:
       GoKind: 22
       Pointee: 181 GoMapType map[string]int
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 883 StructureType math/big.ErrNaN
+      Pointee: 890 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1177
+      ID: 1184
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 914976
       GoKind: 22
-      Pointee: 1178 StructureType mime/multipart.writerOnly·1
+      Pointee: 1185 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1081
+      ID: 1088
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1208096
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType net.AddrError
+      Pointee: 1089 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1112
+      ID: 1119
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1424064
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType net.DNSError
+      Pointee: 1120 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1322
+      ID: 1329
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2235936
       GoKind: 22
-      Pointee: 1323 UnresolvedPointeeType net.IPConn
+      Pointee: 1330 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1110
+      ID: 1117
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1423744
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType net.OpError
+      Pointee: 1118 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1208224
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType net.ParseError
+      Pointee: 1091 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1332
+      ID: 1339
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2266624
       GoKind: 22
-      Pointee: 1333 UnresolvedPointeeType net.TCPConn
+      Pointee: 1340 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1342
+      ID: 1349
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2311616
       GoKind: 22
-      Pointee: 1343 UnresolvedPointeeType net.UDPConn
+      Pointee: 1350 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1330
+      ID: 1337
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2266112
       GoKind: 22
-      Pointee: 1331 UnresolvedPointeeType net.UnixConn
+      Pointee: 1338 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1080
+      ID: 1087
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1207328
       GoKind: 22
-      Pointee: 1049 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1056 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1051
+      ID: 1058
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1050 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1057 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1038336
       GoKind: 22
-      Pointee: 1018 StructureType net.canceledError
+      Pointee: 1025 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1298
+      ID: 1305
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2010944
       GoKind: 22
-      Pointee: 1299 UnresolvedPointeeType net.conn
+      Pointee: 1306 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1152
+      ID: 1159
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1847808
       GoKind: 22
-      Pointee: 1153 StructureType net.dialResult·1
+      Pointee: 1160 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1344
+      ID: 1351
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2315872
       GoKind: 22
-      Pointee: 1345 UnresolvedPointeeType net.netFD
+      Pointee: 1352 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 906432
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType net.notFoundError
+      Pointee: 825 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1414
+      ID: 404
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1423904
       GoKind: 22
-      Pointee: 1415 StructureType net.onlyValuesCtx
+      Pointee: 405 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 907104
       GoKind: 22
-      Pointee: 820 StructureType net.result·2
+      Pointee: 827 StructureType net.result·2
     - __kind: PointerType
-      ID: 1326
+      ID: 1333
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2252160
       GoKind: 22
-      Pointee: 1327 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1334 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1324
+      ID: 1331
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2251680
       GoKind: 22
-      Pointee: 1325 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1332 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1208864
       GoKind: 22
-      Pointee: 1086 UnresolvedPointeeType net.temporaryError
+      Pointee: 1093 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1424224
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType net.timeoutError
+      Pointee: 1122 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1034368
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1015 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1169
+      ID: 1176
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 902208
       GoKind: 22
-      Pointee: 1170 StructureType net/http.bufioFlushWriter
+      Pointee: 1177 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 902880
       GoKind: 22
-      Pointee: 714 BaseType net/http.http2ConnectionError
+      Pointee: 721 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 902976
       GoKind: 22
-      Pointee: 796 StructureType net/http.http2GoAwayError
+      Pointee: 803 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1106
+      ID: 1113
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1420224
       GoKind: 22
-      Pointee: 1107 StructureType net/http.http2StreamError
+      Pointee: 1114 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 903552
       GoKind: 22
-      Pointee: 800 StructureType net/http.http2connError
+      Pointee: 807 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1233
+      ID: 1240
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1557984
       GoKind: 22
-      Pointee: 1234 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1241 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 903456
       GoKind: 22
-      Pointee: 718 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 725 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 719 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 726 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 903744
       GoKind: 22
-      Pointee: 724 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 731 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 725 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 732 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 903648
       GoKind: 22
-      Pointee: 721 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 728 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 723
+      ID: 730
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 722 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 729 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1078
+      ID: 1085
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1204000
       GoKind: 22
-      Pointee: 1079 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1086 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1035008
       GoKind: 22
-      Pointee: 1014 StructureType net/http.http2noCachedConnError
+      Pointee: 1021 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1287
+      ID: 1294
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1953152
       GoKind: 22
-      Pointee: 1288 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1295 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 903360
       GoKind: 22
-      Pointee: 715 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 722 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 717
+      ID: 724
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 716 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 723 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1171
+      ID: 1178
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 903840
       GoKind: 22
-      Pointee: 1172 StructureType net/http.http2stickyErrWriter
+      Pointee: 1179 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1034624
       GoKind: 22
-      Pointee: 1010 StructureType net/http.nothingWrittenError
+      Pointee: 1017 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1235
+      ID: 1242
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2177248
       GoKind: 22
-      Pointee: 1236 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1243 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1191
+      ID: 1198
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1034496
       GoKind: 22
-      Pointee: 1192 StructureType net/http.persistConnWriter
+      Pointee: 1199 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1217
+      ID: 1224
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1203104
       GoKind: 22
-      Pointee: 1218 StructureType net/http.readWriteCloserBody
+      Pointee: 1225 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 803
+      ID: 810
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 903936
       GoKind: 22
-      Pointee: 804 StructureType net/http.requestBodyReadError
+      Pointee: 811 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1108
+      ID: 1115
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1421344
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1116 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1076
+      ID: 1083
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1203872
       GoKind: 22
-      Pointee: 1077 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1084 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1034752
       GoKind: 22
-      Pointee: 1012 StructureType net/http.transportReadFromServerError
+      Pointee: 1019 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1269
+      ID: 1276
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1844672
       GoKind: 22
-      Pointee: 1270 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1277 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 902112
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 800 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1289
+      ID: 1296
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1954944
       GoKind: 22
-      Pointee: 1290 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1297 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1201
+      ID: 1208
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1047424
       GoKind: 22
-      Pointee: 1202 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1209 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 919104
       GoKind: 22
-      Pointee: 875 StructureType net/netip.parseAddrError
+      Pointee: 882 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 873 StructureType net/netip.parsePrefixError
+      Pointee: 880 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1243
+      ID: 1250
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2121920
       GoKind: 22
-      Pointee: 1244 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1251 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1203
+      ID: 1210
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1052288
       GoKind: 22
-      Pointee: 1204 StructureType net/smtp.dataCloser
+      Pointee: 1211 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 915168
       GoKind: 22
-      Pointee: 859 UnresolvedPointeeType net/textproto.Error
+      Pointee: 866 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 915072
       GoKind: 22
-      Pointee: 749 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 756 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 757 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1199
+      ID: 1206
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1046656
       GoKind: 22
-      Pointee: 1200 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1207 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1116
+      ID: 1123
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1424544
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType net/url.Error
+      Pointee: 1124 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 907200
       GoKind: 22
-      Pointee: 727 GoStringHeaderType net/url.EscapeError
+      Pointee: 734 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 729
+      ID: 736
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 728 GoStringDataType net/url.EscapeError.str
+      Pointee: 735 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 907296
       GoKind: 22
-      Pointee: 730 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 737 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 731 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 738 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 536
+      ID: 543
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 537 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 544 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 528
+      ID: 535
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 529 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 536 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 476
+      ID: 483
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 477 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 484 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 495
+      ID: 502
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 496 StructureType noalg.map.group[bool]main.node
+      Pointee: 503 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 654
+      ID: 695
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 655 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 696 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 432
+      ID: 439
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 433 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 440 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1400
+      ID: 1407
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1401 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1408 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1444
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -14759,230 +14759,230 @@ Types:
       ByteSize: 8
       Pointee: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 444
+      ID: 451
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 445 StructureType noalg.map.group[int]int
+      Pointee: 452 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 1474
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 552
+      ID: 559
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 553 StructureType noalg.map.group[int]struct {}
+      Pointee: 560 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 503
+      ID: 510
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 504 StructureType noalg.map.group[int]uint8
+      Pointee: 511 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 703
+      ID: 710
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 711 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 485
+      ID: 492
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 486 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 493 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 468
+      ID: 475
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 469 StructureType noalg.map.group[string][]string
+      Pointee: 476 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 679
+      ID: 677
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 680 StructureType noalg.map.group[string]float64
+      Pointee: 678 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1159
+      ID: 1166
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1167 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 460
+      ID: 467
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 461 StructureType noalg.map.group[string]int
+      Pointee: 468 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 671
+      ID: 669
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 672 StructureType noalg.map.group[string]interface {}
+      Pointee: 670 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 452
+      ID: 459
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 453 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 460 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 663
+      ID: 661
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 664 StructureType noalg.map.group[string]string
+      Pointee: 662 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 544
+      ID: 551
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 545 StructureType noalg.map.group[struct {}]int
+      Pointee: 552 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 600 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 600
+      ID: 607
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 608 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 608
+      ID: 615
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 616
+      ID: 623
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 624
+      ID: 631
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 632
+      ID: 639
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 560
+      ID: 567
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 561 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 568 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 519
+      ID: 526
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 520 StructureType noalg.map.group[uint8][4]int
+      Pointee: 527 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 511
+      ID: 518
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 512 StructureType noalg.map.group[uint8]uint8
+      Pointee: 519 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1350
+      ID: 1357
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2354528
       GoKind: 22
-      Pointee: 1351 UnresolvedPointeeType os.File
+      Pointee: 1358 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 990
+      ID: 997
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1027968
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType os.LinkError
+      Pointee: 998 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1197088
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType os.SyscallError
+      Pointee: 1062 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1348
+      ID: 1355
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2350848
       GoKind: 22
-      Pointee: 1349 StructureType os.fileWithoutReadFrom
+      Pointee: 1356 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1346
+      ID: 1353
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2350112
       GoKind: 22
-      Pointee: 1347 StructureType os.fileWithoutWriteTo
+      Pointee: 1354 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1043328
       GoKind: 22
-      Pointee: 1020 UnresolvedPointeeType os/exec.Error
+      Pointee: 1027 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1155
+      ID: 1162
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2091072
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1163 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1221
+      ID: 1228
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1215904
       GoKind: 22
-      Pointee: 1222 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1229 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1043456
       GoKind: 22
-      Pointee: 1022 StructureType os/exec.wrappedError
+      Pointee: 1029 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 955
+      ID: 962
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 937056
       GoKind: 22
-      Pointee: 763 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 770 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 764 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 771 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 936960
       GoKind: 22
-      Pointee: 762 BaseType os/user.UnknownUserIdError
+      Pointee: 769 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 791 UnresolvedPointeeType reflect.ValueError
+      Pointee: 798 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 919776
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 888 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1028992
       GoKind: 22
-      Pointee: 995 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1002 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1030784
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1006 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -14998,12 +14998,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1029120
       GoKind: 22
-      Pointee: 997 StructureType runtime.boundsError
+      Pointee: 1004 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 64
       Name: '*runtime.cgoCallers'
@@ -15019,24 +15019,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1199392
       GoKind: 22
-      Pointee: 1057 StructureType runtime.errorAddressString
+      Pointee: 1064 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 992
+      ID: 999
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1028608
       GoKind: 22
-      Pointee: 973 GoStringHeaderType runtime.errorString
+      Pointee: 980 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 974 GoStringDataType runtime.errorString.str
+      Pointee: 981 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -15052,17 +15052,17 @@ Types:
       GoKind: 22
       Pointee: 31 StructureType runtime.m
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1028736
       GoKind: 22
-      Pointee: 976 GoStringHeaderType runtime.plainError
+      Pointee: 983 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 978
+      ID: 985
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 977 GoStringDataType runtime.plainError.str
+      Pointee: 984 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -15092,12 +15092,12 @@ Types:
       GoKind: 22
       Pointee: 79 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 988
+      ID: 995
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1026816
       GoKind: 22
-      Pointee: 989 UnresolvedPointeeType strconv.NumError
+      Pointee: 996 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -15106,78 +15106,78 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 420
+      ID: 427
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 419 GoStringDataType string.str
+      Pointee: 426 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1283
+      ID: 1290
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1951616
       GoKind: 22
-      Pointee: 1284 UnresolvedPointeeType strings.Builder
+      Pointee: 1291 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1189
+      ID: 1196
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1026944
       GoKind: 22
-      Pointee: 1190 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1197 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1185
+      ID: 1192
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 970816
       GoKind: 22
-      Pointee: 1186 StructureType struct { io.Writer }
+      Pointee: 1193 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 271
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 125 StructureType struct {}
     - __kind: PointerType
-      ID: 1118
+      ID: 1125
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1426784
       GoKind: 22
-      Pointee: 1105 BaseType syscall.Errno
+      Pointee: 1112 BaseType syscall.Errno
     - __kind: PointerType
       ID: 232
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 534 StructureType table<[4]int,[4]int>
+      Pointee: 541 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 227
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 526 StructureType table<[4]int,uint8>
+      Pointee: 533 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 195
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 474 StructureType table<[4]string,[2]int>
+      Pointee: 481 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 207
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 493 StructureType table<bool,main.node>
+      Pointee: 500 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 383
+      ID: 421
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 652 StructureType table<context.canceler,struct {}>
+      Pointee: 693 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 148
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 430 StructureType table<int,*main.deepMap2>
+      Pointee: 437 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1397
+      ID: 1404
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1398 StructureType table<int,*main.deepMap3>
+      Pointee: 1405 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1441
       Name: '*table<int,*main.deepMap8>'
@@ -15192,7 +15192,7 @@ Types:
       ID: 175
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 442 StructureType table<int,int>
+      Pointee: 449 StructureType table<int,int>
     - __kind: PointerType
       ID: 1471
       Name: '*table<int,interface {}>'
@@ -15202,121 +15202,121 @@ Types:
       ID: 242
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 550 StructureType table<int,struct {}>
+      Pointee: 557 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 212
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 501 StructureType table<int,uint8>
+      Pointee: 508 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 691
+      ID: 689
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 701 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 708 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 202
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 483 StructureType table<string,[]main.structWithMap>
+      Pointee: 490 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 190
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 466 StructureType table<string,[]string>
+      Pointee: 473 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 407
+      ID: 384
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 677 StructureType table<string,float64>
+      Pointee: 675 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1130
+      ID: 1137
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1157 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1164 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 185
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 458 StructureType table<string,int>
+      Pointee: 465 StructureType table<string,int>
     - __kind: PointerType
-      ID: 402
+      ID: 379
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 669 StructureType table<string,interface {}>
+      Pointee: 667 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 180
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 450 StructureType table<string,main.nestedStruct>
+      Pointee: 457 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 397
+      ID: 374
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 661 StructureType table<string,string>
+      Pointee: 659 StructureType table<string,string>
     - __kind: PointerType
       ID: 237
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 542 StructureType table<struct {},int>
+      Pointee: 549 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 294
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 590 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 597 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 299
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 598 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 605 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 304
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 606 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 613 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 309
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 614 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 621 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 314
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 622 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 629 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 319
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 630 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 637 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 247
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 558 StructureType table<struct {},struct {}>
+      Pointee: 565 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 222
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 517 StructureType table<uint8,[4]int>
+      Pointee: 524 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 217
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 509 StructureType table<uint8,uint8>
+      Pointee: 516 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1320
+      ID: 1327
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2162144
       GoKind: 22
-      Pointee: 1321 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1328 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1047
+      ID: 1054
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1089024
       GoKind: 22
-      Pointee: 1048 StructureType text/template.ExecError
+      Pointee: 1055 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 327
       Name: '*time.Location'
@@ -15325,45 +15325,45 @@ Types:
       GoKind: 22
       Pointee: 328 StructureType time.Location
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 898464
       GoKind: 22
-      Pointee: 787 UnresolvedPointeeType time.ParseError
+      Pointee: 794 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 385
+      ID: 424
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1028352
       GoKind: 22
-      Pointee: 386 StructureType time.Timer
+      Pointee: 425 StructureType time.Timer
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 898368
       GoKind: 22
-      Pointee: 711 GoStringHeaderType time.fileSizeError
+      Pointee: 718 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 713
+      ID: 720
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 712 GoStringDataType time.fileSizeError.str
+      Pointee: 719 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 392064
       GoKind: 22
-      Pointee: 640 StructureType time.zone
+      Pointee: 647 StructureType time.zone
     - __kind: PointerType
-      ID: 642
+      ID: 649
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 392128
       GoKind: 22
-      Pointee: 643 StructureType time.zoneTrans
+      Pointee: 650 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -15407,49 +15407,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 919200
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 884 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1312
+      ID: 1319
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2137600
       GoKind: 22
-      Pointee: 1313 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1320 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 915360
       GoKind: 22
-      Pointee: 861 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 868 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 915456
       GoKind: 22
-      Pointee: 752 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 759 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1047168
       GoKind: 22
-      Pointee: 1027 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1034 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1047296
       GoKind: 22
-      Pointee: 981 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 988 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1381
+      ID: 1393
       Name: <-chan time.Time
       GoRuntimeType: 596384
       GoKind: 18
@@ -26177,7 +26177,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 523
+      ID: 530
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 682880
@@ -26186,7 +26186,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 480
+      ID: 487
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 683168
@@ -26212,7 +26212,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1147
+      ID: 1154
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 684704
@@ -26221,7 +26221,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1367
+      ID: 1374
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -26247,7 +26247,7 @@ Types:
       HasCount: true
       Element: 85 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1382
+      ID: 1388
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 481280
@@ -26255,20 +26255,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1383 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1389 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1385 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1391 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1385
+      ID: 1391
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 138
       Name: '[]*main.deepSlice2'
@@ -26285,15 +26285,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 428 GoSliceDataType []*main.deepSlice2.array
+      Data: 435 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 428
+      ID: 435
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 140 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1387
+      ID: 1394
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 477184
@@ -26301,20 +26301,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1388 PointerType **main.deepSlice3
+          Type: 1395 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1391 GoSliceDataType []*main.deepSlice3.array
+      Data: 1398 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1391
+      ID: 1398
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1389 PointerType *main.deepSlice3
+      Element: 1396 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1422
       Name: '[]*main.deepSlice8'
@@ -26377,55 +26377,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 425 GoSliceDataType []*string.array
+      Data: 432 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 425
+      ID: 432
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 95 PointerType *string
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 547
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 232 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 532
+      ID: 539
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 227 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 481
+      ID: 488
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 195 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 499
+      ID: 506
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 207 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 659
+      ID: 700
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 383 PointerType *table<context.canceler,struct {}>
+      Element: 421 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 445
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 148 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1406
+      ID: 1413
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1397 PointerType *table<int,*main.deepMap3>
+      Element: 1404 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1450
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -26439,7 +26439,7 @@ Types:
       ByteSize: 8
       Element: 1456 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 448
+      ID: 455
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26451,127 +26451,127 @@ Types:
       ByteSize: 8
       Element: 1471 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 556
+      ID: 563
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 242 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 507
+      ID: 514
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 212 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 709
+      ID: 716
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 691 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 689 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 491
+      ID: 498
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 202 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 479
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 190 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 681
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 407 PointerType *table<string,float64>
+      Element: 384 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1163
+      ID: 1170
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1130 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1137 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 471
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 185 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 675
+      ID: 673
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 402 PointerType *table<string,interface {}>
+      Element: 379 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 456
+      ID: 463
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 180 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 667
+      ID: 665
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 397 PointerType *table<string,string>
+      Element: 374 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 548
+      ID: 555
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 237 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 596
+      ID: 603
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 294 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 604
+      ID: 611
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 299 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 612
+      ID: 619
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 304 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 620
+      ID: 627
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 309 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 628
+      ID: 635
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 314 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 636
+      ID: 643
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 319 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 564
+      ID: 571
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 247 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 524
+      ID: 531
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 222 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 515
+      ID: 522
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26591,9 +26591,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 588 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 595 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 588
+      ID: 595
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26613,9 +26613,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 586 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 593 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 586
+      ID: 593
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26635,9 +26635,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 584 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 591 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 584
+      ID: 591
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26657,9 +26657,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 582 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 589 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 582
+      ID: 589
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26679,9 +26679,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 580 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 587 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 580
+      ID: 587
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26701,9 +26701,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 568 GoSliceDataType [][]uint.array
+      Data: 575 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 568
+      ID: 575
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26724,15 +26724,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 572 GoSliceDataType []bool.array
+      Data: 579 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 572
+      ID: 579
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1142
+      ID: 1149
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487168
@@ -26747,15 +26747,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1165 GoSliceDataType []float64.array
+      Data: 1172 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1165
+      ID: 1172
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 20 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 408
+      ID: 385
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 480832
@@ -26763,22 +26763,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 386 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 685 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 683 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 685
+      ID: 683
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 410 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 387 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 411
+      ID: 388
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 481024
@@ -26786,20 +26786,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 412 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 389 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 693 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 691 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 693
+      ID: 691
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 413 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 390 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
       ID: 358
       Name: '[]go.shape.float64'
@@ -26816,9 +26816,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 650 GoSliceDataType []go.shape.float64.array
+      Data: 657 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 650
+      ID: 657
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26838,9 +26838,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 646 GoSliceDataType []go.shape.int.array
+      Data: 653 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 646
+      ID: 653
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26860,9 +26860,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 648 GoSliceDataType []go.shape.string.array
+      Data: 655 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 648
+      ID: 655
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -26905,15 +26905,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 578 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 585 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 578
+      ID: 585
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 276 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 489
+      ID: 496
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 477824
@@ -26921,16 +26921,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 490 PointerType *main.structWithMap
+          Type: 497 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 695 GoSliceDataType []main.structWithMap.array
+      Data: 702 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 695
+      ID: 702
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26950,55 +26950,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 570 GoSliceDataType []main.structWithNoStrings.array
+      Data: 577 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 570
+      ID: 577
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 267 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 541
+      ID: 548
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 537 StructureType noalg.map.group[[4]int][4]int
+      Element: 544 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 533
+      ID: 540
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 529 StructureType noalg.map.group[[4]int]uint8
+      Element: 536 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 489
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 477 StructureType noalg.map.group[[4]string][2]int
+      Element: 484 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 507
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 496 StructureType noalg.map.group[bool]main.node
+      Element: 503 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 660
+      ID: 701
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 655 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 696 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 439
+      ID: 446
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 433 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 440 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1407
+      ID: 1414
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1401 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1408 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1451
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -27012,11 +27012,11 @@ Types:
       ByteSize: 136
       Element: 1460 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 449
+      ID: 456
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 445 StructureType noalg.map.group[int]int
+      Element: 452 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 1479
       Name: '[]noalg.map.group[int]interface {}.array'
@@ -27024,131 +27024,131 @@ Types:
       ByteSize: 200
       Element: 1475 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 557
+      ID: 564
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 553 StructureType noalg.map.group[int]struct {}
+      Element: 560 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 508
+      ID: 515
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 504 StructureType noalg.map.group[int]uint8
+      Element: 511 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 710
+      ID: 717
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 711 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 499
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 486 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 493 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 473
+      ID: 480
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 469 StructureType noalg.map.group[string][]string
+      Element: 476 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 684
+      ID: 682
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 680 StructureType noalg.map.group[string]float64
+      Element: 678 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1164
+      ID: 1171
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1167 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 472
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 461 StructureType noalg.map.group[string]int
+      Element: 468 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 676
+      ID: 674
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 672 StructureType noalg.map.group[string]interface {}
+      Element: 670 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 457
+      ID: 464
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 453 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 460 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 668
+      ID: 666
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 664 StructureType noalg.map.group[string]string
+      Element: 662 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 549
+      ID: 556
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 545 StructureType noalg.map.group[struct {}]int
+      Element: 552 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 597
+      ID: 604
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 600 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 605
+      ID: 612
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 608 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 613
+      ID: 620
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 621
+      ID: 628
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 629
+      ID: 636
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 637
+      ID: 644
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 565
+      ID: 572
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 561 StructureType noalg.map.group[struct {}]struct {}
+      Element: 568 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 525
+      ID: 532
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 520 StructureType noalg.map.group[uint8][4]int
+      Element: 527 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 516
+      ID: 523
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 512 StructureType noalg.map.group[uint8]uint8
+      Element: 519 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -27169,9 +27169,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 440 GoSliceDataType []string.array
+      Data: 447 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 440
+      ID: 447
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -27191,14 +27191,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 576 GoSliceDataType []struct {}.array
+      Data: 583 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 576
+      ID: 583
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 125 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 638
+      ID: 645
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485824
@@ -27206,22 +27206,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 639 PointerType *time.zone
+          Type: 646 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 697 GoSliceDataType []time.zone.array
+      Data: 704 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 697
+      ID: 704
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 640 StructureType time.zone
+      Element: 647 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 641
+      ID: 648
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 485888
@@ -27229,20 +27229,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 642 PointerType *time.zoneTrans
+          Type: 649 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 699 GoSliceDataType []time.zoneTrans.array
+      Data: 706 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 699
+      ID: 706
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 643 StructureType time.zoneTrans
+      Element: 650 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 262
       Name: '[]uint'
@@ -27259,9 +27259,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 566 GoSliceDataType []uint.array
+      Data: 573 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 566
+      ID: 573
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -27282,9 +27282,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 574 GoSliceDataType []uint16.array
+      Data: 581 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 574
+      ID: 581
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -27305,9 +27305,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 421 GoSliceDataType []uint8.array
+      Data: 428 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 421
+      ID: 428
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -27328,19 +27328,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 423 GoSliceDataType []uintptr.array
+      Data: 430 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 423
+      ID: 430
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1304
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 941
+      ID: 948
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 930432
@@ -27355,33 +27355,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 942 GoSliceDataType archive/tar.headerError.array
+      Data: 949 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 942
+      ID: 949
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1232
+      ID: 1239
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1180
+      ID: 1187
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1182
+      ID: 1189
       Name: archive/zip.dirWriter
       GoRuntimeType: 1121056
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1280
+      ID: 1287
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1208
+      ID: 1215
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1568544
@@ -27391,7 +27391,7 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1217
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -27401,15 +27401,15 @@ Types:
       GoRuntimeType: 584352
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1262
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1286
+      ID: 1293
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1335
+      ID: 1342
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -27435,13 +27435,13 @@ Types:
       GoRuntimeType: 584096
       GoKind: 15
     - __kind: BaseType
-      ID: 744
+      ID: 751
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834656
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 745
+      ID: 752
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 834752
@@ -27449,26 +27449,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 747 PointerType *compress/flate.InternalError.str
+          Type: 754 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 746 GoStringDataType compress/flate.InternalError.str
+      Data: 753 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 746
+      ID: 753
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1230
+      ID: 1237
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1183
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1252
+      ID: 1259
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27485,19 +27485,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 373
+      ID: 411
       Name: context.backgroundCtx
       GoRuntimeType: 1800896
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 374 StructureType context.emptyCtx
+          Type: 398 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 364
+      ID: 415
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1966976
@@ -27508,13 +27508,13 @@ Types:
           Type: 155 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 375 StructureType sync.Mutex
+          Type: 365 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 378 StructureType sync/atomic.Value
+          Type: 416 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 379 GoMapType map[context.canceler]struct {}
+          Type: 417 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
           Type: 16 GoInterfaceType error
@@ -27524,7 +27524,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 658
+      ID: 699
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1111712
@@ -27537,13 +27537,13 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1053
+      ID: 1060
       Name: context.deadlineExceededError
       GoRuntimeType: 1467424
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 374
+      ID: 398
       Name: context.emptyCtx
       GoRuntimeType: 1599424
       GoKind: 25
@@ -27552,7 +27552,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 400
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1825120
@@ -27563,11 +27563,11 @@ Types:
           Type: 155 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 384 GoSubroutineType func() bool
+          Type: 401 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 423
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1617536
@@ -27575,29 +27575,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 364 StructureType context.cancelCtx
+          Type: 415 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 385 PointerType *time.Timer
+          Type: 424 PointerType *time.Timer
         - Name: deadline
           Offset: 88
           Type: 326 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 387
+      ID: 413
       Name: context.todoCtx
       GoRuntimeType: 1801120
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 374 StructureType context.emptyCtx
+          Type: 398 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 407
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1837056
@@ -27615,7 +27615,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 409
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1800672
@@ -27627,81 +27627,81 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 758
+      ID: 765
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837248
       GoKind: 2
     - __kind: BaseType
-      ID: 759
+      ID: 766
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837344
       GoKind: 2
     - __kind: BaseType
-      ID: 760
+      ID: 767
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837440
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1242
+      ID: 1249
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1276
+      ID: 1283
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1315
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1282
+      ID: 1289
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1278
+      ID: 1285
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1274
+      ID: 1281
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 761
+      ID: 768
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837536
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1292
+      ID: 1299
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1264
+      ID: 1271
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 748
+      ID: 755
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835232
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1032
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1361
+      ID: 1368
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 862
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1733440
@@ -27712,34 +27712,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1147 ArrayType [5]uint8
+          Type: 1154 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 980
+      ID: 987
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 993632
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1240
+      ID: 1247
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1247
+      ID: 1254
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1120
+      ID: 1127
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1139
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 927
+      ID: 934
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1736320
@@ -27747,21 +27747,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1131 PointerType *crypto/x509.Certificate
+          Type: 1138 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1150 BaseType crypto/x509.InvalidReason
+          Type: 1157 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 921
+      ID: 928
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1118624
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 923
+      ID: 930
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1603264
@@ -27769,24 +27769,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1131 PointerType *crypto/x509.Certificate
+          Type: 1138 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 757
+      ID: 764
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 836864
       GoKind: 2
     - __kind: BaseType
-      ID: 1150
+      ID: 1157
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 589536
       GoKind: 2
     - __kind: StructureType
-      ID: 1030
+      ID: 1037
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1564544
@@ -27796,13 +27796,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 929
+      ID: 936
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1118880
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 925
+      ID: 932
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1736128
@@ -27810,15 +27810,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1131 PointerType *crypto/x509.Certificate
+          Type: 1138 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1131 PointerType *crypto/x509.Certificate
+          Type: 1138 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 945
+      ID: 952
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1439104
@@ -27828,7 +27828,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 949
+      ID: 956
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1439264
@@ -27838,55 +27838,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 954
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 742
+      ID: 749
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834272
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1198
+      ID: 1205
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 743
+      ID: 750
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 834464
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 814
+      ID: 821
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1023
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 813
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 812
+      ID: 819
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 810
+      ID: 817
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 815
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1341
+      ID: 1348
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 816
+      ID: 823
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1422784
@@ -27896,19 +27896,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1206
+      ID: 1213
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 915
+      ID: 922
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 913
+      ID: 920
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 754
+      ID: 761
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -27916,22 +27916,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 756 PointerType *encoding/xml.UnmarshalError.str
+          Type: 763 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 755 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 762 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 755
+      ID: 762
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1319
+      ID: 1326
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27948,11 +27948,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 784
+      ID: 791
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 983
+      ID: 990
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -27968,15 +27968,15 @@ Types:
       GoRuntimeType: 584288
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1329
+      ID: 1336
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 992
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 987
+      ID: 994
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -27986,7 +27986,7 @@ Types:
       GoRuntimeType: 475328
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 384
+      ID: 401
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 595232
@@ -28031,11 +28031,11 @@ Types:
           Offset: 0
           Type: 332 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 844
+      ID: 851
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 825
+      ID: 832
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1732288
@@ -28043,7 +28043,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1140 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1147 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -28051,25 +28051,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 827
+      ID: 834
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1144
+      ID: 1151
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 831
+      ID: 838
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1114400
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1153
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 736
+      ID: 743
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 833696
@@ -28077,18 +28077,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 738 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 745 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 737 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 744 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 737
+      ID: 744
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1140
+      ID: 1147
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2221952
@@ -28096,7 +28096,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1141 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1148 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28111,7 +28111,7 @@ Types:
           Type: 20 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1142 GoSliceHeaderType []float64
+          Type: 1149 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -28120,10 +28120,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1143 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1150 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1145 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1152 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 159 GoSliceHeaderType []string
@@ -28137,13 +28137,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 1141
+      ID: 1148
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 585952
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 733
+      ID: 740
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 833600
@@ -28151,18 +28151,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 735 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 742 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 734 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 741 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 734
+      ID: 741
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 739
+      ID: 746
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 833792
@@ -28170,30 +28170,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 741 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 748 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 740 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 747 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 740
+      ID: 747
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1220
+      ID: 1227
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1305
+      ID: 1312
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 389
+      ID: 363
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2345184
@@ -28201,7 +28201,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 390 StructureType sync.RWMutex
+          Type: 364 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -28222,13 +28222,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 398 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 375 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 403 GoMapType map[string]float64
+          Type: 380 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -28243,10 +28243,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 408 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 385 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 411 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 388 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -28258,7 +28258,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 414 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 391 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -28281,7 +28281,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 415
+      ID: 392
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2218816
@@ -28292,13 +28292,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 394 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 391 StructureType sync/atomic.Int32
+          Type: 368 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28307,16 +28307,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 418 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 396 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 390 StructureType sync.RWMutex
+          Type: 364 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -28325,12 +28325,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 408 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 385 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 410
+      ID: 387
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1913216
@@ -28347,7 +28347,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28355,20 +28355,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 398
+      ID: 375
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1284448
       GoKind: 21
-      HeaderType: 400 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 377 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1384
+      ID: 1390
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 583072
       GoKind: 10
     - __kind: StructureType
-      ID: 413
+      ID: 390
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1751264
@@ -28382,16 +28382,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 687 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 685 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 692 GoMapType map[string]interface {}
+          Type: 690 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1410
+      ID: 1417
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 708
+      ID: 715
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1913472
@@ -28399,7 +28399,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1408 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1415 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28414,15 +28414,15 @@ Types:
           Type: 20 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1409 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1408
+      ID: 1415
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 988640
       GoKind: 5
     - __kind: StructureType
-      ID: 417
+      ID: 395
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2107872
@@ -28430,16 +28430,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 390 StructureType sync.RWMutex
+          Type: 364 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1382 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1388 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 393 GoMapType map[string]string
+          Type: 370 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -28454,12 +28454,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1384 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1390 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 418
+      ID: 396
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 897024
@@ -28468,15 +28468,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1088
+      ID: 1095
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1337
+      ID: 1344
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1413
+    - __kind: GoContextImplementationType
+      ID: 403
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1631360
@@ -28485,30 +28485,32 @@ Types:
         - Name: Context
           Offset: 0
           Type: 155 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 871
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1117856
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 753
+      ID: 760
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 835904
       GoKind: 2
     - __kind: StructureType
-      ID: 869
+      ID: 876
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1117728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 867
+      ID: 874
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1601344
@@ -28521,7 +28523,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 887
+      ID: 894
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1602144
@@ -28534,7 +28536,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1735552
@@ -28550,7 +28552,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 889
+      ID: 896
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1432704
@@ -28560,7 +28562,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1432384
@@ -28570,14 +28572,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1126
+      ID: 1133
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1503584
       GoKind: 21
-      HeaderType: 1128 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1135 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1149
+      ID: 1156
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1050752
@@ -28592,15 +28594,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1167 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1174 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1167
+      ID: 1174
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1602464
@@ -28608,12 +28610,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1126 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1133 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1126 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1133 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1432864
@@ -28623,7 +28625,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1735744
@@ -28634,12 +28636,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1156 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1156 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1602304
@@ -28652,7 +28654,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 901
+      ID: 908
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1433024
@@ -28662,7 +28664,7 @@ Types:
           Offset: 0
           Type: 326 GoTimeType time.Time
     - __kind: StructureType
-      ID: 907
+      ID: 914
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1602784
@@ -28675,7 +28677,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 909
+      ID: 916
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1433344
@@ -28685,7 +28687,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 905
+      ID: 912
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1602624
@@ -28698,7 +28700,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 903
+      ID: 910
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1433184
@@ -28708,7 +28710,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 911
+      ID: 918
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1602944
@@ -28721,7 +28723,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 833
+      ID: 840
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1425024
@@ -28731,11 +28733,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1258
+      ID: 1265
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1425184
@@ -28743,21 +28745,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 833 StructureType github.com/cihub/seelog.baseError
+          Type: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1238
+      ID: 1245
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1194
+      ID: 1201
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1228
+      ID: 1235
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 839
+      ID: 846
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1425504
@@ -28765,13 +28767,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 833 StructureType github.com/cihub/seelog.baseError
+          Type: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1295
+      ID: 1302
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1306
+      ID: 1313
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2110336
@@ -28779,12 +28781,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1294 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1301 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 1309
+      ID: 1316
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2134144
@@ -28792,7 +28794,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1294 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1301 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28800,11 +28802,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1196
+      ID: 1203
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 837
+      ID: 844
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1425344
@@ -28812,9 +28814,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 833 StructureType github.com/cihub/seelog.baseError
+          Type: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1425664
@@ -28822,64 +28824,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 833 StructureType github.com/cihub/seelog.baseError
+          Type: 840 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1260
+      ID: 1267
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1301
+      ID: 1308
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1303
+      ID: 1310
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1129
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1045
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1043
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1047
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1049
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1249
+      ID: 1256
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1032
+      ID: 1039
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 847
+      ID: 854
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1426624
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1353
+      ID: 1360
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1103
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1065
+      ID: 1072
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1842880
@@ -28895,11 +28897,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1002
+      ID: 1009
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1706336
@@ -28912,7 +28914,7 @@ Types:
           Offset: 1
           Type: 18 BaseType int8
     - __kind: StructureType
-      ID: 1071
+      ID: 1078
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1843328
@@ -28928,13 +28930,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 979
+      ID: 986
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 990464
       GoKind: 8
     - __kind: StructureType
-      ID: 1063
+      ID: 1070
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1842656
@@ -28950,13 +28952,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1151
+      ID: 1158
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 831968
       GoKind: 8
     - __kind: StructureType
-      ID: 1061
+      ID: 1068
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1842432
@@ -28964,15 +28966,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1151 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1158 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1151 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1158 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1069
+      ID: 1076
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1756832
@@ -28985,7 +28987,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1067
+      ID: 1074
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1843104
@@ -29001,11 +29003,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1357
+      ID: 1364
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1075
+      ID: 1082
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1627136
@@ -29015,19 +29017,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1006
+      ID: 1013
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1284960
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1004
+      ID: 1011
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1284832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1073
+      ID: 1080
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1757024
@@ -29040,7 +29042,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 766
+      ID: 773
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 839360
@@ -29048,13 +29050,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 768 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 775 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 767 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 774 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 767
+      ID: 774
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29085,13 +29087,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 645 PointerType *go.shape.string.str
+          Type: 652 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 644 GoStringDataType go.shape.string.str
+      Data: 651 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 644
+      ID: 651
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29147,11 +29149,11 @@ Types:
           Offset: 32
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1142
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1046
+      ID: 1053
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1450944
@@ -29161,7 +29163,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1226
+      ID: 1233
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1682432
@@ -29169,13 +29171,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1250 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1257 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1317
+      ID: 1324
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1250
+      ID: 1257
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1128608
@@ -29188,7 +29190,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1212
+      ID: 1219
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1573504
@@ -29198,19 +29200,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 769
+      ID: 776
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 839936
       GoKind: 10
     - __kind: BaseType
-      ID: 1133
+      ID: 1140
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1004096
       GoKind: 10
     - __kind: StructureType
-      ID: 1104
+      ID: 1111
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1882528
@@ -29221,12 +29223,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1133 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1140 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 965
+      ID: 972
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1609984
@@ -29234,12 +29236,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1133 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1140 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 773
+      ID: 780
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840128
@@ -29247,18 +29249,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 775 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 782 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 774 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 781 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 774
+      ID: 781
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 779
+      ID: 786
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840320
@@ -29266,18 +29268,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 781 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 788 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 780 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 787 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 780
+      ID: 787
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 776
+      ID: 783
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840224
@@ -29285,18 +29287,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 778 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 785 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 777 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 784 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 777
+      ID: 784
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 770
+      ID: 777
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840032
@@ -29304,22 +29306,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 772 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 779 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 771 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 778 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 771
+      ID: 778
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1315
+      ID: 1322
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 969
+      ID: 976
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1451584
@@ -29329,13 +29331,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 782
+      ID: 789
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 840416
       GoKind: 2
     - __kind: StructureType
-      ID: 957
+      ID: 964
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1446624
@@ -29345,11 +29347,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1109
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1124
+      ID: 1131
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1910432
@@ -29365,7 +29367,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 959
+      ID: 966
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1609504
@@ -29378,7 +29380,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1266
+      ID: 1273
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1968000
@@ -29386,16 +29388,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1293 GoInterfaceType io.Reader
+          Type: 1300 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1224
+      ID: 1231
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1044
+      ID: 1051
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1571104
@@ -29405,29 +29407,29 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1191
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1041
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1107
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1098
+      ID: 1105
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1514144
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 951
+      ID: 958
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1439904
@@ -29437,7 +29439,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1440064
@@ -29447,107 +29449,107 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 535
+      ID: 542
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 536 PointerType *noalg.map.group[[4]int][4]int
+          Type: 543 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 537 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 541 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 544 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 548 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 527
+      ID: 534
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 528 PointerType *noalg.map.group[[4]int]uint8
+          Type: 535 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 529 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 533 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 536 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 540 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 475
+      ID: 482
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 476 PointerType *noalg.map.group[[4]string][2]int
+          Type: 483 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 477 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 482 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 484 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 489 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 494
+      ID: 501
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 495 PointerType *noalg.map.group[bool]main.node
+          Type: 502 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 496 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 500 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 503 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 507 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 653
+      ID: 694
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 654 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 695 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 655 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 660 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 696 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 701 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 431
+      ID: 438
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 432 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 439 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 433 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 439 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 440 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 446 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1399
+      ID: 1406
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1400 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1407 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1401 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1407 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1408 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1414 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1443
       Name: groupReference<int,*main.deepMap8>
@@ -29577,19 +29579,19 @@ Types:
       GroupType: 1460 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 1466 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 443
+      ID: 450
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 444 PointerType *noalg.map.group[int]int
+          Type: 451 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 445 StructureType noalg.map.group[int]int
-      GroupSliceType: 449 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 452 StructureType noalg.map.group[int]int
+      GroupSliceType: 456 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 1473
       Name: groupReference<int,interface {}>
@@ -29605,305 +29607,305 @@ Types:
       GroupType: 1475 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 1479 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 551
+      ID: 558
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 552 PointerType *noalg.map.group[int]struct {}
+          Type: 559 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 553 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 557 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 560 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 564 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 502
+      ID: 509
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 503 PointerType *noalg.map.group[int]uint8
+          Type: 510 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 504 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 508 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 511 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 515 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 702
+      ID: 709
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 703 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 710 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 710 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 711 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 717 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 484
+      ID: 491
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 485 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 492 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 486 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 492 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 493 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 499 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 467
+      ID: 474
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 468 PointerType *noalg.map.group[string][]string
+          Type: 475 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 469 StructureType noalg.map.group[string][]string
-      GroupSliceType: 473 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 476 StructureType noalg.map.group[string][]string
+      GroupSliceType: 480 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 678
+      ID: 676
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 679 PointerType *noalg.map.group[string]float64
+          Type: 677 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 680 StructureType noalg.map.group[string]float64
-      GroupSliceType: 684 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 678 StructureType noalg.map.group[string]float64
+      GroupSliceType: 682 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1158
+      ID: 1165
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1159 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1166 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1164 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1167 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1171 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 459
+      ID: 466
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 460 PointerType *noalg.map.group[string]int
+          Type: 467 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 461 StructureType noalg.map.group[string]int
-      GroupSliceType: 465 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 468 StructureType noalg.map.group[string]int
+      GroupSliceType: 472 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 670
+      ID: 668
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 671 PointerType *noalg.map.group[string]interface {}
+          Type: 669 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 672 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 676 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 670 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 674 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 451
+      ID: 458
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 452 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 459 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 453 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 457 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 460 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 464 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 662
+      ID: 660
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 663 PointerType *noalg.map.group[string]string
+          Type: 661 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 664 StructureType noalg.map.group[string]string
-      GroupSliceType: 668 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 662 StructureType noalg.map.group[string]string
+      GroupSliceType: 666 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 543
+      ID: 550
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 544 PointerType *noalg.map.group[struct {}]int
+          Type: 551 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 545 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 549 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 552 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 556 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 591
+      ID: 598
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 592 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 599 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 597 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 600 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 604 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 599
+      ID: 606
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 600 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 607 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 605 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 608 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 612 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 607
+      ID: 614
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 608 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 615 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 613 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 620 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 615
+      ID: 622
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 616 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 623 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 621 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 628 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 623
+      ID: 630
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 624 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 631 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 629 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 636 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 631
+      ID: 638
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 632 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 639 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 637 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 644 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 559
+      ID: 566
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 560 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 567 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 561 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 565 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 568 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 572 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 518
+      ID: 525
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 519 PointerType *noalg.map.group[uint8][4]int
+          Type: 526 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 520 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 525 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 527 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 532 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 510
+      ID: 517
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 511 PointerType *noalg.map.group[uint8]uint8
+          Type: 518 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 512 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 516 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 519 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 523 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1272
+      ID: 1279
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 979
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -29950,7 +29952,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -29976,29 +29978,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 856
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1174
+      ID: 1181
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1101
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1359
+      ID: 1366
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1092
+      ID: 1099
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1492864
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 789
+      ID: 796
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -30079,7 +30081,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 377
+      ID: 367
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1490304
@@ -30092,11 +30094,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1216
+      ID: 1223
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1256
+      ID: 1263
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1192224
@@ -30109,7 +30111,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1293
+      ID: 1300
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1024384
@@ -30122,7 +30124,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1245
+      ID: 1252
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1111200
@@ -30148,21 +30150,21 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1214
+      ID: 1221
       Name: io.discard
       GoRuntimeType: 1467104
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1188
+      ID: 1195
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1090
+      ID: 1097
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1262
+      ID: 1269
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -30256,7 +30258,7 @@ Types:
           Offset: 0
           Type: 144 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 437
+      ID: 444
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1188384
@@ -30264,9 +30266,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1393 GoMapType map[int]*main.deepMap3
+          Type: 1400 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1405
+      ID: 1412
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -30318,9 +30320,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1362 PointerType *main.deepPtr3
+          Type: 1369 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1363
+      ID: 1370
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -30364,7 +30366,7 @@ Types:
           Offset: 0
           Type: 138 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 427
+      ID: 434
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1190688
@@ -30372,9 +30374,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1387 GoSliceHeaderType []*main.deepSlice3
+          Type: 1394 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1390
+      ID: 1397
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -30424,16 +30426,16 @@ Types:
           Type: 160 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 375 StructureType sync.Mutex
+          Type: 365 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1370 StructureType sync.Once
+          Type: 1377 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1372 StructureType sync.WaitGroup
+          Type: 1379 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 391 StructureType sync/atomic.Int32
+          Type: 368 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 160
       Name: main.esotericStack
@@ -30851,9 +30853,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1367 ArrayType [63]uint64
+          Type: 1374 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1377
+      ID: 1384
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1416224
@@ -30873,7 +30875,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1369
+      ID: 1376
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -30884,18 +30886,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1365 PointerType *main.stringType1.str
+          Type: 1372 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1364 GoStringDataType main.stringType1.str
+      Data: 1371 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1364
+      ID: 1371
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1366
+      ID: 1373
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
@@ -31024,16 +31026,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1378 PointerType **main.t
+          Type: 1385 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1379 GoSliceDataType main.t.array
+      Data: 1386 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1379
+      ID: 1386
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -31190,8 +31192,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 540 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 537 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 547 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 544 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 225
       Name: map<[4]int,uint8>
@@ -31222,8 +31224,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 532 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 529 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 539 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 536 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 193
       Name: map<[4]string,[2]int>
@@ -31254,8 +31256,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 481 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 477 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 488 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 484 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 205
       Name: map<bool,main.node>
@@ -31286,10 +31288,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 499 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 496 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 506 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 503 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 381
+      ID: 419
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -31302,7 +31304,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 382 PointerType **table<context.canceler,struct {}>
+          Type: 420 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31318,8 +31320,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 659 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 655 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 700 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 696 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 146
       Name: map<int,*main.deepMap2>
@@ -31350,10 +31352,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 438 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 433 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 445 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 440 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1395
+      ID: 1402
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -31366,7 +31368,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1396 PointerType **table<int,*main.deepMap3>
+          Type: 1403 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31382,8 +31384,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1406 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1401 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1413 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1408 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1439
       Name: map<int,*main.deepMap8>
@@ -31478,8 +31480,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 448 GoSliceDataType []*table<int,int>.array
-      GroupType: 445 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 455 GoSliceDataType []*table<int,int>.array
+      GroupType: 452 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 1469
       Name: map<int,interface {}>
@@ -31542,8 +31544,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 556 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 553 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 563 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 560 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 210
       Name: map<int,uint8>
@@ -31574,10 +31576,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 507 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 504 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 514 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 511 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 689
+      ID: 687
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -31590,7 +31592,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 690 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 688 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31606,8 +31608,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 709 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 704 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 716 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 711 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 200
       Name: map<string,[]main.structWithMap>
@@ -31638,8 +31640,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 491 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 486 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 498 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 493 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 188
       Name: map<string,[]string>
@@ -31670,10 +31672,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 472 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 469 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 479 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 476 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 405
+      ID: 382
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -31686,7 +31688,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 406 PointerType **table<string,float64>
+          Type: 383 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31702,10 +31704,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 683 GoSliceDataType []*table<string,float64>.array
-      GroupType: 680 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 681 GoSliceDataType []*table<string,float64>.array
+      GroupType: 678 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1128
+      ID: 1135
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31718,7 +31720,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1129 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1136 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31734,8 +31736,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1163 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1160 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1170 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1167 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 183
       Name: map<string,int>
@@ -31766,10 +31768,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 464 GoSliceDataType []*table<string,int>.array
-      GroupType: 461 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 471 GoSliceDataType []*table<string,int>.array
+      GroupType: 468 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 400
+      ID: 377
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -31782,7 +31784,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 401 PointerType **table<string,interface {}>
+          Type: 378 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31798,8 +31800,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 675 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 672 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 673 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 670 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 178
       Name: map<string,main.nestedStruct>
@@ -31830,10 +31832,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 456 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 453 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 463 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 460 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 395
+      ID: 372
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -31846,7 +31848,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 396 PointerType **table<string,string>
+          Type: 373 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31862,8 +31864,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 667 GoSliceDataType []*table<string,string>.array
-      GroupType: 664 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 665 GoSliceDataType []*table<string,string>.array
+      GroupType: 662 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 235
       Name: map<struct {},int>
@@ -31894,8 +31896,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 548 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 545 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 555 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 552 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 292
       Name: map<struct {},main.structWithCyclicMaps>
@@ -31926,8 +31928,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 596 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 593 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 603 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 600 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 297
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -31958,8 +31960,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 604 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 601 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 611 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 608 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 302
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -31990,8 +31992,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 612 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 609 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 619 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 307
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32022,8 +32024,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 620 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 617 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 627 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 312
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32054,8 +32056,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 628 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 625 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 635 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 317
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32086,8 +32088,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 636 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 633 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 643 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 245
       Name: map<struct {},struct {}>
@@ -32118,8 +32120,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 564 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 561 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 571 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 568 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 220
       Name: map<uint8,[4]int>
@@ -32150,8 +32152,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 524 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 520 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 531 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 527 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 215
       Name: map<uint8,uint8>
@@ -32182,8 +32184,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 515 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 512 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 522 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 519 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 228
       Name: map[[4]int][4]int
@@ -32213,12 +32215,12 @@ Types:
       GoKind: 21
       HeaderType: 205 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 379
+      ID: 417
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1132832
       GoKind: 21
-      HeaderType: 381 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 419 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 144
       Name: map[int]*main.deepMap2
@@ -32227,12 +32229,12 @@ Types:
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1393
+      ID: 1400
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1130400
       GoKind: 21
-      HeaderType: 1395 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1402 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1437
       Name: map[int]*main.deepMap8
@@ -32276,12 +32278,12 @@ Types:
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 687
+      ID: 685
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1133088
       GoKind: 21
-      HeaderType: 689 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 687 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 198
       Name: map[string][]main.structWithMap
@@ -32297,12 +32299,12 @@ Types:
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 403
+      ID: 380
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1132960
       GoKind: 21
-      HeaderType: 405 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 382 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 181
       Name: map[string]int
@@ -32311,12 +32313,12 @@ Types:
       GoKind: 21
       HeaderType: 183 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 692
+      ID: 690
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1129376
       GoKind: 21
-      HeaderType: 400 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 377 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 176
       Name: map[string]main.nestedStruct
@@ -32325,12 +32327,12 @@ Types:
       GoKind: 21
       HeaderType: 178 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 393
+      ID: 370
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1132704
       GoKind: 21
-      HeaderType: 395 GoSwissMapHeaderType map<string,string>
+      HeaderType: 372 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 233
       Name: map[struct {}]int
@@ -32396,7 +32398,7 @@ Types:
       GoKind: 21
       HeaderType: 215 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 883
+      ID: 890
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1432064
@@ -32406,7 +32408,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1178
+      ID: 1185
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1428864
@@ -32416,11 +32418,11 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1089
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1148
+      ID: 1155
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1600064
@@ -32433,35 +32435,35 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1120
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1323
+      ID: 1330
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1118
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1091
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1333
+      ID: 1340
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1343
+      ID: 1350
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1331
+      ID: 1338
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1049
+      ID: 1056
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1114016
@@ -32469,28 +32471,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1051 PointerType *net.UnknownNetworkError.str
+          Type: 1058 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1050 GoStringDataType net.UnknownNetworkError.str
+      Data: 1057 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1050
+      ID: 1057
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1018
+      ID: 1025
       Name: net.canceledError
       GoRuntimeType: 1285856
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1299
+      ID: 1306
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1153
+      ID: 1160
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2109632
@@ -32498,7 +32500,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -32509,27 +32511,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1345
+      ID: 1352
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1339
+      ID: 1346
       Name: net.noReadFrom
       GoRuntimeType: 1114272
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1338
+      ID: 1345
       Name: net.noWriteTo
       GoRuntimeType: 1114144
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1415
+    - __kind: GoContextImplementationType
+      ID: 405
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1761824
@@ -32541,8 +32543,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 155 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 820
+      ID: 827
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1732096
@@ -32550,7 +32554,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1136 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1143 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -32558,7 +32562,7 @@ Types:
           Offset: 96
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1327
+      ID: 1334
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2294368
@@ -32566,12 +32570,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1339 StructureType net.noReadFrom
+          Type: 1346 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1332 PointerType *net.TCPConn
+          Type: 1339 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1325
+      ID: 1332
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2293824
@@ -32579,24 +32583,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1338 StructureType net.noWriteTo
+          Type: 1345 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1332 PointerType *net.TCPConn
+          Type: 1339 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1086
+      ID: 1093
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1122
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1015
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1170
+      ID: 1177
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1420544
@@ -32606,19 +32610,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 714
+      ID: 721
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 832448
       GoKind: 10
     - __kind: BaseType
-      ID: 1125
+      ID: 1132
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 990560
       GoKind: 10
     - __kind: StructureType
-      ID: 796
+      ID: 803
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1730752
@@ -32629,12 +32633,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1125 BaseType net/http.http2ErrCode
+          Type: 1132 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1107
+      ID: 1114
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1901728
@@ -32645,12 +32649,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1125 BaseType net/http.http2ErrCode
+          Type: 1132 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 800
+      ID: 807
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1599744
@@ -32658,16 +32662,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1125 BaseType net/http.http2ErrCode
+          Type: 1132 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1234
+      ID: 1241
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 718
+      ID: 725
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832640
@@ -32675,18 +32679,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 720 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 727 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 719 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 726 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 719
+      ID: 726
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 724
+      ID: 731
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 832832
@@ -32694,18 +32698,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 726 PointerType *net/http.http2headerFieldNameError.str
+          Type: 733 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 725 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 732 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 725
+      ID: 732
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 721
+      ID: 728
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 832736
@@ -32713,32 +32717,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 723 PointerType *net/http.http2headerFieldValueError.str
+          Type: 730 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 722 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 729 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 722
+      ID: 729
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1079
+      ID: 1086
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1014
+      ID: 1021
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1285216
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1288
+      ID: 1295
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 715
+      ID: 722
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832544
@@ -32746,18 +32750,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 717 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 724 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 716 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 723 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 716
+      ID: 723
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1172
+      ID: 1179
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1826240
@@ -32765,18 +32769,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1267 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1274 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1268 BaseType time.Duration
+          Type: 1275 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1267
+      ID: 1274
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1419904
@@ -32789,14 +32793,14 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1253
+      ID: 1260
       Name: net/http.incomparable
       GoRuntimeType: 901920
       GoKind: 17
       HasCount: true
       Element: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1010
+      ID: 1017
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1558624
@@ -32806,11 +32810,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1236
+      ID: 1243
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1192
+      ID: 1199
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1558464
@@ -32818,9 +32822,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1235 PointerType *net/http.persistConn
+          Type: 1242 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1218
+      ID: 1225
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1802688
@@ -32828,15 +32832,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1253 ArrayType net/http.incomparable
+          Type: 1260 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1254 PointerType *bufio.Reader
+          Type: 1261 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1256 GoInterfaceType io.ReadWriteCloser
+          Type: 1263 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 804
+      ID: 811
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1421504
@@ -32846,17 +32850,17 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1116
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1077
+      ID: 1084
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1479424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1012
+      ID: 1019
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1558784
@@ -32866,7 +32870,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1270
+      ID: 1277
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2027904
@@ -32874,16 +32878,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1148 GoInterfaceType net.Conn
+          Type: 1155 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1290
+      ID: 1297
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2043936
@@ -32891,13 +32895,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1285 PointerType *bufio.Writer
+          Type: 1292 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1202
+      ID: 1209
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1735168
@@ -32913,7 +32917,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 873
+      ID: 880
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1601504
@@ -32926,11 +32930,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1244
+      ID: 1251
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1204
+      ID: 1211
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1603424
@@ -32938,16 +32942,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1243 PointerType *net/smtp.Client
+          Type: 1250 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1245 GoInterfaceType io.WriteCloser
+          Type: 1252 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 859
+      ID: 866
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 756
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835328
@@ -32955,26 +32959,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *net/textproto.ProtocolError.str
+          Type: 758 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 750 GoStringDataType net/textproto.ProtocolError.str
+      Data: 757 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 757
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1200
+      ID: 1207
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1124
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 727
+      ID: 734
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 833312
@@ -32982,18 +32986,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 729 PointerType *net/url.EscapeError.str
+          Type: 736 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 728 GoStringDataType net/url.EscapeError.str
+      Data: 735 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 728
+      ID: 735
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 730
+      ID: 737
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 833408
@@ -33001,79 +33005,79 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 732 PointerType *net/url.InvalidHostError.str
+          Type: 739 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 731 GoStringDataType net/url.InvalidHostError.str
+      Data: 738 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 731
+      ID: 738
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 538
+      ID: 545
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 682976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 539 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 546 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 530
+      ID: 537
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 683072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 531 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 538 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 478
+      ID: 485
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 683360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 479 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 486 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 497
+      ID: 504
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 683456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 498 StructureType noalg.struct { key bool; elem main.node }
+      Element: 505 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 656
+      ID: 697
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 689024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 657 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 698 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 434
+      ID: 441
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 682208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 435 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 442 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1402
+      ID: 1409
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1403 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1410 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1446
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -33093,14 +33097,14 @@ Types:
       HasCount: true
       Element: 1462 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 446
+      ID: 453
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 680288
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 447 StructureType noalg.struct { key int; elem int }
+      Element: 454 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 1476
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -33111,189 +33115,189 @@ Types:
       HasCount: true
       Element: 1477 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 554
+      ID: 561
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 555 StructureType noalg.struct { key int; elem struct {} }
+      Element: 562 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 505
+      ID: 512
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 683648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 506 StructureType noalg.struct { key int; elem uint8 }
+      Element: 513 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 705
+      ID: 712
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 689664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 706 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 713 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 487
+      ID: 494
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 683744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 488 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 495 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 470
+      ID: 477
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 471 StructureType noalg.struct { key string; elem []string }
+      Element: 478 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 681
+      ID: 679
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 689568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 682 StructureType noalg.struct { key string; elem float64 }
+      Element: 680 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1161
+      ID: 1168
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 758368
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1162 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1169 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 462
+      ID: 469
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 463 StructureType noalg.struct { key string; elem int }
+      Element: 470 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 673
+      ID: 671
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 681056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 674 StructureType noalg.struct { key string; elem interface {} }
+      Element: 672 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 454
+      ID: 461
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 684032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 455 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 462 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 665
+      ID: 663
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 687200
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 666 StructureType noalg.struct { key string; elem string }
+      Element: 664 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 546
+      ID: 553
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 684128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 547 StructureType noalg.struct { key struct {}; elem int }
+      Element: 554 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 594
+      ID: 601
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 595 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 602 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 602
+      ID: 609
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 603 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 610 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 610
+      ID: 617
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 611 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 618 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 618
+      ID: 625
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 619 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 626 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 626
+      ID: 633
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 627 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 634 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 634
+      ID: 641
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 635 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 642 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 562
+      ID: 569
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 684224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 563 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 570 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 521
+      ID: 528
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 684320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 522 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 529 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 513
+      ID: 520
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 684416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 514 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 521 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 537
+      ID: 544
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1297504
@@ -33304,9 +33308,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 538 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 545 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 529
+      ID: 536
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1297760
@@ -33317,9 +33321,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 530 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 537 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 477
+      ID: 484
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1298016
@@ -33330,9 +33334,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 478 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 485 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 496
+      ID: 503
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1298272
@@ -33343,9 +33347,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 497 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 504 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 655
+      ID: 696
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1302368
@@ -33356,9 +33360,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 656 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 697 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 433
+      ID: 440
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1297248
@@ -33369,9 +33373,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 434 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 441 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1401
+      ID: 1408
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1296992
@@ -33382,7 +33386,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1402 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1409 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1445
       Name: noalg.map.group[int]*main.deepMap8
@@ -33410,7 +33414,7 @@ Types:
           Offset: 8
           Type: 1461 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 445
+      ID: 452
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1294176
@@ -33421,7 +33425,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 446 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 453 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 1475
       Name: noalg.map.group[int]interface {}
@@ -33436,7 +33440,7 @@ Types:
           Offset: 8
           Type: 1476 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 553
+      ID: 560
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1298528
@@ -33447,9 +33451,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 554 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 561 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 504
+      ID: 511
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1298784
@@ -33460,9 +33464,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 505 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 512 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 704
+      ID: 711
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1303264
@@ -33473,9 +33477,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 705 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 712 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1299040
@@ -33486,9 +33490,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 487 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 494 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 469
+      ID: 476
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1299296
@@ -33499,9 +33503,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 470 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 477 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 680
+      ID: 678
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1303008
@@ -33512,9 +33516,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 681 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 679 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1160
+      ID: 1167
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1361248
@@ -33525,9 +33529,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1161 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1168 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 461
+      ID: 468
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1299552
@@ -33538,9 +33542,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 462 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 469 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 672
+      ID: 670
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1294944
@@ -33551,9 +33555,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 673 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 671 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 453
+      ID: 460
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1299808
@@ -33564,9 +33568,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 454 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 461 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 664
+      ID: 662
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1301600
@@ -33577,9 +33581,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 665 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 663 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 545
+      ID: 552
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1300064
@@ -33590,9 +33594,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 546 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 553 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 593
+      ID: 600
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -33602,9 +33606,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 594 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 601 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 601
+      ID: 608
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33614,9 +33618,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 602 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 609 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 609
+      ID: 616
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33626,9 +33630,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 610 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 617 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 617
+      ID: 624
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33638,9 +33642,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 618 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 625 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 625
+      ID: 632
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33650,9 +33654,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 626 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 633 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 633
+      ID: 640
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33662,9 +33666,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 634 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 641 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 561
+      ID: 568
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1300320
@@ -33675,9 +33679,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 562 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 569 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 520
+      ID: 527
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1300576
@@ -33688,9 +33692,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 521 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 528 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 512
+      ID: 519
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1300832
@@ -33701,9 +33705,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 513 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 520 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 539
+      ID: 546
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1297376
@@ -33711,12 +33715,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 523 ArrayType [4]int
+          Type: 530 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 523 ArrayType [4]int
+          Type: 530 ArrayType [4]int
     - __kind: StructureType
-      ID: 531
+      ID: 538
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1297632
@@ -33724,12 +33728,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 523 ArrayType [4]int
+          Type: 530 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 479
+      ID: 486
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1297888
@@ -33737,12 +33741,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 480 ArrayType [4]string
+          Type: 487 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 113 ArrayType [2]int
     - __kind: StructureType
-      ID: 498
+      ID: 505
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1298144
@@ -33755,7 +33759,7 @@ Types:
           Offset: 8
           Type: 251 StructureType main.node
     - __kind: StructureType
-      ID: 657
+      ID: 698
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1302240
@@ -33763,12 +33767,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 658 GoInterfaceType context.canceler
+          Type: 699 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 435
+      ID: 442
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1297120
@@ -33779,9 +33783,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 436 PointerType *main.deepMap2
+          Type: 443 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1403
+      ID: 1410
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1296864
@@ -33792,7 +33796,7 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1404 PointerType *main.deepMap3
+          Type: 1411 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1447
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -33820,7 +33824,7 @@ Types:
           Offset: 8
           Type: 1463 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 447
+      ID: 454
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1294048
@@ -33846,7 +33850,7 @@ Types:
           Offset: 8
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 555
+      ID: 562
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1298400
@@ -33859,7 +33863,7 @@ Types:
           Offset: 8
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 506
+      ID: 513
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1298656
@@ -33872,7 +33876,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 706
+      ID: 713
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1303136
@@ -33883,9 +33887,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 707 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 714 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 488
+      ID: 495
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1298912
@@ -33896,9 +33900,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 489 GoSliceHeaderType []main.structWithMap
+          Type: 496 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 471
+      ID: 478
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1299168
@@ -33911,7 +33915,7 @@ Types:
           Offset: 16
           Type: 159 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 682
+      ID: 680
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1302880
@@ -33924,7 +33928,7 @@ Types:
           Offset: 16
           Type: 20 BaseType float64
     - __kind: StructureType
-      ID: 1162
+      ID: 1169
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1361120
@@ -33935,9 +33939,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1149 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1156 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 463
+      ID: 470
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1299424
@@ -33950,7 +33954,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 674
+      ID: 672
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1294816
@@ -33963,7 +33967,7 @@ Types:
           Offset: 16
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 455
+      ID: 462
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1299680
@@ -33976,7 +33980,7 @@ Types:
           Offset: 16
           Type: 123 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 666
+      ID: 664
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1301472
@@ -33989,7 +33993,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 547
+      ID: 554
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1299936
@@ -34002,7 +34006,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 595
+      ID: 602
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -34014,7 +34018,7 @@ Types:
           Offset: 0
           Type: 289 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 603
+      ID: 610
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34026,7 +34030,7 @@ Types:
           Offset: 0
           Type: 290 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 611
+      ID: 618
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34038,7 +34042,7 @@ Types:
           Offset: 0
           Type: 295 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 619
+      ID: 626
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34050,7 +34054,7 @@ Types:
           Offset: 0
           Type: 300 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 627
+      ID: 634
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34062,7 +34066,7 @@ Types:
           Offset: 0
           Type: 305 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 635
+      ID: 642
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34074,7 +34078,7 @@ Types:
           Offset: 0
           Type: 310 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 563
+      ID: 570
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1300192
       GoKind: 25
@@ -34086,7 +34090,7 @@ Types:
           Offset: 0
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 522
+      ID: 529
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1300448
@@ -34097,9 +34101,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 523 ArrayType [4]int
+          Type: 530 ArrayType [4]int
     - __kind: StructureType
-      ID: 514
+      ID: 521
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1300704
@@ -34112,19 +34116,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1351
+      ID: 1358
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 998
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1349
+      ID: 1356
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2362976
@@ -34132,12 +34136,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1355 StructureType os.noReadFrom
+          Type: 1362 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1350 PointerType *os.File
+          Type: 1357 PointerType *os.File
     - __kind: StructureType
-      ID: 1347
+      ID: 1354
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2362176
@@ -34145,36 +34149,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1354 StructureType os.noWriteTo
+          Type: 1361 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1350 PointerType *os.File
+          Type: 1357 PointerType *os.File
     - __kind: StructureType
-      ID: 1355
+      ID: 1362
       Name: os.noReadFrom
       GoRuntimeType: 1112480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1354
+      ID: 1361
       Name: os.noWriteTo
       GoRuntimeType: 1112352
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1020
+      ID: 1027
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1163
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1222
+      ID: 1229
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1029
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1706912
@@ -34187,7 +34191,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 763
+      ID: 770
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 838592
@@ -34195,36 +34199,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 765 PointerType *os/user.UnknownGroupIdError.str
+          Type: 772 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 764 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 771 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 764
+      ID: 771
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 762
+      ID: 769
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 838496
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 791
+      ID: 798
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 888
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 995
+      ID: 1002
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1006
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34236,7 +34240,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 997
+      ID: 1004
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1890144
@@ -34253,9 +34257,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1154 BaseType runtime.boundsErrorCode
+          Type: 1161 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1154
+      ID: 1161
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 584480
@@ -34275,7 +34279,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1057
+      ID: 1064
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1754912
@@ -34288,7 +34292,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 973
+      ID: 980
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 989696
@@ -34296,13 +34300,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 975 PointerType *runtime.errorString.str
+          Type: 982 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 974 GoStringDataType runtime.errorString.str
+      Data: 981 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 974
+      ID: 981
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -34958,7 +34962,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 976
+      ID: 983
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 989792
@@ -34966,13 +34970,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 978 PointerType *runtime.plainError.str
+          Type: 985 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 977 GoStringDataType runtime.plainError.str
+      Data: 984 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 977
+      ID: 984
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -35058,7 +35062,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 989
+      ID: 996
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -35070,26 +35074,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 420 PointerType *string.str
+          Type: 427 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 419 GoStringDataType string.str
+      Data: 426 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 419
+      ID: 426
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1284
+      ID: 1291
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1190
+      ID: 1197
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1186
+      ID: 1193
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1458784
@@ -35105,7 +35109,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 375
+      ID: 365
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1470144
@@ -35113,12 +35117,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 376 StructureType sync.noCopy
+          Type: 366 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 377 StructureType internal/sync.Mutex
+          Type: 367 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1370
+      ID: 1377
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1619840
@@ -35126,15 +35130,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 376 StructureType sync.noCopy
+          Type: 366 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1371 StructureType sync/atomic.Uint32
+          Type: 1378 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 375 StructureType sync.Mutex
+          Type: 365 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 390
+      ID: 364
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1839744
@@ -35142,7 +35146,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 375 StructureType sync.Mutex
+          Type: 365 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -35151,12 +35155,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 391 StructureType sync/atomic.Int32
+          Type: 368 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 391 StructureType sync/atomic.Int32
+          Type: 368 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1372
+      ID: 1379
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1620032
@@ -35164,21 +35168,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 376 StructureType sync.noCopy
+          Type: 366 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1373 StructureType sync/atomic.Uint64
+          Type: 1380 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 376
+      ID: 366
       Name: sync.noCopy
       GoRuntimeType: 989312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 391
+      ID: 368
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1471424
@@ -35186,12 +35190,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 392 StructureType sync/atomic.noCopy
+          Type: 369 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 1371
+      ID: 1378
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1471584
@@ -35199,12 +35203,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 392 StructureType sync/atomic.noCopy
+          Type: 369 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 1373
+      ID: 1380
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1620416
@@ -35212,15 +35216,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 392 StructureType sync/atomic.noCopy
+          Type: 369 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1374 StructureType sync/atomic.align64
+          Type: 1381 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 378
+      ID: 416
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1196576
@@ -35230,25 +35234,25 @@ Types:
           Offset: 0
           Type: 162 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1374
+      ID: 1381
       Name: sync/atomic.align64
       GoRuntimeType: 989504
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 392
+      ID: 369
       Name: sync/atomic.noCopy
       GoRuntimeType: 989408
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1105
+      ID: 1112
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1287264
       GoKind: 12
     - __kind: StructureType
-      ID: 534
+      ID: 541
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35270,9 +35274,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 535 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 542 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 526
+      ID: 533
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35294,9 +35298,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 527 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 534 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 474
+      ID: 481
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -35318,9 +35322,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 475 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 482 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 493
+      ID: 500
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -35342,9 +35346,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 494 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 501 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 652
+      ID: 693
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35366,9 +35370,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 653 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 694 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 430
+      ID: 437
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -35390,9 +35394,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 431 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 438 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1398
+      ID: 1405
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -35414,7 +35418,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1399 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1406 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1442
       Name: table<int,*main.deepMap8>
@@ -35464,7 +35468,7 @@ Types:
           Offset: 16
           Type: 1458 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 442
+      ID: 449
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -35486,7 +35490,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 443 GoSwissMapGroupsType groupReference<int,int>
+          Type: 450 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 1472
       Name: table<int,interface {}>
@@ -35512,7 +35516,7 @@ Types:
           Offset: 16
           Type: 1473 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 550
+      ID: 557
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35534,9 +35538,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 551 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 558 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 501
+      ID: 508
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35558,9 +35562,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 502 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 509 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 701
+      ID: 708
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -35582,9 +35586,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 702 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 709 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 483
+      ID: 490
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -35606,9 +35610,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 484 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 491 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 466
+      ID: 473
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35630,9 +35634,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 467 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 474 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 677
+      ID: 675
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35654,9 +35658,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 678 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 676 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1157
+      ID: 1164
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35678,9 +35682,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1158 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1165 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 458
+      ID: 465
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35702,9 +35706,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 459 GoSwissMapGroupsType groupReference<string,int>
+          Type: 466 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 669
+      ID: 667
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -35726,9 +35730,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 670 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 668 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 450
+      ID: 457
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -35750,9 +35754,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 451 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 458 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 661
+      ID: 659
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -35774,9 +35778,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 662 GoSwissMapGroupsType groupReference<string,string>
+          Type: 660 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 542
+      ID: 549
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -35798,9 +35802,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 543 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 550 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 590
+      ID: 597
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35822,9 +35826,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 591 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 598 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 598
+      ID: 605
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35846,9 +35850,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 599 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 606 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 606
+      ID: 613
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35870,9 +35874,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 607 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 614 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 614
+      ID: 621
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35894,9 +35898,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 615 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 622 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 622
+      ID: 629
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35918,9 +35922,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 623 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 630 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 630
+      ID: 637
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -35942,9 +35946,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 631 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 638 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 558
+      ID: 565
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35966,9 +35970,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 559 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 566 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 517
+      ID: 524
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35990,9 +35994,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 518 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 525 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 509
+      ID: 516
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -36014,13 +36018,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 510 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 517 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1321
+      ID: 1328
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1048
+      ID: 1055
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1711328
@@ -36033,7 +36037,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 1268
+      ID: 1275
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1915008
@@ -36050,10 +36054,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 638 GoSliceHeaderType []time.zone
+          Type: 645 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 641 GoSliceHeaderType []time.zoneTrans
+          Type: 648 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -36065,9 +36069,9 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 639 PointerType *time.zone
+          Type: 646 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 787
+      ID: 794
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
@@ -36095,7 +36099,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 386
+      ID: 425
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1472224
@@ -36103,12 +36107,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1381 GoChannelType <-chan time.Time
+          Type: 1393 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 711
+      ID: 718
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 830912
@@ -36116,18 +36120,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 713 PointerType *time.fileSizeError.str
+          Type: 720 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 712 GoStringDataType time.fileSizeError.str
+      Data: 719 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 712
+      ID: 719
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1621376
@@ -36143,7 +36147,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 643
+      ID: 650
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1753760
@@ -36204,7 +36208,7 @@ Types:
       GoRuntimeType: 584416
       GoKind: 26
     - __kind: StructureType
-      ID: 1136
+      ID: 1143
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2065344
@@ -36215,10 +36219,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1137 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1144 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1138 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1145 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -36233,18 +36237,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1139 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1146 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1139
+      ID: 1146
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995264
       GoKind: 9
     - __kind: StructureType
-      ID: 1137
+      ID: 1144
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1927040
@@ -36269,21 +36273,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1138
+      ID: 1145
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 588064
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1313
+      ID: 1320
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 861
+      ID: 868
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1429184
@@ -36293,13 +36297,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 752
+      ID: 759
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835424
       GoKind: 2
     - __kind: StructureType
-      ID: 1027
+      ID: 1034
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1707104
@@ -36312,7 +36316,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 981
+      ID: 988
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 994112

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -11881,21 +11881,21 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1402
+      ID: 1408
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 395 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
       ID: 141
       Name: '**main.deepSlice2'
       ByteSize: 8
       Pointee: 142 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1407
+      ID: 1414
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1408 PointerType *main.deepSlice3
+      Pointee: 1415 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1442
       Name: '**main.deepSlice8'
@@ -11913,7 +11913,7 @@ Types:
       GoKind: 22
       Pointee: 156 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1397
+      ID: 1404
       Name: '**main.t'
       ByteSize: 8
       Pointee: 255 PointerType *main.t
@@ -11951,20 +11951,20 @@ Types:
       ByteSize: 8
       Pointee: 209 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 384
+      ID: 422
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 385 PointerType *table<context.canceler,struct {}>
+      Pointee: 423 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 149
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 150 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1415
+      ID: 1422
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1416 PointerType *table<int,*main.deepMap3>
+      Pointee: 1423 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1459
       Name: '**table<int,*main.deepMap8>'
@@ -11996,10 +11996,10 @@ Types:
       ByteSize: 8
       Pointee: 214 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 695
+      ID: 693
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 696 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 694 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 203
       Name: '**table<string,[]main.structWithMap>'
@@ -12011,35 +12011,35 @@ Types:
       ByteSize: 8
       Pointee: 192 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 408
+      ID: 385
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 409 PointerType *table<string,float64>
+      Pointee: 386 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1148
+      ID: 1155
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1149 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1156 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 186
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 187 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 403
+      ID: 380
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 404 PointerType *table<string,interface {}>
+      Pointee: 381 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 181
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 182 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 398
+      ID: 375
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 399 PointerType *table<string,string>
+      Pointee: 376 PointerType *table<string,string>
     - __kind: PointerType
       ID: 238
       Name: '**table<struct {},int>'
@@ -12091,20 +12091,20 @@ Types:
       ByteSize: 8
       Pointee: 219 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1405
+      ID: 1411
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1404 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1410 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 434
+      ID: 441
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 433 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 440 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1411
+      ID: 1418
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1410 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1417 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1446
       Name: '*[]*main.deepSlice8.array'
@@ -12116,100 +12116,100 @@ Types:
       ByteSize: 8
       Pointee: 1451 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 429
+      ID: 436
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 428 GoSliceDataType []*runtime.p.array
+      Pointee: 435 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 431
+      ID: 438
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 430 GoSliceDataType []*string.array
+      Pointee: 437 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 594
+      ID: 601
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 593 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 600 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 591 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 598 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 288
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 590
+      ID: 597
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 589 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 596 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 286
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 283 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 588
+      ID: 595
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 587 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 594 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 284
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 281 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 586
+      ID: 593
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 585 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 592 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 574
+      ID: 581
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 573 GoSliceDataType [][]uint.array
+      Pointee: 580 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 578
+      ID: 585
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 577 GoSliceDataType []bool.array
+      Pointee: 584 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1185
+      ID: 1192
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1184 GoSliceDataType []float64.array
+      Pointee: 1191 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 691
+      ID: 689
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 690 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 688 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 699
+      ID: 697
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 696 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 655 GoSliceDataType []go.shape.float64.array
+      Pointee: 662 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 652
+      ID: 659
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 651 GoSliceDataType []go.shape.int.array
+      Pointee: 658 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 653 GoSliceDataType []go.shape.string.array
+      Pointee: 660 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
       ID: 1455
       Name: '*[]interface {}.array'
@@ -12221,20 +12221,20 @@ Types:
       ByteSize: 8
       Pointee: 279 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 584
+      ID: 591
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 583 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 590 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 701
+      ID: 708
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 700 GoSliceDataType []main.structWithMap.array
+      Pointee: 707 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 576
+      ID: 583
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 575 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 582 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 41
       Name: '*[]runtime.ancestorInfo'
@@ -12243,111 +12243,111 @@ Types:
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 446
+      ID: 453
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 445 GoSliceDataType []string.array
+      Pointee: 452 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 582
+      ID: 589
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 581 GoSliceDataType []struct {}.array
+      Pointee: 588 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 703
+      ID: 710
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 702 GoSliceDataType []time.zone.array
+      Pointee: 709 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 705
+      ID: 712
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 704 GoSliceDataType []time.zoneTrans.array
+      Pointee: 711 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 266
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 264 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 572
+      ID: 579
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 571 GoSliceDataType []uint.array
+      Pointee: 578 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 580
+      ID: 587
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 579 GoSliceDataType []uint16.array
+      Pointee: 586 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 424
+      ID: 431
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 423 GoSliceDataType []uint8.array
+      Pointee: 430 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 426
+      ID: 433
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 425 GoSliceDataType []uintptr.array
+      Pointee: 432 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1315
+      ID: 1322
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1996160
       GoKind: 22
-      Pointee: 1316 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1323 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 935040
       GoKind: 22
-      Pointee: 954 GoSliceHeaderType archive/tar.headerError
+      Pointee: 961 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 955 GoSliceDataType archive/tar.headerError.array
+      Pointee: 962 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1250
+      ID: 1257
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1442752
       GoKind: 22
-      Pointee: 1251 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1258 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1198
+      ID: 1205
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 935232
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1206 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1200
+      ID: 1207
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 935328
       GoKind: 22
-      Pointee: 1201 StructureType archive/zip.dirWriter
+      Pointee: 1208 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1294
+      ID: 1301
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1914304
       GoKind: 22
-      Pointee: 1295 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1302 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1226
+      ID: 1233
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1062400
       GoKind: 22
-      Pointee: 1227 StructureType archive/zip.nopCloser
+      Pointee: 1234 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1228
+      ID: 1235
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1062656
       GoKind: 22
-      Pointee: 1229 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1236 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 13
       Name: '*bool'
@@ -12356,491 +12356,491 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1273
+      ID: 1280
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2184960
       GoKind: 22
-      Pointee: 1274 UnresolvedPointeeType bufio.Reader
+      Pointee: 1281 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1304
+      ID: 1311
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1959808
       GoKind: 22
-      Pointee: 1305 UnresolvedPointeeType bufio.Writer
+      Pointee: 1312 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1353
+      ID: 1360
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2277824
       GoKind: 22
-      Pointee: 1354 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1361 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 917472
       GoKind: 22
-      Pointee: 752 BaseType compress/flate.CorruptInputError
+      Pointee: 759 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 917568
       GoKind: 22
-      Pointee: 753 GoStringHeaderType compress/flate.InternalError
+      Pointee: 760 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 754 GoStringDataType compress/flate.InternalError.str
+      Pointee: 761 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1248
+      ID: 1255
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1432352
       GoKind: 22
-      Pointee: 1249 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1256 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1194
+      ID: 1201
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 917664
       GoKind: 22
-      Pointee: 1195 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1202 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1270
+      ID: 1277
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1736192
       GoKind: 22
-      Pointee: 1271 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1278 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 1435
+      ID: 412
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1559456
       GoKind: 22
-      Pointee: 375 StructureType context.backgroundCtx
+      Pointee: 413 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 365
+      ID: 416
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1733888
       GoKind: 22
-      Pointee: 366 StructureType context.cancelCtx
+      Pointee: 417 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1069
+      ID: 1076
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1196672
       GoKind: 22
-      Pointee: 1070 StructureType context.deadlineExceededError
+      Pointee: 1077 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1430
+      ID: 399
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1420352
       GoKind: 22
-      Pointee: 376 StructureType context.emptyCtx
+      Pointee: 400 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 367
+      ID: 401
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1420512
       GoKind: 22
-      Pointee: 368 StructureType context.stopCtx
+      Pointee: 402 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 369
+      ID: 424
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1734080
       GoKind: 22
-      Pointee: 370 StructureType context.timerCtx
+      Pointee: 425 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1436
+      ID: 414
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1559616
       GoKind: 22
-      Pointee: 389 StructureType context.todoCtx
+      Pointee: 415 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 371
+      ID: 408
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1559136
       GoKind: 22
-      Pointee: 372 StructureType context.valueCtx
+      Pointee: 409 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 373
+      ID: 410
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1559296
       GoKind: 22
-      Pointee: 374 StructureType context.withoutCancelCtx
+      Pointee: 411 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929664
       GoKind: 22
-      Pointee: 766 BaseType crypto/aes.KeySizeError
+      Pointee: 773 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 929856
       GoKind: 22
-      Pointee: 767 BaseType crypto/des.KeySizeError
+      Pointee: 774 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 947
+      ID: 954
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930144
       GoKind: 22
-      Pointee: 768 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 775 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1265
+      ID: 1272
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1676544
       GoKind: 22
-      Pointee: 1266 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1273 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1050
+      ID: 1057
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1070208
       GoKind: 22
-      Pointee: 1051 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 1058 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1296
+      ID: 1303
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1914816
       GoKind: 22
-      Pointee: 1297 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1304 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1326
+      ID: 1333
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2130112
       GoKind: 22
-      Pointee: 1327 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1334 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1300
+      ID: 1307
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1915328
       GoKind: 22
-      Pointee: 1301 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1298
+      ID: 1305
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1915072
       GoKind: 22
-      Pointee: 1299 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1306 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1292
+      ID: 1299
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1912512
       GoKind: 22
-      Pointee: 1293 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1300 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 930432
       GoKind: 22
-      Pointee: 769 BaseType crypto/rc4.KeySizeError
+      Pointee: 776 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1313
+      ID: 1320
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1993280
       GoKind: 22
-      Pointee: 1314 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1321 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1288
+      ID: 1295
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1881888
       GoKind: 22
-      Pointee: 1289 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1296 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 869
+      ID: 876
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 919200
       GoKind: 22
-      Pointee: 756 BaseType crypto/tls.AlertError
+      Pointee: 763 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1039
+      ID: 1046
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1050752
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1047 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1379
+      ID: 1386
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2389344
       GoKind: 22
-      Pointee: 1380 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1387 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 918912
       GoKind: 22
-      Pointee: 866 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 873 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 918816
       GoKind: 22
-      Pointee: 864 StructureType crypto/tls.RecordHeaderError
+      Pointee: 871 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1049088
       GoKind: 22
-      Pointee: 993 BaseType crypto/tls.alert
+      Pointee: 1000 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1258
+      ID: 1265
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1567936
       GoKind: 22
-      Pointee: 1259 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1266 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 867
+      ID: 874
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 919008
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 875 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1263
+      ID: 1270
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1651200
       GoKind: 22
-      Pointee: 1264 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1271 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1136
+      ID: 1143
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1432832
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1144 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1150
+      ID: 1157
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2052448
       GoKind: 22
-      Pointee: 1151 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1158 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 928608
       GoKind: 22
-      Pointee: 940 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 947 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 928128
       GoKind: 22
-      Pointee: 934 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 941 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 928224
       GoKind: 22
-      Pointee: 936 StructureType crypto/x509.HostnameError
+      Pointee: 943 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 928032
       GoKind: 22
-      Pointee: 765 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 772 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1044
+      ID: 1051
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1056512
       GoKind: 22
-      Pointee: 1045 StructureType crypto/x509.SystemRootsError
+      Pointee: 1052 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 928704
       GoKind: 22
-      Pointee: 942 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 949 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 928512
       GoKind: 22
-      Pointee: 938 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 945 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 957
+      ID: 964
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 935520
       GoKind: 22
-      Pointee: 958 StructureType encoding/asn1.StructuralError
+      Pointee: 965 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 935712
       GoKind: 22
-      Pointee: 962 StructureType encoding/asn1.SyntaxError
+      Pointee: 969 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 935616
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 967 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 914880
       GoKind: 22
-      Pointee: 747 BaseType encoding/base64.CorruptInputError
+      Pointee: 754 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1216
+      ID: 1223
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1045504
       GoKind: 22
-      Pointee: 1217 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1224 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 915744
       GoKind: 22
-      Pointee: 748 BaseType encoding/hex.InvalidByteError
+      Pointee: 755 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 824 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 831 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1041664
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1036 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 909312
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 823 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 829 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 827 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 909408
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 825 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1359
+      ID: 1366
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2303360
       GoKind: 22
-      Pointee: 1360 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1367 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 910080
       GoKind: 22
-      Pointee: 826 StructureType encoding/json.jsonError
+      Pointee: 833 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1224
+      ID: 1231
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1059328
       GoKind: 22
-      Pointee: 1225 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1232 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927072
       GoKind: 22
-      Pointee: 928 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 935 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 925
+      ID: 932
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 926976
       GoKind: 22
-      Pointee: 926 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 933 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927168
       GoKind: 22
-      Pointee: 762 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 769 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 763 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 770 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 927264
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 938 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1337
+      ID: 1344
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2169952
       GoKind: 22
-      Pointee: 1338 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1345 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 108
       Name: '*error'
@@ -12849,19 +12849,19 @@ Types:
       GoKind: 22
       Pointee: 16 GoInterfaceType error
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 900384
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType errors.errorString
+      Pointee: 799 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 995
+      ID: 1002
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1027456
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType errors.joinError
+      Pointee: 1003 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 110
       Name: '*float32'
@@ -12877,625 +12877,625 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1347
+      ID: 1354
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2270144
       GoKind: 22
-      Pointee: 1348 UnresolvedPointeeType fmt.pp
+      Pointee: 1355 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1027584
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType fmt.wrapError
+      Pointee: 1005 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 999
+      ID: 1006
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1027712
       GoKind: 22
-      Pointee: 1000 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 1007 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 915264
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 861 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 912480
       GoKind: 22
-      Pointee: 835 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 842 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 837 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 844 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1162
+      ID: 1169
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 912288
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1170 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 840
+      ID: 847
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 912864
       GoKind: 22
-      Pointee: 841 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 848 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1164
+      ID: 1171
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 912384
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1172 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 912672
       GoKind: 22
-      Pointee: 741 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 748 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 742 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 912192
       GoKind: 22
-      Pointee: 738 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 745 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 740
+      ID: 747
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 739 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 746 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 912768
       GoKind: 22
-      Pointee: 744 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 751 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 745 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1236
+      ID: 1243
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1213952
       GoKind: 22
-      Pointee: 1237 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1244 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1323
+      ID: 1330
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2067136
       GoKind: 22
-      Pointee: 1324 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1331 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 951
+      ID: 958
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 933984
       GoKind: 22
-      Pointee: 952 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 959 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 390
+      ID: 395
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2288576
       GoKind: 22
-      Pointee: 391 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 365 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 416
+      ID: 393
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2017312
       GoKind: 22
-      Pointee: 417 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 394 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 411
+      ID: 388
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1196928
       GoKind: 22
-      Pointee: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 389 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 414
+      ID: 391
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1197056
       GoKind: 22
-      Pointee: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 392 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1428
+      ID: 1435
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1197696
       GoKind: 22
-      Pointee: 1429 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1436 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1197824
       GoKind: 22
-      Pointee: 713 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 720 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 418
+      ID: 396
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2235456
       GoKind: 22
-      Pointee: 419 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 397 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1104
+      ID: 1111
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1217536
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1112 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1355
+      ID: 1362
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2279872
       GoKind: 22
-      Pointee: 1356 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1363 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1431
+      ID: 404
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1426592
       GoKind: 22
-      Pointee: 1432 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 405 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 884 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 923616
       GoKind: 22
-      Pointee: 884 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 891 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 923328
       GoKind: 22
-      Pointee: 761 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 768 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 882 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 889 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 880 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 887 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 925536
       GoKind: 22
-      Pointee: 900 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 907 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 925728
       GoKind: 22
-      Pointee: 904 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 911 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 925632
       GoKind: 22
-      Pointee: 902 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 909 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 898 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 905 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1187
+      ID: 1194
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1186 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1193 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 926112
       GoKind: 22
-      Pointee: 912 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 919 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 925824
       GoKind: 22
-      Pointee: 906 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 913 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 926016
       GoKind: 22
-      Pointee: 910 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 917 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 925920
       GoKind: 22
-      Pointee: 908 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 915 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 926208
       GoKind: 22
-      Pointee: 914 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 921 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 920 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 927 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 926592
       GoKind: 22
-      Pointee: 922 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 929 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 926400
       GoKind: 22
-      Pointee: 918 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 925 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 926304
       GoKind: 22
-      Pointee: 916 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 923 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 926784
       GoKind: 22
-      Pointee: 924 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 931 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 914016
       GoKind: 22
-      Pointee: 843 StructureType github.com/cihub/seelog.baseError
+      Pointee: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1276
+      ID: 1283
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1812448
       GoKind: 22
-      Pointee: 1277 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1284 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 914112
       GoKind: 22
-      Pointee: 845 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 852 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1256
+      ID: 1263
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1566016
       GoKind: 22
-      Pointee: 1257 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1264 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1212
+      ID: 1219
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1044352
       GoKind: 22
-      Pointee: 1213 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1220 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1246
+      ID: 1253
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1430272
       GoKind: 22
-      Pointee: 1247 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1254 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 849 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 856 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1311
+      ID: 1318
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1984928
       GoKind: 22
-      Pointee: 1312 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1319 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1330
+      ID: 1337
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2142752
       GoKind: 22
-      Pointee: 1325 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1332 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1329
+      ID: 1336
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2142368
       GoKind: 22
-      Pointee: 1328 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1335 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1214
+      ID: 1221
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1044480
       GoKind: 22
-      Pointee: 1215 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1222 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 914208
       GoKind: 22
-      Pointee: 847 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 854 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 851 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 858 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1278
+      ID: 1285
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1814240
       GoKind: 22
-      Pointee: 1279 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1286 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1319
+      ID: 1326
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2021632
       GoKind: 22
-      Pointee: 1320 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1327 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1321
+      ID: 1328
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2052128
       GoKind: 22
-      Pointee: 1322 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1329 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1138
+      ID: 1145
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1445152
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1146 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1070976
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1062 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1070848
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1060 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1074944
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1064 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1075072
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1066 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1267
+      ID: 1274
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1678848
       GoKind: 22
-      Pointee: 1268 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1275 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1046
+      ID: 1053
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1057152
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1054 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 915936
       GoKind: 22
-      Pointee: 857 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 864 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1371
+      ID: 1378
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2365792
       GoKind: 22
-      Pointee: 1372 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1379 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1112
+      ID: 1119
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1227008
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1120 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1081
+      ID: 1088
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1205120
       GoKind: 22
-      Pointee: 1082 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1089 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1075
+      ID: 1082
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1204736
       GoKind: 22
-      Pointee: 1076 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1083 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1014
+      ID: 1021
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1035904
       GoKind: 22
-      Pointee: 1015 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1022 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1087
+      ID: 1094
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1205504
       GoKind: 22
-      Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1095 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1035776
       GoKind: 22
-      Pointee: 992 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 999 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1079
+      ID: 1086
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1204992
       GoKind: 22
-      Pointee: 1080 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1087 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1077
+      ID: 1084
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1204864
       GoKind: 22
-      Pointee: 1078 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1085 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1205376
       GoKind: 22
-      Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1093 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1205248
       GoKind: 22
-      Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1091 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1375
+      ID: 1382
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2378400
       GoKind: 22
-      Pointee: 1376 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1383 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1205888
       GoKind: 22
-      Pointee: 1092 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1099 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1018
+      ID: 1025
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1036160
       GoKind: 22
-      Pointee: 1019 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1026 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1016
+      ID: 1023
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1036032
       GoKind: 22
-      Pointee: 1017 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1024 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1089
+      ID: 1096
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1205760
       GoKind: 22
-      Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1097 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 948480
       GoKind: 22
-      Pointee: 774 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 781 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 775 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 782 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
       ID: 361
       Name: '*go.shape.float64'
@@ -13518,10 +13518,10 @@ Types:
       GoKind: 22
       Pointee: 334 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 650
+      ID: 657
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 649 GoStringDataType go.shape.string.str
+      Pointee: 656 GoStringDataType go.shape.string.str
     - __kind: PointerType
       ID: 340
       Name: '*go.shape.struct { Name string }'
@@ -13541,249 +13541,249 @@ Types:
       GoKind: 22
       Pointee: 356 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1153
+      ID: 1160
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1677312
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1161 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1089792
       GoKind: 22
-      Pointee: 1063 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1070 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1242
+      ID: 1249
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1266944
       GoKind: 22
-      Pointee: 1243 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1250 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1335
+      ID: 1342
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2158112
       GoKind: 22
-      Pointee: 1336 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1343 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1230
+      ID: 1237
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1092096
       GoKind: 22
-      Pointee: 1231 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1238 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 949728
       GoKind: 22
-      Pointee: 777 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 784 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1120
+      ID: 1127
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1268608
       GoKind: 22
-      Pointee: 1121 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1128 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 950016
       GoKind: 22
-      Pointee: 978 StructureType golang.org/x/net/http2.connError
+      Pointee: 985 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 949920
       GoKind: 22
-      Pointee: 781 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 788 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 782 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 789 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 950208
       GoKind: 22
-      Pointee: 787 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 794 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 788 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 795 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 950112
       GoKind: 22
-      Pointee: 784 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 791 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 785 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 792 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 949824
       GoKind: 22
-      Pointee: 778 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 785 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 779 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 786 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1333
+      ID: 1340
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2156192
       GoKind: 22
-      Pointee: 1334 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1341 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 981
+      ID: 988
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 950304
       GoKind: 22
-      Pointee: 982 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 989 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 950400
       GoKind: 22
-      Pointee: 790 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 797 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 943680
       GoKind: 22
-      Pointee: 970 StructureType google.golang.org/grpc.dropError
+      Pointee: 977 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1118
+      ID: 1125
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1265664
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1126 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1140
+      ID: 1147
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1452512
       GoKind: 22
-      Pointee: 1141 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1148 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 946752
       GoKind: 22
-      Pointee: 972 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 979 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1282
+      ID: 1289
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1820064
       GoKind: 22
-      Pointee: 1283 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1290 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1240
+      ID: 1247
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1262208
       GoKind: 22
-      Pointee: 1241 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1248 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1084032
       GoKind: 22
-      Pointee: 1061 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1068 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1202
+      ID: 1209
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 946848
       GoKind: 22
-      Pointee: 1203 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1210 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 949
+      ID: 956
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 957 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1048
+      ID: 1055
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1060736
       GoKind: 22
-      Pointee: 1049 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1056 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1116
+      ID: 1123
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1233536
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1124 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1233280
       GoKind: 22
-      Pointee: 1115 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1122 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 936576
       GoKind: 22
-      Pointee: 964 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 971 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 936672
       GoKind: 22
-      Pointee: 966 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 973 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 924000
       GoKind: 22
-      Pointee: 892 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 899 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1290
+      ID: 1297
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1910464
       GoKind: 22
-      Pointee: 1291 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1298 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 984
+      ID: 991
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 951168
       GoKind: 22
-      Pointee: 985 UnresolvedPointeeType html/template.Error
+      Pointee: 992 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 102
       Name: '*int'
@@ -13827,115 +13827,115 @@ Types:
       GoKind: 22
       Pointee: 164 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 1142
+      ID: 1149
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2222464
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType internal/abi.Type
+      Pointee: 1150 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 929280
       GoKind: 22
-      Pointee: 944 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 951 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 917184
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 867 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1192
+      ID: 1199
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 916320
       GoKind: 22
-      Pointee: 1193 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1200 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1110
+      ID: 1117
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1218816
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1118 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1377
+      ID: 1384
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2384064
       GoKind: 22
-      Pointee: 1378 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1385 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1108
+      ID: 1115
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1218688
       GoKind: 22
-      Pointee: 1109 StructureType internal/poll.errNetClosing
+      Pointee: 1116 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 904800
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 806 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 916992
       GoKind: 22
-      Pointee: 749 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 756 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 750 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 757 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 1032
+      ID: 1039
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1047680
       GoKind: 22
-      Pointee: 1033 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 1040 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1234
+      ID: 1241
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1196416
       GoKind: 22
-      Pointee: 1235 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1242 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1232
+      ID: 1239
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1196032
       GoKind: 22
-      Pointee: 1233 StructureType io.discard
+      Pointee: 1240 StructureType io.discard
     - __kind: PointerType
-      ID: 1206
+      ID: 1213
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1028480
       GoKind: 22
-      Pointee: 1207 UnresolvedPointeeType io.multiWriter
+      Pointee: 1214 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1106
+      ID: 1113
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1218176
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1114 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1280
+      ID: 1287
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1814464
       GoKind: 22
-      Pointee: 1281 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1288 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 347
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
@@ -13955,19 +13955,19 @@ Types:
       GoKind: 22
       Pointee: 324 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 441
+      ID: 448
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 388064
       GoKind: 22
-      Pointee: 442 StructureType main.deepMap2
+      Pointee: 449 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1423
+      ID: 1430
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 388000
       GoKind: 22
-      Pointee: 1424 UnresolvedPointeeType main.deepMap3
+      Pointee: 1431 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 151
       Name: '*main.deepMap7'
@@ -13997,12 +13997,12 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1381
+      ID: 1388
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 388576
       GoKind: 22
-      Pointee: 1382 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1389 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 137
       Name: '*main.deepPtr7'
@@ -14030,14 +14030,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 389216
       GoKind: 22
-      Pointee: 432 StructureType main.deepSlice2
+      Pointee: 439 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1408
+      ID: 1415
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 389152
       GoKind: 22
-      Pointee: 1409 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1416 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepSlice7'
@@ -14073,7 +14073,7 @@ Types:
       GoKind: 22
       Pointee: 167 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1394
+      ID: 1401
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 900096
@@ -14106,19 +14106,19 @@ Types:
       GoKind: 22
       Pointee: 160 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1395
+      ID: 1402
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 900192
       GoKind: 22
-      Pointee: 1396 StructureType main.secondBehavior
+      Pointee: 1403 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1387
+      ID: 1394
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 900288
       GoKind: 22
-      Pointee: 1388 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1395 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 153
       Name: '*main.stringType1'
@@ -14126,16 +14126,16 @@ Types:
       GoKind: 22
       Pointee: 154 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1384
+      ID: 1391
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1383 GoStringDataType main.stringType1.str
+      Pointee: 1390 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 156
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1385 GoStringHeaderType main.stringType2
+      Pointee: 1392 GoStringHeaderType main.stringType2
     - __kind: PointerType
       ID: 1501
       Name: '*main.stringType2.str'
@@ -14147,7 +14147,7 @@ Types:
       ByteSize: 8
       Pointee: 278 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 495
+      ID: 502
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 387552
@@ -14171,10 +14171,10 @@ Types:
       GoKind: 22
       Pointee: 256 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1399
+      ID: 1406
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1398 GoSliceDataType main.t.array
+      Pointee: 1405 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 275
       Name: '*main.threeStringStruct'
@@ -14202,20 +14202,20 @@ Types:
       ByteSize: 8
       Pointee: 207 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 382
+      ID: 420
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 383 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 421 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 147
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 148 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1413
+      ID: 1420
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1414 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1421 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1457
       Name: '*map<int,*main.deepMap8>'
@@ -14247,10 +14247,10 @@ Types:
       ByteSize: 8
       Pointee: 212 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 693
+      ID: 691
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 694 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 692 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 201
       Name: '*map<string,[]main.structWithMap>'
@@ -14262,35 +14262,35 @@ Types:
       ByteSize: 8
       Pointee: 190 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 406
+      ID: 383
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 407 GoSwissMapHeaderType map<string,float64>
+      Pointee: 384 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1146
+      ID: 1153
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1147 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1154 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 184
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 185 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 401
+      ID: 378
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 402 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 379 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 179
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 180 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 396
+      ID: 373
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 397 GoSwissMapHeaderType map<string,string>
+      Pointee: 374 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 236
       Name: '*map<struct {},int>'
@@ -14348,493 +14348,493 @@ Types:
       GoKind: 22
       Pointee: 183 GoMapType map[string]int
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 924864
       GoKind: 22
-      Pointee: 896 StructureType math/big.ErrNaN
+      Pointee: 903 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1196
+      ID: 1203
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 919680
       GoKind: 22
-      Pointee: 1197 StructureType mime/multipart.writerOnly·1
+      Pointee: 1204 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1098
+      ID: 1105
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1211776
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType net.AddrError
+      Pointee: 1106 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1428512
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType net.DNSError
+      Pointee: 1137 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1341
+      ID: 1348
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2242336
       GoKind: 22
-      Pointee: 1342 UnresolvedPointeeType net.IPConn
+      Pointee: 1349 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1127
+      ID: 1134
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1428192
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType net.OpError
+      Pointee: 1135 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1100
+      ID: 1107
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1211904
       GoKind: 22
-      Pointee: 1101 UnresolvedPointeeType net.ParseError
+      Pointee: 1108 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1351
+      ID: 1358
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2271168
       GoKind: 22
-      Pointee: 1352 UnresolvedPointeeType net.TCPConn
+      Pointee: 1359 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1361
+      ID: 1368
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2316672
       GoKind: 22
-      Pointee: 1362 UnresolvedPointeeType net.UDPConn
+      Pointee: 1369 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1349
+      ID: 1356
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2270656
       GoKind: 22
-      Pointee: 1350 UnresolvedPointeeType net.UnixConn
+      Pointee: 1357 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1097
+      ID: 1104
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1211008
       GoKind: 22
-      Pointee: 1066 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1073 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1068
+      ID: 1075
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1067 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1074 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1030
+      ID: 1037
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1042560
       GoKind: 22
-      Pointee: 1031 StructureType net.canceledError
+      Pointee: 1038 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1317
+      ID: 1324
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2019040
       GoKind: 22
-      Pointee: 1318 UnresolvedPointeeType net.conn
+      Pointee: 1325 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1171
+      ID: 1178
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1856576
       GoKind: 22
-      Pointee: 1172 StructureType net.dialResult·1
+      Pointee: 1179 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1363
+      ID: 1370
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2320928
       GoKind: 22
-      Pointee: 1364 UnresolvedPointeeType net.netFD
+      Pointee: 1371 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 911040
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net.notFoundError
+      Pointee: 835 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1433
+      ID: 406
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1428352
       GoKind: 22
-      Pointee: 1434 StructureType net.onlyValuesCtx
+      Pointee: 407 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 911712
       GoKind: 22
-      Pointee: 830 StructureType net.result·2
+      Pointee: 837 StructureType net.result·2
     - __kind: PointerType
-      ID: 1345
+      ID: 1352
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2256704
       GoKind: 22
-      Pointee: 1346 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1353 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1343
+      ID: 1350
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2256224
       GoKind: 22
-      Pointee: 1344 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1351 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1102
+      ID: 1109
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1212544
       GoKind: 22
-      Pointee: 1103 UnresolvedPointeeType net.temporaryError
+      Pointee: 1110 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1131
+      ID: 1138
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1428672
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType net.timeoutError
+      Pointee: 1139 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1020
+      ID: 1027
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1038592
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1028 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1188
+      ID: 1195
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 906816
       GoKind: 22
-      Pointee: 1189 StructureType net/http.bufioFlushWriter
+      Pointee: 1196 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 907488
       GoKind: 22
-      Pointee: 719 BaseType net/http.http2ConnectionError
+      Pointee: 726 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 907584
       GoKind: 22
-      Pointee: 806 StructureType net/http.http2GoAwayError
+      Pointee: 813 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1123
+      ID: 1130
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1424512
       GoKind: 22
-      Pointee: 1124 StructureType net/http.http2StreamError
+      Pointee: 1131 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 908160
       GoKind: 22
-      Pointee: 810 StructureType net/http.http2connError
+      Pointee: 817 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1252
+      ID: 1259
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1563136
       GoKind: 22
-      Pointee: 1253 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1260 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 908064
       GoKind: 22
-      Pointee: 723 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 730 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 725
+      ID: 732
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 724 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 731 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 729 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 736 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 730 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 737 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 908256
       GoKind: 22
-      Pointee: 726 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 733 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 727 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 734 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1207808
       GoKind: 22
-      Pointee: 1096 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1103 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1039232
       GoKind: 22
-      Pointee: 1027 StructureType net/http.http2noCachedConnError
+      Pointee: 1034 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1306
+      ID: 1313
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1961088
       GoKind: 22
-      Pointee: 1307 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1314 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 907968
       GoKind: 22
-      Pointee: 720 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 727 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 721 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 728 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1190
+      ID: 1197
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 908448
       GoKind: 22
-      Pointee: 1191 StructureType net/http.http2stickyErrWriter
+      Pointee: 1198 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1022
+      ID: 1029
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1038848
       GoKind: 22
-      Pointee: 1023 StructureType net/http.nothingWrittenError
+      Pointee: 1030 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1254
+      ID: 1261
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2186208
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1262 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1210
+      ID: 1217
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1038720
       GoKind: 22
-      Pointee: 1211 StructureType net/http.persistConnWriter
+      Pointee: 1218 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1244
+      ID: 1251
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1424672
       GoKind: 22
-      Pointee: 1245 StructureType net/http.readWriteCloserBody
+      Pointee: 1252 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 908544
       GoKind: 22
-      Pointee: 814 StructureType net/http.requestBodyReadError
+      Pointee: 821 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1125
+      ID: 1132
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1425792
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1133 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1207680
       GoKind: 22
-      Pointee: 1094 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1101 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1038976
       GoKind: 22
-      Pointee: 1025 StructureType net/http.transportReadFromServerError
+      Pointee: 1032 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1286
+      ID: 1293
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1853440
       GoKind: 22
-      Pointee: 1287 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1294 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 906720
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 810 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1308
+      ID: 1315
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1963136
       GoKind: 22
-      Pointee: 1309 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1316 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1220
+      ID: 1227
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1051904
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1228 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 923808
       GoKind: 22
-      Pointee: 888 StructureType net/netip.parseAddrError
+      Pointee: 895 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 886 StructureType net/netip.parsePrefixError
+      Pointee: 893 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1260
+      ID: 1267
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2128704
       GoKind: 22
-      Pointee: 1261 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1268 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1222
+      ID: 1229
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1056768
       GoKind: 22
-      Pointee: 1223 StructureType net/smtp.dataCloser
+      Pointee: 1230 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 919872
       GoKind: 22
-      Pointee: 872 UnresolvedPointeeType net/textproto.Error
+      Pointee: 879 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 919776
       GoKind: 22
-      Pointee: 757 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 764 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 758 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 765 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1218
+      ID: 1225
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1051136
       GoKind: 22
-      Pointee: 1219 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1226 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1133
+      ID: 1140
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1428992
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType net/url.Error
+      Pointee: 1141 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 911808
       GoKind: 22
-      Pointee: 732 GoStringHeaderType net/url.EscapeError
+      Pointee: 739 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 733 GoStringDataType net/url.EscapeError.str
+      Pointee: 740 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 832
+      ID: 839
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 911904
       GoKind: 22
-      Pointee: 735 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 742 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 736 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 743 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 541
+      ID: 548
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 542 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 549 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 533
+      ID: 540
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 534 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 541 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 481
+      ID: 488
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 482 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 489 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 500
+      ID: 507
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 501 StructureType noalg.map.group[bool]main.node
+      Pointee: 508 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 659
+      ID: 700
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 660 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 701 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 437
+      ID: 444
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 438 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 445 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1419
+      ID: 1426
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1420 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1427 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1463
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -14846,230 +14846,230 @@ Types:
       ByteSize: 8
       Pointee: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 449
+      ID: 456
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 450 StructureType noalg.map.group[int]int
+      Pointee: 457 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 1493
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 557
+      ID: 564
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 558 StructureType noalg.map.group[int]struct {}
+      Pointee: 565 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 508
+      ID: 515
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 509 StructureType noalg.map.group[int]uint8
+      Pointee: 516 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 708
+      ID: 715
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 716 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 490
+      ID: 497
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 491 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 498 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 473
+      ID: 480
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 474 StructureType noalg.map.group[string][]string
+      Pointee: 481 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 684
+      ID: 682
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 685 StructureType noalg.map.group[string]float64
+      Pointee: 683 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1178
+      ID: 1185
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1186 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 465
+      ID: 472
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 466 StructureType noalg.map.group[string]int
+      Pointee: 473 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 676
+      ID: 674
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 677 StructureType noalg.map.group[string]interface {}
+      Pointee: 675 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 457
+      ID: 464
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 458 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 465 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 668
+      ID: 666
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 669 StructureType noalg.map.group[string]string
+      Pointee: 667 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 549
+      ID: 556
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 550 StructureType noalg.map.group[struct {}]int
+      Pointee: 557 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 597
+      ID: 604
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 605 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 605
+      ID: 612
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 613 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 613
+      ID: 620
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 621
+      ID: 628
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 645 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 565
+      ID: 572
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 566 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 573 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 524
+      ID: 531
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 525 StructureType noalg.map.group[uint8][4]int
+      Pointee: 532 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 516
+      ID: 523
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 517 StructureType noalg.map.group[uint8]uint8
+      Pointee: 524 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1369
+      ID: 1376
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2360416
       GoKind: 22
-      Pointee: 1370 UnresolvedPointeeType os.File
+      Pointee: 1377 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1032192
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType os.LinkError
+      Pointee: 1011 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1071
+      ID: 1078
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1200896
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType os.SyscallError
+      Pointee: 1079 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1367
+      ID: 1374
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2358944
       GoKind: 22
-      Pointee: 1368 StructureType os.fileWithoutReadFrom
+      Pointee: 1375 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1365
+      ID: 1372
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2358208
       GoKind: 22
-      Pointee: 1366 StructureType os.fileWithoutWriteTo
+      Pointee: 1373 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1034
+      ID: 1041
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1047808
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType os/exec.Error
+      Pointee: 1042 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1174
+      ID: 1181
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2099264
       GoKind: 22
-      Pointee: 1175 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1182 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1238
+      ID: 1245
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1219712
       GoKind: 22
-      Pointee: 1239 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1246 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1036
+      ID: 1043
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1047936
       GoKind: 22
-      Pointee: 1037 StructureType os/exec.wrappedError
+      Pointee: 1044 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 941760
       GoKind: 22
-      Pointee: 771 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 778 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 772 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 779 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 941664
       GoKind: 22
-      Pointee: 770 BaseType os/user.UnknownUserIdError
+      Pointee: 777 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType reflect.ValueError
+      Pointee: 808 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 924480
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 901 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1033216
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1015 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1035008
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1019 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 28
       Name: '*runtime._defer'
@@ -15085,12 +15085,12 @@ Types:
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1033344
       GoKind: 22
-      Pointee: 1010 StructureType runtime.boundsError
+      Pointee: 1017 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 67
       Name: '*runtime.cgoCallers'
@@ -15106,24 +15106,24 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1073
+      ID: 1080
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1203328
       GoKind: 22
-      Pointee: 1074 StructureType runtime.errorAddressString
+      Pointee: 1081 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 1005
+      ID: 1012
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1032832
       GoKind: 22
-      Pointee: 986 GoStringHeaderType runtime.errorString
+      Pointee: 993 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 988
+      ID: 995
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 987 GoStringDataType runtime.errorString.str
+      Pointee: 994 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 57
       Name: '*runtime.g'
@@ -15144,19 +15144,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1034368
       GoKind: 22
-      Pointee: 427 UnresolvedPointeeType runtime.p
+      Pointee: 434 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 1006
+      ID: 1013
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1032960
       GoKind: 22
-      Pointee: 989 GoStringHeaderType runtime.plainError
+      Pointee: 996 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 990 GoStringDataType runtime.plainError.str
+      Pointee: 997 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 43
       Name: '*runtime.sudog'
@@ -15172,12 +15172,12 @@ Types:
       GoKind: 22
       Pointee: 52 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 904512
       GoKind: 22
-      Pointee: 797 StructureType runtime.synctestDeadlockError
+      Pointee: 804 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 46
       Name: '*runtime.timer'
@@ -15193,12 +15193,12 @@ Types:
       GoKind: 22
       Pointee: 82 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1031040
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType strconv.NumError
+      Pointee: 1009 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 97
       Name: '*string'
@@ -15207,31 +15207,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 422
+      ID: 429
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 421 GoStringDataType string.str
+      Pointee: 428 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1302
+      ID: 1309
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1959296
       GoKind: 22
-      Pointee: 1303 UnresolvedPointeeType strings.Builder
+      Pointee: 1310 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1208
+      ID: 1215
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1031168
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1216 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1204
+      ID: 1211
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 975712
       GoKind: 22
-      Pointee: 1205 StructureType struct { io.Writer }
+      Pointee: 1212 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 273
       Name: '*struct {}'
@@ -15240,47 +15240,47 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType struct {}
     - __kind: PointerType
-      ID: 1135
+      ID: 1142
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1431232
       GoKind: 22
-      Pointee: 1122 BaseType syscall.Errno
+      Pointee: 1129 BaseType syscall.Errno
     - __kind: PointerType
       ID: 234
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 539 StructureType table<[4]int,[4]int>
+      Pointee: 546 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 229
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 531 StructureType table<[4]int,uint8>
+      Pointee: 538 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 197
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 479 StructureType table<[4]string,[2]int>
+      Pointee: 486 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 209
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 498 StructureType table<bool,main.node>
+      Pointee: 505 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 385
+      ID: 423
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 657 StructureType table<context.canceler,struct {}>
+      Pointee: 698 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 150
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 435 StructureType table<int,*main.deepMap2>
+      Pointee: 442 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1416
+      ID: 1423
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1417 StructureType table<int,*main.deepMap3>
+      Pointee: 1424 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1460
       Name: '*table<int,*main.deepMap8>'
@@ -15295,7 +15295,7 @@ Types:
       ID: 177
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 447 StructureType table<int,int>
+      Pointee: 454 StructureType table<int,int>
     - __kind: PointerType
       ID: 1490
       Name: '*table<int,interface {}>'
@@ -15305,121 +15305,121 @@ Types:
       ID: 244
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 555 StructureType table<int,struct {}>
+      Pointee: 562 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 214
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 506 StructureType table<int,uint8>
+      Pointee: 513 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 696
+      ID: 694
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 706 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 713 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 204
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 488 StructureType table<string,[]main.structWithMap>
+      Pointee: 495 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 192
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 471 StructureType table<string,[]string>
+      Pointee: 478 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 409
+      ID: 386
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 682 StructureType table<string,float64>
+      Pointee: 680 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1149
+      ID: 1156
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1176 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1183 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 187
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 463 StructureType table<string,int>
+      Pointee: 470 StructureType table<string,int>
     - __kind: PointerType
-      ID: 404
+      ID: 381
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 674 StructureType table<string,interface {}>
+      Pointee: 672 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 182
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 455 StructureType table<string,main.nestedStruct>
+      Pointee: 462 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 399
+      ID: 376
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 666 StructureType table<string,string>
+      Pointee: 664 StructureType table<string,string>
     - __kind: PointerType
       ID: 239
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 547 StructureType table<struct {},int>
+      Pointee: 554 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 296
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 595 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 602 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 301
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 603 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 610 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 306
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 611 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 618 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 311
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 619 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 626 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 316
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 627 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 634 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 321
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 635 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 642 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 249
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 563 StructureType table<struct {},struct {}>
+      Pointee: 570 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 224
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 522 StructureType table<uint8,[4]int>
+      Pointee: 529 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 219
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 514 StructureType table<uint8,uint8>
+      Pointee: 521 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1339
+      ID: 1346
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2170336
       GoKind: 22
-      Pointee: 1340 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1347 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1093632
       GoKind: 22
-      Pointee: 1065 StructureType text/template.ExecError
+      Pointee: 1072 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 329
       Name: '*time.Location'
@@ -15428,45 +15428,45 @@ Types:
       GoKind: 22
       Pointee: 330 StructureType time.Location
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902784
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType time.ParseError
+      Pointee: 802 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 387
+      ID: 426
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1032576
       GoKind: 22
-      Pointee: 388 StructureType time.Timer
+      Pointee: 427 StructureType time.Timer
     - __kind: PointerType
-      ID: 793
+      ID: 800
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902688
       GoKind: 22
-      Pointee: 716 GoStringHeaderType time.fileSizeError
+      Pointee: 723 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 717 GoStringDataType time.fileSizeError.str
+      Pointee: 724 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 644
+      ID: 651
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 394784
       GoKind: 22
-      Pointee: 645 StructureType time.zone
+      Pointee: 652 StructureType time.zone
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 394848
       GoKind: 22
-      Pointee: 648 StructureType time.zoneTrans
+      Pointee: 655 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 109
       Name: '*uint'
@@ -15510,49 +15510,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 923904
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 897 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1331
+      ID: 1338
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2145824
       GoKind: 22
-      Pointee: 1332 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1339 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 920064
       GoKind: 22
-      Pointee: 874 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 881 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 875
+      ID: 882
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 760 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 767 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1041
+      ID: 1048
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1051648
       GoKind: 22
-      Pointee: 1042 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1049 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1043
+      ID: 1050
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1051776
       GoKind: 22
-      Pointee: 994 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 1001 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1400
+      ID: 1412
       Name: <-chan time.Time
       GoRuntimeType: 600128
       GoKind: 18
@@ -26286,7 +26286,7 @@ Types:
       HasCount: true
       Element: 34 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 528
+      ID: 535
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 686592
@@ -26295,7 +26295,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 485
+      ID: 492
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 686880
@@ -26321,7 +26321,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1166
+      ID: 1173
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 688416
@@ -26330,7 +26330,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1386
+      ID: 1393
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -26356,7 +26356,7 @@ Types:
       HasCount: true
       Element: 88 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1401
+      ID: 1407
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 484128
@@ -26364,20 +26364,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1402 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1408 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1404 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1410 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1404
+      ID: 1410
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 395 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
       ID: 140
       Name: '[]*main.deepSlice2'
@@ -26394,15 +26394,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 433 GoSliceDataType []*main.deepSlice2.array
+      Data: 440 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 433
+      ID: 440
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 142 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1406
+      ID: 1413
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 480032
@@ -26410,20 +26410,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1407 PointerType **main.deepSlice3
+          Type: 1414 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1410 GoSliceDataType []*main.deepSlice3.array
+      Data: 1417 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1410
+      ID: 1417
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1408 PointerType *main.deepSlice3
+      Element: 1415 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1441
       Name: '[]*main.deepSlice8'
@@ -26486,9 +26486,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 428 GoSliceDataType []*runtime.p.array
+      Data: 435 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 428
+      ID: 435
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26509,55 +26509,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 430 GoSliceDataType []*string.array
+      Data: 437 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 430
+      ID: 437
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 97 PointerType *string
     - __kind: GoSliceDataType
-      ID: 545
+      ID: 552
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 234 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 537
+      ID: 544
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 229 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 486
+      ID: 493
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 197 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 504
+      ID: 511
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 209 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 664
+      ID: 705
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 385 PointerType *table<context.canceler,struct {}>
+      Element: 423 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 450
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 150 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1425
+      ID: 1432
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1416 PointerType *table<int,*main.deepMap3>
+      Element: 1423 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1469
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -26571,7 +26571,7 @@ Types:
       ByteSize: 8
       Element: 1475 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 460
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26583,127 +26583,127 @@ Types:
       ByteSize: 8
       Element: 1490 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 561
+      ID: 568
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 244 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 512
+      ID: 519
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 214 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 721
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 696 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 694 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 503
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 204 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 484
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 192 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 688
+      ID: 686
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 409 PointerType *table<string,float64>
+      Element: 386 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1182
+      ID: 1189
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1149 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1156 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 476
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 187 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 680
+      ID: 678
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 404 PointerType *table<string,interface {}>
+      Element: 381 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 468
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 182 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 672
+      ID: 670
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 399 PointerType *table<string,string>
+      Element: 376 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 553
+      ID: 560
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 239 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 601
+      ID: 608
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 296 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 609
+      ID: 616
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 301 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 617
+      ID: 624
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 306 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 625
+      ID: 632
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 311 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 633
+      ID: 640
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 316 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 641
+      ID: 648
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 321 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 569
+      ID: 576
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 249 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 536
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 224 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 527
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26723,9 +26723,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 593 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 600 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 593
+      ID: 600
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26745,9 +26745,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 591 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 598 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 591
+      ID: 598
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26767,9 +26767,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 589 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 596 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 589
+      ID: 596
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26789,9 +26789,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 587 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 594 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 587
+      ID: 594
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26811,9 +26811,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 585 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 592 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 585
+      ID: 592
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26833,9 +26833,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 573 GoSliceDataType [][]uint.array
+      Data: 580 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 573
+      ID: 580
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26856,15 +26856,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 577 GoSliceDataType []bool.array
+      Data: 584 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 577
+      ID: 584
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1161
+      ID: 1168
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 490400
@@ -26879,15 +26879,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1184 GoSliceDataType []float64.array
+      Data: 1191 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1184
+      ID: 1191
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 410
+      ID: 387
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 483680
@@ -26895,22 +26895,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 411 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 388 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 690 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 688 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 690
+      ID: 688
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 412 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 389 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 413
+      ID: 390
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 483872
@@ -26918,20 +26918,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 414 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 391 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 696 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 698
+      ID: 696
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 415 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 392 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
       ID: 360
       Name: '[]go.shape.float64'
@@ -26948,9 +26948,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 655 GoSliceDataType []go.shape.float64.array
+      Data: 662 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 655
+      ID: 662
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26970,9 +26970,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 651 GoSliceDataType []go.shape.int.array
+      Data: 658 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 651
+      ID: 658
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26992,9 +26992,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 653 GoSliceDataType []go.shape.string.array
+      Data: 660 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 653
+      ID: 660
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -27037,15 +27037,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 583 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 590 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 583
+      ID: 590
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 278 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 494
+      ID: 501
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 480672
@@ -27053,16 +27053,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 495 PointerType *main.structWithMap
+          Type: 502 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 700 GoSliceDataType []main.structWithMap.array
+      Data: 707 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 700
+      ID: 707
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -27082,55 +27082,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 575 GoSliceDataType []main.structWithNoStrings.array
+      Data: 582 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 575
+      ID: 582
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 269 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 546
+      ID: 553
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 542 StructureType noalg.map.group[[4]int][4]int
+      Element: 549 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 538
+      ID: 545
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 534 StructureType noalg.map.group[[4]int]uint8
+      Element: 541 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 494
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 482 StructureType noalg.map.group[[4]string][2]int
+      Element: 489 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 505
+      ID: 512
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 501 StructureType noalg.map.group[bool]main.node
+      Element: 508 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 706
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 660 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 701 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 444
+      ID: 451
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 438 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 445 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1426
+      ID: 1433
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1420 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1427 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1470
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -27144,11 +27144,11 @@ Types:
       ByteSize: 136
       Element: 1479 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 461
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 450 StructureType noalg.map.group[int]int
+      Element: 457 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 1498
       Name: '[]noalg.map.group[int]interface {}.array'
@@ -27156,131 +27156,131 @@ Types:
       ByteSize: 200
       Element: 1494 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 562
+      ID: 569
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 558 StructureType noalg.map.group[int]struct {}
+      Element: 565 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 513
+      ID: 520
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 509 StructureType noalg.map.group[int]uint8
+      Element: 516 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 715
+      ID: 722
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 716 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 504
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 491 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 498 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 485
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 474 StructureType noalg.map.group[string][]string
+      Element: 481 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 689
+      ID: 687
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 685 StructureType noalg.map.group[string]float64
+      Element: 683 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1183
+      ID: 1190
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1186 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 477
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 466 StructureType noalg.map.group[string]int
+      Element: 473 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 681
+      ID: 679
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 677 StructureType noalg.map.group[string]interface {}
+      Element: 675 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 462
+      ID: 469
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 458 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 465 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 673
+      ID: 671
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 669 StructureType noalg.map.group[string]string
+      Element: 667 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 554
+      ID: 561
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 550 StructureType noalg.map.group[struct {}]int
+      Element: 557 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 602
+      ID: 609
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 605 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 610
+      ID: 617
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 613 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 618
+      ID: 625
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 626
+      ID: 633
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 634
+      ID: 641
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 642
+      ID: 649
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 645 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 570
+      ID: 577
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 566 StructureType noalg.map.group[struct {}]struct {}
+      Element: 573 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 537
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 525 StructureType noalg.map.group[uint8][4]int
+      Element: 532 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 521
+      ID: 528
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 517 StructureType noalg.map.group[uint8]uint8
+      Element: 524 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 42
       Name: '[]runtime.ancestorInfo'
@@ -27301,9 +27301,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 445 GoSliceDataType []string.array
+      Data: 452 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 445
+      ID: 452
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -27323,14 +27323,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 581 GoSliceDataType []struct {}.array
+      Data: 588 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 581
+      ID: 588
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 127 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 643
+      ID: 650
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 489056
@@ -27338,22 +27338,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 644 PointerType *time.zone
+          Type: 651 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 702 GoSliceDataType []time.zone.array
+      Data: 709 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 702
+      ID: 709
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 645 StructureType time.zone
+      Element: 652 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 646
+      ID: 653
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 489120
@@ -27361,20 +27361,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 647 PointerType *time.zoneTrans
+          Type: 654 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 704 GoSliceDataType []time.zoneTrans.array
+      Data: 711 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 704
+      ID: 711
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 648 StructureType time.zoneTrans
+      Element: 655 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 264
       Name: '[]uint'
@@ -27391,9 +27391,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 571 GoSliceDataType []uint.array
+      Data: 578 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 571
+      ID: 578
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -27414,9 +27414,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 579 GoSliceDataType []uint16.array
+      Data: 586 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 579
+      ID: 586
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -27437,9 +27437,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 423 GoSliceDataType []uint8.array
+      Data: 430 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 423
+      ID: 430
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -27460,19 +27460,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 425 GoSliceDataType []uintptr.array
+      Data: 432 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 425
+      ID: 432
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1316
+      ID: 1323
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 954
+      ID: 961
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 935136
@@ -27487,33 +27487,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 955 GoSliceDataType archive/tar.headerError.array
+      Data: 962 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 955
+      ID: 962
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1251
+      ID: 1258
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1206
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1201
+      ID: 1208
       Name: archive/zip.dirWriter
       GoRuntimeType: 1125824
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1295
+      ID: 1302
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1227
+      ID: 1234
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1573856
@@ -27523,7 +27523,7 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1229
+      ID: 1236
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -27533,15 +27533,15 @@ Types:
       GoRuntimeType: 588096
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1274
+      ID: 1281
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1305
+      ID: 1312
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1354
+      ID: 1361
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -27567,13 +27567,13 @@ Types:
       GoRuntimeType: 587840
       GoKind: 15
     - __kind: BaseType
-      ID: 752
+      ID: 759
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 838112
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 753
+      ID: 760
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 838208
@@ -27581,26 +27581,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 755 PointerType *compress/flate.InternalError.str
+          Type: 762 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 754 GoStringDataType compress/flate.InternalError.str
+      Data: 761 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 754
+      ID: 761
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1249
+      ID: 1256
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1195
+      ID: 1202
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1271
+      ID: 1278
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27617,19 +27617,19 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 375
+      ID: 413
       Name: context.backgroundCtx
       GoRuntimeType: 1808640
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 376 StructureType context.emptyCtx
+          Type: 400 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 366
+      ID: 417
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1975424
@@ -27640,23 +27640,23 @@ Types:
           Type: 157 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 377 StructureType sync.Mutex
+          Type: 367 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 380 StructureType sync/atomic.Value
+          Type: 418 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 381 GoMapType map[context.canceler]struct {}
+          Type: 419 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 380 StructureType sync/atomic.Value
+          Type: 418 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 16 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 663
+      ID: 704
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1116480
@@ -27669,13 +27669,13 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1070
+      ID: 1077
       Name: context.deadlineExceededError
       GoRuntimeType: 1471936
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 376
+      ID: 400
       Name: context.emptyCtx
       GoRuntimeType: 1603648
       GoKind: 25
@@ -27684,7 +27684,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 368
+      ID: 402
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1833888
@@ -27695,11 +27695,11 @@ Types:
           Type: 157 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 386 GoSubroutineType func() bool
+          Type: 403 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 370
+      ID: 425
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1622400
@@ -27707,29 +27707,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 366 StructureType context.cancelCtx
+          Type: 417 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 387 PointerType *time.Timer
+          Type: 426 PointerType *time.Timer
         - Name: deadline
           Offset: 88
           Type: 328 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 389
+      ID: 415
       Name: context.todoCtx
       GoRuntimeType: 1808864
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 376 StructureType context.emptyCtx
+          Type: 400 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 409
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1846272
@@ -27747,7 +27747,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 374
+      ID: 411
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1808416
@@ -27759,87 +27759,87 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 766
+      ID: 773
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 840704
       GoKind: 2
     - __kind: BaseType
-      ID: 767
+      ID: 774
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 840800
       GoKind: 2
     - __kind: BaseType
-      ID: 768
+      ID: 775
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 840896
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1266
+      ID: 1273
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 1051
+      ID: 1058
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1295680
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1297
+      ID: 1304
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1327
+      ID: 1334
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1301
+      ID: 1308
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1299
+      ID: 1306
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1293
+      ID: 1300
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 769
+      ID: 776
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 840992
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1314
+      ID: 1321
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1289
+      ID: 1296
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 756
+      ID: 763
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 838688
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1047
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1380
+      ID: 1387
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 866
+      ID: 873
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 871
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1740416
@@ -27850,38 +27850,38 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1166 ArrayType [5]uint8
+          Type: 1173 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 993
+      ID: 1000
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 998080
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1259
+      ID: 1266
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 875
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1264
+      ID: 1271
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1144
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1151
+      ID: 1158
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 940
+      ID: 947
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1743296
@@ -27889,21 +27889,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1150 PointerType *crypto/x509.Certificate
+          Type: 1157 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1169 BaseType crypto/x509.InvalidReason
+          Type: 1176 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 934
+      ID: 941
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1123392
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 936
+      ID: 943
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1607968
@@ -27911,24 +27911,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1150 PointerType *crypto/x509.Certificate
+          Type: 1157 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 765
+      ID: 772
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 840320
       GoKind: 2
     - __kind: BaseType
-      ID: 1169
+      ID: 1176
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 593280
       GoKind: 2
     - __kind: StructureType
-      ID: 1045
+      ID: 1052
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1569856
@@ -27938,13 +27938,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 942
+      ID: 949
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1123648
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 938
+      ID: 945
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1743104
@@ -27952,15 +27952,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1150 PointerType *crypto/x509.Certificate
+          Type: 1157 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 16 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1150 PointerType *crypto/x509.Certificate
+          Type: 1157 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 958
+      ID: 965
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1443392
@@ -27970,7 +27970,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 962
+      ID: 969
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1443552
@@ -27980,55 +27980,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 967
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 747
+      ID: 754
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 837632
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1217
+      ID: 1224
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 748
+      ID: 755
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 837824
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 824
+      ID: 831
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1036
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1360
+      ID: 1367
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 826
+      ID: 833
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1427232
@@ -28038,19 +28038,19 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1225
+      ID: 1232
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 928
+      ID: 935
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 926
+      ID: 933
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 762
+      ID: 769
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 840224
@@ -28058,22 +28058,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 764 PointerType *encoding/xml.UnmarshalError.str
+          Type: 771 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 763 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 770 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 763
+      ID: 770
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1338
+      ID: 1345
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -28090,11 +28090,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 799
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 1003
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -28110,15 +28110,15 @@ Types:
       GoRuntimeType: 588032
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1348
+      ID: 1355
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1005
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1000
+      ID: 1007
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -28128,7 +28128,7 @@ Types:
       GoRuntimeType: 478112
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 386
+      ID: 403
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 598976
@@ -28173,11 +28173,11 @@ Types:
           Offset: 0
           Type: 334 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 861
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1739264
@@ -28185,7 +28185,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1159 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1166 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -28193,25 +28193,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 837
+      ID: 844
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1170
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 841
+      ID: 848
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1119168
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1172
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 741
+      ID: 748
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 837056
@@ -28219,18 +28219,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 743 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 750 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 742 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 742
+      ID: 749
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1159
+      ID: 1166
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2229632
@@ -28238,7 +28238,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1160 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1167 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28253,7 +28253,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1161 GoSliceHeaderType []float64
+          Type: 1168 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -28262,10 +28262,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1162 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1169 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1164 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1171 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 161 GoSliceHeaderType []string
@@ -28279,13 +28279,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 1160
+      ID: 1167
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 589696
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 738
+      ID: 745
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 836960
@@ -28293,18 +28293,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 740 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 747 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 739 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 746 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 739
+      ID: 746
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 744
+      ID: 751
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 837152
@@ -28312,30 +28312,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 746 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 753 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 745 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 745
+      ID: 752
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1237
+      ID: 1244
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1324
+      ID: 1331
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 952
+      ID: 959
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 391
+      ID: 365
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2350304
@@ -28343,7 +28343,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 392 StructureType sync.RWMutex
+          Type: 366 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -28364,13 +28364,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 400 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 377 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 405 GoMapType map[string]float64
+          Type: 382 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -28385,10 +28385,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 387 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 413 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 390 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -28400,7 +28400,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 416 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 393 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -28423,7 +28423,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 417
+      ID: 394
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2227392
@@ -28434,13 +28434,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 418 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 396 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 395 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 393 StructureType sync/atomic.Int32
+          Type: 370 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28449,16 +28449,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 420 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 398 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 392 StructureType sync.RWMutex
+          Type: 366 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -28467,12 +28467,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 410 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 387 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 412
+      ID: 389
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1921664
@@ -28489,7 +28489,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28497,20 +28497,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 400
+      ID: 377
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1288896
       GoKind: 21
-      HeaderType: 402 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 379 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1403
+      ID: 1409
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 586880
       GoKind: 10
     - __kind: StructureType
-      ID: 415
+      ID: 392
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1759200
@@ -28524,16 +28524,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 692 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 690 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 697 GoMapType map[string]interface {}
+          Type: 695 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1429
+      ID: 1436
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 713
+      ID: 720
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1921920
@@ -28541,7 +28541,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1427 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1434 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28556,15 +28556,15 @@ Types:
           Type: 18 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1428 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1435 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1427
+      ID: 1434
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 992992
       GoKind: 5
     - __kind: StructureType
-      ID: 419
+      ID: 397
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2114656
@@ -28572,16 +28572,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 392 StructureType sync.RWMutex
+          Type: 366 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1401 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1407 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 395 GoMapType map[string]string
+          Type: 372 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -28596,12 +28596,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1403 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1409 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 390 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 395 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 420
+      ID: 398
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 901344
@@ -28610,15 +28610,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1112
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1356
+      ID: 1363
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1432
+    - __kind: GoContextImplementationType
+      ID: 405
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1636416
@@ -28627,30 +28627,32 @@ Types:
         - Name: Context
           Offset: 0
           Type: 157 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1122624
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 761
+      ID: 768
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 839360
       GoKind: 2
     - __kind: StructureType
-      ID: 882
+      ID: 889
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1122496
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 880
+      ID: 887
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1606048
@@ -28663,7 +28665,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 900
+      ID: 907
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1606848
@@ -28676,7 +28678,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1742528
@@ -28692,7 +28694,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 902
+      ID: 909
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1437312
@@ -28702,7 +28704,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 898
+      ID: 905
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1436992
@@ -28712,14 +28714,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1145
+      ID: 1152
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1508736
       GoKind: 21
-      HeaderType: 1147 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1154 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1168
+      ID: 1175
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1055232
@@ -28734,15 +28736,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1186 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1193 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1186
+      ID: 1193
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 912
+      ID: 919
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1607168
@@ -28750,12 +28752,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1145 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1152 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1145 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1152 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1437472
@@ -28765,7 +28767,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1742720
@@ -28776,12 +28778,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1175 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1175 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 908
+      ID: 915
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1607008
@@ -28794,7 +28796,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 914
+      ID: 921
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1437632
@@ -28804,7 +28806,7 @@ Types:
           Offset: 0
           Type: 328 GoTimeType time.Time
     - __kind: StructureType
-      ID: 920
+      ID: 927
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1607488
@@ -28817,7 +28819,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 922
+      ID: 929
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1437952
@@ -28827,7 +28829,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 918
+      ID: 925
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1607328
@@ -28840,7 +28842,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 916
+      ID: 923
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1437792
@@ -28850,7 +28852,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 924
+      ID: 931
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1607648
@@ -28863,7 +28865,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 843
+      ID: 850
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1429472
@@ -28873,11 +28875,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1277
+      ID: 1284
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 852
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1429632
@@ -28885,21 +28887,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 843 StructureType github.com/cihub/seelog.baseError
+          Type: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1257
+      ID: 1264
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1213
+      ID: 1220
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1247
+      ID: 1254
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 849
+      ID: 856
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1429952
@@ -28907,13 +28909,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 843 StructureType github.com/cihub/seelog.baseError
+          Type: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1312
+      ID: 1319
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1325
+      ID: 1332
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2117120
@@ -28921,12 +28923,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1311 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 1328
+      ID: 1335
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2141984
@@ -28934,7 +28936,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1311 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28942,11 +28944,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1215
+      ID: 1222
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 847
+      ID: 854
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1429792
@@ -28954,9 +28956,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 843 StructureType github.com/cihub/seelog.baseError
+          Type: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 851
+      ID: 858
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1430112
@@ -28964,64 +28966,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 843 StructureType github.com/cihub/seelog.baseError
+          Type: 850 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1279
+      ID: 1286
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1320
+      ID: 1327
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1322
+      ID: 1329
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1146
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1060
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1064
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1268
+      ID: 1275
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1054
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1431072
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1372
+      ID: 1379
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1120
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1082
+      ID: 1089
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1851648
@@ -29037,11 +29039,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1076
+      ID: 1083
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1015
+      ID: 1022
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1711968
@@ -29054,7 +29056,7 @@ Types:
           Offset: 1
           Type: 19 BaseType int8
     - __kind: StructureType
-      ID: 1088
+      ID: 1095
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1852096
@@ -29070,13 +29072,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 992
+      ID: 999
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 994912
       GoKind: 8
     - __kind: StructureType
-      ID: 1080
+      ID: 1087
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1851424
@@ -29092,13 +29094,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1170
+      ID: 1177
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 835328
       GoKind: 8
     - __kind: StructureType
-      ID: 1078
+      ID: 1085
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1851200
@@ -29106,15 +29108,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1170 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1177 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1170 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1177 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1086
+      ID: 1093
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1764960
@@ -29127,7 +29129,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1084
+      ID: 1091
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1851872
@@ -29143,11 +29145,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1376
+      ID: 1383
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1092
+      ID: 1099
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1632192
@@ -29157,19 +29159,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1019
+      ID: 1026
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1289408
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1017
+      ID: 1024
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1289280
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1090
+      ID: 1097
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1765152
@@ -29182,7 +29184,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 774
+      ID: 781
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 842816
@@ -29190,13 +29192,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 776 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 783 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 775 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 782 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 775
+      ID: 782
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29227,13 +29229,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 650 PointerType *go.shape.string.str
+          Type: 657 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 649 GoStringDataType go.shape.string.str
+      Data: 656 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 649
+      ID: 656
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29289,11 +29291,11 @@ Types:
           Offset: 32
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1161
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1063
+      ID: 1070
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1455232
@@ -29303,7 +29305,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1243
+      ID: 1250
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1687680
@@ -29311,13 +29313,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1269 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1276 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1336
+      ID: 1343
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1269
+      ID: 1276
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1133376
@@ -29330,7 +29332,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1231
+      ID: 1238
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1578656
@@ -29340,19 +29342,19 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 777
+      ID: 784
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 843392
       GoKind: 10
     - __kind: BaseType
-      ID: 1152
+      ID: 1159
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1008544
       GoKind: 10
     - __kind: StructureType
-      ID: 1121
+      ID: 1128
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1890624
@@ -29363,12 +29365,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1152 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1159 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1614688
@@ -29376,12 +29378,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1152 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1159 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 781
+      ID: 788
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 843584
@@ -29389,18 +29391,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 783 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 790 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 782 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 789 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 782
+      ID: 789
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 787
+      ID: 794
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 843776
@@ -29408,18 +29410,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 789 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 796 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 788 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 795 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 788
+      ID: 795
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 784
+      ID: 791
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 843680
@@ -29427,18 +29429,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 786 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 793 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 785 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 792 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 785
+      ID: 792
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 778
+      ID: 785
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 843488
@@ -29446,22 +29448,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 780 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 787 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 779 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 786 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 779
+      ID: 786
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1334
+      ID: 1341
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 982
+      ID: 989
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1455872
@@ -29471,13 +29473,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 790
+      ID: 797
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 843872
       GoKind: 2
     - __kind: StructureType
-      ID: 970
+      ID: 977
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1450912
@@ -29487,11 +29489,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1126
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1141
+      ID: 1148
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1918400
@@ -29507,7 +29509,7 @@ Types:
           Offset: 24
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 972
+      ID: 979
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1614208
@@ -29520,7 +29522,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1283
+      ID: 1290
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1976448
@@ -29528,16 +29530,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1310 GoInterfaceType io.Reader
+          Type: 1317 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1241
+      ID: 1248
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1061
+      ID: 1068
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1576256
@@ -29547,29 +29549,29 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1203
+      ID: 1210
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 957
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1049
+      ID: 1056
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1124
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1115
+      ID: 1122
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1519456
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 964
+      ID: 971
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1444192
@@ -29579,7 +29581,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 966
+      ID: 973
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1444352
@@ -29589,107 +29591,107 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 892
+      ID: 899
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 540
+      ID: 547
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 541 PointerType *noalg.map.group[[4]int][4]int
+          Type: 548 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 542 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 546 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 549 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 553 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 532
+      ID: 539
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 533 PointerType *noalg.map.group[[4]int]uint8
+          Type: 540 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 534 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 538 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 541 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 545 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 480
+      ID: 487
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 481 PointerType *noalg.map.group[[4]string][2]int
+          Type: 488 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 482 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 487 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 489 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 494 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 499
+      ID: 506
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 500 PointerType *noalg.map.group[bool]main.node
+          Type: 507 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 501 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 505 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 508 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 512 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 658
+      ID: 699
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 659 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 700 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 660 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 665 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 701 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 706 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 436
+      ID: 443
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 437 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 444 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 438 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 444 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 445 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 451 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1418
+      ID: 1425
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1419 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1426 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1420 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1426 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1427 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1433 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1462
       Name: groupReference<int,*main.deepMap8>
@@ -29719,19 +29721,19 @@ Types:
       GroupType: 1479 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 1485 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 448
+      ID: 455
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 449 PointerType *noalg.map.group[int]int
+          Type: 456 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 450 StructureType noalg.map.group[int]int
-      GroupSliceType: 454 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 457 StructureType noalg.map.group[int]int
+      GroupSliceType: 461 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 1492
       Name: groupReference<int,interface {}>
@@ -29747,305 +29749,305 @@ Types:
       GroupType: 1494 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 1498 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 556
+      ID: 563
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 557 PointerType *noalg.map.group[int]struct {}
+          Type: 564 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 558 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 562 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 565 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 569 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 507
+      ID: 514
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 508 PointerType *noalg.map.group[int]uint8
+          Type: 515 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 509 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 513 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 516 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 520 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 707
+      ID: 714
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 708 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 715 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 715 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 716 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 722 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 489
+      ID: 496
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 490 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 497 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 491 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 497 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 498 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 504 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 472
+      ID: 479
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 473 PointerType *noalg.map.group[string][]string
+          Type: 480 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 474 StructureType noalg.map.group[string][]string
-      GroupSliceType: 478 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 481 StructureType noalg.map.group[string][]string
+      GroupSliceType: 485 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 683
+      ID: 681
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 684 PointerType *noalg.map.group[string]float64
+          Type: 682 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 685 StructureType noalg.map.group[string]float64
-      GroupSliceType: 689 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 683 StructureType noalg.map.group[string]float64
+      GroupSliceType: 687 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1177
+      ID: 1184
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1178 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1185 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1183 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1186 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1190 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 464
+      ID: 471
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 465 PointerType *noalg.map.group[string]int
+          Type: 472 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 466 StructureType noalg.map.group[string]int
-      GroupSliceType: 470 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 473 StructureType noalg.map.group[string]int
+      GroupSliceType: 477 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 675
+      ID: 673
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 676 PointerType *noalg.map.group[string]interface {}
+          Type: 674 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 677 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 681 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 675 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 679 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 456
+      ID: 463
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 457 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 464 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 458 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 462 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 465 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 469 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 667
+      ID: 665
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 668 PointerType *noalg.map.group[string]string
+          Type: 666 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 669 StructureType noalg.map.group[string]string
-      GroupSliceType: 673 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 667 StructureType noalg.map.group[string]string
+      GroupSliceType: 671 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 548
+      ID: 555
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 549 PointerType *noalg.map.group[struct {}]int
+          Type: 556 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 550 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 554 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 557 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 561 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 596
+      ID: 603
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 597 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 604 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 602 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 605 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 609 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 604
+      ID: 611
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 605 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 612 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 610 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 613 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 617 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 612
+      ID: 619
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 613 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 620 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 618 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 625 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 620
+      ID: 627
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 621 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 628 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 626 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 633 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 628
+      ID: 635
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 629 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 636 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 634 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 641 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 636
+      ID: 643
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 637 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 644 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 642 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 645 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 649 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 564
+      ID: 571
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 565 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 572 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 566 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 570 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 573 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 577 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 523
+      ID: 530
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 524 PointerType *noalg.map.group[uint8][4]int
+          Type: 531 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 525 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 530 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 532 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 537 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 515
+      ID: 522
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 516 PointerType *noalg.map.group[uint8]uint8
+          Type: 523 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 517 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 521 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 524 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 528 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1291
+      ID: 1298
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 985
+      ID: 992
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -30092,11 +30094,11 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1150
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 944
+      ID: 951
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -30122,29 +30124,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1193
+      ID: 1200
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1118
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1378
+      ID: 1385
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1109
+      ID: 1116
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1498176
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 806
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -30225,7 +30227,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 749
+      ID: 756
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 838016
@@ -30233,18 +30235,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 751 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 758 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 750 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 757 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 750
+      ID: 757
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1033
+      ID: 1040
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1567616
@@ -30252,9 +30254,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 1142 PointerType *internal/abi.Type
+          Type: 1149 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 379
+      ID: 369
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1495616
@@ -30267,11 +30269,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1235
+      ID: 1242
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1275
+      ID: 1282
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1196160
@@ -30284,7 +30286,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1310
+      ID: 1317
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1028608
@@ -30297,7 +30299,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1262
+      ID: 1269
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1115968
@@ -30323,21 +30325,21 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1233
+      ID: 1240
       Name: io.discard
       GoRuntimeType: 1471616
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1207
+      ID: 1214
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1114
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1281
+      ID: 1288
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -30431,7 +30433,7 @@ Types:
           Offset: 0
           Type: 146 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 442
+      ID: 449
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1192320
@@ -30439,9 +30441,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1412 GoMapType map[int]*main.deepMap3
+          Type: 1419 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1424
+      ID: 1431
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -30493,9 +30495,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1381 PointerType *main.deepPtr3
+          Type: 1388 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1382
+      ID: 1389
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -30539,7 +30541,7 @@ Types:
           Offset: 0
           Type: 140 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 432
+      ID: 439
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1194624
@@ -30547,9 +30549,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1406 GoSliceHeaderType []*main.deepSlice3
+          Type: 1413 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1409
+      ID: 1416
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -30599,16 +30601,16 @@ Types:
           Type: 162 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 377 StructureType sync.Mutex
+          Type: 367 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1389 StructureType sync.Once
+          Type: 1396 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1391 StructureType sync.WaitGroup
+          Type: 1398 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 393 StructureType sync/atomic.Int32
+          Type: 370 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 162
       Name: main.esotericStack
@@ -31026,9 +31028,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1386 ArrayType [63]uint64
+          Type: 1393 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1396
+      ID: 1403
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1420032
@@ -31048,7 +31050,7 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1388
+      ID: 1395
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -31059,18 +31061,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1384 PointerType *main.stringType1.str
+          Type: 1391 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1383 GoStringDataType main.stringType1.str
+      Data: 1390 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1383
+      ID: 1390
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1385
+      ID: 1392
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
@@ -31199,16 +31201,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1397 PointerType **main.t
+          Type: 1404 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1398 GoSliceDataType main.t.array
+      Data: 1405 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1398
+      ID: 1405
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -31368,8 +31370,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 545 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 542 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 552 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 549 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 227
       Name: map<[4]int,uint8>
@@ -31403,8 +31405,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 537 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 534 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 544 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 541 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 195
       Name: map<[4]string,[2]int>
@@ -31438,8 +31440,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 486 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 482 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 493 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 489 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 207
       Name: map<bool,main.node>
@@ -31473,10 +31475,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 504 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 501 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 511 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 508 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 383
+      ID: 421
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -31489,7 +31491,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 384 PointerType **table<context.canceler,struct {}>
+          Type: 422 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31508,8 +31510,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 664 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 660 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 705 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 701 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 148
       Name: map<int,*main.deepMap2>
@@ -31543,10 +31545,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 443 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 438 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 450 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 445 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1414
+      ID: 1421
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -31559,7 +31561,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1415 PointerType **table<int,*main.deepMap3>
+          Type: 1422 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31578,8 +31580,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1425 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1420 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1432 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1427 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1458
       Name: map<int,*main.deepMap8>
@@ -31683,8 +31685,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 453 GoSliceDataType []*table<int,int>.array
-      GroupType: 450 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 460 GoSliceDataType []*table<int,int>.array
+      GroupType: 457 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 1488
       Name: map<int,interface {}>
@@ -31753,8 +31755,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 561 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 558 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 568 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 565 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 212
       Name: map<int,uint8>
@@ -31788,10 +31790,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 512 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 509 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 519 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 516 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 694
+      ID: 692
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -31804,7 +31806,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 695 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 693 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31823,8 +31825,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 714 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 709 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 721 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 716 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 202
       Name: map<string,[]main.structWithMap>
@@ -31858,8 +31860,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 496 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 491 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 503 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 498 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 190
       Name: map<string,[]string>
@@ -31893,10 +31895,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 477 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 474 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 484 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 481 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 407
+      ID: 384
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -31909,7 +31911,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 408 PointerType **table<string,float64>
+          Type: 385 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31928,10 +31930,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 688 GoSliceDataType []*table<string,float64>.array
-      GroupType: 685 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 686 GoSliceDataType []*table<string,float64>.array
+      GroupType: 683 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1147
+      ID: 1154
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31944,7 +31946,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1148 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1155 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31963,8 +31965,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1182 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1179 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1189 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1186 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 185
       Name: map<string,int>
@@ -31998,10 +32000,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 469 GoSliceDataType []*table<string,int>.array
-      GroupType: 466 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 476 GoSliceDataType []*table<string,int>.array
+      GroupType: 473 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 402
+      ID: 379
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -32014,7 +32016,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 403 PointerType **table<string,interface {}>
+          Type: 380 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -32033,8 +32035,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 680 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 677 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 678 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 675 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 180
       Name: map<string,main.nestedStruct>
@@ -32068,10 +32070,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 461 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 458 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 468 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 465 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 397
+      ID: 374
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -32084,7 +32086,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 398 PointerType **table<string,string>
+          Type: 375 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -32103,8 +32105,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 672 GoSliceDataType []*table<string,string>.array
-      GroupType: 669 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 670 GoSliceDataType []*table<string,string>.array
+      GroupType: 667 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 237
       Name: map<struct {},int>
@@ -32138,8 +32140,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 553 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 550 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 560 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 557 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 294
       Name: map<struct {},main.structWithCyclicMaps>
@@ -32173,8 +32175,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 601 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 598 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 608 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 605 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 299
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -32208,8 +32210,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 609 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 606 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 616 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 613 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 304
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32243,8 +32245,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 617 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 614 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 624 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 621 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 309
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32278,8 +32280,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 625 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 622 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 632 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 629 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 314
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32313,8 +32315,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 633 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 630 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 640 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 637 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 319
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32348,8 +32350,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 641 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 638 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 648 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 645 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 247
       Name: map<struct {},struct {}>
@@ -32383,8 +32385,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 569 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 566 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 576 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 573 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 222
       Name: map<uint8,[4]int>
@@ -32418,8 +32420,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 529 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 525 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 536 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 532 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 217
       Name: map<uint8,uint8>
@@ -32453,8 +32455,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 520 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 517 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 527 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 524 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 230
       Name: map[[4]int][4]int
@@ -32484,12 +32486,12 @@ Types:
       GoKind: 21
       HeaderType: 207 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 381
+      ID: 419
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1137600
       GoKind: 21
-      HeaderType: 383 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 421 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 146
       Name: map[int]*main.deepMap2
@@ -32498,12 +32500,12 @@ Types:
       GoKind: 21
       HeaderType: 148 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1412
+      ID: 1419
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1135168
       GoKind: 21
-      HeaderType: 1414 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1421 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1456
       Name: map[int]*main.deepMap8
@@ -32547,12 +32549,12 @@ Types:
       GoKind: 21
       HeaderType: 212 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 692
+      ID: 690
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1137856
       GoKind: 21
-      HeaderType: 694 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 692 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 200
       Name: map[string][]main.structWithMap
@@ -32568,12 +32570,12 @@ Types:
       GoKind: 21
       HeaderType: 190 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 405
+      ID: 382
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1137728
       GoKind: 21
-      HeaderType: 407 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 384 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 183
       Name: map[string]int
@@ -32582,12 +32584,12 @@ Types:
       GoKind: 21
       HeaderType: 185 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 697
+      ID: 695
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1134144
       GoKind: 21
-      HeaderType: 402 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 379 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 178
       Name: map[string]main.nestedStruct
@@ -32596,12 +32598,12 @@ Types:
       GoKind: 21
       HeaderType: 180 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 395
+      ID: 372
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1137472
       GoKind: 21
-      HeaderType: 397 GoSwissMapHeaderType map<string,string>
+      HeaderType: 374 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 235
       Name: map[struct {}]int
@@ -32667,7 +32669,7 @@ Types:
       GoKind: 21
       HeaderType: 217 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 896
+      ID: 903
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1436512
@@ -32677,7 +32679,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1197
+      ID: 1204
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1433312
@@ -32687,11 +32689,11 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1106
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1167
+      ID: 1174
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1604768
@@ -32704,35 +32706,35 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1137
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1342
+      ID: 1349
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1135
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1101
+      ID: 1108
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1352
+      ID: 1359
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1362
+      ID: 1369
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1350
+      ID: 1357
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1066
+      ID: 1073
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1118784
@@ -32740,28 +32742,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1068 PointerType *net.UnknownNetworkError.str
+          Type: 1075 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1067 GoStringDataType net.UnknownNetworkError.str
+      Data: 1074 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1067
+      ID: 1074
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1031
+      ID: 1038
       Name: net.canceledError
       GoRuntimeType: 1290304
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1318
+      ID: 1325
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1172
+      ID: 1179
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2116416
@@ -32769,7 +32771,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 16 GoInterfaceType error
@@ -32780,27 +32782,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1364
+      ID: 1371
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1358
+      ID: 1365
       Name: net.noReadFrom
       GoRuntimeType: 1119040
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1357
+      ID: 1364
       Name: net.noWriteTo
       GoRuntimeType: 1118912
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1434
+    - __kind: GoContextImplementationType
+      ID: 407
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1769952
@@ -32812,8 +32814,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 157 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 830
+      ID: 837
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1739072
@@ -32821,7 +32825,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1155 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1162 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -32829,7 +32833,7 @@ Types:
           Offset: 96
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1346
+      ID: 1353
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2299424
@@ -32837,12 +32841,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1358 StructureType net.noReadFrom
+          Type: 1365 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1351 PointerType *net.TCPConn
+          Type: 1358 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1344
+      ID: 1351
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2298880
@@ -32850,24 +32854,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1357 StructureType net.noWriteTo
+          Type: 1364 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1351 PointerType *net.TCPConn
+          Type: 1358 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1103
+      ID: 1110
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1139
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1028
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1189
+      ID: 1196
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1424992
@@ -32877,19 +32881,19 @@ Types:
           Offset: 0
           Type: 133 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 719
+      ID: 726
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 835808
       GoKind: 10
     - __kind: BaseType
-      ID: 1144
+      ID: 1151
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 995008
       GoKind: 10
     - __kind: StructureType
-      ID: 806
+      ID: 813
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1737728
@@ -32900,12 +32904,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1144 BaseType net/http.http2ErrCode
+          Type: 1151 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1124
+      ID: 1131
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1908928
@@ -32916,12 +32920,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1144 BaseType net/http.http2ErrCode
+          Type: 1151 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1604448
@@ -32929,16 +32933,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1144 BaseType net/http.http2ErrCode
+          Type: 1151 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1253
+      ID: 1260
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 723
+      ID: 730
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836000
@@ -32946,18 +32950,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 725 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 732 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 724 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 731 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 724
+      ID: 731
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 729
+      ID: 736
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 836192
@@ -32965,18 +32969,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 731 PointerType *net/http.http2headerFieldNameError.str
+          Type: 738 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 730 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 737 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 730
+      ID: 737
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 726
+      ID: 733
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 836096
@@ -32984,32 +32988,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 728 PointerType *net/http.http2headerFieldValueError.str
+          Type: 735 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 727 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 734 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 727
+      ID: 734
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1096
+      ID: 1103
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1027
+      ID: 1034
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1289664
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1307
+      ID: 1314
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 720
+      ID: 727
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 835904
@@ -33017,18 +33021,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 722 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 729 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 721 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 728 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 721
+      ID: 728
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1191
+      ID: 1198
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1835008
@@ -33036,18 +33040,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1284 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1291 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1285 BaseType time.Duration
+          Type: 1292 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 108 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1284
+      ID: 1291
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1424192
@@ -33060,14 +33064,14 @@ Types:
           Offset: 8
           Type: 17 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1272
+      ID: 1279
       Name: net/http.incomparable
       GoRuntimeType: 906528
       GoKind: 17
       HasCount: true
       Element: 61 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1023
+      ID: 1030
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1563776
@@ -33077,11 +33081,11 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1262
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1211
+      ID: 1218
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1563616
@@ -33089,9 +33093,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1254 PointerType *net/http.persistConn
+          Type: 1261 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1245
+      ID: 1252
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1810432
@@ -33099,15 +33103,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1272 ArrayType net/http.incomparable
+          Type: 1279 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1273 PointerType *bufio.Reader
+          Type: 1280 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1275 GoInterfaceType io.ReadWriteCloser
+          Type: 1282 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 814
+      ID: 821
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1425952
@@ -33117,17 +33121,17 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1133
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1094
+      ID: 1101
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1484736
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1025
+      ID: 1032
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1563936
@@ -33137,7 +33141,7 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: StructureType
-      ID: 1287
+      ID: 1294
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2035424
@@ -33145,16 +33149,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1167 GoInterfaceType net.Conn
+          Type: 1174 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1309
+      ID: 1316
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2051168
@@ -33162,13 +33166,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1304 PointerType *bufio.Writer
+          Type: 1311 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1228
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 895
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1742144
@@ -33184,7 +33188,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 886
+      ID: 893
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1606208
@@ -33197,11 +33201,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1261
+      ID: 1268
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1223
+      ID: 1230
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1608128
@@ -33209,16 +33213,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1260 PointerType *net/smtp.Client
+          Type: 1267 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1262 GoInterfaceType io.WriteCloser
+          Type: 1269 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 872
+      ID: 879
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 757
+      ID: 764
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 838784
@@ -33226,26 +33230,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 759 PointerType *net/textproto.ProtocolError.str
+          Type: 766 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 758 GoStringDataType net/textproto.ProtocolError.str
+      Data: 765 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 758
+      ID: 765
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1219
+      ID: 1226
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1141
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 732
+      ID: 739
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 836672
@@ -33253,18 +33257,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 734 PointerType *net/url.EscapeError.str
+          Type: 741 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 733 GoStringDataType net/url.EscapeError.str
+      Data: 740 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 733
+      ID: 740
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 735
+      ID: 742
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 836768
@@ -33272,79 +33276,79 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 737 PointerType *net/url.InvalidHostError.str
+          Type: 744 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 736 GoStringDataType net/url.InvalidHostError.str
+      Data: 743 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 736
+      ID: 743
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 543
+      ID: 550
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 686688
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 544 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 551 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 535
+      ID: 542
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 686784
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 536 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 543 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 483
+      ID: 490
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 687072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 484 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 491 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 502
+      ID: 509
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 687168
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 503 StructureType noalg.struct { key bool; elem main.node }
+      Element: 510 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 661
+      ID: 702
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 692640
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 662 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 703 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 439
+      ID: 446
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 685920
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 440 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 447 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1421
+      ID: 1428
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 685824
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1422 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1429 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1465
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -33364,14 +33368,14 @@ Types:
       HasCount: true
       Element: 1481 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 451
+      ID: 458
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 452 StructureType noalg.struct { key int; elem int }
+      Element: 459 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 1495
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -33382,189 +33386,189 @@ Types:
       HasCount: true
       Element: 1496 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 559
+      ID: 566
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 687264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 560 StructureType noalg.struct { key int; elem struct {} }
+      Element: 567 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 510
+      ID: 517
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 687360
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 511 StructureType noalg.struct { key int; elem uint8 }
+      Element: 518 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 710
+      ID: 717
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 693280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 711 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 718 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 492
+      ID: 499
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 687456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 493 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 500 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 475
+      ID: 482
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 687552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 476 StructureType noalg.struct { key string; elem []string }
+      Element: 483 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 686
+      ID: 684
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 693184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 687 StructureType noalg.struct { key string; elem float64 }
+      Element: 685 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1180
+      ID: 1187
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 762720
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1181 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1188 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 467
+      ID: 474
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 687648
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 468 StructureType noalg.struct { key string; elem int }
+      Element: 475 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 678
+      ID: 676
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 684768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 679 StructureType noalg.struct { key string; elem interface {} }
+      Element: 677 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 459
+      ID: 466
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 687744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 460 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 467 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 670
+      ID: 668
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 690912
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 671 StructureType noalg.struct { key string; elem string }
+      Element: 669 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 551
+      ID: 558
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 687840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 552 StructureType noalg.struct { key struct {}; elem int }
+      Element: 559 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 599
+      ID: 606
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 600 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 607 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 607
+      ID: 614
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 608 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 615 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 615
+      ID: 622
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 616 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 623 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 623
+      ID: 630
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 624 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 631 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 631
+      ID: 638
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 632 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 639 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 639
+      ID: 646
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 640 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 647 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 567
+      ID: 574
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 687936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 568 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 575 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 526
+      ID: 533
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 527 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 534 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 518
+      ID: 525
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 688128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 519 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 526 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 542
+      ID: 549
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1301952
@@ -33575,9 +33579,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 543 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 550 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 534
+      ID: 541
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1302208
@@ -33588,9 +33592,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 535 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 542 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 482
+      ID: 489
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1302464
@@ -33601,9 +33605,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 483 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 490 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 501
+      ID: 508
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1302720
@@ -33614,9 +33618,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 502 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 509 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 660
+      ID: 701
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1306816
@@ -33627,9 +33631,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 661 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 702 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 438
+      ID: 445
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1301696
@@ -33640,9 +33644,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 439 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 446 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1420
+      ID: 1427
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1301440
@@ -33653,7 +33657,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1421 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1428 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1464
       Name: noalg.map.group[int]*main.deepMap8
@@ -33681,7 +33685,7 @@ Types:
           Offset: 8
           Type: 1480 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 450
+      ID: 457
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1298624
@@ -33692,7 +33696,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 451 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 458 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 1494
       Name: noalg.map.group[int]interface {}
@@ -33707,7 +33711,7 @@ Types:
           Offset: 8
           Type: 1495 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 558
+      ID: 565
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1302976
@@ -33718,9 +33722,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 559 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 566 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 509
+      ID: 516
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1303232
@@ -33731,9 +33735,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 510 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 517 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 709
+      ID: 716
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1307712
@@ -33744,9 +33748,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 710 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 717 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 491
+      ID: 498
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1303488
@@ -33757,9 +33761,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 492 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 499 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 474
+      ID: 481
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1303744
@@ -33770,9 +33774,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 475 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 482 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 685
+      ID: 683
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1307456
@@ -33783,9 +33787,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 686 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 684 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1179
+      ID: 1186
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1365440
@@ -33796,9 +33800,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1180 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1187 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 466
+      ID: 473
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1304000
@@ -33809,9 +33813,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 467 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 474 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 677
+      ID: 675
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1299392
@@ -33822,9 +33826,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 678 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 676 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 458
+      ID: 465
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1304256
@@ -33835,9 +33839,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 459 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 466 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 669
+      ID: 667
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1306048
@@ -33848,9 +33852,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 670 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 668 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 550
+      ID: 557
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1304512
@@ -33861,9 +33865,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 551 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 558 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 598
+      ID: 605
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -33873,9 +33877,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 599 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 606 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 606
+      ID: 613
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33885,9 +33889,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 607 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 614 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 614
+      ID: 621
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33897,9 +33901,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 615 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 622 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 622
+      ID: 629
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33909,9 +33913,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 623 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 630 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 630
+      ID: 637
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33921,9 +33925,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 631 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 638 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 638
+      ID: 645
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33933,9 +33937,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 639 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 646 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 566
+      ID: 573
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1304768
@@ -33946,9 +33950,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 567 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 574 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 525
+      ID: 532
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1305024
@@ -33959,9 +33963,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 526 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 533 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 517
+      ID: 524
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1305280
@@ -33972,9 +33976,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 518 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 525 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 544
+      ID: 551
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1301824
@@ -33982,12 +33986,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 528 ArrayType [4]int
+          Type: 535 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 528 ArrayType [4]int
+          Type: 535 ArrayType [4]int
     - __kind: StructureType
-      ID: 536
+      ID: 543
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1302080
@@ -33995,12 +33999,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 528 ArrayType [4]int
+          Type: 535 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 484
+      ID: 491
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1302336
@@ -34008,12 +34012,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 485 ArrayType [4]string
+          Type: 492 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 115 ArrayType [2]int
     - __kind: StructureType
-      ID: 503
+      ID: 510
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1302592
@@ -34026,7 +34030,7 @@ Types:
           Offset: 8
           Type: 253 StructureType main.node
     - __kind: StructureType
-      ID: 662
+      ID: 703
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1306688
@@ -34034,12 +34038,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 663 GoInterfaceType context.canceler
+          Type: 704 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 440
+      ID: 447
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1301568
@@ -34050,9 +34054,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 441 PointerType *main.deepMap2
+          Type: 448 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1422
+      ID: 1429
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1301312
@@ -34063,7 +34067,7 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1423 PointerType *main.deepMap3
+          Type: 1430 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1466
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -34091,7 +34095,7 @@ Types:
           Offset: 8
           Type: 1482 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 452
+      ID: 459
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1298496
@@ -34117,7 +34121,7 @@ Types:
           Offset: 8
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 560
+      ID: 567
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1302848
@@ -34130,7 +34134,7 @@ Types:
           Offset: 8
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 511
+      ID: 518
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1303104
@@ -34143,7 +34147,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 711
+      ID: 718
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1307584
@@ -34154,9 +34158,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 712 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 719 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 493
+      ID: 500
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1303360
@@ -34167,9 +34171,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 494 GoSliceHeaderType []main.structWithMap
+          Type: 501 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 476
+      ID: 483
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1303616
@@ -34182,7 +34186,7 @@ Types:
           Offset: 16
           Type: 161 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 687
+      ID: 685
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1307328
@@ -34195,7 +34199,7 @@ Types:
           Offset: 16
           Type: 18 BaseType float64
     - __kind: StructureType
-      ID: 1181
+      ID: 1188
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1365312
@@ -34206,9 +34210,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1168 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1175 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 468
+      ID: 475
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1303872
@@ -34221,7 +34225,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 679
+      ID: 677
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1299264
@@ -34234,7 +34238,7 @@ Types:
           Offset: 16
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 460
+      ID: 467
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1304128
@@ -34247,7 +34251,7 @@ Types:
           Offset: 16
           Type: 125 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 671
+      ID: 669
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1305920
@@ -34260,7 +34264,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 552
+      ID: 559
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1304384
@@ -34273,7 +34277,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 600
+      ID: 607
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -34285,7 +34289,7 @@ Types:
           Offset: 0
           Type: 291 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 608
+      ID: 615
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34297,7 +34301,7 @@ Types:
           Offset: 0
           Type: 292 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 616
+      ID: 623
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34309,7 +34313,7 @@ Types:
           Offset: 0
           Type: 297 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 624
+      ID: 631
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34321,7 +34325,7 @@ Types:
           Offset: 0
           Type: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 632
+      ID: 639
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34333,7 +34337,7 @@ Types:
           Offset: 0
           Type: 307 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34345,7 +34349,7 @@ Types:
           Offset: 0
           Type: 312 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 568
+      ID: 575
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1304640
       GoKind: 25
@@ -34357,7 +34361,7 @@ Types:
           Offset: 0
           Type: 127 StructureType struct {}
     - __kind: StructureType
-      ID: 527
+      ID: 534
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1304896
@@ -34368,9 +34372,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 528 ArrayType [4]int
+          Type: 535 ArrayType [4]int
     - __kind: StructureType
-      ID: 519
+      ID: 526
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1305152
@@ -34383,19 +34387,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1370
+      ID: 1377
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1011
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1079
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1368
+      ID: 1375
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2369792
@@ -34403,12 +34407,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1374 StructureType os.noReadFrom
+          Type: 1381 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1369 PointerType *os.File
+          Type: 1376 PointerType *os.File
     - __kind: StructureType
-      ID: 1366
+      ID: 1373
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2368992
@@ -34416,36 +34420,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1373 StructureType os.noWriteTo
+          Type: 1380 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1369 PointerType *os.File
+          Type: 1376 PointerType *os.File
     - __kind: StructureType
-      ID: 1374
+      ID: 1381
       Name: os.noReadFrom
       GoRuntimeType: 1117248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1373
+      ID: 1380
       Name: os.noWriteTo
       GoRuntimeType: 1117120
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1042
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1175
+      ID: 1182
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1239
+      ID: 1246
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1037
+      ID: 1044
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1712544
@@ -34458,7 +34462,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 771
+      ID: 778
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 842048
@@ -34466,36 +34470,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 773 PointerType *os/user.UnknownGroupIdError.str
+          Type: 780 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 772 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 779 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 772
+      ID: 779
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 770
+      ID: 777
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 841952
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 901
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1015
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1019
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34507,7 +34511,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 1010
+      ID: 1017
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1897792
@@ -34524,9 +34528,9 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1173 BaseType runtime.boundsErrorCode
+          Type: 1180 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 1173
+      ID: 1180
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 588224
@@ -34546,7 +34550,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1074
+      ID: 1081
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1763040
@@ -34559,7 +34563,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 986
+      ID: 993
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 994048
@@ -34567,13 +34571,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 988 PointerType *runtime.errorString.str
+          Type: 995 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 987 GoStringDataType runtime.errorString.str
+      Data: 994 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 987
+      ID: 994
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -35200,7 +35204,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 427
+      ID: 434
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -35236,7 +35240,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 989
+      ID: 996
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 994144
@@ -35244,13 +35248,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 991 PointerType *runtime.plainError.str
+          Type: 998 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 990 GoStringDataType runtime.plainError.str
+      Data: 997 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 990
+      ID: 997
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -35291,7 +35295,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 797
+      ID: 804
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1604128
@@ -35349,7 +35353,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1009
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -35361,26 +35365,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 422 PointerType *string.str
+          Type: 429 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 421 GoStringDataType string.str
+      Data: 428 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 421
+      ID: 428
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1303
+      ID: 1310
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1216
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1205
+      ID: 1212
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1463232
@@ -35396,7 +35400,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 377
+      ID: 367
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1474656
@@ -35404,12 +35408,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 378 StructureType sync.noCopy
+          Type: 368 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 379 StructureType internal/sync.Mutex
+          Type: 369 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1389
+      ID: 1396
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1624896
@@ -35417,15 +35421,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 378 StructureType sync.noCopy
+          Type: 368 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1390 StructureType sync/atomic.Bool
+          Type: 1397 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 377 StructureType sync.Mutex
+          Type: 367 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 392
+      ID: 366
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1848960
@@ -35433,7 +35437,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 377 StructureType sync.Mutex
+          Type: 367 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -35442,12 +35446,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 393 StructureType sync/atomic.Int32
+          Type: 370 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 393 StructureType sync/atomic.Int32
+          Type: 370 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1391
+      ID: 1398
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1624704
@@ -35455,21 +35459,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 378 StructureType sync.noCopy
+          Type: 368 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1392 StructureType sync/atomic.Uint64
+          Type: 1399 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 378
+      ID: 368
       Name: sync.noCopy
       GoRuntimeType: 993664
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1390
+      ID: 1397
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1475776
@@ -35477,12 +35481,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 371 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 393
+      ID: 370
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1475936
@@ -35490,12 +35494,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 371 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 1392
+      ID: 1399
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1625280
@@ -35503,15 +35507,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 371 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1393 StructureType sync/atomic.align64
+          Type: 1400 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 380
+      ID: 418
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1200384
@@ -35521,25 +35525,25 @@ Types:
           Offset: 0
           Type: 164 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1393
+      ID: 1400
       Name: sync/atomic.align64
       GoRuntimeType: 993856
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 394
+      ID: 371
       Name: sync/atomic.noCopy
       GoRuntimeType: 993760
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1122
+      ID: 1129
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1291712
       GoKind: 12
     - __kind: StructureType
-      ID: 539
+      ID: 546
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35561,9 +35565,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 540 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 547 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 531
+      ID: 538
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35585,9 +35589,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 532 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 539 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 479
+      ID: 486
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -35609,9 +35613,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 480 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 487 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 498
+      ID: 505
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -35633,9 +35637,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 499 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 506 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 657
+      ID: 698
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35657,9 +35661,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 658 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 699 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 435
+      ID: 442
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -35681,9 +35685,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 436 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 443 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1417
+      ID: 1424
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -35705,7 +35709,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1418 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1425 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1461
       Name: table<int,*main.deepMap8>
@@ -35755,7 +35759,7 @@ Types:
           Offset: 16
           Type: 1477 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 447
+      ID: 454
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -35777,7 +35781,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 448 GoSwissMapGroupsType groupReference<int,int>
+          Type: 455 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 1491
       Name: table<int,interface {}>
@@ -35803,7 +35807,7 @@ Types:
           Offset: 16
           Type: 1492 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 555
+      ID: 562
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35825,9 +35829,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 556 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 563 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 506
+      ID: 513
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35849,9 +35853,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 507 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 514 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 706
+      ID: 713
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -35873,9 +35877,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 707 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 714 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 488
+      ID: 495
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -35897,9 +35901,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 489 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 496 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 471
+      ID: 478
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35921,9 +35925,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 472 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 479 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 682
+      ID: 680
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35945,9 +35949,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 683 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 681 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1176
+      ID: 1183
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35969,9 +35973,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1177 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1184 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 463
+      ID: 470
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -35993,9 +35997,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 464 GoSwissMapGroupsType groupReference<string,int>
+          Type: 471 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 674
+      ID: 672
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -36017,9 +36021,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 675 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 673 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 455
+      ID: 462
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -36041,9 +36045,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 456 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 463 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 666
+      ID: 664
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -36065,9 +36069,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 667 GoSwissMapGroupsType groupReference<string,string>
+          Type: 665 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 547
+      ID: 554
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -36089,9 +36093,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 548 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 555 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 595
+      ID: 602
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36113,9 +36117,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 596 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 603 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 603
+      ID: 610
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36137,9 +36141,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 604 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 611 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 611
+      ID: 618
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36161,9 +36165,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 612 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 619 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 619
+      ID: 626
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36185,9 +36189,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 620 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 627 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 627
+      ID: 634
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36209,9 +36213,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 628 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 635 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 635
+      ID: 642
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36233,9 +36237,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 636 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 643 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 563
+      ID: 570
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -36257,9 +36261,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 564 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 571 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 522
+      ID: 529
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -36281,9 +36285,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 523 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 530 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 514
+      ID: 521
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -36305,13 +36309,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 515 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 522 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1340
+      ID: 1347
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1065
+      ID: 1072
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1716960
@@ -36324,7 +36328,7 @@ Types:
           Offset: 16
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 1285
+      ID: 1292
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1923456
@@ -36341,10 +36345,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 643 GoSliceHeaderType []time.zone
+          Type: 650 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 646 GoSliceHeaderType []time.zoneTrans
+          Type: 653 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -36356,9 +36360,9 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 644 PointerType *time.zone
+          Type: 651 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 802
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
@@ -36386,7 +36390,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 388
+      ID: 427
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1476896
@@ -36394,12 +36398,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1400 GoChannelType <-chan time.Time
+          Type: 1412 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 716
+      ID: 723
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 834272
@@ -36407,18 +36411,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 718 PointerType *time.fileSizeError.str
+          Type: 725 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 717 GoStringDataType time.fileSizeError.str
+      Data: 724 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 717
+      ID: 724
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 645
+      ID: 652
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1626240
@@ -36434,7 +36438,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 648
+      ID: 655
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1761696
@@ -36495,7 +36499,7 @@ Types:
       GoRuntimeType: 588160
       GoKind: 26
     - __kind: StructureType
-      ID: 1155
+      ID: 1162
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2072896
@@ -36506,10 +36510,10 @@ Types:
           Type: 40 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1156 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1163 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1157 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1164 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -36524,18 +36528,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1158 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1165 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1158
+      ID: 1165
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 999712
       GoKind: 9
     - __kind: StructureType
-      ID: 1156
+      ID: 1163
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1936256
@@ -36560,21 +36564,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1157
+      ID: 1164
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 591808
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1332
+      ID: 1339
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 874
+      ID: 881
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1433632
@@ -36584,13 +36588,13 @@ Types:
           Offset: 0
           Type: 16 GoInterfaceType error
     - __kind: BaseType
-      ID: 760
+      ID: 767
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 838880
       GoKind: 2
     - __kind: StructureType
-      ID: 1042
+      ID: 1049
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1712736
@@ -36603,7 +36607,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 994
+      ID: 1001
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 998560

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -11877,7 +11877,7 @@ Subprograms:
       DictRegister: null
 Types:
     - __kind: PointerType
-      ID: 1405
+      ID: 1411
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
@@ -11888,10 +11888,10 @@ Types:
       ByteSize: 8
       Pointee: 148 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1410
+      ID: 1417
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1411 PointerType *main.deepSlice3
+      Pointee: 1418 PointerType *main.deepSlice3
     - __kind: PointerType
       ID: 1445
       Name: '**main.deepSlice8'
@@ -11909,7 +11909,7 @@ Types:
       GoKind: 22
       Pointee: 162 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1400
+      ID: 1407
       Name: '**main.t'
       ByteSize: 8
       Pointee: 261 PointerType *main.t
@@ -11947,20 +11947,20 @@ Types:
       ByteSize: 8
       Pointee: 215 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 390
+      ID: 428
       Name: '**table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 391 PointerType *table<context.canceler,struct {}>
+      Pointee: 429 PointerType *table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 155
       Name: '**table<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 156 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1418
+      ID: 1425
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1419 PointerType *table<int,*main.deepMap3>
+      Pointee: 1426 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1462
       Name: '**table<int,*main.deepMap8>'
@@ -11992,10 +11992,10 @@ Types:
       ByteSize: 8
       Pointee: 220 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 705
+      ID: 703
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 706 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 704 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 209
       Name: '**table<string,[]main.structWithMap>'
@@ -12007,35 +12007,35 @@ Types:
       ByteSize: 8
       Pointee: 198 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 418
+      ID: 391
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 419 PointerType *table<string,float64>
+      Pointee: 392 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 1154
+      ID: 1161
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1155 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1162 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 192
       Name: '**table<string,int>'
       ByteSize: 8
       Pointee: 193 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 413
+      ID: 386
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 414 PointerType *table<string,interface {}>
+      Pointee: 387 PointerType *table<string,interface {}>
     - __kind: PointerType
       ID: 187
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 188 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 408
+      ID: 381
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 409 PointerType *table<string,string>
+      Pointee: 382 PointerType *table<string,string>
     - __kind: PointerType
       ID: 244
       Name: '**table<struct {},int>'
@@ -12087,20 +12087,20 @@ Types:
       ByteSize: 8
       Pointee: 225 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 1408
+      ID: 1414
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 1407 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 1413 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 444
+      ID: 451
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 443 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 450 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1414
+      ID: 1421
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1413 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1420 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
       ID: 1449
       Name: '*[]*main.deepSlice8.array'
@@ -12112,100 +12112,100 @@ Types:
       ByteSize: 8
       Pointee: 1454 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 439
+      ID: 446
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 438 GoSliceDataType []*runtime.p.array
+      Pointee: 445 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 441
+      ID: 448
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 440 GoSliceDataType []*string.array
+      Pointee: 447 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 604
+      ID: 611
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 603 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 610 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 296
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 293 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 602
+      ID: 609
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 601 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 608 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 294
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 291 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 600
+      ID: 607
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 599 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 606 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 292
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 289 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 598
+      ID: 605
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 597 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 604 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
       ID: 290
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
       Pointee: 287 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 596
+      ID: 603
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 595 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 602 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 584
+      ID: 591
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 583 GoSliceDataType [][]uint.array
+      Pointee: 590 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 588
+      ID: 595
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 587 GoSliceDataType []bool.array
+      Pointee: 594 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1191
+      ID: 1198
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1190 GoSliceDataType []float64.array
+      Pointee: 1197 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 701
+      ID: 699
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 700 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 709
+      ID: 707
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 708 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 706 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 666
+      ID: 673
       Name: '*[]go.shape.float64.array'
       ByteSize: 8
-      Pointee: 665 GoSliceDataType []go.shape.float64.array
+      Pointee: 672 GoSliceDataType []go.shape.float64.array
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*[]go.shape.int.array'
       ByteSize: 8
-      Pointee: 661 GoSliceDataType []go.shape.int.array
+      Pointee: 668 GoSliceDataType []go.shape.int.array
     - __kind: PointerType
-      ID: 664
+      ID: 671
       Name: '*[]go.shape.string.array'
       ByteSize: 8
-      Pointee: 663 GoSliceDataType []go.shape.string.array
+      Pointee: 670 GoSliceDataType []go.shape.string.array
     - __kind: PointerType
       ID: 1458
       Name: '*[]interface {}.array'
@@ -12217,20 +12217,20 @@ Types:
       ByteSize: 8
       Pointee: 285 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 594
+      ID: 601
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 593 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 600 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 711
+      ID: 718
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 710 GoSliceDataType []main.structWithMap.array
+      Pointee: 717 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 586
+      ID: 593
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 585 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 592 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 42
       Name: '*[]runtime.ancestorInfo'
@@ -12239,111 +12239,111 @@ Types:
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 456
+      ID: 463
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 455 GoSliceDataType []string.array
+      Pointee: 462 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 591 GoSliceDataType []struct {}.array
+      Pointee: 598 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 713
+      ID: 720
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 712 GoSliceDataType []time.zone.array
+      Pointee: 719 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 715
+      ID: 722
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 714 GoSliceDataType []time.zoneTrans.array
+      Pointee: 721 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 272
       Name: '*[]uint'
       ByteSize: 8
       Pointee: 270 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 582
+      ID: 589
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 581 GoSliceDataType []uint.array
+      Pointee: 588 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 590
+      ID: 597
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 589 GoSliceDataType []uint16.array
+      Pointee: 596 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 434
+      ID: 441
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 433 GoSliceDataType []uint8.array
+      Pointee: 440 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 436
+      ID: 443
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 435 GoSliceDataType []uintptr.array
+      Pointee: 442 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1322
+      ID: 1329
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2017088
       GoKind: 22
-      Pointee: 1323 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1330 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 943936
       GoKind: 22
-      Pointee: 960 GoSliceHeaderType archive/tar.headerError
+      Pointee: 967 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 961 GoSliceDataType archive/tar.headerError.array
+      Pointee: 968 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1256
+      ID: 1263
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1453824
       GoKind: 22
-      Pointee: 1257 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1264 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1204
+      ID: 1211
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 944128
       GoKind: 22
-      Pointee: 1205 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1212 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1206
+      ID: 1213
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 944224
       GoKind: 22
-      Pointee: 1207 StructureType archive/zip.dirWriter
+      Pointee: 1214 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1299
+      ID: 1306
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1933120
       GoKind: 22
-      Pointee: 1300 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1307 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1232
+      ID: 1239
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1070816
       GoKind: 22
-      Pointee: 1233 StructureType archive/zip.nopCloser
+      Pointee: 1240 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1234
+      ID: 1241
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1071072
       GoKind: 22
-      Pointee: 1235 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1242 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 12
       Name: '*bool'
@@ -12352,26 +12352,26 @@ Types:
       GoKind: 22
       Pointee: 6 BaseType bool
     - __kind: PointerType
-      ID: 1280
+      ID: 1287
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2207168
       GoKind: 22
-      Pointee: 1281 UnresolvedPointeeType bufio.Reader
+      Pointee: 1288 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1311
+      ID: 1318
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1979904
       GoKind: 22
-      Pointee: 1312 UnresolvedPointeeType bufio.Writer
+      Pointee: 1319 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1358
+      ID: 1365
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2309152
       GoKind: 22
-      Pointee: 1359 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1366 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
       ID: 116
       Name: '*complex128'
@@ -12380,451 +12380,451 @@ Types:
       GoKind: 22
       Pointee: 20 BaseType complex128
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 926080
       GoKind: 22
-      Pointee: 763 BaseType compress/flate.CorruptInputError
+      Pointee: 770 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 926176
       GoKind: 22
-      Pointee: 764 GoStringHeaderType compress/flate.InternalError
+      Pointee: 771 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 765 GoStringDataType compress/flate.InternalError.str
+      Pointee: 772 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1254
+      ID: 1261
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1442624
       GoKind: 22
-      Pointee: 1255 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1262 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1200
+      ID: 1207
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 926272
       GoKind: 22
-      Pointee: 1201 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1208 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1276
+      ID: 1283
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1753248
       GoKind: 22
-      Pointee: 1277 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1284 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 371
+      ID: 434
       Name: '*context.afterFuncCtx'
       ByteSize: 8
       GoRuntimeType: 1751136
       GoKind: 22
-      Pointee: 372 StructureType context.afterFuncCtx
+      Pointee: 435 StructureType context.afterFuncCtx
     - __kind: PointerType
-      ID: 1438
+      ID: 418
       Name: '*context.backgroundCtx'
       ByteSize: 8
       GoRuntimeType: 1572576
       GoKind: 22
-      Pointee: 395 StructureType context.backgroundCtx
+      Pointee: 419 StructureType context.backgroundCtx
     - __kind: PointerType
-      ID: 373
+      ID: 422
       Name: '*context.cancelCtx'
       ByteSize: 8
       GoRuntimeType: 1750560
       GoKind: 22
-      Pointee: 374 StructureType context.cancelCtx
+      Pointee: 423 StructureType context.cancelCtx
     - __kind: PointerType
-      ID: 1075
+      ID: 1082
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1204448
       GoKind: 22
-      Pointee: 1076 StructureType context.deadlineExceededError
+      Pointee: 1083 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 1433
+      ID: 405
       Name: '*context.emptyCtx'
       ByteSize: 8
       GoRuntimeType: 1430944
       GoKind: 22
-      Pointee: 396 StructureType context.emptyCtx
+      Pointee: 406 StructureType context.emptyCtx
     - __kind: PointerType
-      ID: 375
+      ID: 407
       Name: '*context.stopCtx'
       ByteSize: 8
       GoRuntimeType: 1431104
       GoKind: 22
-      Pointee: 376 StructureType context.stopCtx
+      Pointee: 408 StructureType context.stopCtx
     - __kind: PointerType
-      ID: 377
+      ID: 430
       Name: '*context.timerCtx'
       ByteSize: 8
       GoRuntimeType: 1750752
       GoKind: 22
-      Pointee: 378 StructureType context.timerCtx
+      Pointee: 431 StructureType context.timerCtx
     - __kind: PointerType
-      ID: 1439
+      ID: 420
       Name: '*context.todoCtx'
       ByteSize: 8
       GoRuntimeType: 1572736
       GoKind: 22
-      Pointee: 400 StructureType context.todoCtx
+      Pointee: 421 StructureType context.todoCtx
     - __kind: PointerType
-      ID: 379
+      ID: 414
       Name: '*context.valueCtx'
       ByteSize: 8
       GoRuntimeType: 1572256
       GoKind: 22
-      Pointee: 380 StructureType context.valueCtx
+      Pointee: 415 StructureType context.valueCtx
     - __kind: PointerType
-      ID: 381
+      ID: 416
       Name: '*context.withoutCancelCtx'
       ByteSize: 8
       GoRuntimeType: 1572416
       GoKind: 22
-      Pointee: 382 StructureType context.withoutCancelCtx
+      Pointee: 417 StructureType context.withoutCancelCtx
     - __kind: PointerType
-      ID: 951
+      ID: 958
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 938560
       GoKind: 22
-      Pointee: 774 BaseType crypto/aes.KeySizeError
+      Pointee: 781 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 938752
       GoKind: 22
-      Pointee: 775 BaseType crypto/des.KeySizeError
+      Pointee: 782 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939040
       GoKind: 22
-      Pointee: 776 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 783 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1271
+      ID: 1278
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1693024
       GoKind: 22
-      Pointee: 1272 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1279 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1078624
       GoKind: 22
-      Pointee: 1057 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 1064 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1301
+      ID: 1308
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1933632
       GoKind: 22
-      Pointee: 1302 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1309 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1333
+      ID: 1340
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2151168
       GoKind: 22
-      Pointee: 1334 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1341 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1307
+      ID: 1314
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1934400
       GoKind: 22
-      Pointee: 1308 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1315 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1303
+      ID: 1310
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1933888
       GoKind: 22
-      Pointee: 1304 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1311 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1297
+      ID: 1304
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1931072
       GoKind: 22
-      Pointee: 1298 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1305 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 777 BaseType crypto/rc4.KeySizeError
+      Pointee: 784 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1320
+      ID: 1327
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 2014784
       GoKind: 22
-      Pointee: 1321 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1328 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1305
+      ID: 1312
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1934144
       GoKind: 22
-      Pointee: 1306 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1313 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 1289
+      ID: 1296
       Name: '*crypto/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1836032
       GoKind: 22
-      Pointee: 1290 UnresolvedPointeeType crypto/sha3.SHAKE
+      Pointee: 1297 UnresolvedPointeeType crypto/sha3.SHAKE
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 927520
       GoKind: 22
-      Pointee: 767 BaseType crypto/tls.AlertError
+      Pointee: 774 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 1045
+      ID: 1052
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1059808
       GoKind: 22
-      Pointee: 1046 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 1053 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1384
+      ID: 1391
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2411680
       GoKind: 22
-      Pointee: 1385 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1392 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 927616
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 885 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 927424
       GoKind: 22
-      Pointee: 875 StructureType crypto/tls.RecordHeaderError
+      Pointee: 882 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 1044
+      ID: 1051
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1058144
       GoKind: 22
-      Pointee: 999 BaseType crypto/tls.alert
+      Pointee: 1006 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1264
+      ID: 1271
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1581856
       GoKind: 22
-      Pointee: 1265 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1272 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 927712
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 887 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1269
+      ID: 1276
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1666720
       GoKind: 22
-      Pointee: 1270 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1277 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 1142
+      ID: 1149
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1443104
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 1150 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 1156
+      ID: 1163
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2043424
       GoKind: 22
-      Pointee: 1157 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 1164 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 945
+      ID: 952
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 937312
       GoKind: 22
-      Pointee: 946 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 953 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 936352
       GoKind: 22
-      Pointee: 940 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 947 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 941
+      ID: 948
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 936832
       GoKind: 22
-      Pointee: 942 StructureType crypto/x509.HostnameError
+      Pointee: 949 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 936256
       GoKind: 22
-      Pointee: 773 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 780 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 1050
+      ID: 1057
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1065056
       GoKind: 22
-      Pointee: 1051 StructureType crypto/x509.SystemRootsError
+      Pointee: 1058 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 947
+      ID: 954
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 937408
       GoKind: 22
-      Pointee: 948 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 955 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 937216
       GoKind: 22
-      Pointee: 944 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 951 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 944416
       GoKind: 22
-      Pointee: 964 StructureType encoding/asn1.StructuralError
+      Pointee: 971 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 967
+      ID: 974
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 944608
       GoKind: 22
-      Pointee: 968 StructureType encoding/asn1.SyntaxError
+      Pointee: 975 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 944512
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 973 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 862
+      ID: 869
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 923392
       GoKind: 22
-      Pointee: 757 BaseType encoding/base64.CorruptInputError
+      Pointee: 764 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1222
+      ID: 1229
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1054560
       GoKind: 22
-      Pointee: 1223 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1230 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 924256
       GoKind: 22
-      Pointee: 758 BaseType encoding/hex.InvalidByteError
+      Pointee: 765 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 918208
       GoKind: 22
-      Pointee: 834 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 841 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 1034
+      ID: 1041
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1050720
       GoKind: 22
-      Pointee: 1035 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 1042 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 917824
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 833 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 839 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 918016
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 837 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 917920
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 835 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1364
+      ID: 1371
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2330272
       GoKind: 22
-      Pointee: 1365 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1372 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 836 StructureType encoding/json.jsonError
+      Pointee: 843 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1230
+      ID: 1237
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1067616
       GoKind: 22
-      Pointee: 1231 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1238 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 935488
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 944 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
       ID: 113
       Name: '*error'
@@ -12833,19 +12833,19 @@ Types:
       GoKind: 22
       Pointee: 17 GoInterfaceType error
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 800 UnresolvedPointeeType errors.errorString
+      Pointee: 807 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1036256
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType errors.joinError
+      Pointee: 1009 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 115
       Name: '*float32'
@@ -12861,625 +12861,625 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 1352
+      ID: 1359
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2291712
       GoKind: 22
-      Pointee: 1353 UnresolvedPointeeType fmt.pp
+      Pointee: 1360 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1036384
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType fmt.wrapError
+      Pointee: 1011 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 1005
+      ID: 1012
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1036512
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 1013 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 871 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 920992
       GoKind: 22
-      Pointee: 845 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 852 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 921088
       GoKind: 22
-      Pointee: 847 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 854 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 1168
+      ID: 1175
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 920800
       GoKind: 22
-      Pointee: 1169 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 1176 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 851 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 858 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 1170
+      ID: 1177
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 920896
       GoKind: 22
-      Pointee: 1171 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 1178 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 751 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 758 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 753
+      ID: 760
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 759 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 920704
       GoKind: 22
-      Pointee: 748 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 755 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 756 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 921280
       GoKind: 22
-      Pointee: 754 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 761 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 755 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 762 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1242
+      ID: 1249
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1222112
       GoKind: 22
-      Pointee: 1243 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1250 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1330
+      ID: 1337
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2088256
       GoKind: 22
-      Pointee: 1331 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1338 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 957
+      ID: 964
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 942880
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 965 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
       ID: 401
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2308608
       GoKind: 22
-      Pointee: 402 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 371 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 426
+      ID: 399
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2038240
       GoKind: 22
-      Pointee: 427 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 400 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: PointerType
-      ID: 421
+      ID: 394
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1204704
       GoKind: 22
-      Pointee: 422 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 395 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 424
+      ID: 397
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1204832
       GoKind: 22
-      Pointee: 425 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 398 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 1431
+      ID: 1438
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1205472
       GoKind: 22
-      Pointee: 1432 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 1439 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1205600
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 730 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 428
+      ID: 402
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2257568
       GoKind: 22
-      Pointee: 429 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 403 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: PointerType
-      ID: 1110
+      ID: 1117
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1225568
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 1118 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1360
+      ID: 1367
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2309696
       GoKind: 22
-      Pointee: 1361 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1368 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 1434
+      ID: 410
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext'
       ByteSize: 8
       GoRuntimeType: 1436864
       GoKind: 22
-      Pointee: 1435 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
+      Pointee: 411 StructureType github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 931168
       GoKind: 22
-      Pointee: 888 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 895 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 932224
       GoKind: 22
-      Pointee: 895 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 902 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 931936
       GoKind: 22
-      Pointee: 772 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 779 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 932128
       GoKind: 22
-      Pointee: 893 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 900 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 932032
       GoKind: 22
-      Pointee: 891 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 898 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 910
+      ID: 917
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 934144
       GoKind: 22
-      Pointee: 911 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 918 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 914
+      ID: 921
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 934336
       GoKind: 22
-      Pointee: 915 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 922 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 912
+      ID: 919
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 934240
       GoKind: 22
-      Pointee: 913 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 920 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 908
+      ID: 915
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 934048
       GoKind: 22
-      Pointee: 909 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 916 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1193
+      ID: 1200
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1192 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1199 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 922
+      ID: 929
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 934720
       GoKind: 22
-      Pointee: 923 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 930 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 916
+      ID: 923
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 934432
       GoKind: 22
-      Pointee: 917 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 924 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 920
+      ID: 927
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 934624
       GoKind: 22
-      Pointee: 921 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 928 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 918
+      ID: 925
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 934528
       GoKind: 22
-      Pointee: 919 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 926 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 934816
       GoKind: 22
-      Pointee: 925 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 932 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 935104
       GoKind: 22
-      Pointee: 931 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 938 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 935200
       GoKind: 22
-      Pointee: 933 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 940 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 935008
       GoKind: 22
-      Pointee: 929 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 936 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 934912
       GoKind: 22
-      Pointee: 927 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 934 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 935392
       GoKind: 22
-      Pointee: 935 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 942 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 922528
       GoKind: 22
-      Pointee: 853 StructureType github.com/cihub/seelog.baseError
+      Pointee: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1283
+      ID: 1290
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1830432
       GoKind: 22
-      Pointee: 1284 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1291 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 922624
       GoKind: 22
-      Pointee: 855 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 862 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1262
+      ID: 1269
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1579936
       GoKind: 22
-      Pointee: 1263 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1270 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1218
+      ID: 1225
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1053408
       GoKind: 22
-      Pointee: 1219 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1226 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1252
+      ID: 1259
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1440544
       GoKind: 22
-      Pointee: 1253 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1260 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 922816
       GoKind: 22
-      Pointee: 859 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 866 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1318
+      ID: 1325
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 2006144
       GoKind: 22
-      Pointee: 1319 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1326 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1337
+      ID: 1344
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2164960
       GoKind: 22
-      Pointee: 1332 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1339 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1336
+      ID: 1343
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2164576
       GoKind: 22
-      Pointee: 1335 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1342 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1220
+      ID: 1227
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1053536
       GoKind: 22
-      Pointee: 1221 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1228 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 922720
       GoKind: 22
-      Pointee: 857 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 864 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 860
+      ID: 867
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 922912
       GoKind: 22
-      Pointee: 861 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 868 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1285
+      ID: 1292
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1832224
       GoKind: 22
-      Pointee: 1286 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1293 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1326
+      ID: 1333
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2043136
       GoKind: 22
-      Pointee: 1327 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1334 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1328
+      ID: 1335
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2074208
       GoKind: 22
-      Pointee: 1329 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1336 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 1144
+      ID: 1151
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1456224
       GoKind: 22
-      Pointee: 1145 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 1152 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1079392
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 1068 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1079264
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 1066 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1083360
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 1070 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1083488
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 1072 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1273
+      ID: 1280
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1695904
       GoKind: 22
-      Pointee: 1274 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1281 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1065568
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 1060 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 867 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 874 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1376
+      ID: 1383
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2385600
       GoKind: 22
-      Pointee: 1377 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1384 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 1118
+      ID: 1125
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1235552
       GoKind: 22
-      Pointee: 1119 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 1126 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 1087
+      ID: 1094
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1213280
       GoKind: 22
-      Pointee: 1088 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 1095 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 1081
+      ID: 1088
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1212896
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 1089 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 1020
+      ID: 1027
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1044832
       GoKind: 22
-      Pointee: 1021 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 1028 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1213664
       GoKind: 22
-      Pointee: 1094 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 1101 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1044704
       GoKind: 22
-      Pointee: 998 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 1005 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1213152
       GoKind: 22
-      Pointee: 1086 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 1093 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1213024
       GoKind: 22
-      Pointee: 1084 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 1091 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1213536
       GoKind: 22
-      Pointee: 1092 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 1099 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 1089
+      ID: 1096
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1213408
       GoKind: 22
-      Pointee: 1090 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 1097 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1380
+      ID: 1387
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2400704
       GoKind: 22
-      Pointee: 1381 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1388 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 1097
+      ID: 1104
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1214048
       GoKind: 22
-      Pointee: 1098 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 1105 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1045088
       GoKind: 22
-      Pointee: 1025 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 1032 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 1022
+      ID: 1029
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1044960
       GoKind: 22
-      Pointee: 1023 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 1030 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1213920
       GoKind: 22
-      Pointee: 1096 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 1103 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 957664
       GoKind: 22
-      Pointee: 782 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 789 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 784
+      ID: 791
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 783 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 790 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
       ID: 367
       Name: '*go.shape.float64'
@@ -13502,10 +13502,10 @@ Types:
       GoKind: 22
       Pointee: 340 GoStringHeaderType go.shape.string
     - __kind: PointerType
-      ID: 660
+      ID: 667
       Name: '*go.shape.string.str'
       ByteSize: 8
-      Pointee: 659 GoStringDataType go.shape.string.str
+      Pointee: 666 GoStringDataType go.shape.string.str
     - __kind: PointerType
       ID: 346
       Name: '*go.shape.struct { Name string }'
@@ -13525,249 +13525,249 @@ Types:
       GoKind: 22
       Pointee: 362 StructureType go.shape.struct { main.x []*string; main.z int; main.writer io.Writer }
     - __kind: PointerType
-      ID: 1159
+      ID: 1166
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1694368
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 1167 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 1068
+      ID: 1075
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1098208
       GoKind: 22
-      Pointee: 1069 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 1076 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1248
+      ID: 1255
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1276512
       GoKind: 22
-      Pointee: 1249 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1256 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1342
+      ID: 1349
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2179936
       GoKind: 22
-      Pointee: 1343 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1350 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1236
+      ID: 1243
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1100512
       GoKind: 22
-      Pointee: 1237 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1244 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 980
+      ID: 987
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 958912
       GoKind: 22
-      Pointee: 785 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 792 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 1126
+      ID: 1133
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1278176
       GoKind: 22
-      Pointee: 1127 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 1134 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 959200
       GoKind: 22
-      Pointee: 984 StructureType golang.org/x/net/http2.connError
+      Pointee: 991 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 982
+      ID: 989
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 959104
       GoKind: 22
-      Pointee: 789 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 796 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 790 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 797 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 986
+      ID: 993
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 959392
       GoKind: 22
-      Pointee: 795 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 802 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 796 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 803 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 959296
       GoKind: 22
-      Pointee: 792 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 799 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 793 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 800 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 981
+      ID: 988
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 959008
       GoKind: 22
-      Pointee: 786 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 793 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 787 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 794 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1340
+      ID: 1347
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2178016
       GoKind: 22
-      Pointee: 1341 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1348 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 959488
       GoKind: 22
-      Pointee: 988 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 995 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 959584
       GoKind: 22
-      Pointee: 798 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 805 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 952864
       GoKind: 22
-      Pointee: 976 StructureType google.golang.org/grpc.dropError
+      Pointee: 983 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 1124
+      ID: 1131
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1275232
       GoKind: 22
-      Pointee: 1125 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 1132 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 1146
+      ID: 1153
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1463584
       GoKind: 22
-      Pointee: 1147 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 1154 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 955936
       GoKind: 22
-      Pointee: 978 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 985 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1291
+      ID: 1298
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1838272
       GoKind: 22
-      Pointee: 1292 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1299 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1246
+      ID: 1253
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1271776
       GoKind: 22
-      Pointee: 1247 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1254 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 1066
+      ID: 1073
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1092448
       GoKind: 22
-      Pointee: 1067 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 1074 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1208
+      ID: 1215
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 956032
       GoKind: 22
-      Pointee: 1209 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1216 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 955
+      ID: 962
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 940768
       GoKind: 22
-      Pointee: 956 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 963 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1069152
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 1062 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 1122
+      ID: 1129
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1242464
       GoKind: 22
-      Pointee: 1123 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 1130 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 1120
+      ID: 1127
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1242208
       GoKind: 22
-      Pointee: 1121 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 1128 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 945472
       GoKind: 22
-      Pointee: 970 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 977 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 945568
       GoKind: 22
-      Pointee: 972 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 979 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 932608
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 910 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1295
+      ID: 1302
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1929024
       GoKind: 22
-      Pointee: 1296 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1303 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 990
+      ID: 997
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 960352
       GoKind: 22
-      Pointee: 991 UnresolvedPointeeType html/template.Error
+      Pointee: 998 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 107
       Name: '*int'
@@ -13811,61 +13811,61 @@ Types:
       GoKind: 22
       Pointee: 170 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 1148
+      ID: 1155
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2230432
       GoKind: 22
-      Pointee: 1149 UnresolvedPointeeType internal/abi.Type
+      Pointee: 1156 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 949
+      ID: 956
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 938176
       GoKind: 22
-      Pointee: 950 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 957 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 925792
       GoKind: 22
-      Pointee: 871 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 878 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1198
+      ID: 1205
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 924928
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1206 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 1116
+      ID: 1123
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1226848
       GoKind: 22
-      Pointee: 1117 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 1124 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1382
+      ID: 1389
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2406368
       GoKind: 22
-      Pointee: 1383 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1390 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1226720
       GoKind: 22
-      Pointee: 1115 StructureType internal/poll.errNetClosing
+      Pointee: 1122 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 913312
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 816 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
       ID: 101
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
@@ -13874,66 +13874,66 @@ Types:
       GoKind: 22
       Pointee: 102 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 869
+      ID: 876
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 925600
       GoKind: 22
-      Pointee: 760 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 767 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 762
+      ID: 769
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 761 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 768 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1056736
       GoKind: 22
-      Pointee: 1039 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 1046 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*internal/strconv.Error'
       ByteSize: 8
       GoRuntimeType: 924544
       GoKind: 22
-      Pointee: 759 BaseType internal/strconv.Error
+      Pointee: 766 BaseType internal/strconv.Error
     - __kind: PointerType
-      ID: 1240
+      ID: 1247
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1204192
       GoKind: 22
-      Pointee: 1241 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1248 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1238
+      ID: 1245
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1203808
       GoKind: 22
-      Pointee: 1239 StructureType io.discard
+      Pointee: 1246 StructureType io.discard
     - __kind: PointerType
-      ID: 1212
+      ID: 1219
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1037280
       GoKind: 22
-      Pointee: 1213 UnresolvedPointeeType io.multiWriter
+      Pointee: 1220 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 1112
+      ID: 1119
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1226208
       GoKind: 22
-      Pointee: 1113 UnresolvedPointeeType io/fs.PathError
+      Pointee: 1120 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1287
+      ID: 1294
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1832448
       GoKind: 22
-      Pointee: 1288 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1295 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
       ID: 353
       Name: '*main.Pair[go.shape.int,go.shape.bool]'
@@ -13953,19 +13953,19 @@ Types:
       GoKind: 22
       Pointee: 330 StructureType main.anotherStruct
     - __kind: PointerType
-      ID: 451
+      ID: 458
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 393024
       GoKind: 22
-      Pointee: 452 StructureType main.deepMap2
+      Pointee: 459 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1426
+      ID: 1433
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 392960
       GoKind: 22
-      Pointee: 1427 UnresolvedPointeeType main.deepMap3
+      Pointee: 1434 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 157
       Name: '*main.deepMap7'
@@ -13995,12 +13995,12 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1386
+      ID: 1393
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 393536
       GoKind: 22
-      Pointee: 1387 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1394 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 143
       Name: '*main.deepPtr7'
@@ -14028,14 +14028,14 @@ Types:
       ByteSize: 8
       GoRuntimeType: 394176
       GoKind: 22
-      Pointee: 442 StructureType main.deepSlice2
+      Pointee: 449 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1411
+      ID: 1418
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 394112
       GoKind: 22
-      Pointee: 1412 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1419 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepSlice7'
@@ -14071,7 +14071,7 @@ Types:
       GoKind: 22
       Pointee: 173 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1397
+      ID: 1404
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 908320
@@ -14104,19 +14104,19 @@ Types:
       GoKind: 22
       Pointee: 166 StructureType main.paddedData
     - __kind: PointerType
-      ID: 1398
+      ID: 1405
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 908416
       GoKind: 22
-      Pointee: 1399 StructureType main.secondBehavior
+      Pointee: 1406 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1392
+      ID: 1399
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 908512
       GoKind: 22
-      Pointee: 1393 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1400 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 159
       Name: '*main.stringType1'
@@ -14124,16 +14124,16 @@ Types:
       GoKind: 22
       Pointee: 160 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1389
+      ID: 1396
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1388 GoStringDataType main.stringType1.str
+      Pointee: 1395 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 162
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1390 GoStringHeaderType main.stringType2
+      Pointee: 1397 GoStringHeaderType main.stringType2
     - __kind: PointerType
       ID: 1504
       Name: '*main.stringType2.str'
@@ -14145,7 +14145,7 @@ Types:
       ByteSize: 8
       Pointee: 284 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 505
+      ID: 512
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 392512
@@ -14169,10 +14169,10 @@ Types:
       GoKind: 22
       Pointee: 262 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1402
+      ID: 1409
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1401 GoSliceDataType main.t.array
+      Pointee: 1408 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 281
       Name: '*main.threeStringStruct'
@@ -14200,20 +14200,20 @@ Types:
       ByteSize: 8
       Pointee: 213 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 388
+      ID: 426
       Name: '*map<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 389 GoSwissMapHeaderType map<context.canceler,struct {}>
+      Pointee: 427 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: PointerType
       ID: 153
       Name: '*map<int,*main.deepMap2>'
       ByteSize: 8
       Pointee: 154 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1416
+      ID: 1423
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1417 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1424 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1460
       Name: '*map<int,*main.deepMap8>'
@@ -14245,10 +14245,10 @@ Types:
       ByteSize: 8
       Pointee: 218 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 703
+      ID: 701
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 704 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 702 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 207
       Name: '*map<string,[]main.structWithMap>'
@@ -14260,35 +14260,35 @@ Types:
       ByteSize: 8
       Pointee: 196 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 416
+      ID: 389
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 417 GoSwissMapHeaderType map<string,float64>
+      Pointee: 390 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 1152
+      ID: 1159
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1153 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1160 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 190
       Name: '*map<string,int>'
       ByteSize: 8
       Pointee: 191 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 411
+      ID: 384
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 412 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 385 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
       ID: 185
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
       Pointee: 186 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 406
+      ID: 379
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 407 GoSwissMapHeaderType map<string,string>
+      Pointee: 380 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
       ID: 242
       Name: '*map<struct {},int>'
@@ -14346,493 +14346,493 @@ Types:
       GoKind: 22
       Pointee: 189 GoMapType map[string]int
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 933472
       GoKind: 22
-      Pointee: 907 StructureType math/big.ErrNaN
+      Pointee: 914 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1202
+      ID: 1209
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 928288
       GoKind: 22
-      Pointee: 1203 StructureType mime/multipart.writerOnly·1
+      Pointee: 1210 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 1104
+      ID: 1111
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1219936
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType net.AddrError
+      Pointee: 1112 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 1135
+      ID: 1142
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1438784
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType net.DNSError
+      Pointee: 1143 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1346
+      ID: 1353
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2265344
       GoKind: 22
-      Pointee: 1347 UnresolvedPointeeType net.IPConn
+      Pointee: 1354 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 1133
+      ID: 1140
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1438464
       GoKind: 22
-      Pointee: 1134 UnresolvedPointeeType net.OpError
+      Pointee: 1141 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 1106
+      ID: 1113
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1220064
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType net.ParseError
+      Pointee: 1114 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1356
+      ID: 1363
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2292736
       GoKind: 22
-      Pointee: 1357 UnresolvedPointeeType net.TCPConn
+      Pointee: 1364 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1366
+      ID: 1373
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2337856
       GoKind: 22
-      Pointee: 1367 UnresolvedPointeeType net.UDPConn
+      Pointee: 1374 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1354
+      ID: 1361
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2292224
       GoKind: 22
-      Pointee: 1355 UnresolvedPointeeType net.UnixConn
+      Pointee: 1362 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 1103
+      ID: 1110
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1219168
       GoKind: 22
-      Pointee: 1072 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 1079 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 1074
+      ID: 1081
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 1073 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 1080 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 1036
+      ID: 1043
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1051616
       GoKind: 22
-      Pointee: 1037 StructureType net.canceledError
+      Pointee: 1044 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1324
+      ID: 1331
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2040256
       GoKind: 22
-      Pointee: 1325 UnresolvedPointeeType net.conn
+      Pointee: 1332 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 1177
+      ID: 1184
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1875008
       GoKind: 22
-      Pointee: 1178 StructureType net.dialResult·1
+      Pointee: 1185 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1368
+      ID: 1375
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2342112
       GoKind: 22
-      Pointee: 1369 UnresolvedPointeeType net.netFD
+      Pointee: 1376 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 919552
       GoKind: 22
-      Pointee: 838 UnresolvedPointeeType net.notFoundError
+      Pointee: 845 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 1436
+      ID: 412
       Name: '*net.onlyValuesCtx'
       ByteSize: 8
       GoRuntimeType: 1438624
       GoKind: 22
-      Pointee: 1437 StructureType net.onlyValuesCtx
+      Pointee: 413 StructureType net.onlyValuesCtx
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 840 StructureType net.result·2
+      Pointee: 847 StructureType net.result·2
     - __kind: PointerType
-      ID: 1350
+      ID: 1357
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2278272
       GoKind: 22
-      Pointee: 1351 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1358 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1348
+      ID: 1355
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2277792
       GoKind: 22
-      Pointee: 1349 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1356 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 1108
+      ID: 1115
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1220704
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType net.temporaryError
+      Pointee: 1116 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 1137
+      ID: 1144
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1438944
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType net.timeoutError
+      Pointee: 1145 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1047648
       GoKind: 22
-      Pointee: 1027 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 1034 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1194
+      ID: 1201
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 915328
       GoKind: 22
-      Pointee: 1195 StructureType net/http.bufioFlushWriter
+      Pointee: 1202 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 729 BaseType net/http.http2ConnectionError
+      Pointee: 736 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 916096
       GoKind: 22
-      Pointee: 816 StructureType net/http.http2GoAwayError
+      Pointee: 823 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1434784
       GoKind: 22
-      Pointee: 1130 StructureType net/http.http2StreamError
+      Pointee: 1137 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 916672
       GoKind: 22
-      Pointee: 820 StructureType net/http.http2connError
+      Pointee: 827 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1258
+      ID: 1265
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1576736
       GoKind: 22
-      Pointee: 1259 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1266 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916576
       GoKind: 22
-      Pointee: 733 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 740 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 734 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 741 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 822
+      ID: 829
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 916864
       GoKind: 22
-      Pointee: 739 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 746 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 740 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 747 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 916768
       GoKind: 22
-      Pointee: 736 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 743 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 737 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 744 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 1101
+      ID: 1108
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1215968
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 1109 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 1032
+      ID: 1039
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1048160
       GoKind: 22
-      Pointee: 1033 StructureType net/http.http2noCachedConnError
+      Pointee: 1040 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1313
+      ID: 1320
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1981184
       GoKind: 22
-      Pointee: 1314 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1321 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 916480
       GoKind: 22
-      Pointee: 730 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 737 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 731 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 738 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1196
+      ID: 1203
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 916960
       GoKind: 22
-      Pointee: 1197 StructureType net/http.http2stickyErrWriter
+      Pointee: 1204 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1047904
       GoKind: 22
-      Pointee: 1029 StructureType net/http.nothingWrittenError
+      Pointee: 1036 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1260
+      ID: 1267
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2226688
       GoKind: 22
-      Pointee: 1261 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1268 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1216
+      ID: 1223
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1047776
       GoKind: 22
-      Pointee: 1217 StructureType net/http.persistConnWriter
+      Pointee: 1224 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1250
+      ID: 1257
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1434944
       GoKind: 22
-      Pointee: 1251 StructureType net/http.readWriteCloserBody
+      Pointee: 1258 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 917056
       GoKind: 22
-      Pointee: 824 StructureType net/http.requestBodyReadError
+      Pointee: 831 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 1131
+      ID: 1138
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1436064
       GoKind: 22
-      Pointee: 1132 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 1139 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 1099
+      ID: 1106
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1215840
       GoKind: 22
-      Pointee: 1100 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 1107 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 1030
+      ID: 1037
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1048032
       GoKind: 22
-      Pointee: 1031 StructureType net/http.transportReadFromServerError
+      Pointee: 1038 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1293
+      ID: 1300
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1871424
       GoKind: 22
-      Pointee: 1294 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1301 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 915232
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 820 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1315
+      ID: 1322
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1983232
       GoKind: 22
-      Pointee: 1316 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1323 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1226
+      ID: 1233
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1060832
       GoKind: 22
-      Pointee: 1227 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1234 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 932416
       GoKind: 22
-      Pointee: 899 StructureType net/netip.parseAddrError
+      Pointee: 906 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 932320
       GoKind: 22
-      Pointee: 897 StructureType net/netip.parsePrefixError
+      Pointee: 904 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1266
+      ID: 1273
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2149760
       GoKind: 22
-      Pointee: 1267 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1274 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1228
+      ID: 1235
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1065184
       GoKind: 22
-      Pointee: 1229 StructureType net/smtp.dataCloser
+      Pointee: 1236 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 928480
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType net/textproto.Error
+      Pointee: 890 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 928384
       GoKind: 22
-      Pointee: 768 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 775 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 769 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 776 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1224
+      ID: 1231
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1060320
       GoKind: 22
-      Pointee: 1225 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1232 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 1139
+      ID: 1146
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1439264
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType net/url.Error
+      Pointee: 1147 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 920320
       GoKind: 22
-      Pointee: 742 GoStringHeaderType net/url.EscapeError
+      Pointee: 749 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 743 GoStringDataType net/url.EscapeError.str
+      Pointee: 750 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 920416
       GoKind: 22
-      Pointee: 745 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 752 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 746 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 753 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 551
+      ID: 558
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 552 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 559 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 543
+      ID: 550
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 544 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 551 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 491
+      ID: 498
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 492 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 499 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 510
+      ID: 517
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 511 StructureType noalg.map.group[bool]main.node
+      Pointee: 518 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 669
+      ID: 710
       Name: '*noalg.map.group[context.canceler]struct {}'
       ByteSize: 8
-      Pointee: 670 StructureType noalg.map.group[context.canceler]struct {}
+      Pointee: 711 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: PointerType
-      ID: 447
+      ID: 454
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 448 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 455 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1422
+      ID: 1429
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1423 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1430 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
       ID: 1466
       Name: '*noalg.map.group[int]*main.deepMap8'
@@ -14844,230 +14844,230 @@ Types:
       ByteSize: 8
       Pointee: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 459
+      ID: 466
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 460 StructureType noalg.map.group[int]int
+      Pointee: 467 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 1496
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
       Pointee: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 567
+      ID: 574
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 568 StructureType noalg.map.group[int]struct {}
+      Pointee: 575 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 518
+      ID: 525
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 519 StructureType noalg.map.group[int]uint8
+      Pointee: 526 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 726 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 500
+      ID: 507
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 501 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 508 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 483
+      ID: 490
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 484 StructureType noalg.map.group[string][]string
+      Pointee: 491 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 694
+      ID: 692
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 695 StructureType noalg.map.group[string]float64
+      Pointee: 693 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 1184
+      ID: 1191
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1192 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 475
+      ID: 482
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 476 StructureType noalg.map.group[string]int
+      Pointee: 483 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 686
+      ID: 684
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 687 StructureType noalg.map.group[string]interface {}
+      Pointee: 685 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 467
+      ID: 474
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 468 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 475 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 678
+      ID: 676
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 679 StructureType noalg.map.group[string]string
+      Pointee: 677 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 559
+      ID: 566
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 560 StructureType noalg.map.group[struct {}]int
+      Pointee: 567 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 607
+      ID: 614
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 615 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 615
+      ID: 622
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 623 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 623
+      ID: 630
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 655 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 575
+      ID: 582
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 576 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 583 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 534
+      ID: 541
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 535 StructureType noalg.map.group[uint8][4]int
+      Pointee: 542 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 526
+      ID: 533
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 527 StructureType noalg.map.group[uint8]uint8
+      Pointee: 534 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1374
+      ID: 1381
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2380224
       GoKind: 22
-      Pointee: 1375 UnresolvedPointeeType os.File
+      Pointee: 1382 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1040992
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType os.LinkError
+      Pointee: 1017 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 1077
+      ID: 1084
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1208672
       GoKind: 22
-      Pointee: 1078 UnresolvedPointeeType os.SyscallError
+      Pointee: 1085 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1372
+      ID: 1379
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2379488
       GoKind: 22
-      Pointee: 1373 StructureType os.fileWithoutReadFrom
+      Pointee: 1380 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1370
+      ID: 1377
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2378752
       GoKind: 22
-      Pointee: 1371 StructureType os.fileWithoutWriteTo
+      Pointee: 1378 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 1040
+      ID: 1047
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1056864
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType os/exec.Error
+      Pointee: 1048 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 1180
+      ID: 1187
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2120672
       GoKind: 22
-      Pointee: 1181 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1188 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1244
+      ID: 1251
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1227872
       GoKind: 22
-      Pointee: 1245 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1252 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 1042
+      ID: 1049
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1056992
       GoKind: 22
-      Pointee: 1043 StructureType os/exec.wrappedError
+      Pointee: 1050 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 974
+      ID: 981
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 950944
       GoKind: 22
-      Pointee: 779 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 786 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 780 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 787 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 950848
       GoKind: 22
-      Pointee: 778 BaseType os/user.UnknownUserIdError
+      Pointee: 785 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 913984
       GoKind: 22
-      Pointee: 811 UnresolvedPointeeType reflect.ValueError
+      Pointee: 818 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 933088
       GoKind: 22
-      Pointee: 905 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 912 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1043296
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 1021 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1043936
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 1025 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 29
       Name: '*runtime._defer'
@@ -15083,12 +15083,12 @@ Types:
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1043424
       GoKind: 22
-      Pointee: 1016 StructureType runtime.boundsError
+      Pointee: 1023 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 71
       Name: '*runtime.cgoCallers'
@@ -15104,24 +15104,24 @@ Types:
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 1079
+      ID: 1086
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1211488
       GoKind: 22
-      Pointee: 1080 StructureType runtime.errorAddressString
+      Pointee: 1087 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1041632
       GoKind: 22
-      Pointee: 992 GoStringHeaderType runtime.errorString
+      Pointee: 999 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 993 GoStringDataType runtime.errorString.str
+      Pointee: 1000 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 61
       Name: '*runtime.g'
@@ -15142,19 +15142,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1043040
       GoKind: 22
-      Pointee: 437 UnresolvedPointeeType runtime.p
+      Pointee: 444 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 1012
+      ID: 1019
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1041760
       GoKind: 22
-      Pointee: 995 GoStringHeaderType runtime.plainError
+      Pointee: 1002 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 996 GoStringDataType runtime.plainError.str
+      Pointee: 1003 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 44
       Name: '*runtime.sudog'
@@ -15170,12 +15170,12 @@ Types:
       GoKind: 22
       Pointee: 53 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 913024
       GoKind: 22
-      Pointee: 807 StructureType runtime.synctestDeadlockError
+      Pointee: 814 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 47
       Name: '*runtime.timer'
@@ -15198,12 +15198,12 @@ Types:
       GoKind: 22
       Pointee: 56 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1039840
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType strconv.NumError
+      Pointee: 1015 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 103
       Name: '*string'
@@ -15212,31 +15212,31 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 432
+      ID: 439
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 431 GoStringDataType string.str
+      Pointee: 438 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1309
+      ID: 1316
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1979392
       GoKind: 22
-      Pointee: 1310 UnresolvedPointeeType strings.Builder
+      Pointee: 1317 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1214
+      ID: 1221
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1039968
       GoKind: 22
-      Pointee: 1215 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1222 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1210
+      ID: 1217
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 985376
       GoKind: 22
-      Pointee: 1211 StructureType struct { io.Writer }
+      Pointee: 1218 StructureType struct { io.Writer }
     - __kind: PointerType
       ID: 279
       Name: '*struct {}'
@@ -15245,47 +15245,47 @@ Types:
       GoKind: 22
       Pointee: 133 StructureType struct {}
     - __kind: PointerType
-      ID: 1141
+      ID: 1148
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1441504
       GoKind: 22
-      Pointee: 1128 BaseType syscall.Errno
+      Pointee: 1135 BaseType syscall.Errno
     - __kind: PointerType
       ID: 240
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 549 StructureType table<[4]int,[4]int>
+      Pointee: 556 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 235
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 541 StructureType table<[4]int,uint8>
+      Pointee: 548 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 203
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 489 StructureType table<[4]string,[2]int>
+      Pointee: 496 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 215
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 508 StructureType table<bool,main.node>
+      Pointee: 515 StructureType table<bool,main.node>
     - __kind: PointerType
-      ID: 391
+      ID: 429
       Name: '*table<context.canceler,struct {}>'
       ByteSize: 8
-      Pointee: 667 StructureType table<context.canceler,struct {}>
+      Pointee: 708 StructureType table<context.canceler,struct {}>
     - __kind: PointerType
       ID: 156
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 445 StructureType table<int,*main.deepMap2>
+      Pointee: 452 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1419
+      ID: 1426
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1420 StructureType table<int,*main.deepMap3>
+      Pointee: 1427 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
       ID: 1463
       Name: '*table<int,*main.deepMap8>'
@@ -15300,7 +15300,7 @@ Types:
       ID: 183
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 457 StructureType table<int,int>
+      Pointee: 464 StructureType table<int,int>
     - __kind: PointerType
       ID: 1493
       Name: '*table<int,interface {}>'
@@ -15310,121 +15310,121 @@ Types:
       ID: 250
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 565 StructureType table<int,struct {}>
+      Pointee: 572 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 220
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 516 StructureType table<int,uint8>
+      Pointee: 523 StructureType table<int,uint8>
     - __kind: PointerType
-      ID: 706
+      ID: 704
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 716 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 723 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
       ID: 210
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 498 StructureType table<string,[]main.structWithMap>
+      Pointee: 505 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 198
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 481 StructureType table<string,[]string>
+      Pointee: 488 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 419
+      ID: 392
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 692 StructureType table<string,float64>
+      Pointee: 690 StructureType table<string,float64>
     - __kind: PointerType
-      ID: 1155
+      ID: 1162
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 1182 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1189 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 193
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 473 StructureType table<string,int>
+      Pointee: 480 StructureType table<string,int>
     - __kind: PointerType
-      ID: 414
+      ID: 387
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 684 StructureType table<string,interface {}>
+      Pointee: 682 StructureType table<string,interface {}>
     - __kind: PointerType
       ID: 188
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 465 StructureType table<string,main.nestedStruct>
+      Pointee: 472 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 409
+      ID: 382
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 676 StructureType table<string,string>
+      Pointee: 674 StructureType table<string,string>
     - __kind: PointerType
       ID: 245
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 557 StructureType table<struct {},int>
+      Pointee: 564 StructureType table<struct {},int>
     - __kind: PointerType
       ID: 302
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 605 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 612 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 307
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 613 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 620 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 312
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 621 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 628 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 317
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 629 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 636 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 322
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 637 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 644 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 327
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 645 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 652 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 255
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 573 StructureType table<struct {},struct {}>
+      Pointee: 580 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 230
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 532 StructureType table<uint8,[4]int>
+      Pointee: 539 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 225
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 524 StructureType table<uint8,uint8>
+      Pointee: 531 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1344
+      ID: 1351
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2192160
       GoKind: 22
-      Pointee: 1345 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1352 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 1070
+      ID: 1077
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1102048
       GoKind: 22
-      Pointee: 1071 StructureType text/template.ExecError
+      Pointee: 1078 StructureType text/template.ExecError
     - __kind: PointerType
       ID: 335
       Name: '*time.Location'
@@ -15433,52 +15433,52 @@ Types:
       GoKind: 22
       Pointee: 336 StructureType time.Location
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 911104
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType time.ParseError
+      Pointee: 812 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 398
+      ID: 432
       Name: '*time.Timer'
       ByteSize: 8
       GoRuntimeType: 1041376
       GoKind: 22
-      Pointee: 399 StructureType time.Timer
+      Pointee: 433 StructureType time.Timer
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 910912
       GoKind: 22
-      Pointee: 726 GoStringHeaderType time.fileSizeError
+      Pointee: 733 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 727 GoStringDataType time.fileSizeError.str
+      Pointee: 734 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*time.parseDurationError'
       ByteSize: 8
       GoRuntimeType: 911008
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType time.parseDurationError
+      Pointee: 810 UnresolvedPointeeType time.parseDurationError
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 399744
       GoKind: 22
-      Pointee: 655 StructureType time.zone
+      Pointee: 662 StructureType time.zone
     - __kind: PointerType
-      ID: 657
+      ID: 664
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 399808
       GoKind: 22
-      Pointee: 658 StructureType time.zoneTrans
+      Pointee: 665 StructureType time.zoneTrans
     - __kind: PointerType
       ID: 114
       Name: '*uint'
@@ -15522,49 +15522,49 @@ Types:
       GoKind: 22
       Pointee: 3 BaseType uintptr
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 932512
       GoKind: 22
-      Pointee: 901 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 908 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1338
+      ID: 1345
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2167648
       GoKind: 22
-      Pointee: 1339 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1346 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 928672
       GoKind: 22
-      Pointee: 885 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 892 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 928768
       GoKind: 22
-      Pointee: 771 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 778 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 1047
+      ID: 1054
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1060576
       GoKind: 22
-      Pointee: 1048 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 1055 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 1049
+      ID: 1056
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1060704
       GoKind: 22
-      Pointee: 1000 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 1007 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: GoChannelType
-      ID: 1403
+      ID: 1415
       Name: <-chan time.Time
       GoRuntimeType: 606240
       GoKind: 18
@@ -26293,7 +26293,7 @@ Types:
       HasCount: true
       Element: 35 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 538
+      ID: 545
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 692832
@@ -26302,7 +26302,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 495
+      ID: 502
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 693120
@@ -26328,7 +26328,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1172
+      ID: 1179
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 694656
@@ -26337,7 +26337,7 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: ArrayType
-      ID: 1391
+      ID: 1398
       Name: '[63]uint64'
       ByteSize: 504
       GoKind: 17
@@ -26363,7 +26363,7 @@ Types:
       HasCount: true
       Element: 91 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceHeaderType
-      ID: 1404
+      ID: 1410
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 489792
@@ -26371,16 +26371,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1405 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1411 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1407 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 1413 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: GoSliceDataType
-      ID: 1407
+      ID: 1413
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26401,15 +26401,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 443 GoSliceDataType []*main.deepSlice2.array
+      Data: 450 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 450
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 148 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1409
+      ID: 1416
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 485568
@@ -26417,20 +26417,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1410 PointerType **main.deepSlice3
+          Type: 1417 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1413 GoSliceDataType []*main.deepSlice3.array
+      Data: 1420 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1413
+      ID: 1420
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1411 PointerType *main.deepSlice3
+      Element: 1418 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
       ID: 1444
       Name: '[]*main.deepSlice8'
@@ -26493,9 +26493,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 438 GoSliceDataType []*runtime.p.array
+      Data: 445 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 445
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26516,55 +26516,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 440 GoSliceDataType []*string.array
+      Data: 447 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 440
+      ID: 447
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 103 PointerType *string
     - __kind: GoSliceDataType
-      ID: 555
+      ID: 562
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 240 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 547
+      ID: 554
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 235 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 503
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 203 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 514
+      ID: 521
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 215 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 674
+      ID: 715
       Name: '[]*table<context.canceler,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 391 PointerType *table<context.canceler,struct {}>
+      Element: 429 PointerType *table<context.canceler,struct {}>
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 460
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 156 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1428
+      ID: 1435
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1419 PointerType *table<int,*main.deepMap3>
+      Element: 1426 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
       ID: 1472
       Name: '[]*table<int,*main.deepMap8>.array'
@@ -26578,7 +26578,7 @@ Types:
       ByteSize: 8
       Element: 1478 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 470
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26590,127 +26590,127 @@ Types:
       ByteSize: 8
       Element: 1493 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 571
+      ID: 578
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 250 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 522
+      ID: 529
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 220 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 724
+      ID: 731
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 706 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 704 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 506
+      ID: 513
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 210 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 494
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 198 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 698
+      ID: 696
       Name: '[]*table<string,float64>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 419 PointerType *table<string,float64>
+      Element: 392 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 1188
+      ID: 1195
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1155 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 1162 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 486
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 193 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 690
+      ID: 688
       Name: '[]*table<string,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 414 PointerType *table<string,interface {}>
+      Element: 387 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 478
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 188 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 682
+      ID: 680
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 409 PointerType *table<string,string>
+      Element: 382 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 563
+      ID: 570
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 245 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 611
+      ID: 618
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 302 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 619
+      ID: 626
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 307 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 627
+      ID: 634
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 312 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 635
+      ID: 642
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 317 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 643
+      ID: 650
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 322 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 651
+      ID: 658
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 327 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 579
+      ID: 586
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 255 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 539
+      ID: 546
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 230 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 530
+      ID: 537
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
@@ -26730,9 +26730,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 603 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 610 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 603
+      ID: 610
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26752,9 +26752,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 601 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 608 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 601
+      ID: 608
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26774,9 +26774,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 599 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 606 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 599
+      ID: 606
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26796,9 +26796,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 597 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 604 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 597
+      ID: 604
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26818,9 +26818,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 595 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 602 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 595
+      ID: 602
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26840,9 +26840,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 583 GoSliceDataType [][]uint.array
+      Data: 590 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 583
+      ID: 590
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
@@ -26863,15 +26863,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 587 GoSliceDataType []bool.array
+      Data: 594 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 587
+      ID: 594
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 6 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 1167
+      ID: 1174
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 496064
@@ -26886,15 +26886,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1190 GoSliceDataType []float64.array
+      Data: 1197 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1190
+      ID: 1197
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 16 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 420
+      ID: 393
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 489344
@@ -26902,22 +26902,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 421 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 394 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 700 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 698 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 700
+      ID: 698
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       DynamicSizeClass: slice
       ByteSize: 56
-      Element: 422 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 395 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: GoSliceHeaderType
-      ID: 423
+      ID: 396
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 489536
@@ -26925,20 +26925,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 424 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 397 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 708 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 706 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 708
+      ID: 706
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       DynamicSizeClass: slice
       ByteSize: 40
-      Element: 425 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 398 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: GoSliceHeaderType
       ID: 366
       Name: '[]go.shape.float64'
@@ -26955,9 +26955,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 665 GoSliceDataType []go.shape.float64.array
+      Data: 672 GoSliceDataType []go.shape.float64.array
     - __kind: GoSliceDataType
-      ID: 665
+      ID: 672
       Name: '[]go.shape.float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26977,9 +26977,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 661 GoSliceDataType []go.shape.int.array
+      Data: 668 GoSliceDataType []go.shape.int.array
     - __kind: GoSliceDataType
-      ID: 661
+      ID: 668
       Name: '[]go.shape.int.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -26999,9 +26999,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 663 GoSliceDataType []go.shape.string.array
+      Data: 670 GoSliceDataType []go.shape.string.array
     - __kind: GoSliceDataType
-      ID: 663
+      ID: 670
       Name: '[]go.shape.string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -27044,15 +27044,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 593 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 600 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 593
+      ID: 600
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
       Element: 284 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 504
+      ID: 511
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 486208
@@ -27060,16 +27060,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 505 PointerType *main.structWithMap
+          Type: 512 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 710 GoSliceDataType []main.structWithMap.array
+      Data: 717 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 710
+      ID: 717
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -27089,55 +27089,55 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 585 GoSliceDataType []main.structWithNoStrings.array
+      Data: 592 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 585
+      ID: 592
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
       Element: 275 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 556
+      ID: 563
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 552 StructureType noalg.map.group[[4]int][4]int
+      Element: 559 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 548
+      ID: 555
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 544 StructureType noalg.map.group[[4]int]uint8
+      Element: 551 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 497
+      ID: 504
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 492 StructureType noalg.map.group[[4]string][2]int
+      Element: 499 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 515
+      ID: 522
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 511 StructureType noalg.map.group[bool]main.node
+      Element: 518 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 675
+      ID: 716
       Name: '[]noalg.map.group[context.canceler]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 670 StructureType noalg.map.group[context.canceler]struct {}
+      Element: 711 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 461
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 448 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 455 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1429
+      ID: 1436
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1423 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1430 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
       ID: 1473
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
@@ -27151,11 +27151,11 @@ Types:
       ByteSize: 136
       Element: 1482 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 471
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 460 StructureType noalg.map.group[int]int
+      Element: 467 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 1501
       Name: '[]noalg.map.group[int]interface {}.array'
@@ -27163,131 +27163,131 @@ Types:
       ByteSize: 200
       Element: 1497 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 572
+      ID: 579
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 568 StructureType noalg.map.group[int]struct {}
+      Element: 575 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 523
+      ID: 530
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 519 StructureType noalg.map.group[int]uint8
+      Element: 526 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 725
+      ID: 732
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 726 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 507
+      ID: 514
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 501 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 508 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 495
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 484 StructureType noalg.map.group[string][]string
+      Element: 491 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 699
+      ID: 697
       Name: '[]noalg.map.group[string]float64.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 695 StructureType noalg.map.group[string]float64
+      Element: 693 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 1189
+      ID: 1196
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1192 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 487
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 476 StructureType noalg.map.group[string]int
+      Element: 483 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 691
+      ID: 689
       Name: '[]noalg.map.group[string]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 687 StructureType noalg.map.group[string]interface {}
+      Element: 685 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 479
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 468 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 475 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 683
+      ID: 681
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 679 StructureType noalg.map.group[string]string
+      Element: 677 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 564
+      ID: 571
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 560 StructureType noalg.map.group[struct {}]int
+      Element: 567 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 612
+      ID: 619
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 615 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 620
+      ID: 627
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 623 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 628
+      ID: 635
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 636
+      ID: 643
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 644
+      ID: 651
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 652
+      ID: 659
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 655 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 580
+      ID: 587
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 576 StructureType noalg.map.group[struct {}]struct {}
+      Element: 583 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 540
+      ID: 547
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 535 StructureType noalg.map.group[uint8][4]int
+      Element: 542 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 531
+      ID: 538
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 527 StructureType noalg.map.group[uint8]uint8
+      Element: 534 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 43
       Name: '[]runtime.ancestorInfo'
@@ -27308,9 +27308,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 455 GoSliceDataType []string.array
+      Data: 462 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 462
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -27330,14 +27330,14 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 591 GoSliceDataType []struct {}.array
+      Data: 598 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 591
+      ID: 598
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 133 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 653
+      ID: 660
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 494720
@@ -27345,22 +27345,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 654 PointerType *time.zone
+          Type: 661 PointerType *time.zone
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 712 GoSliceDataType []time.zone.array
+      Data: 719 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 712
+      ID: 719
       Name: '[]time.zone.array'
       DynamicSizeClass: slice
       ByteSize: 32
-      Element: 655 StructureType time.zone
+      Element: 662 StructureType time.zone
     - __kind: GoSliceHeaderType
-      ID: 656
+      ID: 663
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 494784
@@ -27368,20 +27368,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 657 PointerType *time.zoneTrans
+          Type: 664 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 714 GoSliceDataType []time.zoneTrans.array
+      Data: 721 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 714
+      ID: 721
       Name: '[]time.zoneTrans.array'
       DynamicSizeClass: slice
       ByteSize: 16
-      Element: 658 StructureType time.zoneTrans
+      Element: 665 StructureType time.zoneTrans
     - __kind: GoSliceHeaderType
       ID: 270
       Name: '[]uint'
@@ -27398,9 +27398,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 581 GoSliceDataType []uint.array
+      Data: 588 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 581
+      ID: 588
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -27421,9 +27421,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 589 GoSliceDataType []uint16.array
+      Data: 596 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 589
+      ID: 596
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -27444,9 +27444,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 433 GoSliceDataType []uint8.array
+      Data: 440 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 433
+      ID: 440
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -27467,19 +27467,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 435 GoSliceDataType []uintptr.array
+      Data: 442 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 435
+      ID: 442
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 3 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1323
+      ID: 1330
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 960
+      ID: 967
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 944032
@@ -27494,33 +27494,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 961 GoSliceDataType archive/tar.headerError.array
+      Data: 968 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 961
+      ID: 968
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1257
+      ID: 1264
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1205
+      ID: 1212
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1207
+      ID: 1214
       Name: archive/zip.dirWriter
       GoRuntimeType: 1134176
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1300
+      ID: 1307
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1233
+      ID: 1240
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1587936
@@ -27530,7 +27530,7 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1235
+      ID: 1242
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -27540,15 +27540,15 @@ Types:
       GoRuntimeType: 593760
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1281
+      ID: 1288
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1312
+      ID: 1319
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1359
+      ID: 1366
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -27574,13 +27574,13 @@ Types:
       GoRuntimeType: 593504
       GoKind: 15
     - __kind: BaseType
-      ID: 763
+      ID: 770
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 844992
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 764
+      ID: 771
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 845088
@@ -27588,26 +27588,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 766 PointerType *compress/flate.InternalError.str
+          Type: 773 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 765 GoStringDataType compress/flate.InternalError.str
+      Data: 772 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 765
+      ID: 772
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1255
+      ID: 1262
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1201
+      ID: 1208
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1277
+      ID: 1284
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -27624,7 +27624,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoContextImplementationType
-      ID: 372
+      ID: 435
       Name: context.afterFuncCtx
       ByteSize: 104
       GoRuntimeType: 1750944
@@ -27632,29 +27632,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 374 StructureType context.cancelCtx
+          Type: 423 StructureType context.cancelCtx
         - Name: once
           Offset: 80
-          Type: 392 StructureType sync.Once
+          Type: 436 StructureType sync.Once
         - Name: f
           Offset: 96
           Type: 65 GoSubroutineType func()
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 395
+      ID: 419
       Name: context.backgroundCtx
       GoRuntimeType: 1826624
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 396 StructureType context.emptyCtx
+          Type: 406 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 374
+      ID: 423
       Name: context.cancelCtx
       ByteSize: 80
       GoRuntimeType: 1995776
@@ -27665,23 +27665,23 @@ Types:
           Type: 163 GoInterfaceType context.Context
         - Name: mu
           Offset: 16
-          Type: 383 StructureType sync.Mutex
+          Type: 373 StructureType sync.Mutex
         - Name: done
           Offset: 24
-          Type: 386 StructureType sync/atomic.Value
+          Type: 424 StructureType sync/atomic.Value
         - Name: children
           Offset: 40
-          Type: 387 GoMapType map[context.canceler]struct {}
+          Type: 425 GoMapType map[context.canceler]struct {}
         - Name: err
           Offset: 48
-          Type: 386 StructureType sync/atomic.Value
+          Type: 424 StructureType sync/atomic.Value
         - Name: cause
           Offset: 64
           Type: 17 GoInterfaceType error
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoInterfaceType
-      ID: 673
+      ID: 714
       Name: context.canceler
       ByteSize: 16
       GoRuntimeType: 1124704
@@ -27694,13 +27694,13 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1076
+      ID: 1083
       Name: context.deadlineExceededError
       GoRuntimeType: 1483136
       GoKind: 25
       RawFields: []
     - __kind: GoContextImplementationType
-      ID: 396
+      ID: 406
       Name: context.emptyCtx
       GoRuntimeType: 1618528
       GoKind: 25
@@ -27709,7 +27709,7 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 376
+      ID: 408
       Name: context.stopCtx
       ByteSize: 24
       GoRuntimeType: 1852096
@@ -27720,11 +27720,11 @@ Types:
           Type: 163 GoInterfaceType context.Context
         - Name: stop
           Offset: 16
-          Type: 397 GoSubroutineType func() bool
+          Type: 409 GoSubroutineType func() bool
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 378
+      ID: 431
       Name: context.timerCtx
       ByteSize: 112
       GoRuntimeType: 1637920
@@ -27732,29 +27732,29 @@ Types:
       RawFields:
         - Name: cancelCtx
           Offset: 0
-          Type: 374 StructureType context.cancelCtx
+          Type: 423 StructureType context.cancelCtx
         - Name: timer
           Offset: 80
-          Type: 398 PointerType *time.Timer
+          Type: 432 PointerType *time.Timer
         - Name: deadline
           Offset: 88
           Type: 334 GoTimeType time.Time
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 400
+      ID: 421
       Name: context.todoCtx
       GoRuntimeType: 1826848
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 396 StructureType context.emptyCtx
+          Type: 406 StructureType context.emptyCtx
       ContextOffset: -1
       KeyOffset: -1
       ValueOffset: -1
     - __kind: GoContextImplementationType
-      ID: 380
+      ID: 415
       Name: context.valueCtx
       ByteSize: 48
       GoRuntimeType: 1864256
@@ -27772,7 +27772,7 @@ Types:
       KeyOffset: 16
       ValueOffset: 32
     - __kind: GoContextImplementationType
-      ID: 382
+      ID: 417
       Name: context.withoutCancelCtx
       ByteSize: 16
       GoRuntimeType: 1826400
@@ -27784,91 +27784,91 @@ Types:
       KeyOffset: -1
       ValueOffset: -1
     - __kind: BaseType
-      ID: 774
+      ID: 781
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 847584
       GoKind: 2
     - __kind: BaseType
-      ID: 775
+      ID: 782
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 847680
       GoKind: 2
     - __kind: BaseType
-      ID: 776
+      ID: 783
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 847776
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1272
+      ID: 1279
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 1057
+      ID: 1064
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1306144
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1302
+      ID: 1309
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1334
+      ID: 1341
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1308
+      ID: 1315
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1304
+      ID: 1311
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1298
+      ID: 1305
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 777
+      ID: 784
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 847872
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1321
+      ID: 1328
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1306
+      ID: 1313
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1290
+      ID: 1297
       Name: crypto/sha3.SHAKE
       ByteSize: 8
     - __kind: BaseType
-      ID: 767
+      ID: 774
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 845568
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1046
+      ID: 1053
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1385
+      ID: 1392
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 885
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1757856
@@ -27879,38 +27879,38 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 1172 ArrayType [5]uint8
+          Type: 1179 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 999
+      ID: 1006
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 1007072
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1265
+      ID: 1272
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 887
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1270
+      ID: 1277
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1150
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1157
+      ID: 1164
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 946
+      ID: 953
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1760736
@@ -27918,21 +27918,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1156 PointerType *crypto/x509.Certificate
+          Type: 1163 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 1175 BaseType crypto/x509.InvalidReason
+          Type: 1182 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 940
+      ID: 947
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1131616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 942
+      ID: 949
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1623168
@@ -27940,24 +27940,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 1156 PointerType *crypto/x509.Certificate
+          Type: 1163 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 773
+      ID: 780
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 847104
       GoKind: 2
     - __kind: BaseType
-      ID: 1175
+      ID: 1182
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 598816
       GoKind: 2
     - __kind: StructureType
-      ID: 1051
+      ID: 1058
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1583776
@@ -27967,13 +27967,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 948
+      ID: 955
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1131872
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 944
+      ID: 951
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1760544
@@ -27981,15 +27981,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 1156 PointerType *crypto/x509.Certificate
+          Type: 1163 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 17 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 1156 PointerType *crypto/x509.Certificate
+          Type: 1163 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 964
+      ID: 971
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1454464
@@ -27999,7 +27999,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 968
+      ID: 975
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1454624
@@ -28009,55 +28009,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 973
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 757
+      ID: 764
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 844416
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1223
+      ID: 1230
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 758
+      ID: 765
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 844608
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 834
+      ID: 841
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1035
+      ID: 1042
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 839
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1365
+      ID: 1372
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 836
+      ID: 843
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1437504
@@ -28067,11 +28067,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1231
+      ID: 1238
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -28088,11 +28088,11 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 800
+      ID: 807
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1009
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -28108,15 +28108,15 @@ Types:
       GoRuntimeType: 593696
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1353
+      ID: 1360
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1011
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1013
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -28126,7 +28126,7 @@ Types:
       GoRuntimeType: 483648
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 397
+      ID: 409
       Name: func() bool
       ByteSize: 8
       GoRuntimeType: 604512
@@ -28171,11 +28171,11 @@ Types:
           Offset: 0
           Type: 340 GoStringHeaderType go.shape.string
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 871
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 845
+      ID: 852
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1756704
@@ -28183,7 +28183,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 1165 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 1172 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -28191,25 +28191,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 847
+      ID: 854
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1169
+      ID: 1176
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 851
+      ID: 858
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1127392
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1171
+      ID: 1178
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 751
+      ID: 758
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 843840
@@ -28217,18 +28217,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 753 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 760 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 752 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 759 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 752
+      ID: 759
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1165
+      ID: 1172
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2252192
@@ -28236,7 +28236,7 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 1166 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 1173 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28251,7 +28251,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 1167 GoSliceHeaderType []float64
+          Type: 1174 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 15 BaseType int64
@@ -28260,10 +28260,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 1168 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 1175 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 1170 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 1177 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
           Type: 167 GoSliceHeaderType []string
@@ -28277,13 +28277,13 @@ Types:
           Offset: 184
           Type: 15 BaseType int64
     - __kind: BaseType
-      ID: 1166
+      ID: 1173
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 595296
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 748
+      ID: 755
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 843744
@@ -28291,18 +28291,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 750 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 757 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 749 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 756 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 749
+      ID: 756
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 754
+      ID: 761
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 843936
@@ -28310,30 +28310,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 756 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 763 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 755 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 762 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 755
+      ID: 762
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1243
+      ID: 1250
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1331
+      ID: 1338
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 965
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: DDTraceSpanType
-      ID: 402
+      ID: 371
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2370816
@@ -28341,7 +28341,7 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 403 StructureType sync.RWMutex
+          Type: 372 StructureType sync.RWMutex
         - Name: name
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -28362,13 +28362,13 @@ Types:
           Type: 15 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 410 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 383 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 415 GoMapType map[string]float64
+          Type: 388 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
           Type: 10 BaseType uint64
@@ -28383,10 +28383,10 @@ Types:
           Type: 14 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 420 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 393 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 423 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 396 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
           Type: 6 BaseType bool
@@ -28398,7 +28398,7 @@ Types:
           Type: 6 BaseType bool
         - Name: context
           Offset: 216
-          Type: 426 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 399 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
           Type: 11 GoStringHeaderType string
@@ -28421,7 +28421,7 @@ Types:
       SpanContextOffset: 216
       SpanContextTraceIDOffset: 49
     - __kind: StructureType
-      ID: 427
+      ID: 400
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2249952
@@ -28432,13 +28432,13 @@ Types:
           Type: 6 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 428 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 402 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
           Type: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 404 StructureType sync/atomic.Int32
+          Type: 376 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28447,16 +28447,16 @@ Types:
           Type: 6 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 430 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 404 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
           Type: 10 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 403 StructureType sync.RWMutex
+          Type: 372 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
           Type: 4 BaseType uint32
@@ -28465,12 +28465,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 420 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 393 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 422
+      ID: 395
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1940480
@@ -28487,7 +28487,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
           Type: 11 GoStringHeaderType string
@@ -28495,20 +28495,20 @@ Types:
           Offset: 48
           Type: 4 BaseType uint32
     - __kind: GoMapType
-      ID: 410
+      ID: 383
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1298976
       GoKind: 21
-      HeaderType: 412 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 385 GoSwissMapHeaderType map<string,interface {}>
     - __kind: BaseType
-      ID: 1406
+      ID: 1412
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 592544
       GoKind: 10
     - __kind: StructureType
-      ID: 425
+      ID: 398
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1777184
@@ -28522,16 +28522,16 @@ Types:
           Type: 10 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 702 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 700 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 707 GoMapType map[string]interface {}
+          Type: 705 GoMapType map[string]interface {}
     - __kind: UnresolvedPointeeType
-      ID: 1432
+      ID: 1439
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 8
     - __kind: StructureType
-      ID: 723
+      ID: 730
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1940736
@@ -28539,7 +28539,7 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 1430 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 1437 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28554,15 +28554,15 @@ Types:
           Type: 16 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 1431 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 1438 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 1430
+      ID: 1437
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1001984
       GoKind: 5
     - __kind: StructureType
-      ID: 429
+      ID: 403
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2136064
@@ -28570,16 +28570,16 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 403 StructureType sync.RWMutex
+          Type: 372 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 1404 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 1410 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 405 GoMapType map[string]string
+          Type: 378 GoMapType map[string]string
         - Name: finished
           Offset: 64
           Type: 9 BaseType int
@@ -28594,12 +28594,12 @@ Types:
           Type: 6 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 1406 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 1412 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
           Type: 401 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: ArrayType
-      ID: 430
+      ID: 404
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 909568
@@ -28608,15 +28608,15 @@ Types:
       HasCount: true
       Element: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1118
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1361
+      ID: 1368
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1435
+    - __kind: GoContextImplementationType
+      ID: 411
       Name: github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext
       ByteSize: 16
       GoRuntimeType: 1652128
@@ -28625,30 +28625,32 @@ Types:
         - Name: Context
           Offset: 0
           Type: 163 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: UnresolvedPointeeType
-      ID: 888
+      ID: 895
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1130848
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 772
+      ID: 779
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 2
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1130720
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1621088
@@ -28661,7 +28663,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 911
+      ID: 918
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1621888
@@ -28674,7 +28676,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 915
+      ID: 922
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1759968
@@ -28690,7 +28692,7 @@ Types:
           Offset: 24
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 913
+      ID: 920
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1447424
@@ -28700,7 +28702,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 909
+      ID: 916
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1447104
@@ -28710,14 +28712,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 1151
+      ID: 1158
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1521216
       GoKind: 21
-      HeaderType: 1153 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 1160 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 1174
+      ID: 1181
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1064160
@@ -28732,15 +28734,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1192 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1199 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1192
+      ID: 1199
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 5 BaseType uint8
     - __kind: StructureType
-      ID: 923
+      ID: 930
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1622208
@@ -28748,12 +28750,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 1151 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1158 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 1151 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 1158 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 917
+      ID: 924
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1447584
@@ -28763,7 +28765,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 921
+      ID: 928
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1760160
@@ -28774,12 +28776,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1181 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1181 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 919
+      ID: 926
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1622048
@@ -28792,7 +28794,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 925
+      ID: 932
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1447744
@@ -28802,7 +28804,7 @@ Types:
           Offset: 0
           Type: 334 GoTimeType time.Time
     - __kind: StructureType
-      ID: 931
+      ID: 938
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1622528
@@ -28815,7 +28817,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 933
+      ID: 940
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1448064
@@ -28825,7 +28827,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 929
+      ID: 936
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1622368
@@ -28838,7 +28840,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 927
+      ID: 934
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1447904
@@ -28848,7 +28850,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 935
+      ID: 942
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1622688
@@ -28861,7 +28863,7 @@ Types:
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1439744
@@ -28871,11 +28873,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1284
+      ID: 1291
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 855
+      ID: 862
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1439904
@@ -28883,21 +28885,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 853 StructureType github.com/cihub/seelog.baseError
+          Type: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1263
+      ID: 1270
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1219
+      ID: 1226
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1253
+      ID: 1260
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 859
+      ID: 866
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1440224
@@ -28905,13 +28907,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 853 StructureType github.com/cihub/seelog.baseError
+          Type: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1319
+      ID: 1326
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1332
+      ID: 1339
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2138528
@@ -28919,12 +28921,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1325 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 15 BaseType int64
     - __kind: StructureType
-      ID: 1335
+      ID: 1342
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2164192
@@ -28932,7 +28934,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1318 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1325 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -28940,11 +28942,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1221
+      ID: 1228
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1440064
@@ -28952,9 +28954,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 853 StructureType github.com/cihub/seelog.baseError
+          Type: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 861
+      ID: 868
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1440384
@@ -28962,64 +28964,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 853 StructureType github.com/cihub/seelog.baseError
+          Type: 860 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1286
+      ID: 1293
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1327
+      ID: 1334
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1329
+      ID: 1336
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1145
+      ID: 1152
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1068
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1070
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1072
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1274
+      ID: 1281
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1060
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 867
+      ID: 874
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1441344
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1377
+      ID: 1384
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1119
+      ID: 1126
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 1088
+      ID: 1095
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1869632
@@ -29035,11 +29037,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1089
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 1021
+      ID: 1028
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1729408
@@ -29052,7 +29054,7 @@ Types:
           Offset: 1
           Type: 21 BaseType int8
     - __kind: StructureType
-      ID: 1094
+      ID: 1101
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1870080
@@ -29068,13 +29070,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 998
+      ID: 1005
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 1003904
       GoKind: 8
     - __kind: StructureType
-      ID: 1086
+      ID: 1093
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1869408
@@ -29090,13 +29092,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1176
+      ID: 1183
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 842112
       GoKind: 8
     - __kind: StructureType
-      ID: 1084
+      ID: 1091
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1869184
@@ -29104,15 +29106,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 1176 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1183 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 1176 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1183 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1092
+      ID: 1099
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1783136
@@ -29125,7 +29127,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1090
+      ID: 1097
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1869856
@@ -29141,11 +29143,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1381
+      ID: 1388
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1098
+      ID: 1105
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1648096
@@ -29155,19 +29157,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1025
+      ID: 1032
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1299360
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1023
+      ID: 1030
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1299232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1096
+      ID: 1103
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1783328
@@ -29180,7 +29182,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 782
+      ID: 789
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 849696
@@ -29188,13 +29190,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 784 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 791 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 783 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 790 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 783
+      ID: 790
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29225,13 +29227,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 660 PointerType *go.shape.string.str
+          Type: 667 PointerType *go.shape.string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 659 GoStringDataType go.shape.string.str
+      Data: 666 GoStringDataType go.shape.string.str
     - __kind: GoStringDataType
-      ID: 659
+      ID: 666
       Name: go.shape.string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -29287,11 +29289,11 @@ Types:
           Offset: 32
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1167
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1069
+      ID: 1076
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1466304
@@ -29301,7 +29303,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1249
+      ID: 1256
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1704736
@@ -29309,13 +29311,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1275 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1282 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1343
+      ID: 1350
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1275
+      ID: 1282
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1141728
@@ -29328,7 +29330,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1237
+      ID: 1244
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1593056
@@ -29338,19 +29340,19 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 785
+      ID: 792
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 850272
       GoKind: 10
     - __kind: BaseType
-      ID: 1158
+      ID: 1165
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1017632
       GoKind: 10
     - __kind: StructureType
-      ID: 1127
+      ID: 1134
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1908608
@@ -29361,12 +29363,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1158 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1165 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 984
+      ID: 991
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1630208
@@ -29374,12 +29376,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1158 BaseType golang.org/x/net/http2.ErrCode
+          Type: 1165 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 789
+      ID: 796
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850464
@@ -29387,18 +29389,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 791 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 798 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 790 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 797 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 790
+      ID: 797
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 795
+      ID: 802
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 850656
@@ -29406,18 +29408,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 797 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 804 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 796 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 803 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 796
+      ID: 803
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 792
+      ID: 799
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 850560
@@ -29425,18 +29427,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 794 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 801 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 793 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 800 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 793
+      ID: 800
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 786
+      ID: 793
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 850368
@@ -29444,22 +29446,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 788 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 795 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 787 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 794 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 787
+      ID: 794
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1341
+      ID: 1348
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 988
+      ID: 995
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1466944
@@ -29469,13 +29471,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 798
+      ID: 805
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 850752
       GoKind: 2
     - __kind: StructureType
-      ID: 976
+      ID: 983
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1461984
@@ -29485,11 +29487,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1125
+      ID: 1132
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 1147
+      ID: 1154
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1937472
@@ -29505,7 +29507,7 @@ Types:
           Offset: 24
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1629728
@@ -29518,7 +29520,7 @@ Types:
           Offset: 16
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 1292
+      ID: 1299
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1996800
@@ -29526,16 +29528,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1317 GoInterfaceType io.Reader
+          Type: 1324 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1247
+      ID: 1254
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1067
+      ID: 1074
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1590656
@@ -29545,29 +29547,29 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1209
+      ID: 1216
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 956
+      ID: 963
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1123
+      ID: 1130
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1121
+      ID: 1128
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1532736
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 970
+      ID: 977
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1455264
@@ -29577,7 +29579,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 972
+      ID: 979
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1455424
@@ -29587,107 +29589,107 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 550
+      ID: 557
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 551 PointerType *noalg.map.group[[4]int][4]int
+          Type: 558 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 552 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 556 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 559 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 563 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 542
+      ID: 549
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 543 PointerType *noalg.map.group[[4]int]uint8
+          Type: 550 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 544 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 548 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 551 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 555 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 490
+      ID: 497
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 491 PointerType *noalg.map.group[[4]string][2]int
+          Type: 498 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 492 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 497 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 499 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 504 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 509
+      ID: 516
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 510 PointerType *noalg.map.group[bool]main.node
+          Type: 517 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 511 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 515 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 518 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 522 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 668
+      ID: 709
       Name: groupReference<context.canceler,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 669 PointerType *noalg.map.group[context.canceler]struct {}
+          Type: 710 PointerType *noalg.map.group[context.canceler]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 670 StructureType noalg.map.group[context.canceler]struct {}
-      GroupSliceType: 675 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
+      GroupType: 711 StructureType noalg.map.group[context.canceler]struct {}
+      GroupSliceType: 716 GoSliceDataType []noalg.map.group[context.canceler]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 446
+      ID: 453
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 447 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 454 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 448 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 454 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 455 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 461 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1421
+      ID: 1428
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1422 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1429 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1423 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1429 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1430 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1436 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
       ID: 1465
       Name: groupReference<int,*main.deepMap8>
@@ -29717,19 +29719,19 @@ Types:
       GroupType: 1482 StructureType noalg.map.group[int]*main.deepMap9
       GroupSliceType: 1488 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 458
+      ID: 465
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 459 PointerType *noalg.map.group[int]int
+          Type: 466 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 460 StructureType noalg.map.group[int]int
-      GroupSliceType: 464 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 467 StructureType noalg.map.group[int]int
+      GroupSliceType: 471 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
       ID: 1495
       Name: groupReference<int,interface {}>
@@ -29745,305 +29747,305 @@ Types:
       GroupType: 1497 StructureType noalg.map.group[int]interface {}
       GroupSliceType: 1501 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 566
+      ID: 573
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 567 PointerType *noalg.map.group[int]struct {}
+          Type: 574 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 568 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 572 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 575 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 579 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 517
+      ID: 524
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 518 PointerType *noalg.map.group[int]uint8
+          Type: 525 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 519 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 523 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 526 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 530 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 717
+      ID: 724
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 718 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 725 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 725 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupType: 726 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 732 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: GoSwissMapGroupsType
-      ID: 499
+      ID: 506
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 500 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 507 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 501 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 507 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 508 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 514 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 482
+      ID: 489
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 483 PointerType *noalg.map.group[string][]string
+          Type: 490 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 484 StructureType noalg.map.group[string][]string
-      GroupSliceType: 488 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 491 StructureType noalg.map.group[string][]string
+      GroupSliceType: 495 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 693
+      ID: 691
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 694 PointerType *noalg.map.group[string]float64
+          Type: 692 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 695 StructureType noalg.map.group[string]float64
-      GroupSliceType: 699 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupType: 693 StructureType noalg.map.group[string]float64
+      GroupSliceType: 697 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: GoSwissMapGroupsType
-      ID: 1183
+      ID: 1190
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1184 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1191 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1189 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1192 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1196 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 474
+      ID: 481
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 475 PointerType *noalg.map.group[string]int
+          Type: 482 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 476 StructureType noalg.map.group[string]int
-      GroupSliceType: 480 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 483 StructureType noalg.map.group[string]int
+      GroupSliceType: 487 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 685
+      ID: 683
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 686 PointerType *noalg.map.group[string]interface {}
+          Type: 684 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 687 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 691 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupType: 685 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 689 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 466
+      ID: 473
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 467 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 474 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 468 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 472 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 475 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 479 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 677
+      ID: 675
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 678 PointerType *noalg.map.group[string]string
+          Type: 676 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 679 StructureType noalg.map.group[string]string
-      GroupSliceType: 683 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 677 StructureType noalg.map.group[string]string
+      GroupSliceType: 681 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 558
+      ID: 565
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 559 PointerType *noalg.map.group[struct {}]int
+          Type: 566 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 560 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 564 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 567 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 571 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 606
+      ID: 613
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 607 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 614 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 612 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 615 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 619 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 614
+      ID: 621
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 615 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 622 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 620 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 623 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 627 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 622
+      ID: 629
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 623 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 630 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 628 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 635 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 630
+      ID: 637
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 631 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 638 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 636 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 643 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 638
+      ID: 645
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 639 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 646 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 644 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 651 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 646
+      ID: 653
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 647 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 654 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 652 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 655 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 659 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 574
+      ID: 581
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 575 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 582 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 576 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 580 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 583 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 587 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 533
+      ID: 540
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 534 PointerType *noalg.map.group[uint8][4]int
+          Type: 541 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 535 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 540 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 542 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 547 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 525
+      ID: 532
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 526 PointerType *noalg.map.group[uint8]uint8
+          Type: 533 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 10 BaseType uint64
-      GroupType: 527 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 531 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 534 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 538 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1296
+      ID: 1303
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 991
+      ID: 998
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -30090,17 +30092,17 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: BaseType
-      ID: 1179
+      ID: 1186
       Name: internal/abi.BoundsErrorCode
       ByteSize: 1
       GoRuntimeType: 596192
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1149
+      ID: 1156
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 950
+      ID: 957
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -30126,29 +30128,29 @@ Types:
           Offset: 296
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 871
+      ID: 878
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1206
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1117
+      ID: 1124
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1383
+      ID: 1390
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1115
+      ID: 1122
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1510176
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 816
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -30220,7 +30222,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 760
+      ID: 767
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 844896
@@ -30228,18 +30230,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 762 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 769 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 761 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 768 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 761
+      ID: 768
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1039
+      ID: 1046
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1581536
@@ -30247,15 +30249,15 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 1148 PointerType *internal/abi.Type
+          Type: 1155 PointerType *internal/abi.Type
     - __kind: BaseType
-      ID: 759
+      ID: 766
       Name: internal/strconv.Error
       ByteSize: 8
       GoRuntimeType: 844704
       GoKind: 2
     - __kind: StructureType
-      ID: 385
+      ID: 375
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1507616
@@ -30268,11 +30270,11 @@ Types:
           Offset: 4
           Type: 4 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1241
+      ID: 1248
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1282
+      ID: 1289
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1203936
@@ -30285,7 +30287,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1317
+      ID: 1324
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1037408
@@ -30298,7 +30300,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1268
+      ID: 1275
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1124192
@@ -30324,21 +30326,21 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1239
+      ID: 1246
       Name: io.discard
       GoRuntimeType: 1482816
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1213
+      ID: 1220
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1113
+      ID: 1120
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1288
+      ID: 1295
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
@@ -30432,7 +30434,7 @@ Types:
           Offset: 0
           Type: 152 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 452
+      ID: 459
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1200096
@@ -30440,9 +30442,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1415 GoMapType map[int]*main.deepMap3
+          Type: 1422 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1427
+      ID: 1434
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -30494,9 +30496,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1386 PointerType *main.deepPtr3
+          Type: 1393 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1387
+      ID: 1394
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -30540,7 +30542,7 @@ Types:
           Offset: 0
           Type: 146 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 442
+      ID: 449
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1202400
@@ -30548,9 +30550,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1409 GoSliceHeaderType []*main.deepSlice3
+          Type: 1416 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1412
+      ID: 1419
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -30600,16 +30602,16 @@ Types:
           Type: 168 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 383 StructureType sync.Mutex
+          Type: 373 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 392 StructureType sync.Once
+          Type: 436 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1394 StructureType sync.WaitGroup
+          Type: 1401 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 404 StructureType sync/atomic.Int32
+          Type: 376 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 168
       Name: main.esotericStack
@@ -31027,9 +31029,9 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 8
-          Type: 1391 ArrayType [63]uint64
+          Type: 1398 ArrayType [63]uint64
     - __kind: StructureType
-      ID: 1399
+      ID: 1406
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1430624
@@ -31049,7 +31051,7 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1393
+      ID: 1400
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -31060,18 +31062,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1389 PointerType *main.stringType1.str
+          Type: 1396 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1388 GoStringDataType main.stringType1.str
+      Data: 1395 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1388
+      ID: 1395
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 1390
+      ID: 1397
       Name: main.stringType2
       ByteSize: 16
       GoKind: 24
@@ -31200,16 +31202,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1400 PointerType **main.t
+          Type: 1407 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1401 GoSliceDataType main.t.array
+      Data: 1408 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1401
+      ID: 1408
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
@@ -31369,8 +31371,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 555 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 552 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 562 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 559 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 233
       Name: map<[4]int,uint8>
@@ -31404,8 +31406,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 547 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 544 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 554 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 551 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 201
       Name: map<[4]string,[2]int>
@@ -31439,8 +31441,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 496 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 492 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 503 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 499 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 213
       Name: map<bool,main.node>
@@ -31474,10 +31476,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 514 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 511 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 521 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 518 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
-      ID: 389
+      ID: 427
       Name: map<context.canceler,struct {}>
       ByteSize: 48
       GoKind: 25
@@ -31490,7 +31492,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 390 PointerType **table<context.canceler,struct {}>
+          Type: 428 PointerType **table<context.canceler,struct {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31509,8 +31511,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 674 GoSliceDataType []*table<context.canceler,struct {}>.array
-      GroupType: 670 StructureType noalg.map.group[context.canceler]struct {}
+      TablePtrSliceType: 715 GoSliceDataType []*table<context.canceler,struct {}>.array
+      GroupType: 711 StructureType noalg.map.group[context.canceler]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 154
       Name: map<int,*main.deepMap2>
@@ -31544,10 +31546,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 453 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 448 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 460 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 455 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1417
+      ID: 1424
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -31560,7 +31562,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1418 PointerType **table<int,*main.deepMap3>
+          Type: 1425 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31579,8 +31581,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1428 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1423 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1435 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1430 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
       ID: 1461
       Name: map<int,*main.deepMap8>
@@ -31684,8 +31686,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 463 GoSliceDataType []*table<int,int>.array
-      GroupType: 460 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 470 GoSliceDataType []*table<int,int>.array
+      GroupType: 467 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
       ID: 1491
       Name: map<int,interface {}>
@@ -31754,8 +31756,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 571 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 568 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 578 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 575 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 218
       Name: map<int,uint8>
@@ -31789,10 +31791,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 522 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 519 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 529 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 526 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
-      ID: 704
+      ID: 702
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
@@ -31805,7 +31807,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 705 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 703 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31824,8 +31826,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 724 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 719 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      TablePtrSliceType: 731 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 726 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSwissMapHeaderType
       ID: 208
       Name: map<string,[]main.structWithMap>
@@ -31859,8 +31861,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 506 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 501 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 513 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 508 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 196
       Name: map<string,[]string>
@@ -31894,10 +31896,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 487 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 484 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 494 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 491 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 417
+      ID: 390
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
@@ -31910,7 +31912,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 418 PointerType **table<string,float64>
+          Type: 391 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31929,10 +31931,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 698 GoSliceDataType []*table<string,float64>.array
-      GroupType: 695 StructureType noalg.map.group[string]float64
+      TablePtrSliceType: 696 GoSliceDataType []*table<string,float64>.array
+      GroupType: 693 StructureType noalg.map.group[string]float64
     - __kind: GoSwissMapHeaderType
-      ID: 1153
+      ID: 1160
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -31945,7 +31947,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1154 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1161 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -31964,8 +31966,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 1188 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1185 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1195 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1192 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 191
       Name: map<string,int>
@@ -31999,10 +32001,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 479 GoSliceDataType []*table<string,int>.array
-      GroupType: 476 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 486 GoSliceDataType []*table<string,int>.array
+      GroupType: 483 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
-      ID: 412
+      ID: 385
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -32015,7 +32017,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 413 PointerType **table<string,interface {}>
+          Type: 386 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -32034,8 +32036,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 690 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 687 StructureType noalg.map.group[string]interface {}
+      TablePtrSliceType: 688 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 685 StructureType noalg.map.group[string]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 186
       Name: map<string,main.nestedStruct>
@@ -32069,10 +32071,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 471 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 468 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 478 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 475 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
-      ID: 407
+      ID: 380
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -32085,7 +32087,7 @@ Types:
           Type: 3 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 408 PointerType **table<string,string>
+          Type: 381 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 9 BaseType int
@@ -32104,8 +32106,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 682 GoSliceDataType []*table<string,string>.array
-      GroupType: 679 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 680 GoSliceDataType []*table<string,string>.array
+      GroupType: 677 StructureType noalg.map.group[string]string
     - __kind: GoSwissMapHeaderType
       ID: 243
       Name: map<struct {},int>
@@ -32139,8 +32141,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 563 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 560 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 570 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 567 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
       ID: 300
       Name: map<struct {},main.structWithCyclicMaps>
@@ -32174,8 +32176,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 611 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 608 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 618 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 615 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 305
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
@@ -32209,8 +32211,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 619 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 616 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 626 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 623 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 310
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32244,8 +32246,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 627 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 624 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 634 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 631 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 315
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32279,8 +32281,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 635 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 632 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 642 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 639 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 320
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32314,8 +32316,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 643 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 640 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 650 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 647 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 325
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
@@ -32349,8 +32351,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 651 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 648 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 658 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 655 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 253
       Name: map<struct {},struct {}>
@@ -32384,8 +32386,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 579 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 576 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 586 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 583 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 228
       Name: map<uint8,[4]int>
@@ -32419,8 +32421,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 539 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 535 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 546 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 542 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 223
       Name: map<uint8,uint8>
@@ -32454,8 +32456,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 10 BaseType uint64
-      TablePtrSliceType: 530 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 527 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 537 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 534 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 236
       Name: map[[4]int][4]int
@@ -32485,12 +32487,12 @@ Types:
       GoKind: 21
       HeaderType: 213 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoMapType
-      ID: 387
+      ID: 425
       Name: map[context.canceler]struct {}
       ByteSize: 8
       GoRuntimeType: 1145952
       GoKind: 21
-      HeaderType: 389 GoSwissMapHeaderType map<context.canceler,struct {}>
+      HeaderType: 427 GoSwissMapHeaderType map<context.canceler,struct {}>
     - __kind: GoMapType
       ID: 152
       Name: map[int]*main.deepMap2
@@ -32499,12 +32501,12 @@ Types:
       GoKind: 21
       HeaderType: 154 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1415
+      ID: 1422
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1143520
       GoKind: 21
-      HeaderType: 1417 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1424 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
       ID: 1459
       Name: map[int]*main.deepMap8
@@ -32548,12 +32550,12 @@ Types:
       GoKind: 21
       HeaderType: 218 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoMapType
-      ID: 702
+      ID: 700
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1146208
       GoKind: 21
-      HeaderType: 704 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 702 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoMapType
       ID: 206
       Name: map[string][]main.structWithMap
@@ -32569,12 +32571,12 @@ Types:
       GoKind: 21
       HeaderType: 196 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 415
+      ID: 388
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1146080
       GoKind: 21
-      HeaderType: 417 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 390 GoSwissMapHeaderType map<string,float64>
     - __kind: GoMapType
       ID: 189
       Name: map[string]int
@@ -32583,12 +32585,12 @@ Types:
       GoKind: 21
       HeaderType: 191 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
-      ID: 707
+      ID: 705
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1142496
       GoKind: 21
-      HeaderType: 412 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 385 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoMapType
       ID: 184
       Name: map[string]main.nestedStruct
@@ -32597,12 +32599,12 @@ Types:
       GoKind: 21
       HeaderType: 186 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoMapType
-      ID: 405
+      ID: 378
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1145824
       GoKind: 21
-      HeaderType: 407 GoSwissMapHeaderType map<string,string>
+      HeaderType: 380 GoSwissMapHeaderType map<string,string>
     - __kind: GoMapType
       ID: 241
       Name: map[struct {}]int
@@ -32668,7 +32670,7 @@ Types:
       GoKind: 21
       HeaderType: 223 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 907
+      ID: 914
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1446624
@@ -32678,7 +32680,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1203
+      ID: 1210
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1443584
@@ -32688,11 +32690,11 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1112
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1173
+      ID: 1180
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1619808
@@ -32705,35 +32707,35 @@ Types:
           Offset: 8
           Type: 18 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1143
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1347
+      ID: 1354
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1134
+      ID: 1141
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1114
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1357
+      ID: 1364
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1367
+      ID: 1374
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1355
+      ID: 1362
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 1072
+      ID: 1079
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1127008
@@ -32741,28 +32743,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1074 PointerType *net.UnknownNetworkError.str
+          Type: 1081 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1073 GoStringDataType net.UnknownNetworkError.str
+      Data: 1080 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 1073
+      ID: 1080
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1037
+      ID: 1044
       Name: net.canceledError
       GoRuntimeType: 1300512
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1325
+      ID: 1332
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1178
+      ID: 1185
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2137824
@@ -32770,7 +32772,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 17 GoInterfaceType error
@@ -32781,27 +32783,27 @@ Types:
           Offset: 33
           Type: 6 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1369
+      ID: 1376
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1363
+      ID: 1370
       Name: net.noReadFrom
       GoRuntimeType: 1127264
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1362
+      ID: 1369
       Name: net.noWriteTo
       GoRuntimeType: 1127136
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 838
+      ID: 845
       Name: net.notFoundError
       ByteSize: 8
-    - __kind: StructureType
-      ID: 1437
+    - __kind: GoContextImplementationType
+      ID: 413
       Name: net.onlyValuesCtx
       ByteSize: 32
       GoRuntimeType: 1787744
@@ -32813,8 +32815,10 @@ Types:
         - Name: lookupValues
           Offset: 16
           Type: 163 GoInterfaceType context.Context
+      KeyOffset: -1
+      ValueOffset: -1
     - __kind: StructureType
-      ID: 840
+      ID: 847
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1756512
@@ -32822,7 +32826,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 1161 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 1168 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -32830,7 +32834,7 @@ Types:
           Offset: 96
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1351
+      ID: 1358
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2320000
@@ -32838,12 +32842,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1363 StructureType net.noReadFrom
+          Type: 1370 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1356 PointerType *net.TCPConn
+          Type: 1363 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1349
+      ID: 1356
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2319456
@@ -32851,24 +32855,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1362 StructureType net.noWriteTo
+          Type: 1369 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1356 PointerType *net.TCPConn
+          Type: 1363 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1116
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1145
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1027
+      ID: 1034
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1195
+      ID: 1202
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1435264
@@ -32878,19 +32882,19 @@ Types:
           Offset: 0
           Type: 139 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 729
+      ID: 736
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 842592
       GoKind: 10
     - __kind: BaseType
-      ID: 1150
+      ID: 1157
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 1004000
       GoKind: 10
     - __kind: StructureType
-      ID: 816
+      ID: 823
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1754784
@@ -32901,12 +32905,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 1150 BaseType net/http.http2ErrCode
+          Type: 1157 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1130
+      ID: 1137
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1926720
@@ -32917,12 +32921,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 1150 BaseType net/http.http2ErrCode
+          Type: 1157 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 820
+      ID: 827
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1619488
@@ -32930,16 +32934,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 1150 BaseType net/http.http2ErrCode
+          Type: 1157 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1259
+      ID: 1266
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 733
+      ID: 740
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 842784
@@ -32947,18 +32951,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 735 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 742 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 734 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 741 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 734
+      ID: 741
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 739
+      ID: 746
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 842976
@@ -32966,18 +32970,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 741 PointerType *net/http.http2headerFieldNameError.str
+          Type: 748 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 740 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 747 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 740
+      ID: 747
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 736
+      ID: 743
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 842880
@@ -32985,32 +32989,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 738 PointerType *net/http.http2headerFieldValueError.str
+          Type: 745 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 737 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 744 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 737
+      ID: 744
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1109
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1033
+      ID: 1040
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1299872
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1314
+      ID: 1321
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 730
+      ID: 737
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 842688
@@ -33018,18 +33022,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 732 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 739 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 731 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 738 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 731
+      ID: 738
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1197
+      ID: 1204
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1755552
@@ -33037,22 +33041,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 1278 BaseType time.Duration
+          Type: 1285 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 113 PointerType *error
     - __kind: ArrayType
-      ID: 1279
+      ID: 1286
       Name: net/http.incomparable
       GoRuntimeType: 915040
       GoKind: 17
       HasCount: true
       Element: 65 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1029
+      ID: 1036
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1577536
@@ -33062,11 +33066,11 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1261
+      ID: 1268
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1217
+      ID: 1224
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1577376
@@ -33074,9 +33078,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1260 PointerType *net/http.persistConn
+          Type: 1267 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1251
+      ID: 1258
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1828640
@@ -33084,15 +33088,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1279 ArrayType net/http.incomparable
+          Type: 1286 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1280 PointerType *bufio.Reader
+          Type: 1287 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1282 GoInterfaceType io.ReadWriteCloser
+          Type: 1289 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 824
+      ID: 831
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1436224
@@ -33102,17 +33106,17 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1132
+      ID: 1139
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1100
+      ID: 1107
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1496736
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1031
+      ID: 1038
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1577696
@@ -33122,7 +33126,7 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: StructureType
-      ID: 1294
+      ID: 1301
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2057504
@@ -33130,16 +33134,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 1173 GoInterfaceType net.Conn
+          Type: 1180 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1316
+      ID: 1323
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2073248
@@ -33147,13 +33151,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1311 PointerType *bufio.Writer
+          Type: 1318 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1227
+      ID: 1234
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1759584
@@ -33169,7 +33173,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1621248
@@ -33182,11 +33186,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1267
+      ID: 1274
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1229
+      ID: 1236
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1623488
@@ -33194,16 +33198,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1266 PointerType *net/smtp.Client
+          Type: 1273 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1268 GoInterfaceType io.WriteCloser
+          Type: 1275 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 890
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 768
+      ID: 775
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 845664
@@ -33211,26 +33215,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 770 PointerType *net/textproto.ProtocolError.str
+          Type: 777 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 769 GoStringDataType net/textproto.ProtocolError.str
+      Data: 776 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 769
+      ID: 776
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1225
+      ID: 1232
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1147
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 742
+      ID: 749
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 843456
@@ -33238,18 +33242,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 744 PointerType *net/url.EscapeError.str
+          Type: 751 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 743 GoStringDataType net/url.EscapeError.str
+      Data: 750 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 743
+      ID: 750
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 745
+      ID: 752
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 843552
@@ -33257,79 +33261,79 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 747 PointerType *net/url.InvalidHostError.str
+          Type: 754 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 746 GoStringDataType net/url.InvalidHostError.str
+      Data: 753 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 746
+      ID: 753
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 553
+      ID: 560
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 692928
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 554 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 561 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 545
+      ID: 552
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 693024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 546 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 553 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 493
+      ID: 500
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 693312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 494 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 501 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 512
+      ID: 519
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 513 StructureType noalg.struct { key bool; elem main.node }
+      Element: 520 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 671
+      ID: 712
       Name: noalg.[8]struct { key context.canceler; elem struct {} }
       ByteSize: 192
       GoRuntimeType: 699744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 672 StructureType noalg.struct { key context.canceler; elem struct {} }
+      Element: 713 StructureType noalg.struct { key context.canceler; elem struct {} }
     - __kind: ArrayType
-      ID: 449
+      ID: 456
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 692160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 450 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 457 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1424
+      ID: 1431
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 692064
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1425 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1432 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
       ID: 1468
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
@@ -33349,14 +33353,14 @@ Types:
       HasCount: true
       Element: 1484 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 461
+      ID: 468
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 690240
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 462 StructureType noalg.struct { key int; elem int }
+      Element: 469 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
       ID: 1498
       Name: noalg.[8]struct { key int; elem interface {} }
@@ -33367,189 +33371,189 @@ Types:
       HasCount: true
       Element: 1499 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 569
+      ID: 576
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 693504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 570 StructureType noalg.struct { key int; elem struct {} }
+      Element: 577 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 520
+      ID: 527
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 693600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 521 StructureType noalg.struct { key int; elem uint8 }
+      Element: 528 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 720
+      ID: 727
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 700384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 721 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 728 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 502
+      ID: 509
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 693696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 503 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 510 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 485
+      ID: 492
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 693792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 486 StructureType noalg.struct { key string; elem []string }
+      Element: 493 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 696
+      ID: 694
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 700288
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 697 StructureType noalg.struct { key string; elem float64 }
+      Element: 695 StructureType noalg.struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 1186
+      ID: 1193
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 769408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1187 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1194 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 477
+      ID: 484
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 478 StructureType noalg.struct { key string; elem int }
+      Element: 485 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 688
+      ID: 686
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 691008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 689 StructureType noalg.struct { key string; elem interface {} }
+      Element: 687 StructureType noalg.struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 469
+      ID: 476
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 693984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 470 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 477 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 680
+      ID: 678
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 698016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 681 StructureType noalg.struct { key string; elem string }
+      Element: 679 StructureType noalg.struct { key string; elem string }
     - __kind: ArrayType
-      ID: 561
+      ID: 568
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 694080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 562 StructureType noalg.struct { key struct {}; elem int }
+      Element: 569 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 609
+      ID: 616
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 610 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 617 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 617
+      ID: 624
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 618 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 625 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 625
+      ID: 632
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 626 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 633 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 633
+      ID: 640
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 634 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 641 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 641
+      ID: 648
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 642 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 649 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 649
+      ID: 656
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 650 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 657 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 577
+      ID: 584
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 694176
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 578 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 585 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 536
+      ID: 543
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 694272
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 537 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 544 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 528
+      ID: 535
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 694368
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 529 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 536 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 552
+      ID: 559
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1312416
@@ -33560,9 +33564,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 553 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 560 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 544
+      ID: 551
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1312672
@@ -33573,9 +33577,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 545 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 552 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 492
+      ID: 499
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1312928
@@ -33586,9 +33590,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 493 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 500 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 511
+      ID: 518
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1313184
@@ -33599,9 +33603,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 512 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 519 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 670
+      ID: 711
       Name: noalg.map.group[context.canceler]struct {}
       ByteSize: 200
       GoRuntimeType: 1317280
@@ -33612,9 +33616,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 671 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
+          Type: 712 ArrayType noalg.[8]struct { key context.canceler; elem struct {} }
     - __kind: StructureType
-      ID: 448
+      ID: 455
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1312160
@@ -33625,9 +33629,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 449 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 456 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1423
+      ID: 1430
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1311904
@@ -33638,7 +33642,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1424 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1431 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
       ID: 1467
       Name: noalg.map.group[int]*main.deepMap8
@@ -33666,7 +33670,7 @@ Types:
           Offset: 8
           Type: 1483 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 460
+      ID: 467
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1309088
@@ -33677,7 +33681,7 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 461 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 468 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
       ID: 1497
       Name: noalg.map.group[int]interface {}
@@ -33692,7 +33696,7 @@ Types:
           Offset: 8
           Type: 1498 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 568
+      ID: 575
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1313440
@@ -33703,9 +33707,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 569 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 576 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 519
+      ID: 526
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1313696
@@ -33716,9 +33720,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 520 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 527 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1318304
@@ -33729,9 +33733,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 720 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 727 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 501
+      ID: 508
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1313952
@@ -33742,9 +33746,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 502 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 509 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 484
+      ID: 491
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1314208
@@ -33755,9 +33759,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 485 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 492 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 695
+      ID: 693
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1318048
@@ -33768,9 +33772,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 696 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 694 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 1185
+      ID: 1192
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1375904
@@ -33781,9 +33785,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1186 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1193 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 476
+      ID: 483
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1314464
@@ -33794,9 +33798,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 477 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 484 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 687
+      ID: 685
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1309856
@@ -33807,9 +33811,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 688 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 686 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 468
+      ID: 475
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1314720
@@ -33820,9 +33824,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 469 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 476 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 679
+      ID: 677
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1316512
@@ -33833,9 +33837,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 680 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 678 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 560
+      ID: 567
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1314976
@@ -33846,9 +33850,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 561 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 568 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 608
+      ID: 615
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -33858,9 +33862,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 609 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 616 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 616
+      ID: 623
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33870,9 +33874,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 617 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 624 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 624
+      ID: 631
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33882,9 +33886,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 625 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 632 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 632
+      ID: 639
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33894,9 +33898,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 633 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 640 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33906,9 +33910,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 641 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 648 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 648
+      ID: 655
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -33918,9 +33922,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 649 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 656 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 576
+      ID: 583
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1315232
@@ -33931,9 +33935,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 577 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 584 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 535
+      ID: 542
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1315488
@@ -33944,9 +33948,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 536 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 543 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 527
+      ID: 534
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1315744
@@ -33957,9 +33961,9 @@ Types:
           Type: 10 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 528 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 535 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 554
+      ID: 561
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1312288
@@ -33967,12 +33971,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 538 ArrayType [4]int
+          Type: 545 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 538 ArrayType [4]int
+          Type: 545 ArrayType [4]int
     - __kind: StructureType
-      ID: 546
+      ID: 553
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1312544
@@ -33980,12 +33984,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 538 ArrayType [4]int
+          Type: 545 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 494
+      ID: 501
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1312800
@@ -33993,12 +33997,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 495 ArrayType [4]string
+          Type: 502 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 121 ArrayType [2]int
     - __kind: StructureType
-      ID: 513
+      ID: 520
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1313056
@@ -34011,7 +34015,7 @@ Types:
           Offset: 8
           Type: 259 StructureType main.node
     - __kind: StructureType
-      ID: 672
+      ID: 713
       Name: noalg.struct { key context.canceler; elem struct {} }
       ByteSize: 24
       GoRuntimeType: 1317152
@@ -34019,12 +34023,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 673 GoInterfaceType context.canceler
+          Type: 714 GoInterfaceType context.canceler
         - Name: elem
           Offset: 16
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 450
+      ID: 457
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1312032
@@ -34035,9 +34039,9 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 451 PointerType *main.deepMap2
+          Type: 458 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1425
+      ID: 1432
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1311776
@@ -34048,7 +34052,7 @@ Types:
           Type: 9 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1426 PointerType *main.deepMap3
+          Type: 1433 PointerType *main.deepMap3
     - __kind: StructureType
       ID: 1469
       Name: noalg.struct { key int; elem *main.deepMap8 }
@@ -34076,7 +34080,7 @@ Types:
           Offset: 8
           Type: 1485 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 462
+      ID: 469
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1308960
@@ -34102,7 +34106,7 @@ Types:
           Offset: 8
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 570
+      ID: 577
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1313312
@@ -34115,7 +34119,7 @@ Types:
           Offset: 8
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 521
+      ID: 528
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1313568
@@ -34128,7 +34132,7 @@ Types:
           Offset: 8
           Type: 5 BaseType uint8
     - __kind: StructureType
-      ID: 721
+      ID: 728
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1318176
@@ -34139,9 +34143,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 722 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 729 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 503
+      ID: 510
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1313824
@@ -34152,9 +34156,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 504 GoSliceHeaderType []main.structWithMap
+          Type: 511 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1314080
@@ -34167,7 +34171,7 @@ Types:
           Offset: 16
           Type: 167 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 697
+      ID: 695
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1317920
@@ -34180,7 +34184,7 @@ Types:
           Offset: 16
           Type: 16 BaseType float64
     - __kind: StructureType
-      ID: 1187
+      ID: 1194
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1375776
@@ -34191,9 +34195,9 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 1174 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1181 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 478
+      ID: 485
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1314336
@@ -34206,7 +34210,7 @@ Types:
           Offset: 16
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 689
+      ID: 687
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1309728
@@ -34219,7 +34223,7 @@ Types:
           Offset: 16
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 470
+      ID: 477
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1314592
@@ -34232,7 +34236,7 @@ Types:
           Offset: 16
           Type: 131 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 681
+      ID: 679
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1316384
@@ -34245,7 +34249,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 562
+      ID: 569
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1314848
@@ -34258,7 +34262,7 @@ Types:
           Offset: 0
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 610
+      ID: 617
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -34270,7 +34274,7 @@ Types:
           Offset: 0
           Type: 297 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 618
+      ID: 625
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34282,7 +34286,7 @@ Types:
           Offset: 0
           Type: 298 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 626
+      ID: 633
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34294,7 +34298,7 @@ Types:
           Offset: 0
           Type: 303 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 634
+      ID: 641
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34306,7 +34310,7 @@ Types:
           Offset: 0
           Type: 308 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 642
+      ID: 649
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34318,7 +34322,7 @@ Types:
           Offset: 0
           Type: 313 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -34330,7 +34334,7 @@ Types:
           Offset: 0
           Type: 318 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 578
+      ID: 585
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1315104
       GoKind: 25
@@ -34342,7 +34346,7 @@ Types:
           Offset: 0
           Type: 133 StructureType struct {}
     - __kind: StructureType
-      ID: 537
+      ID: 544
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1315360
@@ -34353,9 +34357,9 @@ Types:
           Type: 5 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 538 ArrayType [4]int
+          Type: 545 ArrayType [4]int
     - __kind: StructureType
-      ID: 529
+      ID: 536
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1315616
@@ -34368,19 +34372,19 @@ Types:
           Offset: 1
           Type: 5 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1375
+      ID: 1382
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1017
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1078
+      ID: 1085
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1373
+      ID: 1380
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2390400
@@ -34388,12 +34392,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1379 StructureType os.noReadFrom
+          Type: 1386 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1374 PointerType *os.File
+          Type: 1381 PointerType *os.File
     - __kind: StructureType
-      ID: 1371
+      ID: 1378
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2389600
@@ -34401,36 +34405,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1378 StructureType os.noWriteTo
+          Type: 1385 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1374 PointerType *os.File
+          Type: 1381 PointerType *os.File
     - __kind: StructureType
-      ID: 1379
+      ID: 1386
       Name: os.noReadFrom
       GoRuntimeType: 1125472
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1378
+      ID: 1385
       Name: os.noWriteTo
       GoRuntimeType: 1125344
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1048
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1181
+      ID: 1188
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1245
+      ID: 1252
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 1043
+      ID: 1050
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1729984
@@ -34443,7 +34447,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 779
+      ID: 786
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 848928
@@ -34451,36 +34455,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 781 PointerType *os/user.UnknownGroupIdError.str
+          Type: 788 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 780 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 787 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 780
+      ID: 787
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 778
+      ID: 785
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 848832
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 811
+      ID: 818
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 905
+      ID: 912
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1021
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1025
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -34492,7 +34496,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 1016
+      ID: 1023
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1915776
@@ -34509,7 +34513,7 @@ Types:
           Type: 6 BaseType bool
         - Name: code
           Offset: 17
-          Type: 1179 BaseType internal/abi.BoundsErrorCode
+          Type: 1186 BaseType internal/abi.BoundsErrorCode
     - __kind: UnresolvedPointeeType
       ID: 72
       Name: runtime.cgoCallers
@@ -34525,7 +34529,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1080
+      ID: 1087
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1781024
@@ -34538,7 +34542,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 992
+      ID: 999
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 1003040
@@ -34546,13 +34550,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 994 PointerType *runtime.errorString.str
+          Type: 1001 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 993 GoStringDataType runtime.errorString.str
+      Data: 1000 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 993
+      ID: 1000
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -35201,7 +35205,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 3 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 437
+      ID: 444
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -35237,7 +35241,7 @@ Types:
           Offset: 16
           Type: 3 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 995
+      ID: 1002
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 1003136
@@ -35245,13 +35249,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 997 PointerType *runtime.plainError.str
+          Type: 1004 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 996 GoStringDataType runtime.plainError.str
+      Data: 1003 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 996
+      ID: 1003
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -35292,7 +35296,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 807
+      ID: 814
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1619168
@@ -35364,7 +35368,7 @@ Types:
       Name: runtime.xRegState
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1015
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -35376,26 +35380,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 432 PointerType *string.str
+          Type: 439 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 431 GoStringDataType string.str
+      Data: 438 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 431
+      ID: 438
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1310
+      ID: 1317
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1215
+      ID: 1222
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1211
+      ID: 1218
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1474304
@@ -35411,7 +35415,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 383
+      ID: 373
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1485856
@@ -35419,12 +35423,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 384 StructureType sync.noCopy
+          Type: 374 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 385 StructureType internal/sync.Mutex
+          Type: 375 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 392
+      ID: 436
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1640416
@@ -35432,15 +35436,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 384 StructureType sync.noCopy
+          Type: 374 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 393 StructureType sync/atomic.Bool
+          Type: 437 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 383 StructureType sync.Mutex
+          Type: 373 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 403
+      ID: 372
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1866944
@@ -35448,7 +35452,7 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 383 StructureType sync.Mutex
+          Type: 373 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
           Type: 4 BaseType uint32
@@ -35457,12 +35461,12 @@ Types:
           Type: 4 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 404 StructureType sync/atomic.Int32
+          Type: 376 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 404 StructureType sync/atomic.Int32
+          Type: 376 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 1394
+      ID: 1401
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1640224
@@ -35470,21 +35474,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 384 StructureType sync.noCopy
+          Type: 374 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1395 StructureType sync/atomic.Uint64
+          Type: 1402 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 384
+      ID: 374
       Name: sync.noCopy
       GoRuntimeType: 1002656
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 393
+      ID: 437
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1486976
@@ -35492,12 +35496,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 377 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 4 BaseType uint32
     - __kind: StructureType
-      ID: 404
+      ID: 376
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1487136
@@ -35505,12 +35509,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 377 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 14 BaseType int32
     - __kind: StructureType
-      ID: 1395
+      ID: 1402
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1640800
@@ -35518,15 +35522,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 394 StructureType sync/atomic.noCopy
+          Type: 377 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1396 StructureType sync/atomic.align64
+          Type: 1403 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 386
+      ID: 424
       Name: sync/atomic.Value
       ByteSize: 16
       GoRuntimeType: 1208160
@@ -35536,25 +35540,25 @@ Types:
           Offset: 0
           Type: 170 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 1396
+      ID: 1403
       Name: sync/atomic.align64
       GoRuntimeType: 1002848
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 394
+      ID: 377
       Name: sync/atomic.noCopy
       GoRuntimeType: 1002752
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 1128
+      ID: 1135
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1301920
       GoKind: 12
     - __kind: StructureType
-      ID: 549
+      ID: 556
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -35576,9 +35580,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 550 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 557 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 541
+      ID: 548
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35600,9 +35604,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 542 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 549 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 489
+      ID: 496
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -35624,9 +35628,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 490 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 497 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 508
+      ID: 515
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -35648,9 +35652,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 509 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 516 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 667
+      ID: 708
       Name: table<context.canceler,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35672,9 +35676,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 668 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
+          Type: 709 GoSwissMapGroupsType groupReference<context.canceler,struct {}>
     - __kind: StructureType
-      ID: 445
+      ID: 452
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -35696,9 +35700,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 446 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 453 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1420
+      ID: 1427
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -35720,7 +35724,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1421 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1428 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
       ID: 1464
       Name: table<int,*main.deepMap8>
@@ -35770,7 +35774,7 @@ Types:
           Offset: 16
           Type: 1480 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 457
+      ID: 464
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -35792,7 +35796,7 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 458 GoSwissMapGroupsType groupReference<int,int>
+          Type: 465 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
       ID: 1494
       Name: table<int,interface {}>
@@ -35818,7 +35822,7 @@ Types:
           Offset: 16
           Type: 1495 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 565
+      ID: 572
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -35840,9 +35844,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 566 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 573 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 516
+      ID: 523
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -35864,9 +35868,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 517 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 524 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 716
+      ID: 723
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
@@ -35888,9 +35892,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 717 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 724 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 498
+      ID: 505
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -35912,9 +35916,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 499 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 506 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 481
+      ID: 488
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -35936,9 +35940,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 482 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 489 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 692
+      ID: 690
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
@@ -35960,9 +35964,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 693 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 691 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: StructureType
-      ID: 1182
+      ID: 1189
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -35984,9 +35988,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1183 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1190 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 473
+      ID: 480
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -36008,9 +36012,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 474 GoSwissMapGroupsType groupReference<string,int>
+          Type: 481 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 684
+      ID: 682
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -36032,9 +36036,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 685 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 683 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: StructureType
-      ID: 465
+      ID: 472
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -36056,9 +36060,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 466 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 473 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 676
+      ID: 674
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -36080,9 +36084,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 677 GoSwissMapGroupsType groupReference<string,string>
+          Type: 675 GoSwissMapGroupsType groupReference<string,string>
     - __kind: StructureType
-      ID: 557
+      ID: 564
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -36104,9 +36108,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 558 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 565 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 605
+      ID: 612
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36128,9 +36132,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 606 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 613 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 613
+      ID: 620
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36152,9 +36156,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 614 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 621 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 621
+      ID: 628
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36176,9 +36180,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 622 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 629 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 629
+      ID: 636
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36200,9 +36204,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 630 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 637 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 637
+      ID: 644
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36224,9 +36228,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 638 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 645 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 645
+      ID: 652
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -36248,9 +36252,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 646 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 653 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 573
+      ID: 580
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -36272,9 +36276,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 574 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 581 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 532
+      ID: 539
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -36296,9 +36300,9 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 533 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 540 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 524
+      ID: 531
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -36320,13 +36324,13 @@ Types:
           Type: 9 BaseType int
         - Name: groups
           Offset: 16
-          Type: 525 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 532 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1345
+      ID: 1352
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 1071
+      ID: 1078
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1734400
@@ -36339,7 +36343,7 @@ Types:
           Offset: 16
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 1278
+      ID: 1285
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1942272
@@ -36356,10 +36360,10 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 653 GoSliceHeaderType []time.zone
+          Type: 660 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 656 GoSliceHeaderType []time.zoneTrans
+          Type: 663 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
           Type: 11 GoStringHeaderType string
@@ -36371,9 +36375,9 @@ Types:
           Type: 15 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 654 PointerType *time.zone
+          Type: 661 PointerType *time.zone
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: time.ParseError
       ByteSize: 8
     - __kind: GoTimeType
@@ -36401,7 +36405,7 @@ Types:
       ZoneOffsetFieldOffset: 16
       ZoneOffsetFieldSize: 8
     - __kind: StructureType
-      ID: 399
+      ID: 433
       Name: time.Timer
       ByteSize: 16
       GoRuntimeType: 1488256
@@ -36409,12 +36413,12 @@ Types:
       RawFields:
         - Name: C
           Offset: 0
-          Type: 1403 GoChannelType <-chan time.Time
+          Type: 1415 GoChannelType <-chan time.Time
         - Name: initTimer
           Offset: 8
           Type: 6 BaseType bool
     - __kind: GoStringHeaderType
-      ID: 726
+      ID: 733
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 841056
@@ -36422,22 +36426,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 728 PointerType *time.fileSizeError.str
+          Type: 735 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 727 GoStringDataType time.fileSizeError.str
+      Data: 734 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 727
+      ID: 734
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: time.parseDurationError
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 662
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1641760
@@ -36453,7 +36457,7 @@ Types:
           Offset: 24
           Type: 6 BaseType bool
     - __kind: StructureType
-      ID: 658
+      ID: 665
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1779680
@@ -36514,7 +36518,7 @@ Types:
       GoRuntimeType: 593824
       GoKind: 26
     - __kind: StructureType
-      ID: 1161
+      ID: 1168
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2094016
@@ -36525,10 +36529,10 @@ Types:
           Type: 41 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 1162 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 1169 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 1163 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 1170 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: "off"
           Offset: 40
           Type: 9 BaseType int
@@ -36543,18 +36547,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 1164 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 1171 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 8 BaseType uint16
     - __kind: BaseType
-      ID: 1164
+      ID: 1171
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 1008704
       GoKind: 9
     - __kind: StructureType
-      ID: 1162
+      ID: 1169
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1955328
@@ -36579,21 +36583,21 @@ Types:
           Offset: 10
           Type: 8 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 901
+      ID: 908
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 1163
+      ID: 1170
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 597536
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1339
+      ID: 1346
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1443744
@@ -36603,13 +36607,13 @@ Types:
           Offset: 0
           Type: 17 GoInterfaceType error
     - __kind: BaseType
-      ID: 771
+      ID: 778
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 845760
       GoKind: 2
     - __kind: StructureType
-      ID: 1048
+      ID: 1055
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1730176
@@ -36622,7 +36626,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 1000
+      ID: 1007
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 1007552


### PR DESCRIPTION


### What does this PR do?

Replace the hardcoded list of context.Context implementations with dynamic discovery via the existing implementor iterator. context.Context's IMethod set is captured during gotype iteration; after the method index is built, the iterator enumerates every concrete implementation in the binary.

Each discovered implementation is added to the type catalog as an exploration root. After expansion materializes placeholder pointees, the resolved struct IR type IDs are passed to annotateSpecialGoTypes, which wraps each as GoContextImplementationType. The 'parent is the first context.Context field' rule is generalized in embeddedContextOffset: any field of type *ir.GoInterfaceType named context.Context, with transitive descent into embedded impls, marks the parent chain pointer. context.valueCtx's key/val offsets remain matched by name (it is the only impl with that extra payload), and dd-trace-go span types still get the DDTraceSpanType annotation by name.

### Motivation

User-defined and third-party context implementations now participate in the chain walk. Snapshots pick up
github.com/DataDog/dd-trace-go/v2/internal/orchestrion.glsContext and net.onlyValuesCtx that the hardcoded list missed.ontext.Context, with transitive descent into embedded impls, marks the parent chain pointer. context.valueCtx's key/val offsets remain matched by name (it is the only impl with that extra payload), and dd-trace-go span types still get the DDTraceSpanType annotation by name.

### Describe how you validated your changes

All the tests that did not change.
