### PR TITLE
refactor AdaptiveSampler to fulfil Sampler contract

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -8,16 +8,20 @@
 --   matching a pattern are emitted while the bucket has credit,
 --   dropped otherwise. New patterns are discovered and added to a
 --   bounded table; when the table is full, the least-frequently-
---   matched pattern is evicted. Used by log sources that opt into
---   adaptive sampling to bound per-pattern throughput while
---   preserving signal from low-frequency patterns.
+--   matched pattern is evicted. When the protect_important_logs
+--   option is enabled, messages whose token sequence contains a
+--   critical-severity keyword bypass rate limiting entirely.
+--   Used by log sources that opt into adaptive sampling to bound
+--   per-pattern throughput while preserving signal from low-
+--   frequency patterns and from severity-critical events.
 -- Includes: The PatternMatching sub-contract (specific to
 --   pattern-based samplers; not lifted to a shared module yet),
 --   the AdaptiveSampler entity, the PatternEntry per-pattern
---   state entity, config, the 4 rules driving the emit/drop/
---   register/evict per-message lifecycle, the 5 expression
---   invariants on PatternEntries state, fulfilment of the Sampler
---   contract at the AdaptiveSampling surface.
+--   state entity, config, the 5 rules driving the
+--   important-bypass / emit / drop / register / evict per-message
+--   lifecycle, the 5 expression invariants on PatternEntries
+--   state, fulfilment of the Sampler contract at the
+--   AdaptiveSampling surface.
 -- Excludes:
 --   - The Sampler contract itself. It lives in sampler.allium and
 --     is imported here to declare fulfilment.
@@ -122,11 +126,49 @@ config {
     -- Maximum bytes of the log message's first line to tokenize.
     -- Bytes beyond this offset are ignored by the tokenizer.
     tokenizer_max_input_bytes: Integer = 2048
+
+    -- When true, messages whose token sequence contains a
+    -- critical-severity keyword (FATAL, ERROR, PANIC, etc.)
+    -- bypass rate limiting entirely. See is_important in the
+    -- AdaptiveSampling surface's @guidance for the predicate's
+    -- scope. When false, severity has no effect on sampling
+    -- decisions and the standard 4 rules apply uniformly.
+    protect_important_logs: Boolean = false
 }
 
 ------------------------------------------------------------
 -- Rules
 ------------------------------------------------------------
+
+-- A critical-severity log bypasses the entire sampler when
+-- protect_important_logs is enabled. The message is emitted
+-- unconditionally; no pattern entry is created, no entry's state
+-- is updated, no credits are consumed. Pattern discovery and rate
+-- limiting do not apply to important logs.
+
+rule ImportantLogBypass {
+    when: ProcessLog(message, incoming)
+    requires: config.protect_important_logs
+    requires: is_important(incoming)
+
+    ensures: LogEmitted(message, sampled_count: 0)
+
+    @guidance
+        -- The is_important predicate is treated as an opaque pure
+        -- function of the input token sequence. The implementation
+        -- checks for critical-severity keyword tokens (FATAL,
+        -- ERROR, PANIC, ALERT, SEVERE, CRITICAL, EMERGENCY, WARN,
+        -- EXCEPTION, CRASH, FAILURE, DEADLOCK, TIMEOUT) — see
+        -- isImportant in sampler.go.
+        --
+        -- The bypass takes precedence over all four pattern-table
+        -- rules below (their requires clauses exclude this case
+        -- explicitly). Pattern table state is wholly untouched —
+        -- an important log with no matching pattern does not
+        -- register a new entry, and a matching pattern's
+        -- match_count, credits, last_seen and sampled_count are
+        -- left as they were.
+}
 
 -- A log matches an existing pattern and has sufficient credits
 -- to be emitted. If logs were suppressed since the last emit for
@@ -134,6 +176,7 @@ config {
 
 rule EmitMatchingLog {
     when: ProcessLog(message, incoming)
+    requires: not (config.protect_important_logs and is_important(incoming))
 
     let matches = filter(PatternEntries, e => is_match(e.signature, incoming, config.match_threshold))
     requires: matches.count > 0
@@ -174,6 +217,7 @@ rule EmitMatchingLog {
 
 rule DropMatchingLog {
     when: ProcessLog(message, incoming)
+    requires: not (config.protect_important_logs and is_important(incoming))
 
     let matches = filter(PatternEntries, e => is_match(e.signature, incoming, config.match_threshold))
     requires: matches.count > 0
@@ -205,6 +249,7 @@ rule DropMatchingLog {
 
 rule RegisterNewPattern {
     when: ProcessLog(message, incoming)
+    requires: not (config.protect_important_logs and is_important(incoming))
     requires: not PatternEntries.any(e => is_match(e.signature, incoming, config.match_threshold))
     requires: PatternEntries.count < config.max_patterns
 
@@ -230,6 +275,7 @@ rule RegisterNewPattern {
 
 rule EvictAndRegisterPattern {
     when: ProcessLog(message, incoming)
+    requires: not (config.protect_important_logs and is_important(incoming))
     requires: not PatternEntries.any(e => is_match(e.signature, incoming, config.match_threshold))
     requires: PatternEntries.count >= config.max_patterns
 
@@ -318,25 +364,32 @@ surface AdaptiveSampling {
 
     @guarantee Determinism
         -- The Sampler contract's Determinism invariant holds:
-        -- process is rule-driven, and the 4 rules
-        -- (EmitMatchingLog, DropMatchingLog, RegisterNewPattern,
-        -- EvictAndRegisterPattern) partition the (incoming, state)
-        -- input space via mutually-exclusive requires clauses.
-        -- Each rule's ensures clauses are deterministic functions
-        -- of pre-state and inputs. The seconds_elapsed,
-        -- is_match, max_by and min_by primitives are pure.
+        -- process is rule-driven, and the 5 rules
+        -- (ImportantLogBypass, EmitMatchingLog, DropMatchingLog,
+        -- RegisterNewPattern, EvictAndRegisterPattern) partition
+        -- the (incoming, state, config) input space via mutually-
+        -- exclusive requires clauses. Each rule's ensures clauses
+        -- are deterministic functions of pre-state and inputs.
+        -- The seconds_elapsed, is_match, is_important, max_by
+        -- and min_by primitives are pure.
 
     @guarantee Totality
         -- The Sampler contract's Totality invariant holds: every
-        -- (incoming, state) input matches the preconditions of
-        -- exactly one rule, so process always terminates with a
+        -- (incoming, state, config) input matches the preconditions
+        -- of exactly one rule, so process always terminates with a
         -- defined verdict — either LogEmitted (returning the
         -- input message, possibly tagged) or LogDropped
-        -- (returning null). The 4 rules cover the cases:
+        -- (returning null). The 5 rules cover the cases:
+        --   (protect_important_logs AND is_important)           → ImportantLogBypass
         --   (matches existing pattern AND credits sufficient)   → EmitMatchingLog
         --   (matches existing pattern AND credits insufficient) → DropMatchingLog
         --   (no match AND table has capacity)                   → RegisterNewPattern
         --   (no match AND table full)                           → EvictAndRegisterPattern
+        --
+        -- The four pattern-table rules each carry a
+        -- `not (config.protect_important_logs and is_important(incoming))`
+        -- guard, making them mutually exclusive with
+        -- ImportantLogBypass.
 
     @guarantee ContentBytePassthrough
         -- The Sampler contract's ContentBytePassthrough invariant
@@ -387,11 +440,38 @@ surface AdaptiveSampling {
         -- the steady-state replenishment. Equivalently, in
         -- steady state after the initial burst, a pattern emits
         -- at most config.rate_limit logs per second.
+        --
+        -- This bound applies only to messages that go through
+        -- the pattern-table rules. Messages flowing through
+        -- ImportantLogBypass are not counted against any
+        -- pattern's rate limit — see ImportantLogProtection.
+
+    @guarantee ImportantLogProtection
+        -- When config.protect_important_logs is true, a message
+        -- whose token sequence satisfies the is_important
+        -- predicate is ALWAYS emitted, regardless of pattern
+        -- table state and regardless of any pattern's credit
+        -- balance. Guaranteed by the ImportantLogBypass rule's
+        -- unconditional `ensures: LogEmitted(...)`.
+        --
+        -- The bypass is non-disruptive: pattern table state is
+        -- entirely unaffected (no entry is created, no entry's
+        -- credits / match_count / sampled_count / last_seen is
+        -- updated). Important logs do not contribute to pattern
+        -- discovery; a critical-severity event observed under
+        -- bypass does not register a new pattern. (This means a
+        -- pattern matching the same shape may still be
+        -- discovered later via a non-important message of the
+        -- same shape.)
+        --
+        -- When config.protect_important_logs is false, the
+        -- predicate has no effect — the four pattern-table rules
+        -- apply uniformly regardless of severity.
 
     @guarantee FlushNoop
         -- flush always returns null. AdaptiveSampler does not
         -- buffer messages — every input is decided immediately
-        -- by one of the 4 rules. The Sampler contract's flush
+        -- by one of the 5 rules. The Sampler contract's flush
         -- observable is provided here as a structural
         -- requirement, not a behavioural one.
 
@@ -400,9 +480,9 @@ surface AdaptiveSampling {
         -- contract operations:
         --
         -- process(msg, tokens) corresponds to firing exactly one
-        -- of the 4 rules in this module — EmitMatchingLog,
-        -- DropMatchingLog, RegisterNewPattern, or
-        -- EvictAndRegisterPattern — chosen by the mutually
+        -- of the 5 rules in this module — ImportantLogBypass,
+        -- EmitMatchingLog, DropMatchingLog, RegisterNewPattern,
+        -- or EvictAndRegisterPattern — chosen by the mutually
         -- exclusive requires clauses. Each rule's
         -- `ensures: LogEmitted(message, ...)` corresponds to
         -- returning the input message from process (with the
@@ -410,6 +490,15 @@ surface AdaptiveSampling {
         -- prior_sampled_count > 0). `ensures: LogDropped(message)`
         -- corresponds to returning null. The `incoming` parameter
         -- of ProcessLog is the tokens argument to process.
+        --
+        -- The is_important predicate referenced in
+        -- ImportantLogBypass is an opaque pure function over the
+        -- input token sequence; semantically it returns true iff
+        -- the sequence contains a critical-severity keyword
+        -- token. The implementation enumerates the keywords in
+        -- isImportant (sampler.go); the spec treats the predicate
+        -- as a black box because severity-keyword tokenization is
+        -- a tokenizer concern, not a sampler concern.
         --
         -- flush corresponds to a no-op in this implementation —
         -- there is no buffer to drain, so the surface observable

--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler.allium
@@ -1,23 +1,44 @@
 -- allium: 3
 -- adaptive_sampler.allium
 
-use "./tokenizer.allium" as tokenizer
-
--- Scope: Adaptive sampling behaviour for one log source in the
---   Datadog Agent's logs preprocessor pipeline.
--- Includes: Pattern matching contract over token sequences (imported
---   from tokenizer.allium), credit-based rate limiting, pattern table
---   management (creation, eviction, ordering), sampled-count metadata
---   tagging.
+-- Scope: A Sampler implementation that applies credit-based rate
+--   limiting per discovered log pattern. Pattern identity is
+--   defined by token-sequence similarity (the PatternMatching
+--   sub-contract). Each pattern carries a token bucket; messages
+--   matching a pattern are emitted while the bucket has credit,
+--   dropped otherwise. New patterns are discovered and added to a
+--   bounded table; when the table is full, the least-frequently-
+--   matched pattern is evicted. Used by log sources that opt into
+--   adaptive sampling to bound per-pattern throughput while
+--   preserving signal from low-frequency patterns.
+-- Includes: The PatternMatching sub-contract (specific to
+--   pattern-based samplers; not lifted to a shared module yet),
+--   the AdaptiveSampler entity, the PatternEntry per-pattern
+--   state entity, config, the 4 rules driving the emit/drop/
+--   register/evict per-message lifecycle, the 5 expression
+--   invariants on PatternEntries state, fulfilment of the Sampler
+--   contract at the AdaptiveSampling surface.
 -- Excludes:
---   - Tokenization (lifted to tokenizer.allium and imported here as
---     `tokenizer/TokenSequence`)
---   - Preprocessor pipeline orchestration (JSON aggregation, multiline
---     labeling and combining, aggregation strategies upstream of sampling)
---   - Decoder configuration resolution and per-source sampler instantiation
---   - Message framing, parsing, and raw content handling
---   - Telemetry counter emissions (dropped, kept, new_patterns, evictions)
---   - NoopSampler (trivial pass-through when sampling is disabled)
+--   - The Sampler contract itself. It lives in sampler.allium and
+--     is imported here to declare fulfilment.
+--   - Tokenization (lifted to tokenizer.allium and imported as
+--     `tokenizer/TokenSequence`).
+--   - Other Sampler implementations. NoopSampler is a trivial
+--     pass-through whose behaviour is described at the Sampler
+--     contract level — its fulfiller is either inlined or
+--     specified separately as a one-line module.
+--   - Preprocessor pipeline orchestration (JSON aggregation,
+--     multi-line labelling and combining, aggregation strategies
+--     upstream of sampling).
+--   - Decoder configuration resolution and per-source sampler
+--     instantiation.
+--   - Message framing, parsing, and raw content handling.
+--   - Telemetry counter emissions (dropped, kept, new_patterns,
+--     evictions, protected). Observability only, no behavioural
+--     effect.
+
+use "./tokenizer.allium" as tokenizer
+use "./sampler.allium" as sampler
 
 ------------------------------------------------------------
 -- Contracts
@@ -56,6 +77,15 @@ contract PatternMatching {
 -- Entities
 ------------------------------------------------------------
 
+entity AdaptiveSampler {
+    -- A configured AdaptiveSampler instance. One per log source
+    -- that uses adaptive sampling. The source field is the
+    -- per-source identifier matching the telemetry source tag
+    -- used by counters; the bulk of behavioural state lives in
+    -- the PatternEntries collection and the module-level config.
+    source: String
+}
+
 entity PatternEntry {
     -- A structural class of log messages tracked in the sampler's
     -- pattern table. Each entry represents one known pattern
@@ -66,9 +96,6 @@ entity PatternEntry {
     last_seen: Timestamp
     match_count: Integer
     sampled_count: Integer
-
-    -- Derived
-    is_exhausted: credits < 1.0
 }
 
 ------------------------------------------------------------
@@ -267,33 +294,130 @@ invariant SampledCountNonNegative {
         entry.sampled_count >= 0
 }
 
--- Behavioural properties not expressible as state predicates
--- but guaranteed by the rules above:
---
--- NewPatternsAlwaysEmitted: the first log of a never-before-seen
---   pattern is always emitted. Guaranteed by RegisterNewPattern and
---   EvictAndRegisterPattern which emit unconditionally. Follows from
---   burst_size >= 1 (validated at construction).
---
--- MessageContentIntegrity: the sampler never modifies log content
---   bytes. Emitted messages are byte-identical to their input.
---   Only metadata (adaptive_sampler_sampled_count tag) may be added.
---
--- SteadyStateRateBound: after burst exhaustion, a pattern emits
---   at most rate_limit logs per second. Over interval T seconds,
---   at most burst_size + rate_limit * T logs of one pattern are
---   emitted (burst_size for the initial allowance, then rate_limit
---   per second in steady state).
-
 ------------------------------------------------------------
--- Deferred Specifications
+-- Surfaces
 ------------------------------------------------------------
 
-deferred "ValidateMatchThreshold"
-    -- The adaptive sampler must reject match_threshold values
-    -- outside (0, 1] at construction time. A threshold of 0 would
-    -- match everything regardless of token content, defeating
-    -- pattern discrimination. The UserSamples path already enforces
-    -- this range (user_samples.go); the same validation needs to be
-    -- added when match_threshold is wired up as user-configurable
-    -- for the adaptive sampler.
+surface AdaptiveSampling {
+    -- The boundary between the preprocessor pipeline and one
+    -- AdaptiveSampler instance. The pipeline invokes process and
+    -- flush per the Sampler contract; this surface supplies the
+    -- pattern-based credit-driven semantics described by the 4
+    -- rules above.
+
+    context sampler: AdaptiveSampler
+
+    exposes:
+        sampler.source
+
+    provides:
+        ProcessLog(message, incoming)
+
+    contracts:
+        fulfils Sampler
+
+    @guarantee Determinism
+        -- The Sampler contract's Determinism invariant holds:
+        -- process is rule-driven, and the 4 rules
+        -- (EmitMatchingLog, DropMatchingLog, RegisterNewPattern,
+        -- EvictAndRegisterPattern) partition the (incoming, state)
+        -- input space via mutually-exclusive requires clauses.
+        -- Each rule's ensures clauses are deterministic functions
+        -- of pre-state and inputs. The seconds_elapsed,
+        -- is_match, max_by and min_by primitives are pure.
+
+    @guarantee Totality
+        -- The Sampler contract's Totality invariant holds: every
+        -- (incoming, state) input matches the preconditions of
+        -- exactly one rule, so process always terminates with a
+        -- defined verdict — either LogEmitted (returning the
+        -- input message, possibly tagged) or LogDropped
+        -- (returning null). The 4 rules cover the cases:
+        --   (matches existing pattern AND credits sufficient)   → EmitMatchingLog
+        --   (matches existing pattern AND credits insufficient) → DropMatchingLog
+        --   (no match AND table has capacity)                   → RegisterNewPattern
+        --   (no match AND table full)                           → EvictAndRegisterPattern
+
+    @guarantee ContentBytePassthrough
+        -- The Sampler contract's ContentBytePassthrough invariant
+        -- holds: each rule's `ensures: LogEmitted(message, ...)`
+        -- references the original input message symbol; the rules
+        -- never construct a new content body, and they do not
+        -- mutate the message's content bytes. Emitted messages
+        -- are byte-identical to their inputs.
+
+    @guarantee TagAugmentationOnly
+        -- The Sampler contract's TagAugmentationOnly invariant
+        -- holds: the only tag the AdaptiveSampler may append is
+        -- "adaptive_sampler_sampled_count:N", added by
+        -- EmitMatchingLog when prior_sampled_count > 0. Existing
+        -- tags on the input message are preserved verbatim.
+
+    @guarantee NoMessageFabrication
+        -- The Sampler contract's NoMessageFabrication invariant
+        -- holds: every LogEmitted ensures clause references the
+        -- `message` bound by the ProcessLog trigger — the input
+        -- message of that specific process call. No rule
+        -- synthesises a Message value.
+
+    @guarantee TokenAware
+        -- Pattern classification uses the tokens argument to
+        -- process via is_match(entry.signature, incoming,
+        -- config.match_threshold). The sampler's decision is
+        -- functionally determined by the (incoming tokens,
+        -- pattern table state) tuple — content bytes do not
+        -- enter the decision logic.
+
+    @guarantee FirstLogAlwaysEmitted
+        -- A log whose token sequence does not match any
+        -- currently-tracked pattern is ALWAYS emitted. Guaranteed
+        -- by RegisterNewPattern and EvictAndRegisterPattern, both
+        -- of which have unconditional `ensures: LogEmitted(...)`
+        -- clauses. (Follows structurally from burst_size >= 1,
+        -- validated at construction, which ensures the new
+        -- pattern's initial credit budget allows the first emit
+        -- without consulting credit balance.)
+
+    @guarantee SteadyStateRateBound
+        -- Over an interval of T seconds, the count of emitted
+        -- messages matching any single pattern is bounded by
+        -- config.burst_size + config.rate_limit * T. The
+        -- burst_size term is the initial allowance available
+        -- during pattern discovery; the rate_limit * T term is
+        -- the steady-state replenishment. Equivalently, in
+        -- steady state after the initial burst, a pattern emits
+        -- at most config.rate_limit logs per second.
+
+    @guarantee FlushNoop
+        -- flush always returns null. AdaptiveSampler does not
+        -- buffer messages — every input is decided immediately
+        -- by one of the 4 rules. The Sampler contract's flush
+        -- observable is provided here as a structural
+        -- requirement, not a behavioural one.
+
+    @guidance
+        -- Bridging the rule-based representation to the typed
+        -- contract operations:
+        --
+        -- process(msg, tokens) corresponds to firing exactly one
+        -- of the 4 rules in this module — EmitMatchingLog,
+        -- DropMatchingLog, RegisterNewPattern, or
+        -- EvictAndRegisterPattern — chosen by the mutually
+        -- exclusive requires clauses. Each rule's
+        -- `ensures: LogEmitted(message, ...)` corresponds to
+        -- returning the input message from process (with the
+        -- adaptive_sampler_sampled_count tag appended when
+        -- prior_sampled_count > 0). `ensures: LogDropped(message)`
+        -- corresponds to returning null. The `incoming` parameter
+        -- of ProcessLog is the tokens argument to process.
+        --
+        -- flush corresponds to a no-op in this implementation —
+        -- there is no buffer to drain, so the surface observable
+        -- always reads null. See FlushNoop above.
+}
+
+------------------------------------------------------------
+-- Open Questions
+------------------------------------------------------------
+
+open question "match_threshold has no construction-time validation. A value of 0 would match everything regardless of token content, defeating pattern discrimination. The UserSamples path (user_samples.go) already enforces a (0, 1] range; the same validation needs to be added in NewAdaptiveSampler when match_threshold becomes user-configurable. Until then this is a latent foot-gun for anyone wiring up a custom AdaptiveSamplerConfig."


### PR DESCRIPTION
  What: Refactors the existing adaptive_sampler.allium to declare fulfils Sampler against the new contract. Adds a thin AdaptiveSampler entity + AdaptiveSampling surface with 9 @guarantees. Also: structural
  cleanups (reorder header, remove unused is_exhausted field, convert deferred-spec to open question because Allium 3's deferred location-hint syntax is unsupported), and adds a previously-missing rule:
  ImportantLogBypass.

  Spec gap fixed mid-stream: the original spec didn't model the production ProtectImportantLogs behaviour. Adding ImportantLogBypass + the not (config.protect_important_logs and is_important(incoming)) guard on the
   four pattern-table rules + a new @guarantee ImportantLogProtection brings the spec to parity with the Go implementation.

  All tested in cmetz/adaptive_sampler_tests.

  Inherited from Sampler:
  - @guarantee Determinism, Totality, ContentBytePassthrough, TagAugmentationOnly, NoMessageFabrication

  Surface-specific:
  - @guarantee TokenAware — pattern classification via tokens
  - @guarantee FirstLogAlwaysEmitted — new patterns always emit
  - @guarantee SteadyStateRateBound — quantitative: ≤ burst_size + rate_limit * T per pattern over interval T
  - @guarantee ImportantLogProtection — critical-severity bypass (is_important predicate; non-disruptive to pattern table)
  - @guarantee FlushNoop — flush always returns null

  Existing constructs retained:
  - contract PatternMatching (internal sub-contract)
  - entity PatternEntry + 5 expression invariants
  - config block + 4 rules (Emit/Drop/Register/Evict) + new ImportantLogBypass rule

  Stack: parent cmetz/sampler_contract. Child cmetz/adaptive_sampler_tests.
