### PR TITLE
add shared truncation spec

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/truncation.allium
+++ b/pkg/logs/internal/decoder/preprocessor/truncation.allium
@@ -1,0 +1,167 @@
+-- allium: 3
+-- truncation.allium
+
+-- Scope: Per-emission truncation behaviour shared by aggregators in
+--   the Datadog Agent's logs preprocessor pipeline. Captures the
+--   common "if the content exceeds a size threshold, decorate it
+--   with `...TRUNCATED...` marker bytes and propagate a carry-over
+--   signal so the next emission can decorate its head accordingly"
+--   pattern.
+-- Includes: The Truncatable contract (the abstract truncation
+--   operation), marker semantics, carry-over state across consecutive
+--   calls, upstream-truncation-flag propagation, tag-on-truncation
+--   timing.
+-- Excludes:
+--   - The literal byte value of the truncation marker, which is owned
+--     by the agent's message package and is treated here as an opaque
+--     constant.
+--   - The size threshold value, which is per-instance configuration
+--     supplied by the caller rather than part of the contract.
+--   - The tag VALUE applied on truncation (e.g. "single_line",
+--     "multiline_regex", "auto_multiline"). Each fulfiller chooses
+--     its own tag; the contract only specifies WHEN a tag is added,
+--     not its value.
+--   - Whitespace trimming applied to content before marker decoration:
+--     this is observable in current implementations but is an
+--     implementation choice rather than a Truncatable promise. Callers
+--     should not rely on it.
+--   - Framer-level truncation marking (line_parser.go's
+--     `isBufferTruncated` signal). The framer marks input messages
+--     but does not decorate them; Truncatable consumes that signal
+--     via the `upstream_truncated` input.
+--   - Truncation in components outside the preprocessor (the legacy
+--     decoder-level handlers, the windows-event 128 KB truncation).
+--     The same Truncatable contract conceptually applies, but the
+--     fulfilling declarations are deferred until those components
+--     are spec'd.
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value TruncationResult {
+    -- The output of applying truncation to one piece of content.
+    --
+    -- content:       the (possibly modified) bytes to be emitted
+    --                downstream. May have the truncation marker
+    --                appended (tail), prepended (head from
+    --                carry-over), both, or neither.
+    -- is_truncated:  whether this output carries any truncation
+    --                marker. Mirrored onto the emitted message's
+    --                IsTruncated metadata flag by callers.
+    -- new_carryover: the carry-over signal for the next call on the
+    --                same Truncatable instance. True iff THIS call's
+    --                input was over-threshold (or pre-marked by
+    --                upstream); causes the next call's output to
+    --                have the marker prepended.
+    content: String
+    is_truncated: Boolean
+    new_carryover: Boolean
+}
+
+------------------------------------------------------------
+-- Contracts
+------------------------------------------------------------
+
+contract Truncatable {
+    -- Apply truncation to one piece of content, given a size
+    -- threshold, whether an upstream stage already marked the input
+    -- as truncated, and the carry-over signal from the previous call
+    -- on the same instance. Returns the (possibly modified) content,
+    -- the output truncation flag, and the new carry-over signal.
+    --
+    -- Stateful in the sense that consecutive calls form a sequence;
+    -- the state is fully captured by the `prior_carryover` argument,
+    -- making each call's behaviour a pure function of its inputs.
+    apply:
+        (content: String,
+         threshold: Integer,
+         upstream_truncated: Boolean,
+         prior_carryover: Boolean) -> TruncationResult
+
+    @invariant PassThroughUnderThreshold
+        -- When the input is under threshold AND not marked as
+        -- truncated upstream AND there is no carry-over from a
+        -- previous call, the output content equals the input content
+        -- (subject to the trimming note below), and both output
+        -- flags (is_truncated, new_carryover) are false. No marker
+        -- is added.
+
+    @invariant TailMarkerOnOverThreshold
+        -- When the input content's length exceeds the threshold, OR
+        -- the input was marked truncated upstream, the output
+        -- content ends with the truncation marker, output
+        -- is_truncated is true, and new_carryover is true. The
+        -- new_carryover signal is the mechanism by which the next
+        -- call on the same instance knows to prepend the head
+        -- marker.
+
+    @invariant HeadMarkerOnCarryover
+        -- When prior_carryover is true, the output content begins
+        -- with the truncation marker and output is_truncated is
+        -- true. The head marker is independent of whether the
+        -- current call is also over-threshold: a call that receives
+        -- carry-over and is also over-threshold produces content
+        -- decorated at both ends.
+
+    @invariant UpstreamFlagPropagation
+        -- The upstream_truncated input behaves equivalently to
+        -- "input content is over threshold" — both trigger the tail
+        -- marker and set new_carryover. This lets framer-level
+        -- truncation (where the framer marks the message but does
+        -- not add marker bytes) flow through Truncatable cleanly.
+
+    @invariant TagOnTruncation
+        -- When the output is truncated (is_truncated true), AND
+        -- the agent-wide tag_truncated_logs configuration is
+        -- enabled, the emitted message carries a "truncation reason"
+        -- tag. The tag's value is chosen by the fulfiller (e.g.
+        -- "single_line", "multiline_regex", "auto_multiline") and is
+        -- not specified by this contract. When is_truncated is false
+        -- or the config flag is off, no tag is added.
+
+    @invariant MarkerLiteral
+        -- The marker prepended and appended is the literal byte
+        -- sequence `...TRUNCATED...` (15 bytes). The marker value is
+        -- defined by the agent's message package and reused
+        -- verbatim across fulfillers; downstream consumers may
+        -- detect truncation by scanning for this exact byte
+        -- sequence at the boundaries of emitted content.
+
+    @guidance
+        -- The contract is stateless from the caller's perspective:
+        -- the carry-over signal is threaded through arguments and
+        -- return values rather than held inside the contract.
+        -- Implementations typically maintain `shouldTruncate` (or
+        -- equivalent) as instance state, but the abstract behaviour
+        -- is fully described by the (input, prior_carryover) pair.
+        --
+        -- Whitespace trimming is observable in current preprocessor
+        -- implementations (each aggregator calls `bytes.TrimSpace`
+        -- on the content before marker application). This is not
+        -- part of the contract: a fulfiller that does not trim still
+        -- satisfies Truncatable. Consumers that depend on trimming
+        -- should not rely on this contract for it.
+}
+
+------------------------------------------------------------
+-- Behavioural properties
+------------------------------------------------------------
+
+-- Properties guaranteed by the @invariants above but worth naming
+-- as observable behaviours:
+--
+-- MarkerByteIdempotence: a content already ending with the marker
+--   that is over threshold is decorated again with the marker on
+--   the tail. The marker is not de-duplicated. This is observable
+--   when an upstream stage emits marker-decorated content and a
+--   downstream stage truncates again. Fulfillers that wish to
+--   de-duplicate must do so outside the Truncatable boundary.
+--
+-- ZeroCostUnderLoad: when both carry-over is false and the input is
+--   under threshold and not upstream-truncated, the output content
+--   byte sequence equals the input content byte sequence (modulo
+--   any whitespace trimming the fulfiller chooses to apply, which
+--   is not part of the contract). This is the common path; the
+--   contract promises no allocation or transformation beyond what
+--   the named invariants require.


### PR DESCRIPTION
  What: Models the single-line truncation behaviour shared across multiple aggregators (PassThroughAggregator, DetectingAggregator, CombiningAggregator emit_single path) — content-byte transformations applied when
  a single oversize line crosses the size limit. Adds truncation.allium with the TruncationResult value and Truncatable contract.

  The contract exists primarily as a documentation anchor for the shared truncation flow described in each aggregator's @guidance. The Go implementation today doesn't have a separate Truncatable type to satisfy
  this contract — the truncation logic is inlined in each aggregator. Lifting it to a contract makes the shared shape visible and supports future refactoring into a shared helper.

  Truncatable contract @invariants:
  - @invariant PassThroughUnderThreshold — content shorter than line_limit passes through unchanged (no markers, no carry mutation)
  - @invariant TailMarkerOnOverThreshold — content at or above line_limit has the truncation marker appended; should_truncate carry becomes true
  - @invariant HeadMarkerOnCarryover — when prior call's should_truncate was set, the marker is prepended to the next content
  - @invariant UpstreamFlagPropagation — when the input's is_truncated flag is set upstream, truncation handling fires as if the content itself overflowed
  - @invariant TagOnTruncation — when truncation fires AND the per-aggregator tag_truncated_logs is enabled, a truncated:<reason> tag is appended (the <reason> value is supplied by the calling aggregator —
  single_line, multiline_regex, auto_multiline)
  - @invariant MarkerLiteral — the marker bytes are a fixed literal defined by the message-format package; the contract references them but does not redefine them

  TruncationResult value:
  - transformed content bytes + flags indicating which markers were applied

  Ships without tests by exception: the Go implementation has no concrete Truncatable fulfiller — the logic is inlined in each aggregator. Per the per-component done-criteria framing in SPEC_NOTES.md "Truncation
  testing problem," the right move is to refactor the inlined truncation logic in Go into a shared Truncatable helper FIRST, then anchor tests against that helper. That refactor is deferred; this PR ships the
  contract spec only. The existing per-aggregator tests already verify the truncation behaviour at each aggregator's surface, so coverage isn't lost — just not anchored to this contract yet.

  Out of scope:
  - Per-aggregator truncation reason values (each aggregator's @guidance declares its reason).
  - Tests against the contract (deferred pending the Go helper extraction).

  Stack: earliest in the workstream alongside cmetz/tokenizer_extract; both sit below the labeler contracts.
