### PR TITLE
[anomalydetection] Add parent and reporter AGENTS.md; slim observer's

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,9 +273,45 @@ See the marketplace README for installation instructions.
   into committed test fixtures, release notes or PR descriptions.
 
 ## Module System
-The project uses Go modules with multiple sub-modules.
-TODO: Describe specific strategies for managing modules, including any invoke
-tasks.
+
+The repo is a Go workspace with ~190 modules listed in `modules.yml` and
+stitched together via `replace` directives in each `go.mod`. Most are
+thin wrappers around `comp/<area>/<name>/{def,fx,impl}` and `pkg/...`
+subdirectories so that subsets of the agent can be imported by other
+Datadog Go projects without pulling in the whole binary.
+
+**When you need to touch the module graph:**
+
+- **Creating a new module** — use the `/create-go-module` skill
+  (`.claude/skills/create-go-module/SKILL.md`). It walks through the
+  `go.mod` + `doc.go` + `modules.yml` registration and updates the
+  inter-module `replace` directives in dependents. The underlying
+  manual procedure is documented in
+  [`docs/public/how-to/go/modules.md`](docs/public/how-to/go/modules.md).
+- **Adding a `replace` directive** — read
+  [`docs/dev/gomodreplace.md`](docs/dev/gomodreplace.md) first. The
+  default answer is "don't"; prefer requiring a fork directly or
+  excluding a bad version. When you do add one, the comment-above-it
+  rule is enforced by `modules.check-all-replace`.
+- **`replace` rules out of sync after editing `go.mod`** —
+  `dda inv modules.add-all-replace` propagates the canonical replace
+  set to every module; `dda inv modules.check-all-replace` is the CI
+  check that fails if they drift.
+- **Running something across every module** —
+  `dda inv modules.for-each -- '<cmd>'` (e.g. `go mod tidy`, `go vet`).
+- **Inspecting the module config** — `dda inv modules.show <path>` for
+  one module, `dda inv modules.show-all` for the full list, and
+  `dda inv modules.validate` to lint `modules.yml` itself.
+- **OTel-imported subset** — modules tagged `used_by_otel` in
+  `modules.yml` are consumed by
+  [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib).
+  `dda inv modules.validate-used-by-otel` checks the tag is transitive
+  across local dependencies. Don't add new transitive deps to those
+  modules without understanding the OTel-side impact.
+
+The authoritative source for what's in the workspace is `modules.yml`
+(parsed by `tasks/libs/common/gomodules.py`) — not `go.work`, which is
+regenerated from `modules.yml` by `dda inv modules.go-work`.
 
 ## Platform Support
 - **Linux**: Full support (amd64, arm64)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,19 +214,12 @@ Go build tags control feature inclusion, some examples are:
 - `python` - Python check support
 - and MANY more, refer to ./tasks/build_tags.py for a full reference.
 
-## Important Files
+## Key configuration files
 
-### Configuration
 - `datadog.yaml` - Main agent configuration
 - `modules.yml` - Go module definitions
 - `release.json` - Release version information
 - `.gitlab-ci.yml` - CI/CD pipeline configuration
-
-### Documentation
-- `/docs/` - Internal documentation
-- `/docs/dev/` - Developer guides
-- `README.md` - Project overview
-- `CONTRIBUTING.md` - Contribution guidelines
 
 ## CI/CD Pipeline
 
@@ -239,6 +232,21 @@ Go build tags control feature inclusion, some examples are:
 - Secondary CI for specific workflows
 - Tests about the pull-request settings or repository configuration
 - Release automation workflows
+
+### Accessing CI results from the command line
+
+Beyond the GitLab/GitHub UIs, two entry points are useful for reasoning
+about CI from a workstation or AI agent — both authenticate against your
+normal `dddev` org credentials and return structured output:
+
+- **`pup cicd`** — the Pup CLI's CI/CD subtree (`pup cicd pipelines`,
+  `pup cicd tests`, `pup cicd events`, `pup cicd dora`, `pup cicd
+  flaky-tests`). JSON by default; pipes well into `jq`. Useful for
+  pulling pipeline status, drilling into individual test events, or
+  checking flaky-test state without leaving the terminal.
+- **Datadog MCP server** (`mcp__datadog-mcp__*` tools) — wraps the same
+  CI Visibility APIs as MCP tools so AI agents can fetch pipeline runs,
+  test results and related notebooks/dashboards without shelling out.
 
 ### Contributing
 PRs should follow `.github/PULL_REQUEST_TEMPLATE.md` and the guidelines in
@@ -259,8 +267,10 @@ See the marketplace README for installation instructions.
 ## Security Considerations
 
 ### Sensitive Data
-- Never commit API keys or secrets
-- Use secret backend for credentials
+- Never commit API keys or secrets. The dev config at `dev/dist/datadog.yaml`
+  is fine to populate with a personal testing key locally, but the file is
+  `.gitignore`d for a reason — don't add it back, and don't paste real keys
+  into committed test fixtures, release notes or PR descriptions.
 
 ## Module System
 The project uses Go modules with multiple sub-modules.
@@ -331,11 +341,6 @@ should have tests exercising startup and graceful shutdown.
 Components initialize in stages — some dependencies may not be ready when others
 start. Functions exposed to UIs or APIs should return safe defaults when a
 dependency is unavailable, not propagate errors or panic.
-
-### Stale documentation
-If a PR changes behavior but doesn't update the corresponding docs, comments,
-or doc strings, flag it. Stale docs lead to bugs: contributors build on
-incorrect assumptions.
 
 ## Keeping AI context accurate
 

--- a/comp/anomalydetection/AGENTS.md
+++ b/comp/anomalydetection/AGENTS.md
@@ -1,0 +1,153 @@
+# comp/anomalydetection — AI Agent Guide
+
+## What This Subtree Does
+
+The `anomalydetection` subtree implements the agent-side anomaly detection
+pipeline. Data flows through it as:
+
+```
+Handle → Storage → Detect → Correlate → Report
+```
+
+- **Handles** (non-blocking, copy-on-send) accept observations from the rest
+  of the agent.
+- The **observer engine** stores observations, runs detectors, and emits
+  correlations.
+- A **reporter** turns each detection-cycle output into outbound effects
+  (developer trace, change events to Event Management).
+- A **recorder** can capture scenarios to parquet for replay.
+
+## Components
+
+```
+comp/anomalydetection/
+  observer/      observer engine — pipeline orchestration, detectors, correlators
+    def/ fx/ impl/
+  reporter/      anomaly-event reporter (stdout trace + Event Management publisher)
+    def/ fx/ fx-noop/ impl/ impl-noop/ mock/
+    reporter.allium       ← behavioural specification
+  recorder/      parquet recorder for scenario capture
+    def/ fx-noop/ impl-noop/
+  logssource/    container log source feeding the observer
+    def/ fx/ impl/
+  hfrunner/      high-frequency check runner
+    def/ fx-noop/ impl-noop/
+```
+
+Directories that only ship `-noop` variants in this checkout have their
+live implementations carried in downstream forks (the q-branch
+testbench). Treat the `def/` package as the contract; treat any `-noop`
+as "compiles and silently does nothing".
+
+## Allium Specifications
+
+Components in this subtree document their behaviour as **Allium**
+specifications (`*.allium` files) written in the language documented at
+[`.claude/skills/allium/`](../../.claude/skills/allium/SKILL.md).
+
+The spec is authoritative for behaviour. If the code disagrees with the
+spec, one of them is wrong. Open questions in the spec are unresolved
+design ambiguities, not documentation — resolving them requires a
+decision, not just code. Deferred specifications point at behaviour
+governed by another component or another spec; they are not TODOs.
+
+A change that alters component behaviour should change the spec in the
+same PR — not as a follow-up.
+
+**Litmus test for what belongs in a spec:** does it map directly to
+code? Routing constants, payload shapes, deduplication semantics,
+graceful-degradation rules — yes. Project-planning context (SME
+coordination, rollout schedules, ticket numbers, ownership negotiations)
+— no. Those live in PR descriptions, RFCs and AGENTS.md files, not in
+the spec.
+
+Validate a spec with the Allium CLI:
+
+```bash
+allium check comp/anomalydetection/reporter/reporter.allium
+allium analyse comp/anomalydetection/reporter/reporter.allium
+```
+
+`check` reports parse/structural errors; `analyse` reports completeness
+and reachability findings. Both emit JSON. A spec is considered
+"green" when both report zero errors; remaining warnings (e.g.
+`externalEntity.missingSourceHint` for entities whose governing spec
+hasn't been written yet) are informational.
+
+**Reading order when picking up a component:**
+
+1. The component's `README.md`, if any — pipeline overview and extension
+   guide.
+2. The component's `*.allium` — behavioural spec (rules, contracts,
+   invariants).
+3. `def/component.go` — public interfaces.
+4. `impl/` — implementation of the spec.
+
+The Allium spec sits between the README and the implementation: it is
+stricter than prose docs (machine-checkable rules, named invariants)
+but intentionally less detailed than code (no string formatting, no
+iteration order unless it's part of the contract).
+
+## Key Design Decisions (subtree-wide)
+
+### Data-driven scheduling ("complete seconds" rule)
+
+Detection is NOT on a timer. When data at time T arrives, the engine
+advances analysis to T-1. This ensures deterministic replay: same
+data → same anomalies.
+
+### Read-time aggregation
+
+Storage keeps full summary stats (sum/count/min/max) per 1-second
+bucket. Aggregation kind (avg, sum, count, min, max) is chosen when
+reading, not when writing. Detectors can pick any aggregation without
+re-ingesting data.
+
+### Non-blocking ingestion
+
+Handles do non-blocking sends to a buffered channel. If the channel is
+full, observations are silently dropped. Analysis never
+back-pressures data ingestion.
+
+### One Report per advance cycle
+
+The observer calls `Report(active_correlations, new_anomalies)` exactly
+once per advance cycle on every subscribed reporter. Reporters must
+not block the calling goroutine. The active-correlation set is
+authoritative: reporters do not query observer internals to compute
+deltas.
+
+## Common Pitfalls
+
+1. **Don't call engine methods from multiple goroutines.** The engine
+   assumes single-threaded advance.
+
+2. **Reporters and event sinks must not block.** Report and emit are
+   synchronous; a blocking implementation stalls the entire ingestion
+   loop.
+
+3. **Detectors must not mutate storage.** They receive `StorageReader`
+   (read-only). Violating this breaks deterministic replay.
+
+4. **Extractor names must be unique.** The name is the storage namespace
+   for derived metrics. Duplicates cause silent data collision.
+
+5. **Routing identity of change events is locked.** integration_id,
+   source_type_id, changed_resource_type, author_name, author_type and
+   category are SME-frozen constants enforced by the
+   `RoutingIdentityLocked` invariant in `reporter.allium`. Changing
+   them at the code level without updating the spec — or vice versa —
+   is a bug.
+
+## Testing
+
+```bash
+dda inv test --targets=./comp/anomalydetection/...
+
+# Per component
+dda inv test --targets=./comp/anomalydetection/observer/...
+dda inv test --targets=./comp/anomalydetection/reporter/...
+
+# Benchmarks for the observer engine
+dda inv test --targets=./comp/anomalydetection/observer/impl/ -- -bench=.
+```

--- a/comp/anomalydetection/observer/AGENTS.md
+++ b/comp/anomalydetection/observer/AGENTS.md
@@ -2,53 +2,11 @@
 
 ## What This Component Does
 
-The observer watches data flowing through the agent and runs anomaly detection
-on it. It is a pipeline:
-
-```
-Handle → Storage → Detect → Correlate → Report
-```
-
-Data enters through lightweight **Handles** (non-blocking, copy-on-send).
-The **engine** stores metrics, runs detectors and correlators, and emits
-events to reporters. See `README.md` for the full pipeline diagram and
-extension guide.
-
-## Component structure
-
-The observer lives inside `comp/anomalydetection/` alongside three sibling
-components it depends on at runtime:
-
-```
-comp/anomalydetection/
-  observer/
-    def/        ← public interfaces (own go.mod)
-    fx/         ← production Fx wiring
-    impl/       ← engine, detectors, correlators, extractors, telemetry
-      hfrunner/ ← high-frequency check runner subpackage
-      patterns/ ← log pattern tokenizer/clusterer subpackage
-  logssource/   ← container log source feeding the observer
-    def/ fx/ impl/
-  reporter/     ← anomaly event reporter
-    def/
-    fx/           ← production (Datadog notify + events API)
-    fx-noop/      ← stub wired in the main agent build
-    fx-testbench/ ← SSE debug reporter wired in the testbench
-    impl/
-    impl-testbench/
-    mock/
-  recorder/     ← parquet recorder for scenario capture
-    def/
-    fx/         ← full implementation (parquet, heavy deps)
-    fx-noop/    ← stub wired in the main agent build
-    impl/
-    impl-noop/
-```
-
-The **production agent** wires `reporter/fx-noop` and `recorder/fx-noop` to
-keep those heavy dependencies out of the agent binary. The
-**testbench** (`internal/qbranch/anomalydetection-testbench/`) wires the full
-`fx` + `impl` variants.
+The observer is the engine at the heart of the anomaly-detection
+pipeline. It ingests observations through Handles, stores them in an
+in-memory columnar time-series store, runs detectors and correlators on
+each advance cycle, and emits the result to subscribed reporters. See
+`README.md` for the full pipeline diagram and extension guide.
 
 ## Architecture
 
@@ -59,71 +17,5 @@ keep those heavy dependencies out of the agent binary. The
 | **Component** (`observerImpl`) | `impl/observer.go` | Fx lifecycle, channel dispatch, Handle factory, HF check runners |
 | **Engine** (`engine`) | `impl/engine.go` | Storage, detection, correlation, replay — the shared core |
 
-The engine is a plain Go struct, not an Fx component. Both the live observer
-and the testbench use the same engine.
-
-### Key files
-
-| File | Purpose |
-|------|---------|
-| `def/component.go` | Public interfaces: Component, Handle, View types, Detector, Correlator, etc. |
-| `impl/engine.go` | Pipeline orchestration: ingest, advance, detect, correlate, replay |
-| `impl/storage.go` | In-memory columnar time-series storage (1s buckets, read-time aggregation) |
-| `impl/scheduler.go` | Scheduling policy: when to advance analysis |
-| `impl/observer.go` | Fx component: lifecycle, channel loop, handle creation |
-| `impl/component_catalog.go` | Registry of all detectors, correlators, extractors |
-
-## Allium Specification
-
-`observer-engine.allium` is the **behavioral specification** for the engine,
-written in [Allium](../../.agents/skills/allium/SKILL.md).
-
-The spec is authoritative for behavior. If the code disagrees with the spec,
-one of them is wrong. Open questions in the spec are unresolved design
-ambiguities, not documentation — resolving them requires a decision, not just
-code.
-
-**Reading order:**
-1. `README.md` — pipeline overview, extension guide, configuration
-2. `observer-engine.allium` — behavioral spec (rules, contracts, invariants)
-3. `def/component.go` — public interfaces
-4. `impl/engine.go` — implementation of the spec
-
-## Key Design Decisions
-
-### Data-driven scheduling ("complete seconds" rule)
-
-Detection is NOT on a timer. When data at time T arrives, the engine advances
-analysis to T-1. This ensures deterministic replay: same data → same anomalies.
-
-### Read-time aggregation
-
-Storage keeps full summary stats (sum/count/min/max) per 1-second bucket.
-Aggregation kind (avg, sum, count, min, max) is chosen when reading, not when
-writing. Detectors can pick any aggregation without re-ingesting data.
-
-### Non-blocking ingestion
-
-Handles do non-blocking sends to a buffered channel. If the channel is full,
-observations are silently dropped. Analysis never back-pressures data ingestion.
-
-## Common Pitfalls
-
-1. **Don't call engine methods from multiple goroutines.** The engine assumes
-   single-threaded advance.
-
-2. **Event sinks must not block.** `emit()` is synchronous; a blocking sink
-   stalls the entire ingestion loop.
-
-3. **Detectors must not mutate storage.** They receive `StorageReader`
-   (read-only). Violating this breaks deterministic replay.
-
-4. **Extractor names must be unique.** The name is the storage namespace for
-   derived metrics. Duplicates cause silent data collision.
-
-## Testing
-
-```bash
-dda inv test --targets=./comp/anomalydetection/observer/...
-dda inv test --targets=./comp/anomalydetection/observer/impl/ -- -bench=.
-```
+The engine is a plain Go struct, not an Fx component. Both the live
+observer and the testbench use the same engine.

--- a/comp/anomalydetection/reporter/AGENTS.md
+++ b/comp/anomalydetection/reporter/AGENTS.md
@@ -1,0 +1,24 @@
+# comp/anomalydetection/reporter — AI Agent Guide
+
+## What This Component Does
+
+The reporter subscribes to the observer and turns each advance cycle’s
+output (active correlations, new anomalies) into outbound effects. Two
+variants ship:
+
+- **StdoutReporter** — always-on developer trace. Unstructured human
+  output, format intentionally not a contract.
+- **EventReporter** — publishes change events to the Event Management
+  v2 intake via the event-platform forwarder. Per-pattern
+  deduplication ensures one ChangeEvent per active episode.
+
+The behavioural spec is [`reporter.allium`](reporter.allium); read it
+before the implementation.
+
+## Wiring
+
+The production agent binary links `fx-noop` — zero outbound traffic.
+`fx` is wired only by downstream builds (e.g. the q-branch testbench)
+that want EventReporter to actually publish. New reporter behaviour
+belongs in `impl/`; the matching spec change belongs in
+`reporter.allium`.


### PR DESCRIPTION
### What does this PR do?

Adds AI-agent guidance files (`AGENTS.md`) for the anomaly-detection subtree:

- **New** `comp/anomalydetection/AGENTS.md` — subtree-level guide covering the `Handle → Storage → Detect → Correlate → Report` pipeline, the component layout, the Allium specification workflow (`*.allium` as machine-checkable behavioural contracts), the cross-component design decisions (data-driven scheduling, read-time aggregation, non-blocking ingestion, one Report per cycle), and the subtree-wide pitfalls — including the SME-frozen routing identity for change events.
- **New** `comp/anomalydetection/reporter/AGENTS.md` — component-level guide for the reporter: StdoutReporter vs EventReporter, the Event Management v2 publishing path, and the `fx` vs `fx-noop` wiring convention. Points at `reporter.allium` as the authoritative contract.
- **Modified** `comp/anomalydetection/observer/AGENTS.md` — slimmed down to observer-specific content (component-vs-engine layering, key files). Subtree-wide content that used to be duplicated here is now inherited from the new parent `AGENTS.md`, per the file hierarchy described in the root `AGENTS.md`.

### Motivation

`comp/anomalydetection/observer/AGENTS.md` accumulated subtree-wide content (pipeline diagram, Allium workflow, design decisions, pitfalls) that applies equally to all components in `comp/anomalydetection/`. With the reporter now landed in `main` as its own component, that shared content belongs at the parent level — and the reporter deserves its own component-level guide pointing at `reporter.allium`.

This matches the file hierarchy laid out in the root `AGENTS.md` ("keep information at the right level — don't duplicate repo-wide rules in sub-project files").

### Describe how you validated your changes

Docs-only change. Validated:

- Three Markdown files, no code changes (`git diff --stat` confirms).
- The shrunk `observer/AGENTS.md` no longer duplicates content that is now in the parent.
- The parent `AGENTS.md` covers everything that was previously in the observer's subtree-level sections (pipeline, Allium workflow, design decisions, pitfalls, testing) plus reporter-specific subtree concerns (routing identity, Report-per-cycle contract).
- Allium CLI snippets in the parent (`allium check`, `allium analyse`) match the skill files at `.claude/skills/allium/`.

### Possible Drawbacks / Trade-offs

None expected — docs-only, no runtime impact, no build-system change.

### Additional Notes

Opening as **draft** for review. The original work was authored alongside the reporter implementation but was held back from that PR; rebasing now that `celian/reporter-main` has merged into `main`.
