### PR TITLE
anchor CombiningAggregator tests to spec

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/aggregator_test.go
@@ -63,6 +63,17 @@ func flushMsgs(ag Aggregator) []*message.Message {
 // aggregator's internal buffer and is only valid until the next Process/Flush call.
 // Tests must assert results before making the next call.
 
+// TestNoAggregate anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee NoAggregateFlushes — A process call with the
+//	                                     no_aggregate label flushes
+//	                                     any buffered bucket then
+//	                                     emits the current line.
+//
+// The simplest path: with an empty bucket, each no_aggregate call
+// flushes nothing (bucket was empty) and emits the current line
+// as single-line. Single-emission per call shape verified.
 func TestNoAggregate(t *testing.T) {
 	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
 
@@ -79,6 +90,21 @@ func TestNoAggregate(t *testing.T) {
 	assertMessageContent(t, msgs[0], "3")
 }
 
+// TestNoAggregateEndsGroup anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee NoAggregateFlushes — produces 1 or 2 emissions
+//	                                     per call: (bucket-flush
+//	                                     if non-empty) followed
+//	                                     by (current line).
+//	    @guarantee StartGroupBoundary — start_group flushes the
+//	                                     prior bucket and begins
+//	                                     a new one.
+//
+// Verifies both boundary-flushing labels: start_group flushes the
+// previously buffered start_group as combined (1 emission, since
+// buffer holds 1 line), then no_aggregate flushes the next
+// start_group AND emits its own line (2 emissions).
 func TestNoAggregateEndsGroup(t *testing.T) {
 	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
 
@@ -94,6 +120,20 @@ func TestNoAggregateEndsGroup(t *testing.T) {
 	assertMessageContent(t, msgs[1], "3")
 }
 
+// TestAggregateGroups anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee StartGroupBoundary — start_group flushes prior
+//	                                     bucket as combined.
+//	    @guarantee ByteConservation (refined) — combined emission
+//	                                             is concat with
+//	                                             escaped-line-feed
+//	                                             separator.
+//
+// Three lines aggregate into one bucket: startGroup + aggregate +
+// aggregate. The next startGroup flushes them as one combined
+// "1\\n2\\n3" message. Then a no_aggregate flushes "4" (single)
+// and emits "5".
 func TestAggregateGroups(t *testing.T) {
 	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
 
@@ -114,6 +154,16 @@ func TestAggregateGroups(t *testing.T) {
 	assertMessageContent(t, msgs[1], "5")
 }
 
+// TestAggregateDoesntStartGroup anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guidance step 3 — If label = aggregate AND bucket_empty:
+//	                       add msg to the bucket, flush_bucket
+//	                       immediately. Emits as single-line.
+//
+// An aggregate label on an empty bucket does NOT start a new group
+// — it emits the line as a single-line message immediately, same
+// shape as no_aggregate (modulo the carry-reset semantic).
 func TestAggregateDoesntStartGroup(t *testing.T) {
 	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
 
@@ -175,6 +225,16 @@ func TestSingleLineKeepsOwnTimestamp(t *testing.T) {
 	assert.Equal(t, ts1, msgs[0].ParsingExtra.Timestamp)
 }
 
+// TestForceFlush anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee FlushDrainsBuffer — external Flush() emits the
+//	                                    buffered bucket as combined.
+//
+// A bucket containing startGroup + 2 aggregates is drained by an
+// external Flush() call into one combined emission. Tests that
+// flush is a valid externally-triggered emission path (not just
+// the per-label dispatch).
 func TestForceFlush(t *testing.T) {
 	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
 
@@ -187,6 +247,24 @@ func TestForceFlush(t *testing.T) {
 	assertMessageContent(t, msgs[0], "1\\n2\\n3")
 }
 
+// TestTagTruncatedLogs anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee TruncationTagging — truncated emissions get
+//	                                    "single_line" reason tag
+//	                                    when tag_truncated_logs.
+//	    @guarantee OverflowExplosion — aggregate continuation that
+//	                                    would overflow explodes
+//	                                    the bucket.
+//	    @guarantee NoAggregateResetsCarry — no_aggregate resets
+//	                                         should_truncate to
+//	                                         false before processing.
+//
+// Comprehensive truncation scenario test: oversized start_group is
+// flushed and tagged single_line; following aggregate inherits the
+// carry; an aggregate-on-empty path; then overflow explosion
+// emits buffered lines individually; finally no_aggregate clears
+// the carry — "00" emerges untruncated.
 func TestTagTruncatedLogs(t *testing.T) {
 	ag := NewCombiningAggregator(10, true, false, status.NewInfoRegistry())
 
@@ -240,6 +318,18 @@ func TestTagTruncatedLogs(t *testing.T) {
 	assertMessageContent(t, msgs[0], "00")
 }
 
+// TestSingleGroupOverflowStopsAggregation anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee OverflowExplosion — buffered lines are emitted
+//	                                    INDIVIDUALLY (not combined+
+//	                                    truncated) when aggregate
+//	                                    continuation would overflow.
+//
+// The defining test for OverflowExplosion: line_limit=8,
+// "123" + "456" would combine to "123\\n456" = 8 bytes ≥ 8.
+// Verifies that BOTH lines come out intact and untagged — the
+// combined message is NEVER produced.
 func TestSingleGroupOverflowStopsAggregation(t *testing.T) {
 	ag := NewCombiningAggregator(8, true, false, status.NewInfoRegistry())
 
@@ -259,6 +349,18 @@ func TestSingleGroupOverflowStopsAggregation(t *testing.T) {
 	assertMessageContent(t, msgs[1], "456")
 }
 
+// TestOverflowedGroupEmitsOriginalTokens anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee TokensFromAggregateLeader — exploded emissions
+//	                                            carry their own
+//	                                            line's tokens (not
+//	                                            a leader's).
+//
+// In the explosion path, each emission's tokens are those passed
+// in the call that buffered that line. The first emission has the
+// start_group's tokens, the second has the aggregate continuation's
+// tokens — they don't all share the leader's.
 func TestOverflowedGroupEmitsOriginalTokens(t *testing.T) {
 	ag := NewCombiningAggregator(8, false, false, status.NewInfoRegistry())
 
@@ -273,6 +375,19 @@ func TestOverflowedGroupEmitsOriginalTokens(t *testing.T) {
 	assert.Equal(t, secondTokens, completed[1].Tokens)
 }
 
+// TestSingleLineTruncatedLogIsTaggedSingleLine anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee TruncationTagging — single-line emissions get
+//	                                    "single_line" reason tag.
+//	    @guidance step 4c — start_group whose RawDataLen >=
+//	                        line_limit triggers immediate
+//	                        single-line flush.
+//
+// A startGroup with content exactly at line_limit triggers the
+// immediate-flush path. Verifies it's tagged "single_line"
+// (not "auto_multiline" — even though it went through a
+// multi-line-capable aggregator).
 func TestSingleLineTruncatedLogIsTaggedSingleLine(t *testing.T) {
 	ag := NewCombiningAggregator(5, true, false, status.NewInfoRegistry())
 
@@ -290,6 +405,19 @@ func TestSingleLineTruncatedLogIsTaggedSingleLine(t *testing.T) {
 	assertMessageContent(t, msgs[0], "...TRUNCATED...456")
 }
 
+// TestTagMultiLineLogs anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee OverflowExplosion — emission of overflowed
+//	                                    group does NOT receive
+//	                                    multi-line tag (each
+//	                                    exploded line is single).
+//
+// Counter-test for MultiLineTagging: even with
+// tag_multi_line_logs=true, the explosion path produces
+// individually emitted lines, none of which are flagged
+// is_multi_line or tagged "auto_multiline". The multi-line
+// signal requires an actual combined emission.
 func TestTagMultiLineLogs(t *testing.T) {
 	ag := NewCombiningAggregator(12, false, true, status.NewInfoRegistry())
 
@@ -322,6 +450,25 @@ func TestTagMultiLineLogs(t *testing.T) {
 	assertMessageContent(t, msgs[0], "2")
 }
 
+// TestSingleLineTooLongTruncation anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee NoAggregateResetsCarry — no_aggregate resets
+//	                                         should_truncate
+//	                                         before processing
+//	                                         (the JSON-protection
+//	                                         semantic).
+//	    @guarantee TruncationTagging (rolling carry behaviour)
+//
+// Three phases of single-line truncation cases:
+//  1. Aggregation overflow leaves no carry (exploded lines aren't
+//     marked truncated by the explosion itself).
+//  2. Consecutive oversized single-line emissions chain via the
+//     should_truncate carry, producing prepended-and-appended
+//     markers in the middle.
+//  3. A no_aggregate clears the carry — even with carry set from
+//     prior emission, the no_aggregate line emerges with no
+//     prepended marker. This is the JSON-protection guarantee.
 func TestSingleLineTooLongTruncation(t *testing.T) {
 	ag := NewCombiningAggregator(5, false, true, status.NewInfoRegistry())
 
@@ -892,8 +1039,19 @@ func TestDetectingAggregator_TrimSpaceMatchesOtherAggregators(t *testing.T) {
 	}
 }
 
-// Verify that PassThroughAggregator and CombiningAggregator already handle trailing
-// whitespace correctly (they call bytes.TrimSpace), serving as the baseline.
+// TestPassThroughAndCombiningAggregator_TrimSpaceBaseline anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guidance flush_bucket / emit_single — trim-space the
+//	                                            combined / single
+//	                                            content.
+//	(plus the analogous step in PassThroughAggregation —
+//	anchored from this same test for the PassThrough side.)
+//
+// Verifies that both PassThroughAggregator and CombiningAggregator
+// trim trailing whitespace (notably \r from windows-style framing).
+// The aggregators' shared use of bytes.TrimSpace before emission
+// ensures the JSON-pattern regex matches.
 func TestPassThroughAndCombiningAggregator_TrimSpaceBaseline(t *testing.T) {
 	jsonPattern := regexp.MustCompile(`^\{.*\}$`)
 	contentWithCR := `{"key":"val"}` + "\r"

--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator_proptest_test.go
@@ -1,0 +1,232 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package preprocessor
+
+import (
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+)
+
+// Property tests for the CombiningAggregation surface declared in
+// combining_aggregator.allium. Each test names the spec
+// @guarantee it anchors so that drift in either direction is easy
+// to spot during review.
+//
+// Anchoring unit tests for the same surface live in
+// combining_aggregator_test.go and aggregator_test.go.
+
+type combiningCall struct {
+	content string
+	label   Label
+	tokens  []Token
+}
+
+func genCombiningCall() *rapid.Generator[combiningCall] {
+	return rapid.Custom(func(t *rapid.T) combiningCall {
+		content := string(rapid.SliceOfN(
+			rapid.SampledFrom([]byte("abc 012")),
+			0, 20,
+		).Draw(t, "content"))
+		label := rapid.SampledFrom([]Label{startGroup, noAggregate, aggregate}).Draw(t, "label")
+		nTokens := rapid.IntRange(0, 4).Draw(t, "nTokens")
+		tokens := make([]Token, nTokens)
+		for i := 0; i < nTokens; i++ {
+			tokens[i] = Token(rapid.IntRange(0, int(End)-1).Draw(t, "token"))
+		}
+		return combiningCall{content: content, label: label, tokens: tokens}
+	})
+}
+
+// combiningEmission captures one emitted message's observable state.
+type combiningEmission struct {
+	content     string
+	isTruncated bool
+	isMultiLine bool
+	tagsLen     int
+	tokensLen   int
+}
+
+func runCombiningCalls(lineLimit int, tagTrunc, tagMulti bool, calls []combiningCall) []combiningEmission {
+	ag := NewCombiningAggregator(lineLimit, tagTrunc, tagMulti, status.NewInfoRegistry())
+	var out []combiningEmission
+	for _, c := range calls {
+		emitted := ag.Process(newMessage(c.content), c.label, c.tokens)
+		for _, e := range emitted {
+			out = append(out, combiningEmission{
+				content:     string(e.Msg.GetContent()),
+				isTruncated: e.Msg.ParsingExtra.IsTruncated,
+				isMultiLine: e.Msg.ParsingExtra.IsMultiLine,
+				tagsLen:     len(e.Msg.ParsingExtra.Tags),
+				tokensLen:   len(e.Tokens),
+			})
+		}
+	}
+	for _, e := range ag.Flush() {
+		out = append(out, combiningEmission{
+			content:     string(e.Msg.GetContent()),
+			isTruncated: e.Msg.ParsingExtra.IsTruncated,
+			isMultiLine: e.Msg.ParsingExtra.IsMultiLine,
+			tagsLen:     len(e.Msg.ParsingExtra.Tags),
+			tokensLen:   len(e.Tokens),
+		})
+	}
+	return out
+}
+
+// TestCombiningAggregator_Determinism_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee Determinism
+//
+// Two aggregators of identical configuration, fed identical call
+// sequences, produce equal observed emission sequences.
+func TestCombiningAggregator_Determinism_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genCombiningCall(), 1, 12).Draw(t, "calls")
+		lineLimit := rapid.IntRange(1, 100).Draw(t, "lineLimit")
+
+		outA := runCombiningCalls(lineLimit, false, false, calls)
+		outB := runCombiningCalls(lineLimit, false, false, calls)
+
+		if len(outA) != len(outB) {
+			t.Fatalf("Determinism violated: emission counts %d vs %d", len(outA), len(outB))
+		}
+		for i := range outA {
+			if outA[i] != outB[i] {
+				t.Fatalf("Determinism violated at emission %d: %+v vs %+v", i, outA[i], outB[i])
+			}
+		}
+	})
+}
+
+// TestCombiningAggregator_FlushClearsBucket_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee FlushDrainsBuffer — after flush, bucket_empty
+//	                                    is true.
+//	    @guarantee IsEmptyConsistency
+//
+// Across arbitrary call sequences, flush followed by is_empty
+// always yields true. A second flush returns empty.
+func TestCombiningAggregator_FlushClearsBucket_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genCombiningCall(), 0, 12).Draw(t, "calls")
+		ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+		for _, c := range calls {
+			ag.Process(newMessage(c.content), c.label, c.tokens)
+		}
+		ag.Flush()
+		if !ag.IsEmpty() {
+			t.Fatal("FlushDrainsBuffer violated: is_empty false after flush")
+		}
+		second := ag.Flush()
+		if len(second) != 0 {
+			t.Fatalf("FlushDrainsBuffer violated: second flush returned %d messages, expected 0", len(second))
+		}
+	})
+}
+
+// TestCombiningAggregator_NoCombinedOverflow_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee OverflowExplosion — CombiningAggregator never
+//	                                    produces a combined
+//	                                    emission whose body
+//	                                    crosses line_limit purely
+//	                                    because of multi-line
+//	                                    aggregation.
+//
+// The strong form: across arbitrary call sequences with arbitrary
+// line_limits, no emission's content (minus markers) exceeds
+// line_limit when the emission is multi-line (is_multi_line set).
+// A 2+ line combined emission staying under line_limit is the
+// observable manifestation of OverflowExplosion's "abandon
+// combination rather than truncate-combine" policy.
+func TestCombiningAggregator_NoCombinedOverflow_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genCombiningCall(), 1, 12).Draw(t, "calls")
+		// line_limit must be big enough to fit at least small inputs,
+		// otherwise everything goes through the oversize-single-line
+		// paths and the multi-line case never fires. >= 20 covers
+		// typical small generated content.
+		lineLimit := rapid.IntRange(20, 200).Draw(t, "lineLimit")
+
+		ag := NewCombiningAggregator(lineLimit, false, false, status.NewInfoRegistry())
+		marker := string(message.TruncatedFlag)
+		check := func(emitted []AggregatedMessageWithTokens) {
+			for _, e := range emitted {
+				if !e.Msg.ParsingExtra.IsMultiLine {
+					continue
+				}
+				body := strings.TrimPrefix(string(e.Msg.GetContent()), marker)
+				body = strings.TrimSuffix(body, marker)
+				if len(body) >= lineLimit {
+					t.Fatalf("NoCombinedOverflow violated: multi-line emission body %d bytes >= line_limit %d (content %q)",
+						len(body), lineLimit, e.Msg.GetContent())
+				}
+			}
+		}
+		for _, c := range calls {
+			check(ag.Process(newMessage(c.content), c.label, c.tokens))
+		}
+		check(ag.Flush())
+	})
+}
+
+// TestCombiningAggregator_NoAggregateClearsCarry_Property anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee NoAggregateResetsCarry — no_aggregate resets
+//	                                         should_truncate to
+//	                                         false before
+//	                                         processing.
+//
+// The observable manifestation: across arbitrary inputs, a
+// no_aggregate-labelled line whose content fits within line_limit
+// and is not upstream-flagged never emerges with a prepended
+// truncation marker — even if the prior emission set the carry.
+//
+// We construct a deterministic preamble that sets the carry (an
+// oversized startGroup), then sample a no_aggregate continuation.
+// The no_aggregate line must not have the prepend marker.
+func TestCombiningAggregator_NoAggregateClearsCarry_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lineLimit := rapid.IntRange(8, 50).Draw(t, "lineLimit")
+		// Construct fitting content for the no_aggregate line: must
+		// be <= line_limit and not upstream-flagged.
+		contentLen := rapid.IntRange(1, lineLimit).Draw(t, "contentLen")
+		content := strings.Repeat("x", contentLen)
+		ag := NewCombiningAggregator(lineLimit, false, false, status.NewInfoRegistry())
+
+		// Set the carry: oversized startGroup. Forces an immediate
+		// single-line truncated emission and leaves should_truncate
+		// set to true.
+		oversized := strings.Repeat("y", lineLimit*2)
+		msg := newMessage(oversized)
+		msg.RawDataLen = len(oversized)
+		first := ag.Process(msg, startGroup, nil)
+		if len(first) != 1 {
+			return // skip degenerate cases where startGroup doesn't immediately flush
+		}
+
+		// no_aggregate next: should NOT receive the prepended marker.
+		nextMsg := newMessage(content)
+		nextMsg.RawDataLen = len(content)
+		emitted := ag.Process(nextMsg, noAggregate, nil)
+		if len(emitted) != 1 {
+			t.Fatalf("expected 1 emission for fitting no_aggregate, got %d", len(emitted))
+		}
+		emittedContent := string(emitted[0].Msg.GetContent())
+		if strings.HasPrefix(emittedContent, string(message.TruncatedFlag)) {
+			t.Fatalf("NoAggregateResetsCarry violated: no_aggregate emission has prepended marker (content=%q)", emittedContent)
+		}
+	})
+}

--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator_test.go
@@ -1,0 +1,238 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package preprocessor contains auto multiline detection and aggregation logic.
+package preprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
+)
+
+// Anchoring unit tests for the CombiningAggregation surface
+// declared in combining_aggregator.allium. Each test names the
+// spec construct (@guarantee or @guidance step) it anchors so that
+// drift in either direction is easy to spot during review.
+//
+// Property tests for the same surface live in
+// combining_aggregator_proptest_test.go. The bulk of the scenario
+// coverage (per-label dispatch, overflow explosion, truncation
+// flow, carry semantics) lives in aggregator_test.go's
+// CombiningAggregator-related tests with their own anchoring
+// docstrings; the tests in THIS file cover guarantees those
+// existing tests don't yet anchor.
+
+// TestCombiningAggregator_TokensFromAggregateLeader_Combined anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee TokensFromAggregateLeader — A combined
+//	                                            emission's tokens
+//	                                            are the tokens of
+//	                                            the FIRST line of
+//	                                            the bucket.
+//
+// On the combined-flush path (NOT the explosion path which the
+// existing TestOverflowedGroupEmitsOriginalTokens covers), the
+// emitted message's tokens are exactly the start_group leader's
+// tokens — not the last continuation's, not a concatenation.
+func TestCombiningAggregator_TokensFromAggregateLeader_Combined(t *testing.T) {
+	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+
+	leaderTokens := []Token{D4, Space, C5}
+	continuationTokens := []Token{C5, Space, D1}
+
+	// Build a 2-line bucket via startGroup + aggregate.
+	require.Empty(t, ag.Process(newMessage("leader"), startGroup, leaderTokens))
+	require.Empty(t, ag.Process(newMessage("cont"), aggregate, continuationTokens))
+
+	// Force flush → combined emission.
+	emitted := ag.Flush()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, leaderTokens, emitted[0].Tokens,
+		"combined emission must carry the leader's tokens, not the continuation's")
+}
+
+// TestCombiningAggregator_MultiLineTagAttached anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee MultiLineTagging — A combined emission of two
+//	                                   or more lines receives the
+//	                                   multi-line source tag with
+//	                                   value "auto_multiline" —
+//	                                   gated by tag_multi_line_logs.
+//
+// With tag_multi_line_logs = true and a 2-line bucket, the
+// flushed combined message has the multi-line tag and the
+// is_multi_line flag set.
+func TestCombiningAggregator_MultiLineTagAttached(t *testing.T) {
+	ag := NewCombiningAggregator(100, false, true, status.NewInfoRegistry())
+
+	require.Empty(t, processMsg(ag, newMessage("leader"), startGroup))
+	require.Empty(t, processMsg(ag, newMessage("cont"), aggregate))
+
+	msgs := flushMsgs(ag)
+	require.Len(t, msgs, 1)
+	assert.True(t, msgs[0].ParsingExtra.IsMultiLine, "is_multi_line must be set on a 2+ line combined emission")
+	assert.Contains(t, msgs[0].ParsingExtra.Tags, message.MultiLineSourceTag("auto_multiline"),
+		"multi-line source tag with 'auto_multiline' value must be attached when tag_multi_line_logs is true")
+}
+
+// TestCombiningAggregator_MultiLineTagNotAttachedSingleLine anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee MultiLineTagging (negative case) — A combined
+//	                                                   emission of
+//	                                                   exactly one
+//	                                                   line does
+//	                                                   NOT receive
+//	                                                   the
+//	                                                   multi-line
+//	                                                   tag.
+//
+// A bucket with only one line (a lonely start_group, flushed
+// via external flush) does not receive the multi-line tag even
+// when tag_multi_line_logs is enabled. The bucket_lines_count > 1
+// guard holds.
+func TestCombiningAggregator_MultiLineTagNotAttachedSingleLine(t *testing.T) {
+	ag := NewCombiningAggregator(100, false, true, status.NewInfoRegistry())
+
+	require.Empty(t, processMsg(ag, newMessage("solo"), startGroup))
+
+	msgs := flushMsgs(ag)
+	require.Len(t, msgs, 1)
+	assert.False(t, msgs[0].ParsingExtra.IsMultiLine, "is_multi_line must be false for single-line combined emission")
+	assert.NotContains(t, msgs[0].ParsingExtra.Tags, message.MultiLineSourceTag("auto_multiline"),
+		"multi-line tag must NOT be attached to a single-line emission even with tag_multi_line_logs enabled")
+}
+
+// TestCombiningAggregator_MultiLineTagNotAttachedConfigDisabled anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee MultiLineTagging (config gating) — The tag is
+//	                                                   gated by
+//	                                                   tag_multi_line_logs.
+//	                                                   is_multi_line
+//	                                                   flag is set
+//	                                                   regardless.
+//
+// With tag_multi_line_logs = false but a 2-line combined emission,
+// the tag is absent — but is_multi_line is still set on the
+// emitted message.
+func TestCombiningAggregator_MultiLineTagNotAttachedConfigDisabled(t *testing.T) {
+	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+
+	require.Empty(t, processMsg(ag, newMessage("leader"), startGroup))
+	require.Empty(t, processMsg(ag, newMessage("cont"), aggregate))
+
+	msgs := flushMsgs(ag)
+	require.Len(t, msgs, 1)
+	assert.True(t, msgs[0].ParsingExtra.IsMultiLine, "is_multi_line is set independently of the tag config")
+	assert.NotContains(t, msgs[0].ParsingExtra.Tags, message.MultiLineSourceTag("auto_multiline"),
+		"multi-line tag must NOT be attached when tag_multi_line_logs is disabled")
+}
+
+// TestCombiningAggregator_IsEmptyConsistency anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee IsEmptyConsistency — is_empty reflects
+//	                                     bucket_empty exactly.
+//
+// Walks state transitions and asserts IsEmpty's value at each step:
+// true at construction, true after no_aggregate (no buffering),
+// false during a buffered start_group, true after flush.
+func TestCombiningAggregator_IsEmptyConsistency(t *testing.T) {
+	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+
+	assert.True(t, ag.IsEmpty(), "construction")
+
+	processMsg(ag, newMessage("first"), noAggregate)
+	assert.True(t, ag.IsEmpty(), "after no_aggregate (never buffered)")
+
+	require.Empty(t, processMsg(ag, newMessage("leader"), startGroup))
+	assert.False(t, ag.IsEmpty(), "while start_group is buffered")
+
+	processMsg(ag, newMessage("cont"), aggregate)
+	assert.False(t, ag.IsEmpty(), "while aggregate is added to bucket")
+
+	flushMsgs(ag)
+	assert.True(t, ag.IsEmpty(), "after explicit flush")
+}
+
+// TestCombiningAggregator_LabelDriven anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee LabelDriven — output is determined by (label,
+//	                              state) — contradicting
+//	                              LabelIgnored from
+//	                              PassThroughAggregator and
+//	                              RegexAggregator.
+//
+// Identical content delivered under different label sequences
+// produces observably different output sequences. Anything but a
+// label-observing aggregator would emit identical outputs.
+//
+// Comparison: ("A" start_group, "B" aggregate) → 0 emissions
+// then 0 emissions, flush produces 1 combined emission "A\\nB".
+// Versus ("A" no_aggregate, "B" no_aggregate) → 2 separate
+// emissions, flush produces 0.
+func TestCombiningAggregator_LabelDriven(t *testing.T) {
+	t.Run("startGroup then aggregate combines", func(t *testing.T) {
+		ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+		assert.Empty(t, processMsg(ag, newMessage("A"), startGroup))
+		assert.Empty(t, processMsg(ag, newMessage("B"), aggregate))
+		msgs := flushMsgs(ag)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, "A\\nB", string(msgs[0].GetContent()))
+	})
+
+	t.Run("no_aggregate then no_aggregate stays separate", func(t *testing.T) {
+		ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+		first := processMsg(ag, newMessage("A"), noAggregate)
+		require.Len(t, first, 1)
+		assert.Equal(t, "A", string(first[0].GetContent()))
+		second := processMsg(ag, newMessage("B"), noAggregate)
+		require.Len(t, second, 1)
+		assert.Equal(t, "B", string(second[0].GetContent()))
+		// Nothing left to flush.
+		assert.Empty(t, flushMsgs(ag))
+	})
+}
+
+// TestCombiningAggregator_FlushIdempotentOnEmpty anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee FlushDrainsBuffer — A flush call on an empty
+//	                                    bucket returns an empty
+//	                                    sequence and changes no
+//	                                    observable state.
+//
+// Second consecutive flush returns empty; is_empty remains true.
+// flush after no_aggregate (which itself flushes) returns empty.
+func TestCombiningAggregator_FlushIdempotentOnEmpty(t *testing.T) {
+	ag := NewCombiningAggregator(100, false, false, status.NewInfoRegistry())
+
+	// Empty at construction.
+	assert.Empty(t, flushMsgs(ag))
+	assert.True(t, ag.IsEmpty())
+
+	// Buffer + flush.
+	require.Empty(t, processMsg(ag, newMessage("pending"), startGroup))
+	require.Len(t, flushMsgs(ag), 1)
+	assert.True(t, ag.IsEmpty())
+
+	// Second flush.
+	assert.Empty(t, flushMsgs(ag))
+	assert.True(t, ag.IsEmpty())
+
+	// Flush after no_aggregate (no_aggregate already drained the bucket).
+	processMsg(ag, newMessage("standalone"), noAggregate)
+	assert.Empty(t, flushMsgs(ag))
+	assert.True(t, ag.IsEmpty())
+}

--- a/pkg/logs/internal/decoder/preprocessor/combining_aggregator_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/combining_aggregator_test.go
@@ -205,6 +205,66 @@ func TestCombiningAggregator_LabelDriven(t *testing.T) {
 	})
 }
 
+// TestCombiningAggregator_AutoMultilineReasonViaCarry anchors:
+//
+//	surface CombiningAggregation (combining_aggregator.allium)
+//	    @guarantee TruncationTagging — "auto_multiline" reason
+//	                                    fires on combined flushes
+//	                                    (lines > 1) that have ANY
+//	                                    truncation applied,
+//	                                    including via the
+//	                                    prepended carry from a
+//	                                    prior single-line oversize
+//	                                    emission.
+//
+// Sequence:
+//
+//  1. Oversize start_group flushes immediately with append marker
+//     and sets should_truncate = true.
+//  2. Smaller start_group buffers (no flush).
+//  3. Aggregate that fits is added to the bucket (now 2 lines).
+//  4. External flush emits the combined message with the
+//     PREPEND marker (inherited carry) and the "auto_multiline"
+//     truncation-reason tag — even though the combined content
+//     itself is well under line_limit.
+//
+// This exercises the dispatch-reachable "auto_multiline" reason
+// path (carry-driven) — distinct from the structurally-present
+// but dispatch-unreachable append-on-combined-overflow path
+// noted in the spec.
+func TestCombiningAggregator_AutoMultilineReasonViaCarry(t *testing.T) {
+	ag := NewCombiningAggregator(10, true, false, status.NewInfoRegistry())
+
+	// Phase 1: oversize start_group sets the carry.
+	first := processMsg(ag, newMessage("1234567890"), startGroup)
+	require.Len(t, first, 1)
+	require.True(t, first[0].ParsingExtra.IsTruncated)
+	require.Equal(t, []string{message.TruncatedReasonTag("single_line")}, first[0].ParsingExtra.Tags,
+		"phase-1 emission must be tagged single_line (lineCount=1)")
+
+	// Phase 2: build a 2-line bucket with content well under line_limit.
+	require.Empty(t, processMsg(ag, newMessage("ab"), startGroup))
+	require.Empty(t, processMsg(ag, newMessage("cd"), aggregate))
+
+	// Phase 3: external flush emits the combined message — carry
+	// drives the prepend marker, lineCount=2 selects auto_multiline.
+	flushed := flushMsgs(ag)
+	require.Len(t, flushed, 1)
+	assert.True(t, flushed[0].ParsingExtra.IsTruncated, "combined flush following carry must have is_truncated set")
+	assert.True(t, flushed[0].ParsingExtra.IsMultiLine, "combined flush with 2+ lines is multi-line")
+	assert.Contains(t, flushed[0].ParsingExtra.Tags, message.TruncatedReasonTag("auto_multiline"),
+		"combined flush carrying truncation must use auto_multiline reason (not single_line)")
+	assert.NotContains(t, flushed[0].ParsingExtra.Tags, message.TruncatedReasonTag("single_line"),
+		"combined flush must NOT receive the single_line reason — auto_multiline overrides")
+
+	// Sanity: the combined content has the prepend marker (carry)
+	// but NOT an appended marker (combined content fits in
+	// line_limit, per OverflowExplosion).
+	emitted := string(flushed[0].GetContent())
+	assert.Equal(t, string(message.TruncatedFlag)+"ab\\ncd", emitted,
+		"combined emission has prepend marker (from carry) but not append (would_overflow_bucket prevented it)")
+}
+
 // TestCombiningAggregator_FlushIdempotentOnEmpty anchors:
 //
 //	surface CombiningAggregation (combining_aggregator.allium)


### PR DESCRIPTION
  What: Anchoring docstrings on 12 existing tests + 7 new gap unit tests + 4 property tests.

  - @guarantee NoAggregateFlushes (degenerate empty-bucket case) — TestNoAggregate (Unit, existing, anchored)
  - @guarantee NoAggregateFlushes (2-emission shape) + StartGroupBoundary — TestNoAggregateEndsGroup (Unit, existing, anchored)
  - @guarantee StartGroupBoundary + ByteConservation (separator) — TestAggregateGroups (Unit, existing, anchored)
  - @guidance step 3 (aggregate-on-empty single-line emit) — TestAggregateDoesntStartGroup (Unit, existing, anchored)
  - @guarantee FlushDrainsBuffer (external Flush()) — TestForceFlush (Unit, existing, anchored)
  - @guarantee TruncationTagging (single_line) + OverflowExplosion + NoAggregateResetsCarry — TestTagTruncatedLogs (Unit, existing, anchored)
  - @guarantee OverflowExplosion (defining test) — TestSingleGroupOverflowStopsAggregation (Unit, existing, anchored)
  - @guarantee TokensFromAggregateLeader (explosion path; each emission carries own tokens) — TestOverflowedGroupEmitsOriginalTokens (Unit, existing, anchored)
  - @guarantee TruncationTagging + @guidance step 4c (oversized start_group → immediate flush, single_line reason) — TestSingleLineTruncatedLogIsTaggedSingleLine (Unit, existing, anchored)
  - @guarantee OverflowExplosion (counter-test: explosion path doesn't get multi-line tag) — TestTagMultiLineLogs (Unit, existing, anchored)
  - @guarantee NoAggregateResetsCarry (3-phase comprehensive truncation) — TestSingleLineTooLongTruncation (Unit, existing, anchored)
  - @guidance flush_bucket / emit_single (trim) — TestPassThroughAndCombiningAggregator_TrimSpaceBaseline (Unit, existing, anchored — CombiningAggregator side)
  - @guarantee TokensFromAggregateLeader (combined path) — TestCombiningAggregator_TokensFromAggregateLeader_Combined (Unit)
  - @guarantee MultiLineTagging (2+ lines + config enabled) — TestCombiningAggregator_MultiLineTagAttached (Unit)
  - @guarantee MultiLineTagging (single-line + config enabled, tag absent) — TestCombiningAggregator_MultiLineTagNotAttachedSingleLine (Unit)
  - @guarantee MultiLineTagging (2+ lines + config disabled) — TestCombiningAggregator_MultiLineTagNotAttachedConfigDisabled (Unit)
  - @guarantee IsEmptyConsistency (state transitions) — TestCombiningAggregator_IsEmptyConsistency (Unit)
  - @guarantee LabelDriven — TestCombiningAggregator_LabelDriven (Unit, 2 subtests)
  - @guarantee FlushDrainsBuffer (idempotent on empty) — TestCombiningAggregator_FlushIdempotentOnEmpty (Unit)
  - @guarantee TruncationTagging (auto_multiline reason via carry) — TestCombiningAggregator_AutoMultilineReasonViaCarry (Unit)
  - @guarantee Determinism — TestCombiningAggregator_Determinism_Property (Property)
  - @guarantee FlushDrainsBuffer + IsEmptyConsistency — TestCombiningAggregator_FlushClearsBucket_Property (Property)
  - @guarantee OverflowExplosion (no combined emission's body crosses line_limit) — TestCombiningAggregator_NoCombinedOverflow_Property (Property)
  - @guarantee NoAggregateResetsCarry — TestCombiningAggregator_NoAggregateClearsCarry_Property (Property)

  Stack: parent cmetz/combining_aggregator.