### PR TITLE
Fix check_runners default disabling dynamic worker scaling

### DIFF
--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -64,7 +64,28 @@ type Runner struct {
 
 // NewRunner takes the number of desired goroutines processing incoming checks.
 func NewRunner(senderManager sender.SenderManager, haAgent haagent.Component, healthPlatform healthplatform.Component) *Runner {
-	numWorkers := pkgconfigsetup.Datadog().GetInt("check_runners")
+	cfg := pkgconfigsetup.Datadog()
+	numWorkers := cfg.GetInt("check_runners")
+
+	// Determine whether the worker pool should be fixed at the configured size
+	// ("static") or allowed to scale with the number of scheduled checks
+	// ("dynamic", up to MaxNumWorkers via UpdateNumWorkers).
+	//
+	// The previous behaviour (`isStaticWorkerCount = numWorkers != 0`) relied
+	// on the absence of a default value for `check_runners` to trigger dynamic
+	// scaling. Because `check_runners` is registered with `BindEnvAndSetDefault(
+	// "check_runners", int64(4))`, GetInt returns 4 even when the operator
+	// hasn't configured anything, so `numWorkers != 0` was unconditionally
+	// true and dynamic scaling was effectively dead code in default installs.
+	// This was particularly visible on cluster-checks runners with large
+	// numbers of cluster checks (e.g. Prometheus HTTP service discovery), where
+	// the runner stayed pinned at 4 workers regardless of load.
+	//
+	// IsConfigured returns true only when the value was set by the user
+	// (config file, env var, runtime Set, etc.) and false when only the default
+	// is in effect. The legacy `check_runners: 0` sentinel for opting in to
+	// dynamic scaling is preserved for backwards compatibility.
+	isStaticWorkerCount := cfg.IsConfigured("check_runners") && numWorkers != 0
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -75,11 +96,11 @@ func NewRunner(senderManager sender.SenderManager, haAgent haagent.Component, he
 		id:                  int(runnerIDGenerator.Inc()),
 		isRunning:           atomic.NewBool(true),
 		workers:             make(map[int]*worker.Worker),
-		isStaticWorkerCount: numWorkers != 0,
+		isStaticWorkerCount: isStaticWorkerCount,
 		pendingChecksChan:   make(chan check.Check),
 		checksTracker:       tracker.NewRunningChecksTracker(),
-		utilizationMonitor:  worker.NewUtilizationMonitor(pkgconfigsetup.Datadog().GetFloat64("check_runner_utilization_threshold")),
-		utilizationLogLimit: log.NewLogLimit(1, pkgconfigsetup.Datadog().GetDuration("check_runner_utilization_warning_cooldown")),
+		utilizationMonitor:  worker.NewUtilizationMonitor(cfg.GetFloat64("check_runner_utilization_threshold")),
+		utilizationLogLimit: log.NewLogLimit(1, cfg.GetDuration("check_runner_utilization_warning_cooldown")),
 		ctx:                 ctx,
 		cancel:              cancel,
 	}

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -236,6 +236,34 @@ func TestRunnerDynamicUpdateNumWorkers(t *testing.T) {
 	}
 }
 
+// TestRunnerDynamicUpdateNumWorkersWhenUnconfigured verifies that the worker
+// pool scales dynamically when check_runners is left at its default value
+// (i.e. the operator did not explicitly configure it). Prior to the fix for
+// the `check_runners` BindEnvAndSetDefault footgun, the runner would treat
+// the default value of 4 as if the user had explicitly configured a fixed
+// pool, leaving dynamic scaling unreachable in default installs.
+func TestRunnerDynamicUpdateNumWorkersWhenUnconfigured(t *testing.T) {
+	testSetUp(t)
+	// Note: deliberately no SetWithoutSource call for check_runners so the
+	// only source for the key is the BindEnvAndSetDefault default of 4.
+	require.False(t, pkgconfigsetup.Datadog().IsConfigured("check_runners"))
+
+	assertAsyncWorkerCount(t, 0)
+
+	r := NewRunner(aggregator.NewNoOpSenderManager(), haagentmock.NewMockHaAgent(), healthplatformmock.Mock(t))
+	require.NotNil(t, r)
+	defer r.Stop()
+
+	// With 30 scheduled checks we expect dynamic scaling to ramp up to
+	// MaxNumWorkers; if the runner were locked at the static default of 4
+	// this call would be a no-op.
+	for checks := 0; checks <= 30; checks++ {
+		r.UpdateNumWorkers(int64(checks))
+	}
+
+	assertAsyncWorkerCount(t, pkgconfigsetup.MaxNumWorkers)
+}
+
 func TestRunner(t *testing.T) {
 	testSetUp(t)
 	numChecks := 10

--- a/releasenotes/notes/fix-check-runners-dynamic-scaling-default-cda1b4f829a0bcf2.yaml
+++ b/releasenotes/notes/fix-check-runners-dynamic-scaling-default-cda1b4f829a0bcf2.yaml
@@ -1,0 +1,21 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The check runner's dynamic worker scaling (up to 25 workers) is now
+    re-enabled when ``check_runners`` is left unconfigured. Previously,
+    ``check_runners`` was registered with a default value of 4, which caused
+    the runner to treat the default as an explicit configuration and pin
+    the worker pool at 4 — leaving the documented dynamic scaling code path
+    effectively unreachable in default installations. The worker pool now
+    grows automatically with the number of scheduled checks when
+    ``check_runners`` is not explicitly configured by the operator.
+    Explicitly setting ``check_runners`` continues to pin the pool at the
+    configured size; the legacy ``check_runners: 0`` sentinel for opting
+    in to dynamic scaling is preserved.


### PR DESCRIPTION
## What does this PR do?

Fixes a `BindEnvAndSetDefault` interaction that makes the check runner's documented dynamic worker-scaling code path unreachable in default installations.

## Motivation

The check runner exposes a dynamic worker pool: `UpdateNumWorkers` ramps the pool from 4 up to `MaxNumWorkers` (25) based on how many checks are scheduled. The choice between static (fixed-size) and dynamic (auto-scaling) pools is made in `NewRunner`:

```go
numWorkers := pkgconfigsetup.Datadog().GetInt("check_runners")
...
isStaticWorkerCount: numWorkers != 0,
...
if !r.isStaticWorkerCount {
    numWorkers = pkgconfigsetup.DefaultNumWorkers
}
```

The original intent reads cleanly: "if the user set `check_runners`, use that fixed value; otherwise auto-scale." The footgun is on the config registration side:

```go
// pkg/config/setup/common_settings.go:1125
config.BindEnvAndSetDefault("check_runners", int64(4))
```

Because `BindEnvAndSetDefault` registers a default of `4`, `GetInt("check_runners")` returns `4` even when no operator has configured anything. The check `numWorkers != 0` is therefore unconditionally true, the runner is always pinned at 4 workers, and the entire dynamic-scaling code path is effectively dead unless the operator opts in by explicitly setting `check_runners: 0` — an undocumented and counter-intuitive sentinel.

This was discovered while debugging a customer case where cluster-check runners with ~500 Prometheus-HTTP-SD-generated openmetrics cluster checks per pod were pinned at 4 workers (~11x oversubscribed). The orchestrator check on those CLCRs could never get a worker slot, and the customer saw permanent `orchestrator=PARTIAL` status in the Cluster Agent Installation Updates modal. With dynamic scaling re-enabled, those runners would scale to 25 workers automatically — still undersized for that load, but a 6x improvement and at least the documented behavior.

## What changed

Switch the decision from "the value is non-zero" (always true given the default) to "the user explicitly configured this key" using `Config.IsConfigured`, which returns false when only the `BindEnvAndSetDefault` default is in effect. The legacy `check_runners: 0` opt-in is preserved by retaining the `numWorkers != 0` clause for forward-compatibility with any existing operator config that uses it.

```go
isStaticWorkerCount := cfg.IsConfigured("check_runners") && numWorkers != 0
```

### Behavior summary

| Configuration                  | Before              | After               |
|--------------------------------|---------------------|---------------------|
| (unset)                        | 4, static           | 4..25, dynamic      |
| `check_runners: 0` (explicit)  | 4..25, dynamic      | 4..25, dynamic      |
| `check_runners: N` (explicit)  | N, static           | N, static           |

Only the first row changes. Operators who have explicitly set `check_runners` (any non-zero value or the legacy `0` sentinel) get identical behavior.

## Tests

- Added `TestRunnerDynamicUpdateNumWorkersWhenUnconfigured`, which calls `NewRunner` without any `SetWithoutSource("check_runners", ...)` and asserts that the worker pool scales up to `MaxNumWorkers` as checks are added. Pre-fix this test fails (pool stays at 4); post-fix it passes.
- All existing runner tests still pass, because they explicitly call `SetWithoutSource("check_runners", ...)` (which causes `IsConfigured` to return true).

## Risk

Low. The behavior change is strictly additive (more workers available when needed) and only affects deployments that left `check_runners` unconfigured. Resource impact per added worker is minimal (one goroutine waiting on a channel). The change is gated on `IsConfigured`, which is part of the stable config API and is already used in similar "did the user set this?" patterns elsewhere in the agent (e.g. `pkg/config/setup/config.go:1164`).

## Why draft

Filing as draft to get reviewer input on:

1. Whether this behavior change is acceptable as a fix vs. an opt-in.
2. Whether the legacy `check_runners: 0` sentinel should be deprecated in a follow-up (it's now redundant).
3. Whether there's a broader pattern to audit — several other `BindEnvAndSetDefault` calls in `common_settings.go` likely have similar "default value disables auto-detection" issues (e.g. `check_watchdog_warning_timeout = 0` for opt-in warnings is intentional by comment, but `check_runners` was not).

## Motivation

* [x] Investigation: customer case, Cluster Agent operator v1.24.0, orchestrator check starvation on CLCRs.

## Describe how you validated your changes

* [x] Added unit test `TestRunnerDynamicUpdateNumWorkersWhenUnconfigured`.
* [x] All existing `pkg/collector/runner/` tests pass under `go test -tags test -count=1`.
* [x] `go vet -tags test ./pkg/collector/runner/` clean.

## Possible Drawbacks / Trade-offs

Deployments that have been silently relying on "4 workers, no auto-scaling" as their default capacity ceiling will now auto-scale up to 25 workers under load. This is the documented behavior, and the dynamic curve only adds workers when more than 10 checks are scheduled (4 → 10 at 11 checks, 10 → 15 at 16, etc.), so light deployments are unaffected. Heavy deployments stand to benefit but should still right-size explicitly.

## Additional Notes

Follow-ups (out of scope for this PR but worth flagging):
- Consider deprecating the `check_runners: 0` sentinel in favor of "unset".
- The same `IsConfigured` pattern could replace `IsSet` in other call sites in `pkg/config/setup/config.go` that have the same "default makes IsSet always-true" anti-pattern.
