### PR TITLE
add tokenizer test pairs for ByteClassification, RunLengthEncoding, SpecialTokenPromotion, EmptyInput; label existing tests with the spec property they anchor

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/tokenizer_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/tokenizer_test.go
@@ -7,6 +7,7 @@
 package preprocessor
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,19 @@ type testCase struct {
 	expectedToken string
 }
 
+// TestTokenizer is a broad table-driven anchoring test that exercises
+// most named properties in the Tokenization contract at once:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant ByteClassification     — digit/letter/whitespace/punctuation/other
+//	    @invariant RunLengthEncoding      — Dn / Cn token emission with run-length preserved
+//	    @invariant SpecialTokenPromotion  — Month, Day, Zone, Apm, T promotions
+//	    @invariant EmptyInput             — empty input → empty token sequence
+//
+// Each named property also has dedicated anchoring + property tests
+// further down in this file. This table-driven test is the
+// human-readable demonstration that representative inputs produce the
+// token sequences the spec describes.
 func TestTokenizer(t *testing.T) {
 	testCases := []testCase{
 		{input: "", expectedToken: ""},
@@ -83,18 +97,43 @@ func TestTokenizer(t *testing.T) {
 	}
 }
 
+// TestTokenizerMaxCharRun anchors the run-length cap clause of:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant RunLengthEncoding
+//
+// "Runs of digits or characters longer than 10 are capped: 15
+// consecutive characters produce C10, identical to 10 characters."
+// 16 input letters → exactly 10 'C' tokens (one C10).
 func TestTokenizerMaxCharRun(t *testing.T) {
 	tokens, indicies := NewTokenizer(0).tokenize([]byte("ABCDEFGHIJKLMNOP"))
 	assert.Equal(t, "CCCCCCCCCC", TokensToString(tokens))
 	assert.Equal(t, []int{0}, indicies)
 }
 
+// TestTokenizerMaxDigitRun anchors the run-length cap clause of:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant RunLengthEncoding
+//
+// 16 input digits → exactly 10 'D' tokens (one D10). Mirrors
+// TestTokenizerMaxCharRun for the digit category.
 func TestTokenizerMaxDigitRun(t *testing.T) {
 	tokens, indicies := NewTokenizer(0).tokenize([]byte("0123456789012345"))
 	assert.Equal(t, "DDDDDDDDDD", TokensToString(tokens))
 	assert.Equal(t, []int{0}, indicies)
 }
 
+// TestAllSymbolsAreHandled anchors the "each ASCII punctuation
+// character is a distinct token" clause of:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant ByteClassification
+//
+// Every dedicated punctuation token between Space and D1 must produce
+// a non-empty string representation and round-trip through the
+// classification lookup as its own token (not as the generic character
+// run C1).
 func TestAllSymbolsAreHandled(t *testing.T) {
 	for i := Space; i < D1; i++ {
 		str := tokenToString(i)
@@ -103,6 +142,14 @@ func TestAllSymbolsAreHandled(t *testing.T) {
 	}
 }
 
+// TestTokenizerMaxEvalBytes anchors:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant InputTruncation
+//
+// "Only the first max_bytes of the input are tokenized. Bytes beyond
+// this offset are ignored." A tokenizer with max=10 sees only the
+// first 10 input bytes; downstream content is invisible.
 func TestTokenizerMaxEvalBytes(t *testing.T) {
 	tokenizer := NewTokenizer(10)
 
@@ -128,10 +175,14 @@ func TestTokenizerMaxEvalBytes(t *testing.T) {
 }
 
 // --- Fuzz tests ---
-// Each fuzz test below maps to an @invariant in adaptive_sampler.allium.
+//
+// Each fuzz / property test below names the spec construct it anchors
+// in its docstring so that drift in either direction is easy to spot
+// during review. Tokenization @invariants live in tokenizer.allium;
+// PatternMatching @invariants live in adaptive_sampler.allium.
 
 // Reference tokenizer: an independent implementation of the tokenization
-// rules from adaptive_sampler.allium. Used as an oracle to verify the
+// rules from tokenizer.allium. Used as an oracle to verify the
 // production tokenizer matches the spec.
 
 func refClassify(b byte) Token {
@@ -344,8 +395,12 @@ func referenceTokenize(input []byte) []Token {
 	return tokens
 }
 
-// Verify the production tokenizer matches the reference implementation
-// derived from adaptive_sampler.allium for all inputs.
+// FuzzTokenizerCorrectness verifies the production tokenizer matches
+// the reference implementation derived from tokenizer.allium for all
+// inputs. This is the broad oracle test — it implicitly covers every
+// Tokenization @invariant by exercising the entire rule set against an
+// independent encoding of the same rules. Per-invariant property tests
+// further down provide more diagnostic failure modes.
 func FuzzTokenizerCorrectness(f *testing.F) {
 	f.Add([]byte("2024-01-15 10:30:45 INFO request processed id=123"))
 	f.Add([]byte(""))
@@ -364,8 +419,15 @@ func FuzzTokenizerCorrectness(f *testing.F) {
 	})
 }
 
-// Tokenization.Determinism: same input always produces the same tokens.
-// Catches state leaks in the Tokenizer's reusable buffers.
+// FuzzTokenizerDeterminism anchors:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant Determinism
+//
+// "tokenize is a pure function: the same input and max_bytes always
+// produce the same token sequence." Re-tokenizes the same input twice
+// on a reused tokenizer and asserts the outputs match. Catches state
+// leaks in the tokenizer's reusable internal buffers across calls.
 func FuzzTokenizerDeterminism(f *testing.F) {
 	f.Add([]byte("2024-01-15 10:30:45 INFO request processed id=123"))
 	f.Add([]byte(""))
@@ -380,8 +442,15 @@ func FuzzTokenizerDeterminism(f *testing.F) {
 	})
 }
 
-// Tokenization.InputTruncation: tokenizing N bytes of input with no limit
-// produces the same result as tokenizing the full input with an N-byte limit.
+// FuzzTokenizerInputTruncation anchors:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant InputTruncation
+//
+// "Only the first max_bytes of the input are tokenized." Tokenizing N
+// bytes of input with no limit produces the same result as tokenizing
+// the full input with an N-byte limit — a direct restatement of the
+// invariant.
 func FuzzTokenizerInputTruncation(f *testing.F) {
 	f.Add([]byte("2024-01-15 10:30:45 INFO request processed"), uint8(10))
 	f.Add([]byte("Jan Mon UTC PST"), uint8(5))
@@ -399,8 +468,14 @@ func FuzzTokenizerInputTruncation(f *testing.F) {
 	})
 }
 
-// Tokenization.StructuralCollapsing (digits): substituting any digit with
-// a different digit does not change the token sequence.
+// FuzzTokenizerDigitCollapsing anchors the digit clause of:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant StructuralCollapsing
+//
+// "Digits may be substituted with other digits" without changing the
+// token sequence. Fuzz substitutes every digit byte with a different
+// digit byte and asserts the resulting token sequence is identical.
 func FuzzTokenizerDigitCollapsing(f *testing.F) {
 	f.Add([]byte("2024-01-15 10:30:45 INFO request"))
 	f.Add([]byte("error code 404 at 192.168.1.1"))
@@ -421,10 +496,17 @@ func FuzzTokenizerDigitCollapsing(f *testing.F) {
 	})
 }
 
-// Tokenization.StructuralCollapsing + ByteClassification: flipping the case
-// of every ASCII letter does not change the token sequence. Lowercase and
-// uppercase letters are the same base category (character), and special
-// token promotion is case-insensitive.
+// FuzzTokenizerCaseInsensitive anchors the case clause of:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant StructuralCollapsing
+//	    @invariant ByteClassification (letter category insensitive to case)
+//	    @invariant SpecialTokenPromotion (case-insensitive matching)
+//
+// Flipping the case of every ASCII letter does not change the token
+// sequence: lowercase and uppercase letters share the character base
+// category, and special token promotion is case-insensitive (so e.g.
+// "jan", "JAN", "Jan" all promote to Month).
 func FuzzTokenizerCaseInsensitive(f *testing.F) {
 	f.Add([]byte("Jan Mon UTC INFO request"))
 	f.Add([]byte("jan mon utc info REQUEST"))
@@ -448,7 +530,15 @@ func FuzzTokenizerCaseInsensitive(f *testing.F) {
 	})
 }
 
-// PatternMatching.Symmetry: is_match(a, b, t) = is_match(b, a, t).
+// FuzzIsMatchSymmetry anchors:
+//
+//	contract PatternMatching (adaptive_sampler.allium)
+//	    @invariant Symmetry
+//
+// "is_match(a, b, t) = is_match(b, a, t) for all a, b, t."
+// PatternMatching is defined in adaptive_sampler.allium (separate from
+// the Tokenization contract above), but the test lives here because it
+// shares the tokenizer + IsMatch infrastructure.
 func FuzzIsMatchSymmetry(f *testing.F) {
 	f.Add([]byte("INFO request ok"), []byte("WARN startup ok"), uint8(90))
 	f.Add([]byte(""), []byte("hello"), uint8(50))
@@ -468,8 +558,14 @@ func FuzzIsMatchSymmetry(f *testing.F) {
 	})
 }
 
-// PatternMatching.MonotonicThreshold: if two sequences match at threshold t1,
-// they must also match at any t2 <= t1.
+// FuzzIsMatchMonotonicity anchors:
+//
+//	contract PatternMatching (adaptive_sampler.allium)
+//	    @invariant MonotonicThreshold
+//
+// "For fixed a and b, if is_match(a, b, t1) and t2 <= t1, then
+// is_match(a, b, t2). Lowering the threshold cannot cause a previously
+// passing match to fail."
 func FuzzIsMatchMonotonicity(f *testing.F) {
 	f.Add([]byte("INFO request ok"), []byte("WARN startup ok"), uint8(90), uint8(50))
 	f.Add([]byte("abc"), []byte("abd"), uint8(70), uint8(60))
@@ -523,4 +619,271 @@ func TestIsMatch(t *testing.T) {
 
 	assert.True(t, IsMatch(ta, tb, 1))
 	assert.True(t, IsMatch(ta, tb, 0.01))
+}
+
+// --- Dedicated anchoring + property test pairs ---
+//
+// The Tokenization contract in tokenizer.allium names seven invariants.
+// The tests above provide partial coverage; the pairs below give each
+// remaining invariant a dedicated anchoring test and (where the input
+// space is non-trivial) a property test, so every named Tokenization
+// invariant has both layers of coverage.
+
+// TestTokenizer_EmptyInput anchors:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant EmptyInput
+//
+// "An empty input produces an empty token sequence (length 0)."
+//
+// No property test pair: the input space for this invariant is a
+// single value (empty bytes). A fuzz would be degenerate.
+func TestTokenizer_EmptyInput(t *testing.T) {
+	tokens, indices := NewTokenizer(0).Tokenize([]byte{})
+	assert.Empty(t, tokens, "empty input must produce an empty token sequence")
+	assert.Empty(t, indices, "empty input must produce no indices")
+}
+
+// TestTokenizer_ByteClassification anchors:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant ByteClassification
+//
+// "Each input byte maps to exactly one base category via a 256-entry
+// lookup table." Demonstrates the classification with one
+// representative byte per category. The property pair
+// FuzzTokenizerByteClassification covers the full byte space.
+func TestTokenizer_ByteClassification(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    byte
+		expected string
+	}{
+		{"digit", '5', "D"},
+		{"lowercase letter", 'a', "C"},
+		{"uppercase letter", 'A', "C"},
+		{"space", ' ', " "},
+		{"tab", '\t', " "},
+		{"newline", '\n', " "},
+		{"carriage return", '\r', " "},
+		{"colon", ':', ":"},
+		{"semicolon", ';', ";"},
+		{"dash", '-', "-"},
+		{"underscore", '_', "_"},
+		{"forward slash", '/', "/"},
+		{"backslash", '\\', "\\"},
+		{"period", '.', "."},
+		{"comma", ',', ","},
+		{"single quote", '\'', "'"},
+		{"double quote", '"', "\""},
+		{"backtick", '`', "`"},
+		{"tilde", '~', "~"},
+		{"star", '*', "*"},
+		{"plus", '+', "+"},
+		{"equal", '=', "="},
+		{"open paren", '(', "("},
+		{"close paren", ')', ")"},
+		{"open brace", '{', "{"},
+		{"close brace", '}', "}"},
+		{"open bracket", '[', "["},
+		{"close bracket", ']', "]"},
+		{"ampersand", '&', "&"},
+		{"exclamation", '!', "!"},
+		{"at sign", '@', "@"},
+		{"pound", '#', "#"},
+		{"dollar", '$', "$"},
+		{"percent", '%', "%"},
+		{"caret", '^', "^"},
+		{"non-ASCII byte", 0xff, "C"},
+		{"control byte", 0x01, "C"},
+	}
+	tok := NewTokenizer(0)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tokens, _ := tok.tokenize([]byte{tc.input})
+			assert.Equal(t, tc.expected, TokensToString(tokens),
+				"byte 0x%02x classified incorrectly", tc.input)
+		})
+	}
+}
+
+// FuzzTokenizerByteClassification anchors:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant ByteClassification
+//
+// Property: every byte in [0, 255] tokenized as a single-byte input
+// must produce a token matching the reference implementation. The
+// fuzz seeds enumerate the full input space; generated inputs add no
+// additional coverage (the input space is finite) but the test
+// follows the property-test convention. Uses referenceTokenize (not
+// refClassify alone) so that single-byte special-token promotion —
+// 'T' → T token, 'Z' → Zone token — is also exercised; the test
+// would otherwise miss the length-1 cases of SpecialTokenPromotion
+// which interact with classification.
+func FuzzTokenizerByteClassification(f *testing.F) {
+	for i := 0; i < 256; i++ {
+		f.Add(byte(i))
+	}
+	f.Fuzz(func(t *testing.T, b byte) {
+		tok := NewTokenizer(0)
+		tokens, _ := tok.tokenize([]byte{b})
+		expected := referenceTokenize([]byte{b})
+		assert.Equal(t, expected, tokens,
+			"byte 0x%02x: expected tokens %v, got %v", b, expected, tokens)
+	})
+}
+
+// TestTokenizer_RunLengthEncoding anchors the run-boundary clause of:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant RunLengthEncoding
+//
+// "Consecutive bytes of the same base token form a run. When a
+// different base token is encountered, the accumulated run is emitted
+// as a single token." Demonstrates that homogeneous runs merge into
+// one token and that category transitions produce token boundaries.
+// The length-cap clause (runs of 10+ → D10/C10) is covered separately
+// by TestTokenizerMaxCharRun and TestTokenizerMaxDigitRun.
+func TestTokenizer_RunLengthEncoding(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"a", "C"},
+		{"abc", "CCC"},
+		{"abcdefghi", "CCCCCCCCC"},
+		{"123", "DDD"},
+		{"abc123", "CCCDDD"},
+		{"a1b2c3", "CDCDCD"},
+		{"abc !@# def", "CCC !@# CCC"},
+	}
+	tok := NewTokenizer(0)
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			tokens, _ := tok.tokenize([]byte(tc.input))
+			assert.Equal(t, tc.expected, TokensToString(tokens))
+		})
+	}
+}
+
+// FuzzTokenizerRunLengthEncoding anchors:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant RunLengthEncoding
+//
+// Property: a homogeneous digit run of length N produces exactly one
+// token. For N <= 10 the token encodes the exact run length (D_N);
+// for N >= 10 it is capped at D10. Digit runs are chosen because they
+// never trigger special token promotion, isolating run-length encoding
+// from SpecialTokenPromotion concerns.
+func FuzzTokenizerRunLengthEncoding(f *testing.F) {
+	for n := uint8(1); n <= 15; n++ {
+		f.Add(n)
+	}
+	f.Fuzz(func(t *testing.T, n uint8) {
+		if n == 0 || n > 30 {
+			return
+		}
+		input := strings.Repeat("5", int(n))
+		tok := NewTokenizer(0)
+		tokens, _ := tok.tokenize([]byte(input))
+		assert.Len(t, tokens, 1,
+			"homogeneous digit run of length %d must produce exactly one token, got %d",
+			n, len(tokens))
+		runLen := int(n)
+		if runLen > 10 {
+			runLen = 10
+		}
+		expected := D1 + Token(runLen-1)
+		assert.Equal(t, expected, tokens[0],
+			"digit run of length %d: expected %v, got %v", n, expected, tokens[0])
+	})
+}
+
+// TestTokenizer_SpecialTokenPromotion anchors:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant SpecialTokenPromotion
+//
+// "Before emitting a character run of length 1-4, the run's bytes are
+// uppercased and checked against a fixed table. If matched, the
+// special token replaces the regular C1-C4." Demonstrates each
+// promotion category (T, Zone, Apm, Month, Day) and the "no promotion
+// for length >= 5" boundary.
+func TestTokenizer_SpecialTokenPromotion(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// Length 1: T → T, Z → Zone
+		{"T", "T"},
+		{"Z", "ZONE"},
+		{"t", "T"}, // case insensitive
+		// Length 2: AM, PM → Apm
+		{"AM", "PM"},
+		{"PM", "PM"},
+		{"am", "PM"},
+		// Length 3: Months
+		{"JAN", "MTH"},
+		{"DEC", "MTH"},
+		{"Jan", "MTH"}, // case insensitive
+		// Length 3: Days
+		{"MON", "DAY"},
+		{"SUN", "DAY"},
+		// Length 3: Zones
+		{"UTC", "ZONE"},
+		// Length 4: Zones
+		{"CEST", "ZONE"},
+		{"AKDT", "ZONE"},
+		// Boundary: length 5+ is never promoted via the 1-4 table
+		{"JANUA", "CCCCC"},
+		// No-match within length range falls back to regular C-tokens
+		{"FOO", "CCC"},
+		{"X", "C"},
+	}
+	tok := NewTokenizer(0)
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			tokens, _ := tok.tokenize([]byte(tc.input))
+			assert.Equal(t, tc.expected, TokensToString(tokens))
+		})
+	}
+}
+
+// FuzzTokenizerSpecialTokenPromotion anchors:
+//
+//	contract Tokenization (tokenizer.allium)
+//	    @invariant SpecialTokenPromotion
+//
+// Property: for any letter-only input of length 1-4, the tokenizer's
+// output must match the reference function, which independently
+// encodes the special token table. Inputs of length 5+ must NOT
+// promote to a special token (they emit regular Cn for n in 5..10).
+// Letter-only inputs isolate this property from ByteClassification
+// and RunLengthEncoding concerns.
+func FuzzTokenizerSpecialTokenPromotion(f *testing.F) {
+	f.Add("T")
+	f.Add("Z")
+	f.Add("PM")
+	f.Add("Jan")
+	f.Add("CEST")
+	f.Add("Foo")
+	f.Add("Hello") // length 5, must not promote
+	f.Add("EXCEPTIONAL")
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) == 0 || len(input) > 12 {
+			return
+		}
+		for _, b := range []byte(input) {
+			if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')) {
+				return
+			}
+		}
+		tok := NewTokenizer(0)
+		actual, _ := tok.Tokenize([]byte(input))
+		expected := referenceTokenize([]byte(input))
+		assert.Equal(t, expected, actual,
+			"tokenize(%q): expected %v, got %v", input, expected, actual)
+	})
 }


### PR DESCRIPTION
  What: Adds anchoring docstrings to existing tokenizer tests (clarifying which @invariant each test pins) and adds 4 new test pairs covering the @invariants that weren't previously anchored.

  - @invariant ByteClassification — TestAllSymbolsAreHandled (Unit) + per-class assertions throughout existing tests
  - @invariant RunLengthEncoding — TestTokenizerMaxCharRun (Unit, 15 letters → C10) + TestTokenizerMaxDigitRun (Unit, 16 digits → D10)
  - @invariant SpecialTokenPromotion — anchored existing severity-token tests + dedicated test for promoted sequences
  - @invariant InputTruncation — TestTokenizerMaxEvalBytes (Unit) — bytes past max_bytes are not represented
  - @invariant EmptyInput — dedicated test for empty input → empty token sequence
  - @invariant Determinism — FuzzTokenizerDeterminism (Property / Fuzz) — same input → same tokens across repeated calls

  Stack: parent cmetz/tokenizer_extract. Tests for this contract precede the labeler workstream because heuristics in the chain depend on the tokeniser's properties.
