### PR TITLE
Fix configstream consumers silently loading their own datadog.yaml

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -125,16 +125,21 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "Run the System Probe",
 		Long:  `Runs the system-probe in the foreground`,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			configstreamEnabled := isConfigstreamEnabled(globalParams.DatadogConfFilePath())
+			var configOpts []func(*config.Params)
+			if configstreamEnabled {
+				configOpts = append(configOpts, config.WithConfigstreamEnabled(true))
+			}
 			opts := []fx.Option{
 				fx.Invoke(func(_ log.Component) {
 					ddruntime.SetMaxProcs()
 				}),
-				fx.Supply(config.NewAgentParams(globalParams.DatadogConfFilePath())),
+				fx.Supply(config.NewAgentParams(globalParams.DatadogConfFilePath(), configOpts...)),
 				fx.Supply(sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath))),
 				fx.Supply(pidimpl.NewParams(cliParams.pidfilePath)),
 				getSharedFxOption(),
 			}
-			if isConfigstreamEnabled(globalParams.DatadogConfFilePath()) {
+			if configstreamEnabled {
 				opts = append(opts, configstreamFxOptions())
 			}
 			return fxutil.OneShot(run, opts...)

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -125,9 +125,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "Run the System Probe",
 		Long:  `Runs the system-probe in the foreground`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			configstreamEnabled := isConfigstreamEnabled(globalParams.DatadogConfFilePath())
+			bs := readConfigstreamBootstrap(globalParams.DatadogConfFilePath(), os.LookupEnv)
 			var configOpts []func(*config.Params)
-			if configstreamEnabled {
+			if bs.Enabled {
 				configOpts = append(configOpts, config.WithConfigstreamEnabled(true))
 			}
 			opts := []fx.Option{
@@ -139,8 +139,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(pidimpl.NewParams(cliParams.pidfilePath)),
 				getSharedFxOption(),
 			}
-			if configstreamEnabled {
-				opts = append(opts, configstreamFxOptions())
+			if bs.Enabled {
+				opts = append(opts, configstreamFxOptions(bs.CmdHost, bs.CmdPort))
 			}
 			return fxutil.OneShot(run, opts...)
 		},
@@ -217,7 +217,10 @@ func getSharedFxOption() fx.Option {
 
 // configstreamFxOptions returns FX options for the config stream consumer.
 // Only include this when remote_agent.configstream.consumer.enabled is true.
-func configstreamFxOptions() fx.Option {
+// host/port are the pre-FX dial address for the core agent; reading them
+// here (instead of from config.Component) keeps the bootstrap working when
+// WithConfigstreamEnabled skips the disk load.
+func configstreamFxOptions(host string, port int) fx.Option {
 	return fx.Options(
 		// Expose config.Component as model.Writer for the config stream consumer to write remote config into.
 		fx.Provide(func(c config.Component) model.Writer {
@@ -233,12 +236,7 @@ func configstreamFxOptions() fx.Option {
 			}
 			return nil
 		}),
-		fx.Provide(func(c config.Component, sessionProvider configstreamconsumer.SessionIDProvider) configstreamconsumer.Params {
-			host := c.GetString("cmd_host")
-			port := c.GetInt("cmd_port")
-			if port <= 0 {
-				port = 5001
-			}
+		fx.Provide(func(sessionProvider configstreamconsumer.SessionIDProvider) configstreamconsumer.Params {
 			return configstreamconsumer.Params{
 				ClientName:        "system-probe",
 				CoreAgentAddress:  net.JoinHostPort(host, strconv.Itoa(port)),
@@ -251,13 +249,39 @@ func configstreamFxOptions() fx.Option {
 	)
 }
 
-// isConfigstreamEnabled is a pre-FX feature flag check; the env var takes precedence over YAML.
-func isConfigstreamEnabled(cliConfigPath string) bool {
-	if v, ok := os.LookupEnv(configstreamConsumerEnabledEnvVar); ok {
-		if enabled, err := strconv.ParseBool(v); err == nil {
-			return enabled
+// configstreamBootstrap holds the pre-FX settings needed to start the configstream
+// consumer before the config component has loaded (or before WithConfigstreamEnabled
+// tells it to skip loading).
+type configstreamBootstrap struct {
+	Enabled bool
+	CmdHost string
+	CmdPort int
+}
+
+// readConfigstreamBootstrap resolves Enabled / CmdHost / CmdPort from env vars
+// first (matching viper's BindEnv precedence), then from datadog.yaml as a
+// fallback, then from BindEnvAndSetDefault's defaults (localhost:5001).
+func readConfigstreamBootstrap(cliConfigPath string, lookupEnv func(string) (string, bool)) configstreamBootstrap {
+	bs := configstreamBootstrap{CmdHost: "localhost", CmdPort: 5001}
+
+	enabledEnv, hasEnabledEnv := lookupEnv(configstreamConsumerEnabledEnvVar)
+	hostEnv, hasHostEnv := lookupEnv("DD_CMD_HOST")
+	portEnv, hasPortEnv := lookupEnv("DD_CMD_PORT")
+
+	if hasEnabledEnv {
+		if enabled, err := strconv.ParseBool(enabledEnv); err == nil {
+			bs.Enabled = enabled
 		}
 	}
+	if hasHostEnv && hostEnv != "" {
+		bs.CmdHost = hostEnv
+	}
+	if hasPortEnv {
+		if p, err := strconv.Atoi(portEnv); err == nil && p > 0 {
+			bs.CmdPort = p
+		}
+	}
+
 	for _, path := range []string{cliConfigPath, config.DefaultConfPath} {
 		if path == "" {
 			continue
@@ -270,6 +294,8 @@ func isConfigstreamEnabled(cliConfigPath string) bool {
 			continue
 		}
 		var cfg struct {
+			CmdHost     string `yaml:"cmd_host"`
+			CmdPort     int    `yaml:"cmd_port"`
 			RemoteAgent struct {
 				ConfigStream struct {
 					Consumer struct {
@@ -279,11 +305,20 @@ func isConfigstreamEnabled(cliConfigPath string) bool {
 			} `yaml:"remote_agent"`
 		}
 		if err := yaml.Unmarshal(data, &cfg); err != nil {
-			return false
+			return bs
 		}
-		return cfg.RemoteAgent.ConfigStream.Consumer.Enabled
+		if !hasEnabledEnv {
+			bs.Enabled = cfg.RemoteAgent.ConfigStream.Consumer.Enabled
+		}
+		if !hasHostEnv && cfg.CmdHost != "" {
+			bs.CmdHost = cfg.CmdHost
+		}
+		if !hasPortEnv && cfg.CmdPort > 0 {
+			bs.CmdPort = cfg.CmdPort
+		}
+		return bs
 	}
-	return false
+	return bs
 }
 
 // run starts the main loop.

--- a/cmd/system-probe/subcommands/run/command_configstream_integration_test.go
+++ b/cmd/system-probe/subcommands/run/command_configstream_integration_test.go
@@ -195,3 +195,80 @@ system_probe_config:
 		}
 	})
 }
+
+// TestConfigComponentSkipsDiskWhenConfigstreamEnabled verifies that with
+// WithConfigstreamEnabled(true), config values come from the snapshot and
+// datadog.yaml is never read.
+func TestConfigComponentSkipsDiskWhenConfigstreamEnabled(t *testing.T) {
+	ipcComp := ipcmock.New(t)
+	serverAddr, events, cleanup := setupMockConfigStreamServer(t, ipcComp)
+	defer cleanup()
+
+	host, port, err := net.SplitHostPort(serverAddr)
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	datadogPath := filepath.Join(tmpDir, "datadog.yaml")
+	sysprobePath := filepath.Join(tmpDir, "system_probe.yaml")
+
+	// Poison datadog.yaml: if the config component reads this, the test fails.
+	datadogYaml := fmt.Sprintf(`
+cmd_host: %s
+cmd_port: %s
+site: from-disk
+remote_agent:
+  configstream:
+    consumer:
+      enabled: true
+`, host, port)
+	require.NoError(t, os.WriteFile(datadogPath, []byte(datadogYaml), 0600))
+	require.NoError(t, os.WriteFile(sysprobePath, []byte("system_probe_config:\n  enabled: false\n"), 0600))
+
+	events <- &pb.ConfigEvent{
+		Event: &pb.ConfigEvent_Snapshot{
+			Snapshot: &pb.ConfigSnapshot{
+				SequenceId: 1,
+				Settings: []*pb.ConfigSetting{
+					{Key: "site", Value: mustNewValue(t, "from-stream"), Source: string(model.SourceFile)},
+				},
+			},
+		},
+	}
+
+	opts := fx.Options(
+		// The flag under test: skip disk load, rely on the stream.
+		fx.Supply(config.NewAgentParams(datadogPath, config.WithConfigstreamEnabled(true))),
+		fx.Supply(sysprobeconfigimpl.NewParams(
+			sysprobeconfigimpl.WithSysProbeConfFilePath(sysprobePath),
+			sysprobeconfigimpl.WithFleetPoliciesDirPath(""),
+		)),
+		config.Module(),
+		delegatedauthnoopfx.Module(),
+		secretsnoopfx.Module(),
+		sysprobeconfigimpl.Module(),
+		fx.Supply(log.ForDaemon("SP", "log_file", "")),
+		systemprobeloggerfx.Module(),
+		telemetryfx.Module(),
+		fx.Provide(func() ipc.Component { return ipcComp }),
+		fx.Provide(func(c config.Component) model.Writer { return c }),
+		fx.Supply(configstreamconsumer.Params{
+			ClientName:        "system-probe",
+			CoreAgentAddress:  serverAddr,
+			SessionIDProvider: &mockRAR{},
+			ReadyTimeout:      10 * time.Second,
+		}),
+		configstreamconsumerfx.Module(),
+	)
+
+	verify := func(_ configstreamconsumer.Component, cfg config.Component) error {
+		if used := cfg.ConfigFileUsed(); used != "" {
+			return fmt.Errorf("ConfigFileUsed = %q; want empty (disk should not have been read)", used)
+		}
+		if got := cfg.GetString("site"); got != "from-stream" {
+			return fmt.Errorf("site = %q; want %q (streamed value)", got, "from-stream")
+		}
+		return nil
+	}
+
+	require.NoError(t, fxutil.OneShot(verify, opts))
+}

--- a/cmd/system-probe/subcommands/run/command_test.go
+++ b/cmd/system-probe/subcommands/run/command_test.go
@@ -7,7 +7,11 @@ package run
 
 import (
 	_ "net/http/pprof"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -19,4 +23,69 @@ func TestRunCommand(t *testing.T) {
 		[]string{"run"},
 		run,
 		func() {})
+}
+
+// envFunc builds a lookup function from a map, so tests never touch os env.
+func envFunc(m map[string]string) func(string) (string, bool) {
+	return func(k string) (string, bool) {
+		v, ok := m[k]
+		return v, ok
+	}
+}
+
+func TestReadConfigstreamBootstrap(t *testing.T) {
+	t.Run("defaults when env and yaml are empty", func(t *testing.T) {
+		// Use an empty YAML at cliConfigPath so the function doesn't fall through
+		// to a system-installed /etc or /opt datadog.yaml.
+		dir := t.TempDir()
+		path := filepath.Join(dir, "datadog.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(""), 0600))
+
+		bs := readConfigstreamBootstrap(path, envFunc(nil))
+		require.False(t, bs.Enabled)
+		require.Equal(t, "localhost", bs.CmdHost)
+		require.Equal(t, 5001, bs.CmdPort)
+	})
+
+	t.Run("yaml supplies custom cmd_host and cmd_port", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "datadog.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+cmd_host: 10.0.0.5
+cmd_port: 9000
+remote_agent:
+  configstream:
+    consumer:
+      enabled: true
+`), 0600))
+
+		bs := readConfigstreamBootstrap(path, envFunc(nil))
+		require.True(t, bs.Enabled)
+		require.Equal(t, "10.0.0.5", bs.CmdHost)
+		require.Equal(t, 9000, bs.CmdPort)
+	})
+
+	t.Run("env vars override yaml", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "datadog.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`
+cmd_host: 10.0.0.5
+cmd_port: 9000
+remote_agent:
+  configstream:
+    consumer:
+      enabled: false
+`), 0600))
+
+		env := envFunc(map[string]string{
+			configstreamConsumerEnabledEnvVar: "true",
+			"DD_CMD_HOST":                     "192.168.1.1",
+			"DD_CMD_PORT":                     "7000",
+		})
+
+		bs := readConfigstreamBootstrap(path, env)
+		require.True(t, bs.Enabled)
+		require.Equal(t, "192.168.1.1", bs.CmdHost)
+		require.Equal(t, 7000, bs.CmdPort)
+	})
 }

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -81,6 +81,11 @@ func newConfig(deps dependencies) (*cfg, error) {
 	config := pkgconfigsetup.GlobalConfigBuilder()
 	warnings := &pkgconfigmodel.Warnings{}
 
+	if deps.Params.isConfigstreamEnabled {
+		// configstreamconsumer is the sole source of configuration.
+		return &cfg{Config: config, warnings: warnings}, nil
+	}
+
 	err := setupConfig(config, deps.Secret, deps.DelegatedAuth, deps.Params)
 	returnErrFct := func(e error) (*cfg, error) {
 		if e != nil && deps.Params.ignoreErrors {

--- a/comp/core/config/params.go
+++ b/comp/core/config/params.go
@@ -47,6 +47,9 @@ type Params struct {
 	// cliOverride is a list of setting overrides from the CLI given to the configuration. The map associate
 	// settings name like "logs_config.enabled" to its value.
 	cliOverride map[string]interface{}
+
+	// isConfigstreamEnabled skips loading datadog.yaml; the configstreamconsumer populates config instead.
+	isConfigstreamEnabled bool
 }
 
 // NewParams creates a new instance of Params
@@ -144,5 +147,12 @@ func WithFleetPoliciesDirPath(fleetPoliciesDirPath string) func(*Params) {
 func WithCLIOverride(setting string, value interface{}) func(*Params) {
 	return func(b *Params) {
 		b.cliOverride[setting] = value
+	}
+}
+
+// WithConfigstreamEnabled tells the config component not to read datadog.yaml.
+func WithConfigstreamEnabled(v bool) func(*Params) {
+	return func(b *Params) {
+		b.isConfigstreamEnabled = v
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Adds a `WithConfigstreamEnabled` option to `comp/core/config`. When set, `newConfig` short-circuits before `setupConfig`, so the config component never calls `LoadDatadog` / fleet-policy merge / CLI override / secret resolution. The streamed snapshot from the core agent (written by the configstreamconsumer into the same global config builder) becomes the only source of values for system-probe. system-probe's `run` command passes the option whenever the pre-FX `isConfigstreamEnabled` check returns true.

### Motivation
Although PR #46281 wired the configstreamconsumer into system-probe's FX graph, the config component itself was unaware of configstream and continued to load `datadog.yaml` from disk. The streamed snapshot then overwrote those values at the same source priority, so the visible behavior usually looked correct — but the local load was still running, which means:

- A malformed or unreadable `datadog.yaml` aborts system-probe startup even when the core agent has a perfectly good snapshot to stream.
- Local secret resolution still runs (and can fail) on the remote agent.
- Any value present in system-probe's local `datadog.yaml` but not on the core agent rides at `SourceFile`, and the only thing keeping it from leaking through is last-write-wins at the same priority — fragile and not how we want this to work.

The fix makes the remote agent's config component a thin consumer of the streamed snapshot:
- **Configstream disabled** → unchanged: remote agent resolves locally.
- **Configstream enabled** → core agent is the source of truth, remote agent receives. If a value exists only on the remote agent's local config, it is ignored and the registered default applies.

### Note on the dep ordering
A more direct version of this change would add the `configstreamconsumer` component as an fx dependency of `comp/core/config` — that is what was originally suggested. Doing so creates a cycle: `config → configstreamconsumer → ipc → config` (the IPC component depends on `config.Component` to resolve auth-token and IPC cert paths). The flag-based approach gives the same end state — the config component skips disk and the streamed values land in the same global builder — without requiring a refactor of the IPC dep chain. The implicit ordering guarantee instead comes from FX invoke order: the configstreamconsumer is constructed inside an `fx.Invoke` block that runs before workload components read config values.

### Note on the pre-FX bootstrap
`WithConfigstreamEnabled(true)` skips disk loading, but the dial address still has to come from somewhere. `readConfigstreamBootstrap` reads `enabled` / `cmd_host` / `cmd_port` pre-FX (env vars, then YAML, then defaults) and `configstreamFxOptions` takes them as args. Scoped to those three values — extend it if a future configstream connect-time setting is added.

### Describe how you validated your changes
Added `TestConfigComponentSkipsDiskWhenConfigstreamEnabled` in `cmd/system-probe/subcommands/run/command_configstream_integration_test.go`. It writes a poisoned `datadog.yaml` (`site: from-disk`) to a tempdir, brings up the FX graph with `WithConfigstreamEnabled(true)`, pre-buffers a snapshot with `site: from-stream` on a mock gRPC server, and asserts two things on the resulting `config.Component`:

- `ConfigFileUsed() == ""` — proves `setupConfig` was skipped entirely.
- `GetString("site") == "from-stream"` — proves the streamed value reached the component.

Without the new `WithConfigstreamEnabled(true)` argument, the same test fails with `ConfigFileUsed = ".../datadog.yaml"; want empty`, which directly catches the regression PR #46281's existing integration test could not detect (that test only asserted that startup blocked until a snapshot arrived; it never asserted that the streamed value was the value the config component reported).

I also ran an end-to-end smoke test: built core + system-probe, started the core agent on `bin/agent/dist/datadog.yaml` (which has the distinctive `site: datad0g.com`), and ran system-probe pointing at a poisoned `datadog.yaml` with `site: POISON_LOCAL_VALUE_should_not_appear`:

> 2026-05-15 12:33:25 EDT | SYS-PROBE | INFO | (comp/core/configstreamconsumer/impl/consumer.go:152 in start) | Initial configuration received from core agent.
> 2026-05-15 12:33:27 EDT | SYS-PROBE | INFO | (comp/forwarder/defaultforwarder/default_forwarder.go:458 in Start) | Forwarder started, sending to 1 endpoint(s) with 1 worker(s) each: "https://process.datad0g.com." (1 api key(s))

The forwarder URL is derived from `site` and is unfakeable — `process.datad0g.com` is the core agent's value, not the default (`datadoghq.com`) and not the poison. The same test against a binary with `WithConfigstreamEnabled(true)` removed exits with `unable to load Datadog config file` because `LoadDatadog` was reached and parsed the poisoned YAML — a clean before/after that confirms the fix is what's bypassing the disk read.

### Additional Notes
Process env vars (`DD_*`) still override streamed values via `BindEnvAndSetDefault`'s read-time binding. This is the intended ordering (env > stream): subprocess-local environment should win over what the core agent sent. `system_probe_config.*` keys are unaffected by this change — they live in `system-probe.yaml` and are owned by `sysprobeconfig`, which still reads its file regardless of the flag.

This PR is scoped to system-probe; the same option can be wired into trace-agent / process-agent / security-agent in their respective in-flight PRs.
