### PR TITLE
feat(fleet): add datadog-apm-library-c to installer packages

### DIFF
--- a/pkg/fleet/installer/default_packages.go
+++ b/pkg/fleet/installer/default_packages.go
@@ -39,6 +39,7 @@ var PackagesList = []Package{
 	{Name: "datadog-apm-library-iis", version: apmLanguageVersion, released: false, releasedWithRemoteUpdates: true, condition: apmLanguageExplicitlyEnabled},
 	{Name: "datadog-apm-library-iis-rum", version: apmLanguageVersion, released: false, releasedWithRemoteUpdates: true, condition: apmLanguageExplicitlyEnabled},
 	{Name: "datadog-apm-library-httpd", version: apmLanguageVersion, released: false, releasedWithRemoteUpdates: true, condition: apmLanguageExplicitlyEnabled},
+	{Name: "datadog-apm-library-c", version: apmLanguageVersion, released: false, releasedWithRemoteUpdates: true, condition: apmLanguageExplicitlyEnabled},
 }
 
 // Default versions pinned for CentOS 6

--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -59,6 +59,7 @@ func TestDefaultPackagesAPMLibrariesIncludingIIS(t *testing.T) {
 			"httpd":   "1",
 			"iis-rum": "1",
 			"iis":     "1",
+			"c":       "1",
 		},
 	}
 	packages := DefaultPackages(env)
@@ -76,6 +77,7 @@ func TestDefaultPackagesAPMLibrariesIncludingIIS(t *testing.T) {
 		"oci://install.datadoghq.com/apm-library-iis-package:1",
 		"oci://install.datadoghq.com/apm-library-iis-rum-package:1",
 		"oci://install.datadoghq.com/apm-library-httpd-package:1",
+		"oci://install.datadoghq.com/apm-library-c-package:1",
 	}, packages)
 }
 
@@ -99,6 +101,7 @@ func TestPreRegisteredPackagesNotSelectedByDefault(t *testing.T) {
 				assert.NotContains(t, url, "apm-library-iis-package")
 				assert.NotContains(t, url, "apm-library-iis-rum-package")
 				assert.NotContains(t, url, "apm-library-httpd-package")
+				assert.NotContains(t, url, "apm-library-c-package")
 			}
 		})
 	}

--- a/pkg/fleet/installer/setup/common/packages.go
+++ b/pkg/fleet/installer/setup/common/packages.go
@@ -38,6 +38,8 @@ const (
 	DatadogAPMLibraryIISRumPackage string = "datadog-apm-library-iis-rum"
 	// DatadogAPMLibraryHttpdPackage is the datadog apm library httpd package
 	DatadogAPMLibraryHttpdPackage string = "datadog-apm-library-httpd"
+	// DatadogAPMLibraryCPackage is the datadog apm library c package
+	DatadogAPMLibraryCPackage string = "datadog-apm-library-c"
 )
 
 var (
@@ -55,6 +57,7 @@ var (
 		DatadogAPMLibraryIISPackage,
 		DatadogAPMLibraryIISRumPackage,
 		DatadogAPMLibraryHttpdPackage,
+		DatadogAPMLibraryCPackage,
 	}
 
 	// ApmLibraries is the list of apm libraries selectable via the setup
@@ -79,6 +82,7 @@ var (
 		DatadogAPMLibraryIISPackage,
 		DatadogAPMLibraryIISRumPackage,
 		DatadogAPMLibraryHttpdPackage,
+		DatadogAPMLibraryCPackage,
 	}
 )
 


### PR DESCRIPTION
## Summary
- Register `datadog-apm-library-c` (dd-trace-c / native C tracer) as an explicit-only APM library package in the fleet installer
- Gated behind `releasedWithRemoteUpdates` and `apmLanguageExplicitlyEnabled` — same pattern as IIS, IIS-RUM, and httpd packages
- Install via `DD_APM_INSTRUMENTATION_LIBRARIES=c`

## Dependency
- Requires DataDog/dd-trace-c OCI package rename from `dd-trace-c-package` to `apm-library-c-package` (https://github.com/DataDog/dd-trace-c/pull/67)

## Changes
- `pkg/fleet/installer/default_packages.go`: Add package entry to `PackagesList`
- `pkg/fleet/installer/setup/common/packages.go`: Add constant, add to `order` and `ExplicitOnlyApmLibraries`
- `pkg/fleet/installer/default_packages_test.go`: Update tests for new package

## Test plan
- [x] Unit tests pass (`go test -run 'TestDefaultPackages|TestPreRegistered' -v .`)
- [ ] Verify OCI package rename lands in dd-trace-c first
- [ ] E2E: install dd-trace-c via `DD_APM_INSTRUMENTATION_LIBRARIES=c` on a test host