### PR TITLE
anchor DetectingAggregator tests to spec

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -502,6 +502,26 @@ func TestRegexAggregatorFirstLineMatchesWorksNormally(t *testing.T) {
 
 // Tests for detectingAggregator
 
+// TestDetectingAggregator_TagsMultilineStartOnly anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee MultiLineDetectionTag — When aggregate follows
+//	                                        a pending start_group,
+//	                                        the buffered message is
+//	                                        emitted with
+//	                                        "auto_multiline_detected:true"
+//	                                        appended. The aggregate
+//	                                        line itself is emitted
+//	                                        WITHOUT the tag.
+//	    @guarantee StartGroupBufferedUntilNextCall
+//	    @guarantee NoLineCombination — both messages emit as
+//	                                    separate AggregatedMessage-
+//	                                    WithTokens entries, not
+//	                                    combined.
+//
+// Pins the load-bearing detection-tag asymmetry: the tag goes
+// only on the start_group line, not on the aggregate that
+// triggered it, and not on subsequent aggregates.
 func TestDetectingAggregator_TagsMultilineStartOnly(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
@@ -523,6 +543,21 @@ func TestDetectingAggregator_TagsMultilineStartOnly(t *testing.T) {
 	assert.NotContains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
 }
 
+// TestDetectingAggregator_SingleLineNotTagged anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee MultiLineDetectionTag (negative case) — A
+//	                                        start_group flushed by
+//	                                        a SUBSEQUENT start_group
+//	                                        (not by aggregate) is
+//	                                        emitted without the
+//	                                        detection tag.
+//
+// The detection signal is "start_group followed by aggregate" —
+// not just "start_group seen." A start_group followed by another
+// start_group represents two distinct single-line entries that
+// happen to share the start_group classification; neither earns
+// the detection tag.
 func TestDetectingAggregator_SingleLineNotTagged(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
@@ -542,6 +577,14 @@ func TestDetectingAggregator_SingleLineNotTagged(t *testing.T) {
 	assert.NotContains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
 }
 
+// TestDetectingAggregator_NoAggregateOutputsImmediately anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guidance step 3 — If label = noAggregate: emit current
+//	                       immediately (after flushing any pending).
+//
+// Pure noAggregate sequence emits each message on the same call.
+// No buffering, no tags applied.
 func TestDetectingAggregator_NoAggregateOutputsImmediately(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
@@ -556,6 +599,17 @@ func TestDetectingAggregator_NoAggregateOutputsImmediately(t *testing.T) {
 	assert.Empty(t, msgs[0].ParsingExtra.Tags)
 }
 
+// TestDetectingAggregator_FlushPendingMessage anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee FlushDrainsBuffer — flush emits any pending
+//	                                    message and clears state.
+//	    @guidance flush procedure — Pending is emitted WITHOUT the
+//	                                detection tag (flush is not an
+//	                                aggregate trigger).
+//
+// A buffered start_group that never sees an aggregate label
+// is emitted on flush as a plain single-line message.
 func TestDetectingAggregator_FlushPendingMessage(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
@@ -567,6 +621,15 @@ func TestDetectingAggregator_FlushPendingMessage(t *testing.T) {
 	assert.NotContains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
 }
 
+// TestDetectingAggregator_MixedSingleAndMultiLine anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guidance steps 2 + 4 (label-dispatch interleaving)
+//
+// Walks a realistic sequence: standalone start_group → next
+// start_group (flushes prior untagged) → aggregate (tags this
+// pending start + emits cont) → standalone start_group (pending).
+// The full per-label dispatch table runs across one test.
 func TestDetectingAggregator_MixedSingleAndMultiLine(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
@@ -596,6 +659,17 @@ func TestDetectingAggregator_MixedSingleAndMultiLine(t *testing.T) {
 	assert.NotContains(t, msgs[0].ParsingExtra.Tags, "auto_multiline_detected:true")
 }
 
+// TestDetectingAggregator_IsEmpty anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee IsEmptyConsistency — is_empty reflects
+//	                                     pending_message_present
+//	                                     inverted exactly.
+//
+// is_empty tracks the buffered-message state: true at
+// construction, false while a start_group is pending, true after
+// flush drains it, true after a noAggregate emission (which never
+// buffers).
 func TestDetectingAggregator_IsEmpty(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
 
@@ -613,6 +687,25 @@ func TestDetectingAggregator_IsEmpty(t *testing.T) {
 	assert.True(t, ag.IsEmpty())
 }
 
+// TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee SingleLineTruncationFlow — Identical in shape
+//	                                          to PassThrough's:
+//	                                          rolling carry,
+//	                                          prepend on prior,
+//	                                          append on overflow.
+//	    @guarantee MultiLineDetectionTag (interaction with
+//	                                      truncation tagging)
+//
+// Three properties verified at once:
+//  1. The start_group line gets truncated (oversize) → marker
+//     appended, is_truncated set, "single_line" truncation tag,
+//     AND the detection tag.
+//  2. The carry from emission #1 prepends the marker to
+//     emission #2's content.
+//  3. The detection tag stays on the start_group line only —
+//     the aggregate line carries no detection tag.
 func TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true, false)
 
@@ -631,6 +724,15 @@ func TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation(t *
 	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[1].ParsingExtra.Tags)
 }
 
+// TestDetectingAggregator_NoAggregateInheritsTruncationCarry anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee SingleLineTruncationFlow (carry across noAggregate)
+//
+// The truncation carry follows the SEQUENCE of emissions, not the
+// label sequence — a noAggregate that overflows sets the carry,
+// and the next noAggregate (which emits immediately) gets the
+// prepended marker.
 func TestDetectingAggregator_NoAggregateInheritsTruncationCarry(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true, false)
 
@@ -645,6 +747,18 @@ func TestDetectingAggregator_NoAggregateInheritsTruncationCarry(t *testing.T) {
 	assert.Equal(t, []string{message.TruncatedReasonTag("single_line")}, msgs[0].ParsingExtra.Tags)
 }
 
+// TestDetectingAggregator_StartGroupInheritsTruncationCarry anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee SingleLineTruncationFlow (carry across the
+//	                                          start_group buffer)
+//
+// The carry crosses the start_group buffering boundary: a
+// noAggregate overflow sets the carry, then a start_group is
+// buffered (no emission), then an aggregate flushes the buffered
+// start_group — which now gets the prepended marker from the
+// carry. After that emission, the carry is consumed; the
+// aggregate's own emission is unaffected.
 func TestDetectingAggregator_StartGroupInheritsTruncationCarry(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, true, false)
 
@@ -666,6 +780,22 @@ func TestDetectingAggregator_StartGroupInheritsTruncationCarry(t *testing.T) {
 	assert.Empty(t, msgs[1].ParsingExtra.Tags)
 }
 
+// TestDetectingAggregator_TruncationDoesNotTagWhenDisabled anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee SingleLineTruncationFlow — the truncation-
+//	                                          reason tag is
+//	                                          attached when
+//	                                          tag_truncated_logs
+//	                                          is true (and only
+//	                                          then).
+//
+// With tag_truncated_logs = false at construction, a truncated
+// emission still has is_truncated set and the appended marker —
+// but the "truncated:single_line" tag is absent. Note that
+// DetectingAggregator takes tag_truncated_logs as a constructor
+// argument, NOT from global runtime config (unlike PassThrough
+// and Regex).
 func TestDetectingAggregator_TruncationDoesNotTagWhenDisabled(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 5, false, false)
 
@@ -676,6 +806,22 @@ func TestDetectingAggregator_TruncationDoesNotTagWhenDisabled(t *testing.T) {
 	assert.Empty(t, msgs[0].ParsingExtra.Tags)
 }
 
+// TestDetectingAggregator_UsesExistingTruncatedFlag anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guidance SingleLineTruncationFlow step 1 — should_truncate
+//	                                                 becomes true
+//	                                                 iff the input
+//	                                                 message's
+//	                                                 is_truncated
+//	                                                 is already
+//	                                                 true (OR
+//	                                                 content exceeds
+//	                                                 line_limit).
+//
+// An input message whose is_truncated flag is already set
+// triggers the truncation flow even when content fits within
+// line_limit. The marker is appended; the rolling carry is set.
 func TestDetectingAggregator_UsesExistingTruncatedFlag(t *testing.T) {
 	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, true, false)
 
@@ -695,6 +841,19 @@ func TestDetectingAggregator_UsesExistingTruncatedFlag(t *testing.T) {
 // PassThroughAggregator, and CombiningAggregator do. Without TrimSpace, trailing \r from
 // CRLF line endings (or other trailing whitespace) breaks anchored log_processing_rules
 // like ^\{.*\}$ because the anchor can't match past the trailing bytes.
+// TestDetectingAggregator_TrimSpaceMatchesOtherAggregators anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guidance SingleLineTruncationFlow step 2 — Trim leading
+//	                                                 and trailing
+//	                                                 whitespace
+//	                                                 from
+//	                                                 emit_msg.content.
+//
+// The trim-space step ensures trailing whitespace (notably \r
+// from windows-style framing) does not appear in emitted content.
+// Compares behavior against PassThrough and Combining as a
+// cross-aggregator sanity check.
 func TestDetectingAggregator_TrimSpaceMatchesOtherAggregators(t *testing.T) {
 	jsonPattern := regexp.MustCompile(`^\{.*\}$`)
 

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator_proptest_test.go
@@ -1,0 +1,164 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package preprocessor
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+)
+
+// Property tests for the DetectingAggregation surface declared in
+// detecting_aggregator.allium. Each test names the spec
+// @guarantee it anchors so that drift in either direction is easy
+// to spot during review.
+//
+// Anchoring unit tests for the same surface live in
+// detecting_aggregator_test.go and aggregator_test.go.
+
+// detectingCall bundles one process call's worth of inputs.
+type detectingCall struct {
+	content string
+	label   Label
+	tokens  []Token
+}
+
+func genDetectingCall() *rapid.Generator[detectingCall] {
+	return rapid.Custom(func(t *rapid.T) detectingCall {
+		content := string(rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abc 012")),
+			0, 30,
+		).Draw(t, "content"))
+		label := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "label")
+		nTokens := rapid.IntRange(0, 4).Draw(t, "nTokens")
+		tokens := make([]Token, nTokens)
+		for i := 0; i < nTokens; i++ {
+			tokens[i] = Token(rapid.IntRange(0, int(End)-1).Draw(t, "token"))
+		}
+		return detectingCall{content: content, label: label, tokens: tokens}
+	})
+}
+
+// detectingEmission captures one emitted message's observable
+// state. Used to compare across runs for determinism tests.
+type detectingEmission struct {
+	content     string
+	isTruncated bool
+	tagsLen     int
+	tokensLen   int
+}
+
+// runDetectingCalls feeds a sequence of calls into a freshly
+// constructed DetectingAggregator and returns the observable state
+// of each emission, in arrival order, including a final flush.
+func runDetectingCalls(lineLimit int, tagTruncated bool, calls []detectingCall) []detectingEmission {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), lineLimit, tagTruncated, false)
+	var out []detectingEmission
+	for _, c := range calls {
+		emitted := ag.Process(newMessage(c.content), c.label, c.tokens)
+		for _, e := range emitted {
+			out = append(out, detectingEmission{
+				content:     string(e.Msg.GetContent()),
+				isTruncated: e.Msg.ParsingExtra.IsTruncated,
+				tagsLen:     len(e.Msg.ParsingExtra.Tags),
+				tokensLen:   len(e.Tokens),
+			})
+		}
+	}
+	for _, e := range ag.Flush() {
+		out = append(out, detectingEmission{
+			content:     string(e.Msg.GetContent()),
+			isTruncated: e.Msg.ParsingExtra.IsTruncated,
+			tagsLen:     len(e.Msg.ParsingExtra.Tags),
+			tokensLen:   len(e.Tokens),
+		})
+	}
+	return out
+}
+
+// TestDetectingAggregator_NoLineCombination_Property anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee NoLineCombination — Every emitted
+//	                                    AggregatedMessageWithTokens
+//	                                    carries the content of
+//	                                    exactly one input message.
+//
+// Across arbitrary call sequences, the total number of emissions
+// (process across all calls + final flush) equals the total
+// number of input process calls. No input is dropped; no input
+// is folded into another's emission.
+func TestDetectingAggregator_NoLineCombination_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genDetectingCall(), 1, 12).Draw(t, "calls")
+		out := runDetectingCalls(100, false, calls)
+		if len(out) != len(calls) {
+			t.Fatalf("NoLineCombination violated: %d inputs produced %d emissions", len(calls), len(out))
+		}
+	})
+}
+
+// TestDetectingAggregator_Determinism_Property anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee Determinism — process, flush and is_empty are
+//	                              pure functions of the
+//	                              aggregator's current state plus
+//	                              their inputs.
+//
+// Two aggregators of identical configuration, fed identical
+// call sequences, produce equal observed emission sequences. The
+// per-call label dispatch and the rolling truncation carry are
+// both deterministic functions of inputs.
+func TestDetectingAggregator_Determinism_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genDetectingCall(), 1, 12).Draw(t, "calls")
+		lineLimit := rapid.IntRange(1, 100).Draw(t, "lineLimit")
+
+		outA := runDetectingCalls(lineLimit, false, calls)
+		outB := runDetectingCalls(lineLimit, false, calls)
+
+		if len(outA) != len(outB) {
+			t.Fatalf("Determinism violated: emission counts %d vs %d", len(outA), len(outB))
+		}
+		for i := range outA {
+			if outA[i] != outB[i] {
+				t.Fatalf("Determinism violated at emission %d: %+v vs %+v", i, outA[i], outB[i])
+			}
+		}
+	})
+}
+
+// TestDetectingAggregator_FlushClearsState_Property anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee FlushDrainsBuffer — After flush returns,
+//	                                    pending_message_present is
+//	                                    false.
+//	    @guarantee IsEmptyConsistency
+//
+// Across arbitrary call sequences, flush followed by is_empty
+// always yields true. Calling flush twice in a row produces an
+// empty second flush.
+func TestDetectingAggregator_FlushClearsState_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genDetectingCall(), 0, 12).Draw(t, "calls")
+		ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
+		for _, c := range calls {
+			ag.Process(newMessage(c.content), c.label, c.tokens)
+		}
+		ag.Flush()
+		if !ag.IsEmpty() {
+			t.Fatal("FlushDrainsBuffer violated: is_empty false after flush")
+		}
+		second := ag.Flush()
+		if len(second) != 0 {
+			t.Fatalf("FlushDrainsBuffer violated: second flush returned %d messages, expected 0", len(second))
+		}
+	})
+}

--- a/pkg/logs/internal/decoder/preprocessor/detecting_aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/detecting_aggregator_test.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package preprocessor contains auto multiline detection and aggregation logic.
+package preprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+)
+
+// Anchoring unit tests for the DetectingAggregation surface
+// declared in detecting_aggregator.allium. Each test names the
+// spec construct (@guarantee or @guidance step) it anchors so that
+// drift in either direction is easy to spot during review.
+//
+// Property tests for the same surface live in
+// detecting_aggregator_proptest_test.go. The bulk of the
+// scenario coverage (label dispatch, detection tagging, truncation
+// flow) lives in aggregator_test.go's Test_DetectingAggregator*
+// tests with their own anchoring docstrings; the tests in THIS
+// file cover guarantees those existing tests don't yet anchor.
+
+func newDetectingAggregator(_ *testing.T, lineLimit int, tagTruncated bool) Aggregator {
+	return NewDetectingAggregator(status.NewInfoRegistry(), lineLimit, tagTruncated, false)
+}
+
+// TestDetectingAggregator_LabelDriven anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee LabelDriven — output emissions are determined
+//	                              by the (label, state) tuple;
+//	                              contradicts LabelIgnored from
+//	                              PassThroughAggregator and
+//	                              RegexAggregator.
+//
+// Identical content delivered under different labels produces
+// observably different output sequences. This is the explicit
+// counter to PassThrough/Regex's LabelIgnored:
+//
+//   - "start_group" then "aggregate" → two emissions, first
+//     with the detection tag.
+//   - "no_aggregate" then "no_aggregate" → two emissions, no
+//     detection tag on either.
+//
+// The bytes-of-content are identical between runs; only the
+// label sequence differs. Anything but a label-observing
+// aggregator would emit identical outputs.
+func TestDetectingAggregator_LabelDriven(t *testing.T) {
+	const detectionTag = "auto_multiline_detected:true"
+
+	t.Run("start_group then aggregate emits with detection tag", func(t *testing.T) {
+		ag := newDetectingAggregator(t, 100, false)
+		require.Empty(t, processMsg(ag, newMessage("A"), startGroup))
+		msgs := processMsg(ag, newMessage("B"), aggregate)
+		require.Len(t, msgs, 2)
+		assert.Contains(t, msgs[0].ParsingExtra.Tags, detectionTag)
+		assert.NotContains(t, msgs[1].ParsingExtra.Tags, detectionTag)
+	})
+
+	t.Run("no_aggregate then no_aggregate emits without detection tag", func(t *testing.T) {
+		ag := newDetectingAggregator(t, 100, false)
+		first := processMsg(ag, newMessage("A"), noAggregate)
+		require.Len(t, first, 1)
+		assert.NotContains(t, first[0].ParsingExtra.Tags, detectionTag)
+		second := processMsg(ag, newMessage("B"), noAggregate)
+		require.Len(t, second, 1)
+		assert.NotContains(t, second[0].ParsingExtra.Tags, detectionTag)
+	})
+}
+
+// TestDetectingAggregator_NoLineCombination anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee NoLineCombination — Every emitted
+//	                                    AggregatedMessageWithTokens
+//	                                    carries the content of
+//	                                    exactly one input message.
+//	                                    DetectingAggregator never
+//	                                    combines content bytes from
+//	                                    multiple input lines into
+//	                                    one emission.
+//
+// Across a mixed-label sequence, total emissions (across all
+// process calls plus final flush) equals total input calls, and
+// each emission's trim-spaced content equals exactly one input's
+// trim-spaced content. No emission's content contains the
+// concatenation of multiple inputs.
+func TestDetectingAggregator_NoLineCombination(t *testing.T) {
+	ag := newDetectingAggregator(t, 100, false)
+
+	inputs := []struct {
+		content string
+		label   Label
+	}{
+		{"first", startGroup},
+		{"second", aggregate},
+		{"third", noAggregate},
+		{"fourth", startGroup},
+		{"fifth", aggregate},
+	}
+
+	var emitted []string
+	for _, in := range inputs {
+		for _, m := range processMsg(ag, newMessage(in.content), in.label) {
+			emitted = append(emitted, string(m.GetContent()))
+		}
+	}
+	for _, m := range flushMsgs(ag) {
+		emitted = append(emitted, string(m.GetContent()))
+	}
+
+	// Total emissions == total inputs.
+	require.Equal(t, len(inputs), len(emitted),
+		"total emissions must equal total input count (no combination, no drops)")
+
+	// Each emission's content equals exactly one input's content
+	// (in arrival order — DetectingAggregator preserves order).
+	for i, in := range inputs {
+		assert.Equal(t, in.content, emitted[i],
+			"emission %d must carry exactly one input's content; got %q expected %q", i, emitted[i], in.content)
+	}
+}
+
+// TestDetectingAggregator_TokensFromSameCall anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee TokensFromSameCall — The tokens emitted on each
+//	                                     AggregatedMessageWithTokens
+//	                                     are the tokens passed to
+//	                                     process alongside the SAME
+//	                                     input message whose
+//	                                     content the emission
+//	                                     carries.
+//
+// Distinct token sequences attached to each input call. After
+// the test runs, each emission's tokens match exactly the tokens
+// passed in the call whose content the emission carries — not
+// the call that triggered emission (when those differ, as in
+// start_group → aggregate).
+func TestDetectingAggregator_TokensFromSameCall(t *testing.T) {
+	ag := NewDetectingAggregator(status.NewInfoRegistry(), 100, false, false)
+
+	tokensA := []Token{D4, Space, C5}
+	tokensB := []Token{C5, Space, D1}
+	tokensC := []Token{D2}
+
+	// start_group A buffers, no emission.
+	emitted := ag.Process(newMessage("A"), startGroup, tokensA)
+	require.Empty(t, emitted)
+
+	// aggregate B emits A (with A's tokens, plus detection tag) then B (with B's tokens).
+	emitted = ag.Process(newMessage("B"), aggregate, tokensB)
+	require.Len(t, emitted, 2)
+	assert.Equal(t, tokensA, emitted[0].Tokens, "emission of buffered start_group must carry that call's tokens, not the triggering aggregate's tokens")
+	assert.Equal(t, tokensB, emitted[1].Tokens, "emission of aggregate must carry that call's tokens")
+
+	// no_aggregate C emits C (with C's tokens).
+	emitted = ag.Process(newMessage("C"), noAggregate, tokensC)
+	require.Len(t, emitted, 1)
+	assert.Equal(t, tokensC, emitted[0].Tokens)
+}
+
+// TestDetectingAggregator_FlushIdempotentOnEmpty anchors:
+//
+//	surface DetectingAggregation (detecting_aggregator.allium)
+//	    @guarantee FlushDrainsBuffer — A flush call on an aggregator
+//	                                    with no pending message
+//	                                    returns an empty sequence
+//	                                    and changes no observable
+//	                                    state.
+//
+// Second consecutive flush returns empty; is_empty remains true.
+func TestDetectingAggregator_FlushIdempotentOnEmpty(t *testing.T) {
+	ag := newDetectingAggregator(t, 100, false)
+
+	// Empty at construction.
+	assert.Empty(t, flushMsgs(ag))
+	assert.True(t, ag.IsEmpty())
+
+	// Buffer + flush.
+	require.Empty(t, processMsg(ag, newMessage("pending"), startGroup))
+	require.Len(t, flushMsgs(ag), 1)
+	assert.True(t, ag.IsEmpty())
+
+	// Second flush on already-empty.
+	assert.Empty(t, flushMsgs(ag))
+	assert.True(t, ag.IsEmpty())
+}


### PR DESCRIPTION
  What: Anchoring docstrings on 12 existing tests + 4 new gap unit tests + 3 property tests.

  - @guarantee MultiLineDetectionTag (the load-bearing asymmetry: tag on start_group, not on aggregate) — TestDetectingAggregator_TagsMultilineStartOnly (Unit, existing, anchored)
  - @guarantee MultiLineDetectionTag (negative case — start_group followed by another start_group) — TestDetectingAggregator_SingleLineNotTagged (Unit, existing, anchored)
  - @guidance step 3 (no_aggregate emits immediately) — TestDetectingAggregator_NoAggregateOutputsImmediately (Unit, existing, anchored)
  - @guarantee FlushDrainsBuffer + flush procedure (no detection tag on flush) — TestDetectingAggregator_FlushPendingMessage (Unit, existing, anchored)
  - @guidance per-label interleaving — TestDetectingAggregator_MixedSingleAndMultiLine (Unit, existing, anchored)
  - @guarantee IsEmptyConsistency — TestDetectingAggregator_IsEmpty (Unit, existing, anchored)
  - @guarantee SingleLineTruncationFlow + interaction with detection tag — TestDetectingAggregator_TruncatesTaggedStartLineAndPrefixesContinuation (Unit, existing, anchored)
  - @guarantee SingleLineTruncationFlow (carry across no_aggregate) — TestDetectingAggregator_NoAggregateInheritsTruncationCarry (Unit, existing, anchored)
  - @guarantee SingleLineTruncationFlow (carry crosses start_group buffer) — TestDetectingAggregator_StartGroupInheritsTruncationCarry (Unit, existing, anchored)
  - @guarantee SingleLineTruncationFlow (per-aggregator tag_truncated_logs = false) — TestDetectingAggregator_TruncationDoesNotTagWhenDisabled (Unit, existing, anchored)
  - @guidance SingleLineTruncationFlow step 1 (upstream-truncated flag) — TestDetectingAggregator_UsesExistingTruncatedFlag (Unit, existing, anchored)
  - @guidance SingleLineTruncationFlow step 2 (trim) — TestDetectingAggregator_TrimSpaceMatchesOtherAggregators (Unit, existing, anchored)
  - @guarantee LabelDriven (explicit comparison: different labels → different outputs) — TestDetectingAggregator_LabelDriven (Unit, 2 subtests)
  - @guarantee NoLineCombination (explicit input count = output count) — TestDetectingAggregator_NoLineCombination (Unit)
  - @guarantee TokensFromSameCall — TestDetectingAggregator_TokensFromSameCall (Unit)
  - @guarantee FlushDrainsBuffer (idempotent on empty) — TestDetectingAggregator_FlushIdempotentOnEmpty (Unit)
  - @guarantee NoLineCombination — TestDetectingAggregator_NoLineCombination_Property (Property)
  - @guarantee Determinism — TestDetectingAggregator_Determinism_Property (Property)
  - @guarantee FlushDrainsBuffer + IsEmptyConsistency — TestDetectingAggregator_FlushClearsState_Property (Property)

  Stack: parent cmetz/detecting_aggregator.
