### PR TITLE
JSONDetector tests to spec

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/json_detector_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/json_detector_proptest_test.go
@@ -1,0 +1,226 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package preprocessor
+
+import (
+	"bytes"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// Property tests for the JSONDetection surface declared in
+// json_detector.allium. Each test names the spec @guarantee it
+// anchors so that drift in either direction is easy to spot during
+// review.
+//
+// Anchoring unit tests for the same surface live in
+// json_detector_test.go.
+
+// genDetectorInput bundles a randomly-generated context state for
+// JSONDetector. The fields cover every input the detector can
+// observe: raw_message bytes, a tokens / token_indices pair (the
+// detector should ignore these per InputImmutability), and a
+// label / label_assigned_by pair (the detector may observe these
+// to decide deference). The fields are independent — the
+// generator does not bias toward JSON-shaped raw messages, so
+// claim and no-claim paths are both exercised.
+type detectorInput struct {
+	rawMessage      []byte
+	tokens          []Token
+	tokenIndicies   []int
+	label           Label
+	labelAssignedBy string
+}
+
+func genDetectorInput() *rapid.Generator[detectorInput] {
+	return rapid.Custom(func(t *rapid.T) detectorInput {
+		raw := rapid.SliceOfN(rapid.Byte(), 0, 80).Draw(t, "raw")
+		n := rapid.IntRange(0, 12).Draw(t, "nTokens")
+		tokens := make([]Token, n)
+		indicies := make([]int, n)
+		for i := 0; i < n; i++ {
+			tokens[i] = Token(rapid.IntRange(0, int(End)-1).Draw(t, "token"))
+			indicies[i] = rapid.IntRange(0, 200).Draw(t, "tokenIndex")
+		}
+		label := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "label")
+		// SampledFrom covers both the "default" sentinel and various
+		// prior-assigner ids, exercising deference (case 1) and
+		// non-deference (cases 2 and 3) branches.
+		assignedBy := rapid.SampledFrom([]string{defaultLabelSource, "JSON_detector", "timestamp_detector", "other"}).Draw(t, "assignedBy")
+		return detectorInput{
+			rawMessage:      raw,
+			tokens:          tokens,
+			tokenIndicies:   indicies,
+			label:           label,
+			labelAssignedBy: assignedBy,
+		}
+	})
+}
+
+// makeDetectorContext returns a fresh messageContext populated from the
+// generated input. The returned context owns its own copies of the
+// byte/Token/int slices so tests can compare pre-call and post-call
+// state without aliasing.
+func makeDetectorContext(in detectorInput) *messageContext {
+	return &messageContext{
+		rawMessage:      append([]byte(nil), in.rawMessage...),
+		tokens:          append([]Token(nil), in.tokens...),
+		tokenIndicies:   append([]int(nil), in.tokenIndicies...),
+		label:           in.label,
+		labelAssignedBy: in.labelAssignedBy,
+	}
+}
+
+// TestJSONDetector_Determinism_Property anchors:
+//
+//	contract Heuristic (labeler.allium)
+//	    @invariant TerminationSemantics — A Heuristic must return
+//	                                       a stable value for a
+//	                                       given context state
+//
+// (Determinism is the Heuristic contract's general requirement;
+// JSONDetection's @guarantee TerminationSemantics inherits it.)
+//
+// Two back-to-back invocations of ProcessAndContinue on
+// equivalent fresh contexts produce equal return values and equal
+// post-call context state — both the label and label_assigned_by
+// transitions are deterministic functions of the input.
+func TestJSONDetector_Determinism_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := genDetectorInput().Draw(t, "input")
+		d := NewJSONDetector()
+
+		ctxA := makeDetectorContext(in)
+		retA := d.ProcessAndContinue(ctxA)
+
+		ctxB := makeDetectorContext(in)
+		retB := d.ProcessAndContinue(ctxB)
+
+		if retA != retB {
+			t.Fatalf("Determinism violated (return value): %v vs %v", retA, retB)
+		}
+		if ctxA.label != ctxB.label {
+			t.Fatalf("Determinism violated (label): %v vs %v", ctxA.label, ctxB.label)
+		}
+		if ctxA.labelAssignedBy != ctxB.labelAssignedBy {
+			t.Fatalf("Determinism violated (labelAssignedBy): %q vs %q", ctxA.labelAssignedBy, ctxB.labelAssignedBy)
+		}
+	})
+}
+
+// TestJSONDetector_LabelDomain_Property anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guarantee LabelDomain — when JSONDetector claims the
+//	                              label, it sets context.label to
+//	                              no_aggregate
+//
+// The strong form: whenever ProcessAndContinue returns false (the
+// claim path, per @guarantee TerminationSemantics), context.label
+// MUST be exactly no_aggregate. JSONDetector never claims with
+// any other label value, regardless of input.
+//
+// Sufficient (but not strictly necessary): also pin that the
+// returned label is always within the Label enum.
+func TestJSONDetector_LabelDomain_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := genDetectorInput().Draw(t, "input")
+		ctx := makeDetectorContext(in)
+		ret := NewJSONDetector().ProcessAndContinue(ctx)
+
+		switch ctx.label {
+		case startGroup, noAggregate, aggregate:
+			// ok — value is in the Label enum
+		default:
+			t.Fatalf("post-call label %v is not in the Label enum", ctx.label)
+		}
+
+		// If the detector claimed, the label MUST be no_aggregate.
+		if !ret && ctx.label != noAggregate {
+			t.Fatalf("claim path produced label %v, expected no_aggregate", ctx.label)
+		}
+	})
+}
+
+// TestJSONDetector_LabelAssignedByConsistency_Property anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guarantee LabelAssignedByConsistency
+//
+// The biconditional form of LabelAssignedByConsistency: across all
+// inputs, EITHER both context.label and context.label_assigned_by
+// change, OR neither does. The detector never mutates only one of
+// the pair.
+//
+// Restating: changed(label) ⇔ changed(label_assigned_by).
+func TestJSONDetector_LabelAssignedByConsistency_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := genDetectorInput().Draw(t, "input")
+		ctx := makeDetectorContext(in)
+		labelBefore := ctx.label
+		assignedByBefore := ctx.labelAssignedBy
+
+		NewJSONDetector().ProcessAndContinue(ctx)
+
+		labelChanged := ctx.label != labelBefore
+		assignedByChanged := ctx.labelAssignedBy != assignedByBefore
+
+		if labelChanged != assignedByChanged {
+			t.Fatalf("LabelAssignedByConsistency violated: labelChanged=%v assignedByChanged=%v (label %v→%v, assignedBy %q→%q)",
+				labelChanged, assignedByChanged,
+				labelBefore, ctx.label,
+				assignedByBefore, ctx.labelAssignedBy)
+		}
+	})
+}
+
+// TestJSONDetector_InputImmutability_Property anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guarantee InputImmutability — JSONDetector reads
+//	                                    context.raw_message but
+//	                                    never modifies it. It does
+//	                                    not read or modify
+//	                                    context.tokens or
+//	                                    context.token_indices.
+//
+// Across all inputs, the underlying byte/Token/int slices held by
+// the context are bitwise-equal to their pre-call snapshots after
+// ProcessAndContinue returns. This catches both in-place mutation
+// and unexpected aliasing.
+func TestJSONDetector_InputImmutability_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		in := genDetectorInput().Draw(t, "input")
+		ctx := makeDetectorContext(in)
+
+		rawSnapshot := append([]byte(nil), ctx.rawMessage...)
+		tokensSnapshot := append([]Token(nil), ctx.tokens...)
+		indicesSnapshot := append([]int(nil), ctx.tokenIndicies...)
+
+		NewJSONDetector().ProcessAndContinue(ctx)
+
+		if !bytes.Equal(rawSnapshot, ctx.rawMessage) {
+			t.Fatalf("InputImmutability violated: raw_message mutated\nbefore: %q\nafter:  %q", rawSnapshot, ctx.rawMessage)
+		}
+		if len(tokensSnapshot) != len(ctx.tokens) {
+			t.Fatalf("InputImmutability violated: tokens length changed %d → %d", len(tokensSnapshot), len(ctx.tokens))
+		}
+		for i := range tokensSnapshot {
+			if tokensSnapshot[i] != ctx.tokens[i] {
+				t.Fatalf("InputImmutability violated: tokens[%d] %v → %v", i, tokensSnapshot[i], ctx.tokens[i])
+			}
+		}
+		if len(indicesSnapshot) != len(ctx.tokenIndicies) {
+			t.Fatalf("InputImmutability violated: token_indices length changed %d → %d", len(indicesSnapshot), len(ctx.tokenIndicies))
+		}
+		for i := range indicesSnapshot {
+			if indicesSnapshot[i] != ctx.tokenIndicies[i] {
+				t.Fatalf("InputImmutability violated: token_indices[%d] %v → %v", i, indicesSnapshot[i], ctx.tokenIndicies[i])
+			}
+		}
+	})
+}

--- a/pkg/logs/internal/decoder/preprocessor/json_detector_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/json_detector_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package automultilinedetection contains auto multiline detection and aggregation logic.
+// Package preprocessor contains auto multiline detection and aggregation logic.
 package preprocessor
 
 import (
@@ -12,6 +12,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Anchoring unit tests for the JSONDetection surface declared in
+// json_detector.allium. Each test names the spec construct
+// (@guarantee or @guidance case) it anchors so that drift in either
+// direction is easy to spot during review.
+//
+// Property tests for the same surface live in
+// json_detector_proptest_test.go.
+
+// TestJsonDetector anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guidance case 2 — shape match with no prior claim:
+//	                       set label = no_aggregate, return false
+//	    @guidance case 3 — no shape match: take no action, return true
+//
+// Each row exercises one of the two cases. The detection condition
+// is "opening brace `{` followed (possibly with intervening
+// whitespace) by either a string-opening `\"` or a closing `}`,
+// with leading whitespace permitted." Rows that match this shape
+// claim no_aggregate and return false; rows that do not match
+// leave the default `aggregate` label and return true.
 func TestJsonDetector(t *testing.T) {
 	jsonDetector := NewJSONDetector()
 	testCases := []struct {
@@ -50,6 +71,17 @@ func TestJsonDetector(t *testing.T) {
 	}
 }
 
+// TestJsonDetectorDoesntOverrideAssignedLabel anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guidance case 1 — if context.label_assigned_by indicates
+//	                       that a prior heuristic has already
+//	                       claimed the label, JSONDetector takes
+//	                       no action: it returns true and yields
+//
+// Even when the raw message matches the JSON shape, a non-default
+// label_assigned_by causes JSONDetector to defer: the label is
+// preserved, the return value is true (chain proceeds).
 func TestJsonDetectorDoesntOverrideAssignedLabel(t *testing.T) {
 	jsonDetector := NewJSONDetector()
 	messageContext := &messageContext{
@@ -59,4 +91,173 @@ func TestJsonDetectorDoesntOverrideAssignedLabel(t *testing.T) {
 	}
 	assert.Equal(t, true, jsonDetector.ProcessAndContinue(messageContext))
 	assert.Equal(t, aggregate, messageContext.label)
+}
+
+// TestJSONDetector_InputImmutability anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guarantee InputImmutability — JSONDetector reads
+//	                                    context.raw_message but
+//	                                    never modifies it. It does
+//	                                    not read or modify
+//	                                    context.tokens or
+//	                                    context.token_indices.
+//
+// After a call to ProcessAndContinue, raw_message bytes, tokens,
+// and token_indices are byte-equal to their pre-call state — on
+// both the claim path and the no-claim path.
+func TestJSONDetector_InputImmutability(t *testing.T) {
+	cases := []struct {
+		name       string
+		rawMessage string
+	}{
+		{"shape match (claim)", `{"key": "value"}`},
+		{"no shape match (pass)", `not json`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rawBefore := []byte(tc.rawMessage)
+			rawSnapshot := append([]byte(nil), rawBefore...)
+			tokensBefore := []Token{D4, Space, C5}
+			tokensSnapshot := append([]Token(nil), tokensBefore...)
+			indicesBefore := []int{0, 4, 5}
+			indicesSnapshot := append([]int(nil), indicesBefore...)
+
+			ctx := &messageContext{
+				rawMessage:      rawBefore,
+				tokens:          tokensBefore,
+				tokenIndicies:   indicesBefore,
+				label:           aggregate,
+				labelAssignedBy: defaultLabelSource,
+			}
+			NewJSONDetector().ProcessAndContinue(ctx)
+
+			assert.Equal(t, rawSnapshot, rawBefore, "raw_message bytes must not be mutated")
+			assert.Equal(t, tokensSnapshot, tokensBefore, "tokens must not be mutated")
+			assert.Equal(t, indicesSnapshot, indicesBefore, "token_indices must not be mutated")
+		})
+	}
+}
+
+// TestJSONDetector_LabelDomain_OnClaim anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guarantee LabelDomain — when JSONDetector claims the
+//	                              label, it sets context.label to
+//	                              no_aggregate
+//
+// Pins the specific Label value JSONDetector emits on a claim.
+// JSONDetector NEVER emits start_group or aggregate as a claim
+// outcome — only no_aggregate.
+func TestJSONDetector_LabelDomain_OnClaim(t *testing.T) {
+	ctx := &messageContext{
+		rawMessage:      []byte(`{"k": "v"}`),
+		label:           aggregate,
+		labelAssignedBy: defaultLabelSource,
+	}
+	NewJSONDetector().ProcessAndContinue(ctx)
+	assert.Equal(t, noAggregate, ctx.label)
+}
+
+// TestJSONDetector_LabelAssignedByConsistency_OnClaim anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guarantee LabelAssignedByConsistency — when JSONDetector
+//	                                             sets context.label,
+//	                                             it also sets
+//	                                             context.label_assigned_by
+//	                                             to its assigner_id
+//
+// On a claim, label and label_assigned_by move together: the
+// assigner_id observable downstream is the JSONDetector's own
+// provenance tag, not the "default" sentinel and not some other
+// heuristic's id.
+func TestJSONDetector_LabelAssignedByConsistency_OnClaim(t *testing.T) {
+	ctx := &messageContext{
+		rawMessage:      []byte(`{"k": "v"}`),
+		label:           aggregate,
+		labelAssignedBy: defaultLabelSource,
+	}
+	NewJSONDetector().ProcessAndContinue(ctx)
+	assert.NotEqual(t, defaultLabelSource, ctx.labelAssignedBy,
+		"label_assigned_by must move off the default sentinel when JSONDetector claims")
+	assert.NotEmpty(t, ctx.labelAssignedBy, "label_assigned_by must be a non-empty assigner_id")
+}
+
+// TestJSONDetector_LabelAssignedByConsistency_OnNoClaim anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guarantee LabelAssignedByConsistency — when JSONDetector
+//	                                             does NOT set
+//	                                             context.label, it
+//	                                             leaves
+//	                                             context.label_assigned_by
+//	                                             unchanged
+//
+// On the no-claim paths (both case 1 — prior claim — and case 3
+// — no shape match), JSONDetector must not modify
+// label_assigned_by. This is what allows downstream consumers to
+// trust the provenance tag as identifying the heuristic that
+// actually decided the label.
+func TestJSONDetector_LabelAssignedByConsistency_OnNoClaim(t *testing.T) {
+	cases := []struct {
+		name            string
+		rawMessage      string
+		labelAssignedBy string
+	}{
+		{"case 1 — prior claim", `{"k": "v"}`, "other_heuristic"},
+		{"case 3 — no shape match", `not json`, defaultLabelSource},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &messageContext{
+				rawMessage:      []byte(tc.rawMessage),
+				label:           aggregate,
+				labelAssignedBy: tc.labelAssignedBy,
+			}
+			NewJSONDetector().ProcessAndContinue(ctx)
+			assert.Equal(t, tc.labelAssignedBy, ctx.labelAssignedBy,
+				"label_assigned_by must be unchanged when JSONDetector does not claim")
+		})
+	}
+}
+
+// TestJSONDetector_TerminationSemantics anchors:
+//
+//	surface JSONDetection (json_detector.allium)
+//	    @guarantee TerminationSemantics — process_and_continue
+//	                                       returns false when
+//	                                       JSONDetector claims the
+//	                                       label, terminating the
+//	                                       labelling chain. It
+//	                                       returns true when
+//	                                       JSONDetector does NOT
+//	                                       claim the label.
+//
+// Pins the return-value pairing as a named anchor. Both halves
+// are exercised: claim (case 2) → false; no claim (cases 1 and 3)
+// → true.
+func TestJSONDetector_TerminationSemantics(t *testing.T) {
+	cases := []struct {
+		name            string
+		rawMessage      string
+		labelAssignedBy string
+		expectClaim     bool
+	}{
+		{"case 1 — defers, returns true", `{"k": "v"}`, "other_heuristic", false},
+		{"case 2 — claims, returns false", `{"k": "v"}`, defaultLabelSource, true},
+		{"case 3 — no match, returns true", `not json`, defaultLabelSource, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &messageContext{
+				rawMessage:      []byte(tc.rawMessage),
+				label:           aggregate,
+				labelAssignedBy: tc.labelAssignedBy,
+			}
+			result := NewJSONDetector().ProcessAndContinue(ctx)
+			// claim → false (terminate); no claim → true (continue)
+			assert.Equal(t, !tc.expectClaim, result)
+		})
+	}
 }


### PR DESCRIPTION
  What: Anchoring unit + property tests for the JSONDetection surface (from cmetz/json_detector). Includes the existing table-driven shape test (anchored) plus gap coverage on @guarantees.

  - @guidance cases 2 + 3 (shape match → claim, no match → pass) — TestJsonDetector table-driven (Unit, existing, anchored)
  - @guidance case 1 (defer to prior claim) — TestJsonDetectorDoesntOverrideAssignedLabel (Unit, existing, anchored)
  - @guarantee InputImmutability — TestJSONDetector_InputImmutability (Unit) + TestJSONDetector_InputImmutability_Property (Property)
  - @guarantee LabelDomain — TestJSONDetector_LabelDomain_OnClaim (Unit) + TestJSONDetector_LabelDomain_Property (Property)
  - @guarantee LabelAssignedByConsistency — TestJSONDetector_LabelAssignedByConsistency_OnClaim (Unit), TestJSONDetector_LabelAssignedByConsistency_OnNoClaim (Unit),
  TestJSONDetector_LabelAssignedByConsistency_Property (Property)
  - @guarantee TerminationSemantics — TestJSONDetector_TerminationSemantics (Unit, both halves)
  - Determinism (from Heuristic contract) — TestJSONDetector_Determinism_Property (Property)

  Stack: parent cmetz/json_detector.
