### PR TITLE
anchor PassThroughAggregator tests to spec

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/pass_through_aggregator_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/pass_through_aggregator_proptest_test.go
@@ -1,0 +1,266 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package preprocessor
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// Property tests for the PassThroughAggregation surface declared in
+// pass_through_aggregator.allium. Each test names the spec
+// @guarantee it anchors so that drift in either direction is easy
+// to spot during review.
+//
+// Anchoring unit tests for the same surface live in
+// pass_through_aggregator_test.go.
+
+// passThroughInput bundles a single randomly-generated process call.
+type passThroughInput struct {
+	content             []byte
+	upstreamIsTruncated bool
+	label               Label
+	tokens              []Token
+}
+
+// genPassThroughInput produces a single call's worth of input. The
+// generated content spans both sides of any reasonable line_limit so
+// generators that draw a sequence of calls exercise both the
+// "fits" and "oversize" branches of the @guidance step 2 truncation
+// recomputation.
+func genPassThroughInput() *rapid.Generator[passThroughInput] {
+	return rapid.Custom(func(t *rapid.T) passThroughInput {
+		// Bytes drawn from a printable range so the trim-space
+		// effect is visually predictable. Spaces and tabs included
+		// so trimming exercises both leading and trailing cases.
+		raw := rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abcdef 0123\t")),
+			0, 60,
+		).Draw(t, "raw")
+		isTruncated := rapid.Bool().Draw(t, "isTruncated")
+		label := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "label")
+		nTokens := rapid.IntRange(0, 6).Draw(t, "nTokens")
+		tokens := make([]Token, nTokens)
+		for i := 0; i < nTokens; i++ {
+			tokens[i] = Token(rapid.IntRange(0, int(End)-1).Draw(t, "token"))
+		}
+		return passThroughInput{
+			content:             raw,
+			upstreamIsTruncated: isTruncated,
+			label:               label,
+			tokens:              tokens,
+		}
+	})
+}
+
+// runOne builds a fresh message from the generated input and calls
+// process once. Returned values are copied so subsequent calls to
+// process (which reuse the internal buffer) do not invalidate them
+// — this is part of how the test honours the ResultLifetime
+// invariant.
+func runOne(ag *PassThroughAggregator, in passThroughInput) (content []byte, isTruncated bool, tokens []Token) {
+	msg := message.NewMessage(append([]byte(nil), in.content...), nil, message.StatusInfo, 0)
+	msg.RawDataLen = len(in.content)
+	msg.ParsingExtra.IsTruncated = in.upstreamIsTruncated
+	emitted := ag.Process(msg, in.label, in.tokens)
+	if len(emitted) != 1 {
+		return nil, false, nil
+	}
+	content = append([]byte(nil), emitted[0].Msg.GetContent()...)
+	isTruncated = emitted[0].Msg.ParsingExtra.IsTruncated
+	tokens = append([]Token(nil), emitted[0].Tokens...)
+	return content, isTruncated, tokens
+}
+
+// TestPassThroughAggregator_NoGrouping_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee NoGrouping — Every call to process emits exactly
+//	                             one AggregatedMessageWithTokens
+//
+// Across a randomly-generated sequence of process calls of
+// arbitrary length, every call emits exactly one
+// AggregatedMessageWithTokens. PassThrough never buffers a line,
+// regardless of label, content, or truncation state.
+func TestPassThroughAggregator_NoGrouping_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		ag := NewPassThroughAggregator(rapid.IntRange(1, 200).Draw(t, "lineLimit"))
+		calls := rapid.SliceOfN(genPassThroughInput(), 1, 10).Draw(t, "calls")
+		for i, in := range calls {
+			msg := message.NewMessage(append([]byte(nil), in.content...), nil, message.StatusInfo, 0)
+			msg.RawDataLen = len(in.content)
+			msg.ParsingExtra.IsTruncated = in.upstreamIsTruncated
+			emitted := ag.Process(msg, in.label, in.tokens)
+			if len(emitted) != 1 {
+				t.Fatalf("NoGrouping violated: call %d emitted %d messages, expected exactly 1", i, len(emitted))
+			}
+		}
+	})
+}
+
+// TestPassThroughAggregator_IsEmptyAlwaysTrue_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee IsEmptyConsistency — is_empty always returns
+//	                                     true (PassThrough has no
+//	                                     buffer state)
+//
+// is_empty returns true after construction and after every process
+// call, across arbitrary call sequences. The rolling
+// should_truncate flag does not influence is_empty.
+func TestPassThroughAggregator_IsEmptyAlwaysTrue_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		ag := NewPassThroughAggregator(rapid.IntRange(1, 200).Draw(t, "lineLimit"))
+		if !ag.IsEmpty() {
+			t.Fatal("IsEmptyConsistency violated: is_empty false at construction")
+		}
+		calls := rapid.SliceOfN(genPassThroughInput(), 0, 10).Draw(t, "calls")
+		for i, in := range calls {
+			runOne(ag, in)
+			if !ag.IsEmpty() {
+				t.Fatalf("IsEmptyConsistency violated: is_empty false after call %d", i)
+			}
+		}
+	})
+}
+
+// TestPassThroughAggregator_FlushEmpty_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee FlushDrainsBuffer — flush always returns an
+//	                                    empty sequence (PassThrough
+//	                                    has no buffer state)
+//
+// Flush returns an empty sequence after arbitrary process call
+// sequences. The rolling should_truncate flag is not drained by
+// flush.
+func TestPassThroughAggregator_FlushEmpty_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		ag := NewPassThroughAggregator(rapid.IntRange(1, 200).Draw(t, "lineLimit"))
+		calls := rapid.SliceOfN(genPassThroughInput(), 0, 10).Draw(t, "calls")
+		for _, in := range calls {
+			runOne(ag, in)
+		}
+		if got := ag.Flush(); len(got) != 0 {
+			t.Fatalf("FlushDrainsBuffer violated: flush returned %d messages, expected empty", len(got))
+		}
+	})
+}
+
+// TestPassThroughAggregator_LabelIgnored_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee LabelIgnored — The label argument is consumed
+//	                               but has no observable effect on
+//	                               the output sequence or on the
+//	                               should_truncate state.
+//
+// For arbitrary content and truncation state, two aggregators
+// fed an identical sequence of inputs (one with all-start_group
+// labels, one with all-no_aggregate labels) produce identical
+// emitted content, IsTruncated flags, and tokens. The label has
+// no observable effect.
+func TestPassThroughAggregator_LabelIgnored_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(1, 200).Draw(t, "lineLimit")
+		agA := NewPassThroughAggregator(lineLimit)
+		agB := NewPassThroughAggregator(lineLimit)
+		calls := rapid.SliceOfN(genPassThroughInput(), 1, 8).Draw(t, "calls")
+		for i, in := range calls {
+			inA := in
+			inA.label = startGroup
+			inB := in
+			inB.label = aggregate
+
+			contentA, truncA, _ := runOne(agA, inA)
+			contentB, truncB, _ := runOne(agB, inB)
+
+			if !bytes.Equal(contentA, contentB) {
+				t.Fatalf("LabelIgnored violated at call %d: content %q (start_group) vs %q (aggregate)", i, contentA, contentB)
+			}
+			if truncA != truncB {
+				t.Fatalf("LabelIgnored violated at call %d: is_truncated %v (start_group) vs %v (aggregate)", i, truncA, truncB)
+			}
+		}
+	})
+}
+
+// TestPassThroughAggregator_TokensForwarded_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee TokensForwarded — The tokens argument is
+//	                                  forwarded unchanged into
+//	                                  AggregatedMessageWithTokens.tokens
+//
+// For arbitrary inputs, the tokens emitted on the single output
+// message are byte-equal to the tokens passed in.
+func TestPassThroughAggregator_TokensForwarded_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		ag := NewPassThroughAggregator(rapid.IntRange(1, 200).Draw(t, "lineLimit"))
+		in := genPassThroughInput().Draw(t, "input")
+		msg := message.NewMessage(append([]byte(nil), in.content...), nil, message.StatusInfo, 0)
+		msg.RawDataLen = len(in.content)
+		msg.ParsingExtra.IsTruncated = in.upstreamIsTruncated
+		emitted := ag.Process(msg, in.label, in.tokens)
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 emission, got %d", len(emitted))
+		}
+		if len(in.tokens) != len(emitted[0].Tokens) {
+			t.Fatalf("TokensForwarded violated: length %d → %d", len(in.tokens), len(emitted[0].Tokens))
+		}
+		for i := range in.tokens {
+			if in.tokens[i] != emitted[0].Tokens[i] {
+				t.Fatalf("TokensForwarded violated: tokens[%d] %v → %v", i, in.tokens[i], emitted[0].Tokens[i])
+			}
+		}
+	})
+}
+
+// TestPassThroughAggregator_ByteConservation_Property anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee ByteConservation — emitted bytes derive from
+//	                                   trimmed input plus optional
+//	                                   prepended/appended truncation
+//	                                   markers
+//
+// The emitted content, after stripping any prepended/appended
+// truncation marker, must equal the trim-spaced input bytes. This
+// is the strong form: every byte in the output traces back to
+// either (a) a non-whitespace input byte, or (b) the truncation
+// marker. No other bytes appear.
+func TestPassThroughAggregator_ByteConservation_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		ag := NewPassThroughAggregator(rapid.IntRange(1, 200).Draw(t, "lineLimit"))
+		in := genPassThroughInput().Draw(t, "input")
+		msg := message.NewMessage(append([]byte(nil), in.content...), nil, message.StatusInfo, 0)
+		msg.RawDataLen = len(in.content)
+		msg.ParsingExtra.IsTruncated = in.upstreamIsTruncated
+		emitted := ag.Process(msg, in.label, in.tokens)
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 emission, got %d", len(emitted))
+		}
+
+		out := string(emitted[0].Msg.GetContent())
+		marker := string(message.TruncatedFlag)
+
+		// Strip at most one prepended and one appended marker.
+		stripped := out
+		stripped = strings.TrimPrefix(stripped, marker)
+		stripped = strings.TrimSuffix(stripped, marker)
+
+		expectedCore := strings.TrimSpace(string(in.content))
+		if stripped != expectedCore {
+			t.Fatalf("ByteConservation violated: stripped %q != trimmed input %q (full output %q)",
+				stripped, expectedCore, out)
+		}
+	})
+}

--- a/pkg/logs/internal/decoder/preprocessor/pass_through_aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/pass_through_aggregator_test.go
@@ -1,0 +1,349 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package preprocessor contains auto multiline detection and aggregation logic.
+package preprocessor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// Anchoring unit tests for the PassThroughAggregation surface
+// declared in pass_through_aggregator.allium. Each test names the
+// spec construct (@guarantee or @guidance step) it anchors so that
+// drift in either direction is easy to spot during review.
+//
+// Property tests for the same surface live in
+// pass_through_aggregator_proptest_test.go. Helpers (newMessage,
+// processMsg, flushMsgs, assertMessageContent) are shared with
+// aggregator_test.go.
+
+// TestPassThroughAggregator_NoGrouping anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee NoGrouping — Every call to process emits
+//	                             exactly one AggregatedMessageWithTokens;
+//	                             PassThroughAggregator does not
+//	                             combine consecutive lines.
+//
+// Multiple consecutive process calls each emit their own message;
+// no buffering occurs across calls.
+func TestPassThroughAggregator_NoGrouping(t *testing.T) {
+	ag := NewPassThroughAggregator(1000)
+
+	first := processMsg(ag, newMessage("line one"), aggregate)
+	require.Len(t, first, 1, "first call must emit exactly one message")
+
+	second := processMsg(ag, newMessage("line two"), aggregate)
+	require.Len(t, second, 1, "second call must emit exactly one message")
+
+	third := processMsg(ag, newMessage("line three"), aggregate)
+	require.Len(t, third, 1, "third call must emit exactly one message")
+}
+
+// TestPassThroughAggregator_LabelIgnored anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee LabelIgnored — The label argument to process is
+//	                               consumed but has no observable
+//	                               effect on the output sequence or
+//	                               on the should_truncate state.
+//
+// The same input under three different labels produces the same
+// emitted content. This guards against accidental label-driven
+// branching being introduced in the aggregator.
+func TestPassThroughAggregator_LabelIgnored(t *testing.T) {
+	for _, label := range []Label{startGroup, noAggregate, aggregate} {
+		ag := NewPassThroughAggregator(1000)
+		msgs := processMsg(ag, newMessage("identical content"), label)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, "identical content", string(msgs[0].GetContent()),
+			"output content must be identical regardless of label (got under label %v)", label)
+		assert.False(t, msgs[0].ParsingExtra.IsTruncated,
+			"is_truncated must be identical regardless of label")
+	}
+}
+
+// TestPassThroughAggregator_TokensForwarded anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee TokensForwarded — The tokens argument is
+//	                                  forwarded unchanged into
+//	                                  AggregatedMessageWithTokens.tokens
+//	                                  of the emitted message.
+//
+// Both nil and non-empty token slices are forwarded byte-for-byte
+// onto the emitted AggregatedMessageWithTokens.
+func TestPassThroughAggregator_TokensForwarded(t *testing.T) {
+	cases := []struct {
+		name   string
+		tokens []Token
+	}{
+		{"nil tokens", nil},
+		{"non-empty tokens", []Token{D4, Space, C5, D2}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := NewPassThroughAggregator(1000)
+			emitted := ag.Process(newMessage("content"), aggregate, tc.tokens)
+			require.Len(t, emitted, 1)
+			assert.Equal(t, tc.tokens, emitted[0].Tokens,
+				"tokens must be forwarded unchanged onto the emitted AggregatedMessageWithTokens")
+		})
+	}
+}
+
+// TestPassThroughAggregator_FlushReturnsEmpty anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee FlushDrainsBuffer — flush always returns an empty
+//	                                    sequence (PassThrough has no
+//	                                    buffer state to drain)
+//
+// Flush is empty at construction and after process calls — there
+// is never anything to drain.
+func TestPassThroughAggregator_FlushReturnsEmpty(t *testing.T) {
+	ag := NewPassThroughAggregator(1000)
+
+	assert.Empty(t, flushMsgs(ag), "flush must return empty at construction")
+
+	processMsg(ag, newMessage("anything"), aggregate)
+	assert.Empty(t, flushMsgs(ag), "flush must return empty after a process call")
+
+	// Even after a truncation that updates should_truncate, flush stays empty.
+	processMsg(ag, newMessage(strings.Repeat("x", 2000)), aggregate)
+	assert.Empty(t, flushMsgs(ag), "flush must return empty even when should_truncate carry is set")
+}
+
+// TestPassThroughAggregator_IsEmptyAlwaysTrue anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee IsEmptyConsistency — is_empty always returns true
+//	                                     (no buffered content state
+//	                                     ever exists)
+//
+// Verifies the trivial form: is_empty is true at construction,
+// after a normal process call, after a truncation, and after flush.
+// The rolling should_truncate flag is not buffered content and
+// therefore does not influence is_empty.
+func TestPassThroughAggregator_IsEmptyAlwaysTrue(t *testing.T) {
+	ag := NewPassThroughAggregator(1000)
+	assert.True(t, ag.IsEmpty(), "is_empty must be true at construction")
+
+	processMsg(ag, newMessage("anything"), aggregate)
+	assert.True(t, ag.IsEmpty(), "is_empty must remain true after a process call")
+
+	processMsg(ag, newMessage(strings.Repeat("x", 2000)), aggregate)
+	assert.True(t, ag.IsEmpty(), "is_empty must remain true after should_truncate carry is set")
+
+	flushMsgs(ag)
+	assert.True(t, ag.IsEmpty(), "is_empty must remain true after flush")
+}
+
+// TestPassThroughAggregator_TrimsWhitespace anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guidance step 3 — Trim leading and trailing whitespace from
+//	                       the input content. This is unconditional;
+//	                       it applies whether or not the line was
+//	                       truncated.
+//
+// Leading and trailing whitespace is removed from the emitted
+// content. Interior whitespace is preserved.
+func TestPassThroughAggregator_TrimsWhitespace(t *testing.T) {
+	ag := NewPassThroughAggregator(1000)
+	msgs := processMsg(ag, newMessage("  \t  hello  world  \r\n"), aggregate)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "hello  world", string(msgs[0].GetContent()))
+}
+
+// TestPassThroughAggregator_ByteConservation_NoTruncation anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guarantee ByteConservation — emitted bytes derive only
+//	                                   from the input bytes plus
+//	                                   well-known truncation markers
+//
+// When neither truncation condition fires, the emitted content
+// is bytewise equal to the trimmed input bytes — no truncation
+// marker is added.
+func TestPassThroughAggregator_ByteConservation_NoTruncation(t *testing.T) {
+	ag := NewPassThroughAggregator(1000)
+	in := "  short content with internal spaces  "
+	msgs := processMsg(ag, newMessage(in), aggregate)
+	require.Len(t, msgs, 1)
+	emitted := string(msgs[0].GetContent())
+	assert.Equal(t, strings.TrimSpace(in), emitted)
+	assert.False(t, strings.Contains(emitted, string(message.TruncatedFlag)),
+		"no truncation marker must appear when truncation does not fire")
+}
+
+// TestPassThroughAggregator_AppendsMarkerOnOversize anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guidance step 5 — If should_truncate is true (i.e., this
+//	                       line itself triggers truncation), append
+//	                       the truncation marker to the content.
+//
+// When the input content exceeds line_limit, the emitted content
+// has the truncation marker appended and the emitted message is
+// flagged truncated.
+func TestPassThroughAggregator_AppendsMarkerOnOversize(t *testing.T) {
+	ag := NewPassThroughAggregator(10)
+	msgs := processMsg(ag, newMessage("12345678901234567890"), aggregate)
+	require.Len(t, msgs, 1)
+	emitted := string(msgs[0].GetContent())
+	assert.Equal(t, "12345678901234567890"+string(message.TruncatedFlag), emitted)
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+}
+
+// TestPassThroughAggregator_AppendsMarkerOnUpstreamTruncated anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guidance step 2 — should_truncate becomes true if … the
+//	                       input msg.is_truncated is already true
+//	    @guidance step 5 — append the truncation marker
+//
+// Upstream-flagged truncation (input msg.IsTruncated = true) is
+// itself a truncation trigger, even if the content fits within
+// line_limit.
+func TestPassThroughAggregator_AppendsMarkerOnUpstreamTruncated(t *testing.T) {
+	ag := NewPassThroughAggregator(1000)
+	in := newMessage("short content")
+	in.ParsingExtra.IsTruncated = true
+	msgs := processMsg(ag, in, aggregate)
+	require.Len(t, msgs, 1)
+	emitted := string(msgs[0].GetContent())
+	assert.True(t, strings.HasSuffix(emitted, string(message.TruncatedFlag)),
+		"upstream-truncated input must produce a marker-suffixed emission; got %q", emitted)
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated)
+}
+
+// TestPassThroughAggregator_PrependsMarkerAfterPriorTruncation anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guidance step 1+4 — Capture the current should_truncate
+//	                          value as `prepend_marker` … If
+//	                          prepend_marker is true, prepend the
+//	                          truncation marker to the trimmed
+//	                          content.
+//
+// Two-call test: the first call's oversize content sets the
+// should_truncate carry; the second call's emitted content has the
+// truncation marker prepended. This is the "continuation" half of
+// the marker pair.
+func TestPassThroughAggregator_PrependsMarkerAfterPriorTruncation(t *testing.T) {
+	ag := NewPassThroughAggregator(10)
+
+	// First call: oversize content. Sets should_truncate.
+	first := processMsg(ag, newMessage("12345678901234567890"), aggregate)
+	require.Len(t, first, 1)
+
+	// Second call: short content (would not truncate on its own).
+	// Emitted content must have the truncation marker prepended.
+	second := processMsg(ag, newMessage("short"), aggregate)
+	require.Len(t, second, 1)
+	emitted := string(second[0].GetContent())
+	assert.Equal(t, string(message.TruncatedFlag)+"short", emitted)
+	assert.True(t, second[0].ParsingExtra.IsTruncated,
+		"emitted message must be flagged truncated when the marker is prepended")
+}
+
+// TestPassThroughAggregator_PrependAndAppendOnConsecutiveOversize anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guidance step 4 + step 5 (in combination)
+//
+// Two consecutive oversized lines: the second line gets both
+// prepend (from the first line's truncation carry) AND append (from
+// its own oversize state).
+func TestPassThroughAggregator_PrependAndAppendOnConsecutiveOversize(t *testing.T) {
+	ag := NewPassThroughAggregator(10)
+
+	first := processMsg(ag, newMessage("aaaaaaaaaaaaaaaa"), aggregate) // 16 chars > 10
+	require.Len(t, first, 1)
+	assert.Equal(t, "aaaaaaaaaaaaaaaa"+string(message.TruncatedFlag), string(first[0].GetContent()))
+
+	second := processMsg(ag, newMessage("bbbbbbbbbbbbbbbb"), aggregate) // 16 chars > 10
+	require.Len(t, second, 1)
+	expected := string(message.TruncatedFlag) + "bbbbbbbbbbbbbbbb" + string(message.TruncatedFlag)
+	assert.Equal(t, expected, string(second[0].GetContent()))
+	assert.True(t, second[0].ParsingExtra.IsTruncated)
+}
+
+// TestPassThroughAggregator_TruncationCarryClearedAfterNormalLine anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guidance step 2 — Otherwise should_truncate becomes false
+//
+// After an oversized line sets the carry, a subsequent short line
+// gets the prepended marker AND clears the carry. The line AFTER
+// that one is back to normal — no markers added.
+func TestPassThroughAggregator_TruncationCarryClearedAfterNormalLine(t *testing.T) {
+	ag := NewPassThroughAggregator(10)
+
+	processMsg(ag, newMessage("12345678901234567890"), aggregate) // oversize: sets carry
+	processMsg(ag, newMessage("short"), aggregate)                // gets prepended marker; clears carry
+
+	third := processMsg(ag, newMessage("clean"), aggregate)
+	require.Len(t, third, 1)
+	emitted := string(third[0].GetContent())
+	assert.Equal(t, "clean", emitted, "third line must have no truncation markers — carry should have been cleared")
+	assert.False(t, third[0].ParsingExtra.IsTruncated)
+}
+
+// TestPassThroughAggregator_TruncationTagsWhenEnabled anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guidance step 6 — when the runtime's truncated-log
+//	                       tagging is enabled — attach a
+//	                       truncation-reason tag identifying this
+//	                       aggregator as the source
+//
+// With the logs_config.tag_truncated_logs flag enabled, a truncated
+// emission has the "truncated:single_line" tag appended.
+func TestPassThroughAggregator_TruncationTagsWhenEnabled(t *testing.T) {
+	mockConfig := configmock.New(t)
+	prev := mockConfig.GetBool("logs_config.tag_truncated_logs")
+	mockConfig.SetWithoutSource("logs_config.tag_truncated_logs", true)
+	defer mockConfig.SetWithoutSource("logs_config.tag_truncated_logs", prev)
+
+	ag := NewPassThroughAggregator(10)
+	msgs := processMsg(ag, newMessage("12345678901234567890"), aggregate)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"),
+		"truncation-reason tag must be attached when the runtime flag is enabled")
+}
+
+// TestPassThroughAggregator_TruncationDoesNotTagWhenDisabled anchors:
+//
+//	surface PassThroughAggregation (pass_through_aggregator.allium)
+//	    @guidance step 6 — when the runtime's truncated-log
+//	                       tagging is enabled (and only then)
+//
+// With the flag disabled, a truncated emission has no
+// truncation-reason tag appended — even though IsTruncated is still
+// set and the marker is still in the content.
+func TestPassThroughAggregator_TruncationDoesNotTagWhenDisabled(t *testing.T) {
+	mockConfig := configmock.New(t)
+	prev := mockConfig.GetBool("logs_config.tag_truncated_logs")
+	mockConfig.SetWithoutSource("logs_config.tag_truncated_logs", false)
+	defer mockConfig.SetWithoutSource("logs_config.tag_truncated_logs", prev)
+
+	ag := NewPassThroughAggregator(10)
+	msgs := processMsg(ag, newMessage("12345678901234567890"), aggregate)
+	require.Len(t, msgs, 1)
+	assert.True(t, msgs[0].ParsingExtra.IsTruncated,
+		"is_truncated must still be set even when tagging is disabled")
+	assert.NotContains(t, msgs[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"),
+		"truncation-reason tag must NOT be attached when the runtime flag is disabled")
+}


### PR DESCRIPTION
  What: Anchoring unit + property tests for PassThroughAggregation.

  - @guarantee NoGrouping — TestPassThroughAggregator_NoGrouping (Unit) + _Property (Property)
  - @guarantee LabelIgnored — TestPassThroughAggregator_LabelIgnored (Unit) + _Property (Property)
  - @guarantee TokensForwarded — TestPassThroughAggregator_TokensForwarded (Unit) + _Property (Property)
  - @guarantee FlushDrainsBuffer — TestPassThroughAggregator_FlushReturnsEmpty (Unit) + TestPassThroughAggregator_FlushEmpty_Property (Property)
  - @guarantee IsEmptyConsistency — TestPassThroughAggregator_IsEmptyAlwaysTrue (Unit) + _Property (Property)
  - @guidance step 3 (trim) — TestPassThroughAggregator_TrimsWhitespace (Unit)
  - @guarantee ByteConservation (no-truncation path) — TestPassThroughAggregator_ByteConservation_NoTruncation (Unit) + _Property (Property)
  - @guidance step 5 (append on oversize) — TestPassThroughAggregator_AppendsMarkerOnOversize (Unit)
  - @guidance step 2+5 (append on upstream-truncated input) — TestPassThroughAggregator_AppendsMarkerOnUpstreamTruncated (Unit)
  - @guidance steps 1+4 (prepend on prior-call carry) — TestPassThroughAggregator_PrependsMarkerAfterPriorTruncation (Unit)
  - @guidance combined (prepend + append on consecutive oversize) — TestPassThroughAggregator_PrependAndAppendOnConsecutiveOversize (Unit)
  - @guidance step 2 (carry clears after normal line) — TestPassThroughAggregator_TruncationCarryClearedAfterNormalLine (Unit)
  - @guidance step 6 (truncation tag attached when config enabled) — TestPassThroughAggregator_TruncationTagsWhenEnabled (Unit)
  - @guidance step 6 (tag absent when config disabled, is_truncated still set) — TestPassThroughAggregator_TruncationDoesNotTagWhenDisabled (Unit)

  Stack: parent cmetz/pass_through_aggregator.
