### PR TITLE
[noisy_neighbor] Skip PMU sampling when no event is enabled

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor-kern.c
@@ -31,6 +31,17 @@ BPF_PERF_EVENT_ARRAY_MAP(cache_references_pmu, u32)
 // non-preemptible context so per-CPU storage is sufficient.
 BPF_PERCPU_ARRAY_MAP(softirq_start_ns, __u64, 1)
 
+// pmu_any_enabled is rewritten by userspace at load time to a non-zero value
+// when at least one PMU event is configured. Used to short-circuit the
+// per-sched-switch PMU sampling fast path so the disabled-by-default case
+// pays only a single immediate compare instead of seven bpf_perf_event_read
+// helper calls per context switch.
+static __always_inline __u64 pmu_any_enabled(void) {
+    __u64 val = 0;
+    LOAD_CONSTANT("pmu_any_enabled", val);
+    return val;
+}
+
 void bpf_rcu_read_lock(void) __ksym;
 void bpf_rcu_read_unlock(void) __ksym;
 extern void *bpf_rdonly_cast(const void *obj, __u32 btf_id) __ksym __weak;
@@ -265,10 +276,16 @@ int tp_sched_switch(u64 *ctx) {
     u32 next_pid = next->pid;
 
     // Sample PMU counters once. Each read is independent — if iTLB events
-    // aren't supported but cycles are, only iTLB deltas are skipped.
+    // aren't supported but cycles are, only iTLB deltas are skipped. Skip
+    // the sampling entirely when no PMU toggle is enabled: every read would
+    // return -ENOENT and the helper-call cost is the dominant overhead
+    // here.
     pmu_sample_t pmu = {};
-    pmu_sample_all(&pmu);
-    bool pmu_ok = pmu_any_ok(&pmu);
+    bool pmu_ok = false;
+    if (pmu_any_enabled()) {
+        pmu_sample_all(&pmu);
+        pmu_ok = pmu_any_ok(&pmu);
+    }
 
     if (pmu_ok && prev_pid) {
         task_pmu_stamp_t *stamp = bpf_task_storage_get(&task_oncpu_pmu, prev, NULL, 0);

--- a/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/noisyneighbor/probe.go
@@ -53,6 +53,19 @@ func NewProbe(cfg *ddebpf.Config, modCfg Config) (*Probe, error) {
 
 	p := &Probe{}
 
+	// Summarise the per-event toggles into a single bit. The BPF program
+	// reads this through LOAD_CONSTANT and skips the seven bpf_perf_event_read
+	// helper calls per sched_switch when every counter is off. Per-counter
+	// gating (which events get perf-event-array fds) is still driven by
+	// attachPMU below; this is only the hot-path summary.
+	var pmuAnyEnabled uint64
+	for _, on := range modCfg.PMUMetrics {
+		if on {
+			pmuAnyEnabled = 1
+			break
+		}
+	}
+
 	filename := "noisy-neighbor.o"
 	if cfg.BPFDebug {
 		filename = "noisy-neighbor-debug.o"
@@ -81,6 +94,17 @@ func NewProbe(cfg *ddebpf.Config, modCfg Config) (*Probe, error) {
 			{Name: "cache_references_pmu"},
 			{Name: "softirq_start_ns"},
 		}
+		opts.ConstantEditors = append(opts.ConstantEditors, manager.ConstantEditor{
+			Name:          "pmu_any_enabled",
+			Value:         pmuAnyEnabled,
+			FailOnMissing: true,
+			// Only tp_sched_switch reads this constant; restricting the
+			// editor avoids "unreferenced symbol" errors against the other
+			// programs in the manager.
+			ProbeIdentificationPairs: []manager.ProbeIdentificationPair{
+				{EBPFFuncName: "tp_sched_switch", UID: uid},
+			},
+		})
 		if err := p.mgr.InitWithOptions(buf, &opts); err != nil {
 			return fmt.Errorf("failed to init ebpf manager: %w", err)
 		}


### PR DESCRIPTION
### What does this PR do?

Adds a userspace-rewritten BPF constant `pmu_any_enabled` that gates the per-`sched_switch` PMU sampling path. When all `PMUMetrics` toggles are off, the constant is 0, the verifier dead-code-eliminates the seven `bpf_perf_event_read_value` calls in `pmu_sample_all`, and the JIT'd program shrinks ~3960 → ~1616 bytes.

### Motivation

The `noisy_neighbor` module is experimental and ships with all PMU metrics off by default. Today the BPF program still issues seven perf-event-read helper calls per `sched_switch` even when no perf fds are attached; each returns `-ENOENT` but costs ~20 ns. On a Graviton2 dev host this added ~136 ns/`sched_switch` (+29 %) vs the pre-PR-#50350 baseline — a regression for the disabled-by-default case that everyone running the agent pays.

### Describe how you validated your changes

bpftool prog stat measurement on Graviton2 (kernel 6.8.0-1053-aws, `kernel.bpf_stats_enabled=1`, 60s window after 6s warmup, ambient sched_switch load ~28k/s):

| Config | ns/call | bytes_jited | Δ vs pre-#50350 baseline |
|---|---:|---:|---:|
| Pre-PR baseline (`2733956b6`, parent of #50350) | 465 | 1368 | — |
| Main (post-#50350, no gate) | 601 | 3960 | +136 ns (+29 %) |
| This PR, PMUs off | 456 | 1616 | −9 ns (within noise) |
| This PR, PMUs on (all 7) | 3857 | 4072 | +3,392 ns (intrinsic PMU cost) |

The gate brings the disabled-by-default case back to within ~2 % of pre-#50350 cost. PMU emission with toggles on is unaffected — all 7 counters (cycles, instructions, cache_misses, cache_references, itlb_misses, branch_misses, cpu_migrations) sum non-zero in `GetAndFlush` on every cgroup that scheduled in the window.

Verified functionality by running the experimental module with:
- `all-on`: 45 cgroups returned, every PMU sum field non-zero
- `all-off`: PMU sum fields all zero (gate elided the sampling path), non-PMU signals (EventCount, WakeupCount, SumSoftirqNs, BlockIORequests) unchanged

### Additional Notes

- `pmu_any_enabled` is scoped via `ProbeIdentificationPairs` to `tp_sched_switch` only — other programs in the manager would otherwise reject the editor as an unreferenced symbol.
- `FailOnMissing: true` on the editor: if a future rebuild drops the constant from the BPF program by accident, NewProbe fails loudly rather than silently re-introducing the unconditional path.
- This is purely a hot-path optimisation; no API or behaviour changes for the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)