### PR TITLE
Solve flake in TestLocalFlareFileContent

### DIFF
--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -393,6 +393,11 @@ func TestLocalFlareFileContent(t *testing.T) {
 
 	errIpc := errors.New("connection refused")
 	flareComp := getFlareWithParams(t, NewLocalParams("", "", "", "", "", ""), nil)
+	// Override providers to prevent them from running past the timeout and writing into
+	// t.TempDir()-backed flare directories during test cleanup.
+	// This also avoids side-effects caused by default providers.
+	// The "local" file under test is written before providers run, so this is safe to nil out.
+	flareComp.providers = nil
 	// Save() is a no-op in the mock and returns an error; the local file is still written.
 	_, _ = flareComp.Create(types.ProfileData{}, 0, errIpc, []byte{})
 


### PR DESCRIPTION
### What does this PR do?

Fixes a flake in `/comp/core/flare:TestLocalFlareFileContent` by overriding default providers (with unpredictable side-effects and running under goroutines) to remove them. This should also make these tests run faster.

### Motivation

This test is quite flaky ([CI visibility](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.name%3A%2ATestLocalFlareFileContent%2A%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&index=citest&refresh_mode=paused&start=1776251603938&end=1778843603938&paused=true)). It often gets saved by retries, but from time to time a pipeline fails because of it. This seems to happen mainly on macos runners, the reason probably being that `collectConfigFiles` is reading the actual Agent configuration from the Agent running on the runner.

Note that the actual test assertions pass, it's the cleanup that fails, as seen ([here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1685120366/viewer#L2560)):
```
    testing.go:1369: TempDir RemoveAll cleanup: unlinkat /tmp/gitlabci/TestLocalFlareFileContent3340246588/001/test-hostname: directory not empty

```

The apparent reason is that providers time out but keep running, causing a race condition with the cleanup of the temporary directory.

### Describe how you validated your changes

I tried setting a tiny provider timeout when running the tests locally to reproduce the issue, which worked. The failures don't come up when the fix implemented here is applied.

### Additional Notes

There's precedent to this fix here, with a similar intent and result: https://github.com/DataDog/datadog-agent/blob/a83bc15ce840ccfe85582f1c2a296ba5c33f7585/comp/core/flare/flare_test.go#L155-L169
