### PR TITLE
lift Tokenization contract and TokenSequence value type into tokenizer.allium module

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -1,13 +1,17 @@
 -- allium: 3
 -- adaptive_sampler.allium
 
+use "./tokenizer.allium" as tokenizer
+
 -- Scope: Adaptive sampling behaviour for one log source in the
 --   Datadog Agent's logs preprocessor pipeline.
--- Includes: Tokenization (byte-to-token classification, run-length
---   encoding, special token promotion), pattern matching contract,
---   credit-based rate limiting, pattern table management (creation,
---   eviction, ordering), sampled-count metadata tagging.
+-- Includes: Pattern matching contract over token sequences (imported
+--   from tokenizer.allium), credit-based rate limiting, pattern table
+--   management (creation, eviction, ordering), sampled-count metadata
+--   tagging.
 -- Excludes:
+--   - Tokenization (lifted to tokenizer.allium and imported here as
+--     `tokenizer/TokenSequence`)
 --   - Preprocessor pipeline orchestration (JSON aggregation, multiline
 --     labeling and combining, aggregation strategies upstream of sampling)
 --   - Decoder configuration resolution and per-source sampler instantiation
@@ -16,47 +20,11 @@
 --   - NoopSampler (trivial pass-through when sampling is disabled)
 
 ------------------------------------------------------------
--- Value Types
-------------------------------------------------------------
-
--- A Token is a single byte classifying a run of input characters.
--- Tokens fall into five categories:
---
---   Space: whitespace (space, tab, newline, carriage return).
---     Each whitespace run produces one Space token regardless of length.
---
---   Punctuation: each ASCII punctuation character is a distinct token:
---     : ; - _ / \ . , ' " ` ~ * + = ( ) { } [ ] & ! @ # $ % ^
---     Consecutive identical punctuation characters collapse into one
---     token (run length discarded). Different punctuation characters
---     are distinct tokens and do not form runs with each other.
---
---   Digit runs: consecutive digits [0-9] produce a single token
---     encoding the run length: D1 (1 digit) through D10 (10+ digits).
---     Runs longer than 10 are capped at D10.
---
---   Character runs: consecutive letters [a-zA-Z] and any byte not
---     classified above produce a single token encoding the run length:
---     C1 (1 char) through C10 (10+ chars). Capped at C10.
---     Before emitting, short runs (1-4 chars) are checked for special
---     token promotion (see Tokenization contract).
---
---   Special: character runs of 1-4 chars that match known patterns
---     are promoted to one of: Month, Day, Zone, Apm, T.
---     The regular C1-C4 token is replaced by the special token.
-
-value TokenSequence {
-    -- Ordered sequence of tokens produced by the tokenizer from
-    -- the first line of a log message.
-    length: Integer
-}
-
-------------------------------------------------------------
 -- Contracts
 ------------------------------------------------------------
 
 contract PatternMatching {
-    is_match: (a: TokenSequence, b: TokenSequence, threshold: Decimal) -> Boolean
+    is_match: (a: tokenizer/TokenSequence, b: tokenizer/TokenSequence, threshold: Decimal) -> Boolean
 
     @invariant Symmetry
         -- is_match(a, b, t) = is_match(b, a, t) for all a, b, t.
@@ -84,96 +52,6 @@ contract PatternMatching {
         -- This affects performance, not results.
 }
 
-contract Tokenization {
-    tokenize: (input: ByteArray, max_bytes: Integer) -> TokenSequence
-
-    @invariant ByteClassification
-        -- Each input byte maps to exactly one base category via a
-        -- 256-entry lookup table:
-        --   Digits [0-9] → digit
-        --   Letters [a-zA-Z] → character
-        --   Whitespace (0x20 space, 0x09 tab, 0x0A newline, 0x0D CR) → space
-        --   Specific ASCII punctuation → one distinct token each:
-        --     : ; - _ / \ . , ' " ` ~ * + = ( ) { } [ ] & ! @ # $ % ^
-        --   All other byte values (non-ASCII, control chars) → character
-
-    @invariant RunLengthEncoding
-        -- Consecutive bytes of the same base token form a run.
-        -- When a different base token is encountered, the accumulated
-        -- run is emitted as a single token:
-        --   Digit runs → D1 through D10 (run length preserved)
-        --   Character runs → C1 through C10 (run length preserved,
-        --     subject to special token promotion)
-        --   Space runs → one Space token (run length discarded)
-        --   Punctuation runs → one token (run length discarded;
-        --     "!!!" produces one Exclamation, same as "!")
-        -- Runs of digits or characters longer than 10 are capped:
-        -- 15 consecutive digits produce D10, identical to 10 digits.
-
-    @invariant SpecialTokenPromotion
-        -- Before emitting a character run of length 1-4, the run's
-        -- bytes are uppercased and checked against a fixed table.
-        -- If matched, the special token replaces the regular C1-C4:
-        --   Length 1: T → time_separator, Z → zone
-        --   Length 2: AM, PM → apm
-        --   Length 3:
-        --     JAN FEB MAR APR MAY JUN JUL AUG SEP OCT NOV DEC → month
-        --     MON TUE WED THU FRI SAT SUN → day
-        --     UTC GMT EST EDT CST CDT MST MDT PST PDT JST KST
-        --       IST MSK CET BST HST HDT NST NDT → zone
-        --   Length 4:
-        --     CEST NZST NZDT ACST ACDT AEST AEDT AWST AWDT
-        --       AKST AKDT CHST CHDT → zone
-        -- Character runs of length 5+ are never promoted. Runs of
-        -- length 1-4 that match no pattern emit the regular token.
-        -- Matching is case-insensitive: "jan", "JAN", "Jan" all
-        -- match month.
-
-    @invariant InputTruncation
-        -- Only the first max_bytes of the input are tokenized.
-        -- Bytes beyond this offset are ignored. Two messages that
-        -- differ only after max_bytes produce identical token
-        -- sequences.
-
-    @invariant EmptyInput
-        -- An empty input produces an empty token sequence (length 0).
-
-    @invariant Determinism
-        -- tokenize is a pure function: the same input and max_bytes
-        -- always produce the same token sequence.
-
-    @invariant StructuralCollapsing
-        -- Two log lines produce identical token sequences if, at
-        -- every run boundary, the replacement preserves the base
-        -- token category and the run length. Specifically:
-        --   Digits may be substituted with other digits.
-        --   Letters may be substituted with other letters of the
-        --     same case (or any case — case does not affect
-        --     classification or run boundaries).
-        --   A special-token-matching string (e.g. "Jan") may be
-        --     replaced with another that matches the same special
-        --     token (e.g. "Dec"), but NOT with an arbitrary 3-letter
-        --     string (e.g. "Foo"), which would produce C3 instead
-        --     of Month.
-        -- This is the mechanism by which the sampler groups
-        -- structurally similar logs into one pattern.
-        -- Example: "2024-01-15 10:30:45 Jan request" and
-        -- "2025-12-31 23:59:59 Dec startup" both produce:
-        --   D4 Dash D2 Dash D2 Space D2 Colon D2 Colon D2
-        --   Space Month Space C7
-
-    @guidance
-        -- The default classification maps all unrecognised bytes to
-        -- the character category. Non-ASCII bytes, UTF-8 multibyte
-        -- sequences, and control characters all produce character
-        -- run tokens. This means binary content in log lines is
-        -- treated as character runs.
-        --
-        -- The special token table is non-exhaustive and can be
-        -- expanded. Adding new recognised patterns changes which
-        -- log lines are considered structurally equivalent.
-}
-
 ------------------------------------------------------------
 -- Entities
 ------------------------------------------------------------
@@ -183,7 +61,7 @@ entity PatternEntry {
     -- pattern table. Each entry represents one known pattern
     -- identified by token-sequence similarity and carries the
     -- per-pattern rate-limiting state.
-    signature: TokenSequence
+    signature: tokenizer/TokenSequence
     credits: Decimal
     last_seen: Timestamp
     match_count: Integer

--- a/pkg/logs/internal/decoder/preprocessor/tokenizer.allium
+++ b/pkg/logs/internal/decoder/preprocessor/tokenizer.allium
@@ -1,0 +1,148 @@
+-- allium: 3
+-- tokenizer.allium
+
+-- Scope: Tokenization behaviour for the Datadog Agent's logs
+--   preprocessor pipeline. The tokenizer is a pure function from a
+--   byte input to a structural TokenSequence describing the run-length
+--   shape of the input — used by downstream stages (adaptive sampling,
+--   labelling, multiline detection) that reason about log line
+--   structure rather than content.
+-- Includes: Byte-to-token classification, run-length encoding,
+--   special token promotion, input truncation, structural collapsing.
+-- Excludes:
+--   - Pattern matching across token sequences (lives in
+--     adaptive_sampler.allium as the PatternMatching contract).
+--   - Any concrete token-type enum or implementation detail; the
+--     contract describes the observable behaviour of tokenize() as a
+--     pure function from bytes to a sequence of opaque tokens.
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+-- A Token is a single byte classifying a run of input characters.
+-- Tokens fall into five categories:
+--
+--   Space: whitespace (space, tab, newline, carriage return).
+--     Each whitespace run produces one Space token regardless of length.
+--
+--   Punctuation: each ASCII punctuation character is a distinct token:
+--     : ; - _ / \ . , ' " ` ~ * + = ( ) { } [ ] & ! @ # $ % ^
+--     Consecutive identical punctuation characters collapse into one
+--     token (run length discarded). Different punctuation characters
+--     are distinct tokens and do not form runs with each other.
+--
+--   Digit runs: consecutive digits [0-9] produce a single token
+--     encoding the run length: D1 (1 digit) through D10 (10+ digits).
+--     Runs longer than 10 are capped at D10.
+--
+--   Character runs: consecutive letters [a-zA-Z] and any byte not
+--     classified above produce a single token encoding the run length:
+--     C1 (1 char) through C10 (10+ chars). Capped at C10.
+--     Before emitting, short runs (1-4 chars) are checked for special
+--     token promotion (see Tokenization contract).
+--
+--   Special: character runs of 1-4 chars that match known patterns
+--     are promoted to one of: Month, Day, Zone, Apm, T.
+--     The regular C1-C4 token is replaced by the special token.
+
+value TokenSequence {
+    -- Ordered sequence of tokens produced by the tokenizer from
+    -- the first line of a log message.
+    length: Integer
+}
+
+------------------------------------------------------------
+-- Contracts
+------------------------------------------------------------
+
+contract Tokenization {
+    tokenize: (input: ByteArray, max_bytes: Integer) -> TokenSequence
+
+    @invariant ByteClassification
+        -- Each input byte maps to exactly one base category via a
+        -- 256-entry lookup table:
+        --   Digits [0-9] → digit
+        --   Letters [a-zA-Z] → character
+        --   Whitespace (0x20 space, 0x09 tab, 0x0A newline, 0x0D CR) → space
+        --   Specific ASCII punctuation → one distinct token each:
+        --     : ; - _ / \ . , ' " ` ~ * + = ( ) { } [ ] & ! @ # $ % ^
+        --   All other byte values (non-ASCII, control chars) → character
+
+    @invariant RunLengthEncoding
+        -- Consecutive bytes of the same base token form a run.
+        -- When a different base token is encountered, the accumulated
+        -- run is emitted as a single token:
+        --   Digit runs → D1 through D10 (run length preserved)
+        --   Character runs → C1 through C10 (run length preserved,
+        --     subject to special token promotion)
+        --   Space runs → one Space token (run length discarded)
+        --   Punctuation runs → one token (run length discarded;
+        --     "!!!" produces one Exclamation, same as "!")
+        -- Runs of digits or characters longer than 10 are capped:
+        -- 15 consecutive digits produce D10, identical to 10 digits.
+
+    @invariant SpecialTokenPromotion
+        -- Before emitting a character run of length 1-4, the run's
+        -- bytes are uppercased and checked against a fixed table.
+        -- If matched, the special token replaces the regular C1-C4:
+        --   Length 1: T → time_separator, Z → zone
+        --   Length 2: AM, PM → apm
+        --   Length 3:
+        --     JAN FEB MAR APR MAY JUN JUL AUG SEP OCT NOV DEC → month
+        --     MON TUE WED THU FRI SAT SUN → day
+        --     UTC GMT EST EDT CST CDT MST MDT PST PDT JST KST
+        --       IST MSK CET BST HST HDT NST NDT → zone
+        --   Length 4:
+        --     CEST NZST NZDT ACST ACDT AEST AEDT AWST AWDT
+        --       AKST AKDT CHST CHDT → zone
+        -- Character runs of length 5+ are never promoted. Runs of
+        -- length 1-4 that match no pattern emit the regular token.
+        -- Matching is case-insensitive: "jan", "JAN", "Jan" all
+        -- match month.
+
+    @invariant InputTruncation
+        -- Only the first max_bytes of the input are tokenized.
+        -- Bytes beyond this offset are ignored. Two messages that
+        -- differ only after max_bytes produce identical token
+        -- sequences.
+
+    @invariant EmptyInput
+        -- An empty input produces an empty token sequence (length 0).
+
+    @invariant Determinism
+        -- tokenize is a pure function: the same input and max_bytes
+        -- always produce the same token sequence.
+
+    @invariant StructuralCollapsing
+        -- Two log lines produce identical token sequences if, at
+        -- every run boundary, the replacement preserves the base
+        -- token category and the run length. Specifically:
+        --   Digits may be substituted with other digits.
+        --   Letters may be substituted with other letters of the
+        --     same case (or any case — case does not affect
+        --     classification or run boundaries).
+        --   A special-token-matching string (e.g. "Jan") may be
+        --     replaced with another that matches the same special
+        --     token (e.g. "Dec"), but NOT with an arbitrary 3-letter
+        --     string (e.g. "Foo"), which would produce C3 instead
+        --     of Month.
+        -- This is the mechanism by which downstream consumers (e.g.
+        -- the adaptive sampler) group structurally similar logs into
+        -- one pattern.
+        -- Example: "2024-01-15 10:30:45 Jan request" and
+        -- "2025-12-31 23:59:59 Dec startup" both produce:
+        --   D4 Dash D2 Dash D2 Space D2 Colon D2 Colon D2
+        --   Space Month Space C7
+
+    @guidance
+        -- The default classification maps all unrecognised bytes to
+        -- the character category. Non-ASCII bytes, UTF-8 multibyte
+        -- sequences, and control characters all produce character
+        -- run tokens. This means binary content in log lines is
+        -- treated as character runs.
+        --
+        -- The special token table is non-exhaustive and can be
+        -- expanded. Adding new recognised patterns changes which
+        -- log lines are considered structurally equivalent.
+}


### PR DESCRIPTION
  What: Extracts the tokeniser's behaviour into an Allium contract. Adds tokenizer.allium with the TokenSequence value and the Tokenization contract. The tokeniser is consumed by every downstream stage that needs
  token-aware decisions (Labeler heuristics, Aggregator first-line tokens, Sampler pattern matching) — lifting it to a contract gives those consumers a typed reference to depend on.

  All tested in cmetz/tokenizer_tests.

  Tokenization contract @invariants:
  - @invariant ByteClassification — input bytes are classified into a fixed set of token categories (digits / characters / specific punctuation tokens / space)
  - @invariant RunLengthEncoding — runs of digits or characters longer than 10 are capped at 10 (a run of 15 letters produces a single C10 token, byte-equivalent to 10 letters)
  - @invariant SpecialTokenPromotion — certain byte sequences are promoted to dedicated tokens (severity keywords, named structural tokens) ahead of generic character classification
  - @invariant InputTruncation — only the first max_bytes of input are tokenised; bytes beyond that offset are not represented in the output
  - @invariant EmptyInput — an empty input produces an empty token sequence
  - @invariant Determinism — same input bytes always produce the same token sequence
  - @invariant StructuralCollapsing — adjacent identical tokens are collapsed per the run-length rules

  TokenSequence value:
  - ordered sequence of tokens + parallel byte-index sequence
  - byte indices align positionally with tokens (length-matched)

  Out of scope: the concrete byte-to-token mapping table (treated as an implementation detail of the tokenizer); downstream stages' use of tokens (those live in labeler / aggregator / sampler specs).

  Stack: earliest branch in the workstream (sits below the labeler contracts).
