### PR TITLE
packaging/aix: make agent and trace-agent self-contained wrappers

### DIFF
--- a/packaging/aix/agent-wrapper.sh
+++ b/packaging/aix/agent-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Agent entry point wrapper.
+#
+# AIX's dynamic loader uses LIBPATH (not RPATH) for library resolution.
+# The agent binary's loader section has the build-host staging path baked in
+# (a Go/ld limitation on AIX); this wrapper sets the correct installed paths
+# so the binary works when invoked directly, not just via SRC.
+export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib
+export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:"${PATH}"
+exec /opt/datadog-agent/bin/agent/agent-bin "$@"

--- a/packaging/aix/package-scripts/postinst
+++ b/packaging/aix/package-scripts/postinst
@@ -26,31 +26,6 @@ chown dd-agent:dd-agent /opt/datadog-agent/run 2>/dev/null || true
 chown dd-agent:dd-agent /etc/datadog-agent 2>/dev/null || true
 chmod 750 /etc/datadog-agent               2>/dev/null || true
 
-# Write SRC wrapper script.
-# AIX's mkssys does not support setting environment variables (-e is stderr
-# redirect, not env-var injection). This wrapper sets LIBPATH so all shared
-# libraries and Python C extensions are found, then exec's the agent binary.
-WRAPPER=/opt/datadog-agent/bin/agent-svc
-LIBPATH_VAL=/opt/datadog-agent/rtloader
-LIBPATH_VAL=${LIBPATH_VAL}:/opt/datadog-agent/embedded/lib
-LIBPATH_VAL=${LIBPATH_VAL}:/opt/mqm/lib64:/opt/mqm/lib
-LIBPATH_VAL=${LIBPATH_VAL}:/opt/ibm/db2/clidriver/lib
-LIBPATH_VAL=${LIBPATH_VAL}:/opt/freeware/lib64:/opt/freeware/lib
-
-printf '#!/bin/sh\n'                                                          > "$WRAPPER"
-printf 'export LIBPATH=%s\n' "$LIBPATH_VAL"                                  >> "$WRAPPER"
-printf 'export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:${PATH}\n' >> "$WRAPPER"
-printf 'exec /opt/datadog-agent/bin/agent/agent "$@"\n'                      >> "$WRAPPER"
-chmod 755 "$WRAPPER"
-
-# Write SRC wrapper for trace-agent.
-TRACE_WRAPPER=/opt/datadog-agent/bin/trace-agent-svc
-printf '#!/bin/sh\n'                                                              > "$TRACE_WRAPPER"
-printf 'export LIBPATH=%s\n' "$LIBPATH_VAL"                                      >> "$TRACE_WRAPPER"
-printf 'export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:${PATH}\n' >> "$TRACE_WRAPPER"
-printf 'exec /opt/datadog-agent/embedded/bin/trace-agent run --config /etc/datadog-agent/datadog.yaml\n' >> "$TRACE_WRAPPER"
-chmod 755 "$TRACE_WRAPPER"
-
 # Remove ALL stale SRC entries then register fresh.
 #
 # On AIX, the SRC has two levels of state:
@@ -68,13 +43,14 @@ while rmssys -s datadog-agent       > /dev/null 2>&1; do :; done
 while rmssys -s datadog-trace-agent > /dev/null 2>&1; do :; done
 
 mkssys -s datadog-agent \
-       -p /opt/datadog-agent/bin/agent-svc \
+       -p /opt/datadog-agent/bin/agent/agent \
        -a "run -c /etc/datadog-agent/datadog.yaml" \
        -u dd-agent \
        -R -S -n 15 -f 9
 
 mkssys -s datadog-trace-agent \
-       -p /opt/datadog-agent/bin/trace-agent-svc \
+       -p /opt/datadog-agent/embedded/bin/trace-agent \
+       -a "run --config /etc/datadog-agent/datadog.yaml" \
        -u dd-agent \
        -R -S -n 15 -f 9
 

--- a/packaging/aix/package-scripts/unconfig
+++ b/packaging/aix/package-scripts/unconfig
@@ -19,9 +19,7 @@ rmgroup dd-agent 2>/dev/null || true
 rm -rf /var/run/datadog 2>/dev/null || true
 # Remove files written at runtime or by preinst that are not in the package
 # file list and would otherwise prevent installp from removing the directories.
-rm -f /opt/datadog-agent/bin/agent-svc \
-      /opt/datadog-agent/bin/trace-agent-svc \
-      /opt/datadog-agent/.profile 2>/dev/null || true
+rm -f /opt/datadog-agent/.profile 2>/dev/null || true
 # Python stdlib __pycache__ .pyc files created at runtime (not in package).
 find /opt/datadog-agent -name "*.pyc" -type f -exec rm -f {} \; 2>/dev/null || true
 rm -rf /opt/datadog-agent/run 2>/dev/null || true

--- a/packaging/aix/stages/04-agent.sh
+++ b/packaging/aix/stages/04-agent.sh
@@ -106,15 +106,22 @@ log "Building agent version $AGENT_VERSION at commit $COMMIT"
 
 log "Building agent binary via inv agent.build"
 cd /opt/datadog-agent
-rm -f "$STAGING/opt/datadog-agent/bin/agent/agent"
+rm -f "$STAGING/opt/datadog-agent/bin/agent/agent-bin"
 python3.12 -m invoke agent.build \
     --exclude-rtloader \
     --rtloader-root=/opt/datadog-agent/rtloader \
     --embedded-path="$EMBEDDED_DESTDIR" \
-    --agent-bin="$STAGING/opt/datadog-agent/bin/agent/agent"
+    --agent-bin="$STAGING/opt/datadog-agent/bin/agent/agent-bin"
 
-strip -X64 "$STAGING/opt/datadog-agent/bin/agent/agent"
-log "agent binary build complete: $STAGING/opt/datadog-agent/bin/agent/agent"
+strip -X64 "$STAGING/opt/datadog-agent/bin/agent/agent-bin"
+log "agent binary build complete: $STAGING/opt/datadog-agent/bin/agent/agent-bin"
+
+# Install the agent wrapper: sets LIBPATH/PATH so the binary works when invoked
+# directly (not just via SRC). The wrapper execs agent-bin, so the process is
+# replaced immediately — SRC PID tracking and signal handling are unaffected.
+cp "$(dirname "$0")/../agent-wrapper.sh" "$STAGING/opt/datadog-agent/bin/agent/agent"
+chmod 755 "$STAGING/opt/datadog-agent/bin/agent/agent"
+log "agent wrapper installed at $STAGING/opt/datadog-agent/bin/agent/agent"
 
 # ─── Step 5: Build the trace-agent binary ─────────────────────────────────────
 #
@@ -124,10 +131,14 @@ log "Building trace-agent binary via inv trace-agent.build"
 cd /opt/datadog-agent
 python3.12 -m invoke trace-agent.build
 mkdir -p "$STAGING/opt/datadog-agent/embedded/bin"
-rm -f "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
-cp /opt/datadog-agent/bin/trace-agent/trace-agent "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
-strip -X64 "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
-log "trace-agent binary build complete: $STAGING/opt/datadog-agent/embedded/bin/trace-agent"
+rm -f "$STAGING/opt/datadog-agent/embedded/bin/trace-agent-bin"
+cp /opt/datadog-agent/bin/trace-agent/trace-agent "$STAGING/opt/datadog-agent/embedded/bin/trace-agent-bin"
+strip -X64 "$STAGING/opt/datadog-agent/embedded/bin/trace-agent-bin"
+log "trace-agent binary build complete: $STAGING/opt/datadog-agent/embedded/bin/trace-agent-bin"
+
+cp "$(dirname "$0")/../trace-agent-wrapper.sh" "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
+chmod 755 "$STAGING/opt/datadog-agent/embedded/bin/trace-agent"
+log "trace-agent wrapper installed at $STAGING/opt/datadog-agent/embedded/bin/trace-agent"
 
 # ─── Step 6: Verify XCOFF64 magic bytes ───────────────────────────────────────
 #
@@ -135,7 +146,7 @@ log "trace-agent binary build complete: $STAGING/opt/datadog-agent/embedded/bin/
 # would indicate a cross-compile or wrong-format build.
 
 log "Verifying agent binary is XCOFF64"
-MAGIC=$(od -A x -t x1 "$STAGING/opt/datadog-agent/bin/agent/agent" | head -1 | awk '{print $2 $3}')
+MAGIC=$(od -A x -t x1 "$STAGING/opt/datadog-agent/bin/agent/agent-bin" | head -1 | awk '{print $2 $3}')
 if [ "$MAGIC" != "01f7" ]; then
     log "ERROR: agent binary is not XCOFF64 (got: $MAGIC)"
     log "       Expected magic bytes: 01 f7"
@@ -145,7 +156,7 @@ fi
 log "XCOFF64 magic verified for agent binary (magic: $MAGIC)"
 
 log "Verifying trace-agent binary is XCOFF64"
-MAGIC=$(od -A x -t x1 "$STAGING/opt/datadog-agent/embedded/bin/trace-agent" | head -1 | awk '{print $2 $3}')
+MAGIC=$(od -A x -t x1 "$STAGING/opt/datadog-agent/embedded/bin/trace-agent-bin" | head -1 | awk '{print $2 $3}')
 if [ "$MAGIC" != "01f7" ]; then
     log "ERROR: trace-agent binary is not XCOFF64 (got: $MAGIC)"
     log "       Expected magic bytes: 01 f7"

--- a/packaging/aix/stages/10-assemble.sh
+++ b/packaging/aix/stages/10-assemble.sh
@@ -39,7 +39,7 @@ trap cleanup EXIT
 # The agent binary is the primary deliverable. If it is absent the staging
 # tree is incomplete and packaging will produce a broken BFF.
 
-AGENT_BIN="$STAGING/opt/datadog-agent/bin/agent/agent"
+AGENT_BIN="$STAGING/opt/datadog-agent/bin/agent/agent-bin"
 if [ ! -f "$AGENT_BIN" ]; then
     log "ERROR: agent binary not found at $AGENT_BIN"
     log "       Did Stage 04 (04-agent) complete successfully?"

--- a/packaging/aix/trace-agent-wrapper.sh
+++ b/packaging/aix/trace-agent-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib
+export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:"${PATH}"
+exec /opt/datadog-agent/embedded/bin/trace-agent-bin "$@"


### PR DESCRIPTION
### What does this PR do?

Rename the real `agent` and `trace-agent` binaries to `agent-bin` / `trace-agent-bin` and ship thin shell wrappers as `agent` / `trace-agent`. The wrappers set `LIBPATH`/`PATH` and `exec` the binary, making the commands work correctly when invoked directly rather than only through SRC.

### Motivation

The XCOFF64 binaries have build-host staging paths baked into their loader section. Running them directly (e.g. `agent status`, `agent check`) would fail with missing library errors. As a side effect, the dynamically-generated `agent-svc` / `trace-agent-svc` install-time scripts are eliminated.

### Describe how you validated your changes

Local testing.

### Additional Notes

None.