### PR TITLE
anchor AdaptiveSampler tests to spec

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler_proptest_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler_proptest_test.go
@@ -1,0 +1,309 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package preprocessor
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// Property tests for the AdaptiveSampling surface declared in
+// adaptive_sampler.allium. Each test names the spec @guarantee or
+// @invariant it anchors so that drift in either direction is easy
+// to spot during review.
+//
+// Anchoring unit tests for the same surface live in
+// adaptive_sampler_test.go and sampler_test.go.
+
+// samplerCall bundles one process call's worth of input.
+type samplerCall struct {
+	content         []byte
+	tokens          []Token
+	inputTags       []string
+	advanceMs       int64
+	isImportantCall bool // when true, draw an ERROR-tagged token sequence
+}
+
+// genSamplerCall produces one call. The token sequences are drawn
+// from a small pool of structurally-distinct patterns plus the
+// option to embed an ERROR token (driving the is_important
+// predicate true) so generated sequences exercise the
+// ImportantLogBypass branch alongside the pattern-table rules.
+func genSamplerCall() *rapid.Generator[samplerCall] {
+	return rapid.Custom(func(t *rapid.T) samplerCall {
+		content := rapid.SliceOfN(rapid.Byte(), 0, 40).Draw(t, "content")
+		patternChoice := rapid.IntRange(0, 2).Draw(t, "patternChoice")
+		var tokens []Token
+		switch patternChoice {
+		case 0:
+			tokens = tokenize("2024-01-15 10:30:45 INFO request id=123")
+		case 1:
+			tokens = tokenize("metric cpu_usage=45.67 host=web-01")
+		default:
+			tokens = tokenize("http GET /api/users 200 42ms")
+		}
+		isImp := rapid.Bool().Draw(t, "isImportant")
+		if isImp {
+			// Replace with an ERROR-tagged token sequence to drive
+			// the is_important predicate true.
+			tokens = tokenize("ERROR something went wrong with the operation")
+		}
+		// Optional input tags drawn from a small pool — exercises
+		// TagAugmentationOnly's "preserve existing tags" half.
+		tagCount := rapid.IntRange(0, 2).Draw(t, "tagCount")
+		tags := make([]string, tagCount)
+		for i := 0; i < tagCount; i++ {
+			tags[i] = rapid.SampledFrom([]string{"env:prod", "service:web", "team:platform"}).Draw(t, "tag")
+		}
+		advance := rapid.IntRange(0, 5000).Draw(t, "advanceMs")
+		return samplerCall{
+			content:         content,
+			tokens:          tokens,
+			inputTags:       tags,
+			advanceMs:       int64(advance),
+			isImportantCall: isImp,
+		}
+	})
+}
+
+// newSamplerForProptest builds a sampler with a deterministic
+// clock injected via the now field. The clock advances on each
+// call by the call's advanceMs amount; this gives rapid control
+// over the credit-refill behaviour without real time.
+func newSamplerForProptest(burst, rateLimit float64, protect bool) *AdaptiveSampler {
+	s := NewAdaptiveSampler(AdaptiveSamplerConfig{
+		MaxPatterns:          10,
+		RateLimit:            rateLimit,
+		BurstSize:            burst,
+		MatchThreshold:       0.9,
+		ProtectImportantLogs: protect,
+	}, "proptest")
+	t0 := time.Now()
+	s.now = func() time.Time { return t0 }
+	return s
+}
+
+// runOneCall feeds one generated call into the sampler and returns
+// whether the message was emitted (non-nil result), the emitted
+// message's tag set (or nil if dropped), and a copy of the
+// content bytes (or nil if dropped).
+//
+// The clock advance for the call is applied BEFORE the Process
+// invocation, modelling time elapsed since the last call.
+func runOneCall(s *AdaptiveSampler, t0 time.Time, totalElapsed *time.Duration, call samplerCall) (emitted bool, tags []string, content []byte) {
+	*totalElapsed += time.Duration(call.advanceMs) * time.Millisecond
+	elapsed := *totalElapsed
+	s.now = func() time.Time { return t0.Add(elapsed) }
+	msg := message.NewMessage(append([]byte(nil), call.content...), nil, message.StatusInfo, 0)
+	msg.ParsingExtra.Tags = append([]string(nil), call.inputTags...)
+	out := s.Process(msg, call.tokens)
+	if out == nil {
+		return false, nil, nil
+	}
+	return true, append([]string(nil), out.ParsingExtra.Tags...), append([]byte(nil), out.GetContent()...)
+}
+
+// TestAdaptiveSampler_Determinism_Property anchors:
+//
+//	surface AdaptiveSampling (adaptive_sampler.allium)
+//	    @guarantee Determinism
+//
+// Two samplers with identical configuration, fed identical
+// (call sequence, clock schedule) inputs, produce identical
+// emission decisions and identical emitted-tag sets.
+func TestAdaptiveSampler_Determinism_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genSamplerCall(), 1, 12).Draw(t, "calls")
+		burst := rapid.Float64Range(1.0, 5.0).Draw(t, "burst")
+		rateLimit := rapid.Float64Range(0, 3).Draw(t, "rateLimit")
+		protect := rapid.Bool().Draw(t, "protect")
+
+		runSampler := func() (decisions []bool, tagSets [][]string) {
+			s := newSamplerForProptest(burst, rateLimit, protect)
+			t0 := time.Now()
+			s.now = func() time.Time { return t0 }
+			var elapsed time.Duration
+			for _, c := range calls {
+				emitted, tags, _ := runOneCall(s, t0, &elapsed, c)
+				decisions = append(decisions, emitted)
+				tagSets = append(tagSets, tags)
+			}
+			return
+		}
+
+		decA, tagsA := runSampler()
+		decB, tagsB := runSampler()
+
+		if len(decA) != len(decB) {
+			t.Fatalf("Determinism violated: emission counts %d vs %d", len(decA), len(decB))
+		}
+		for i := range decA {
+			if decA[i] != decB[i] {
+				t.Fatalf("Determinism violated at call %d: emit decision %v vs %v", i, decA[i], decB[i])
+			}
+			if !stringSlicesEqualAsSet(tagsA[i], tagsB[i]) {
+				t.Fatalf("Determinism violated at call %d: tag sets %v vs %v", i, tagsA[i], tagsB[i])
+			}
+		}
+	})
+}
+
+// TestAdaptiveSampler_ContentBytePassthrough_Property anchors:
+//
+//	contract Sampler (sampler.allium)
+//	    @invariant ContentBytePassthrough — when process returns a
+//	                                         Message, the returned
+//	                                         Message's content
+//	                                         bytes equal the input
+//	                                         msg's content bytes.
+//
+// For arbitrary inputs, every non-null emission preserves the
+// content bytes exactly.
+func TestAdaptiveSampler_ContentBytePassthrough_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genSamplerCall(), 1, 8).Draw(t, "calls")
+		s := newSamplerForProptest(3.0, 1.0, true)
+		t0 := time.Now()
+		s.now = func() time.Time { return t0 }
+		var elapsed time.Duration
+
+		for _, c := range calls {
+			emitted, _, content := runOneCall(s, t0, &elapsed, c)
+			if emitted && !bytes.Equal(content, c.content) {
+				t.Fatalf("ContentBytePassthrough violated: input %q → output %q", c.content, content)
+			}
+		}
+	})
+}
+
+// TestAdaptiveSampler_TagAugmentationOnly_Property anchors:
+//
+//	contract Sampler (sampler.allium)
+//	    @invariant TagAugmentationOnly — returned message's tags
+//	                                      are a superset of the
+//	                                      input msg's tags; the
+//	                                      only tag the sampler may
+//	                                      append is
+//	                                      "adaptive_sampler_sampled_count:N".
+//
+// Across arbitrary inputs: every emitted message's tag set is a
+// superset of the input's tag set, and any added tags are
+// adaptive_sampler_sampled_count tags.
+func TestAdaptiveSampler_TagAugmentationOnly_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genSamplerCall(), 1, 8).Draw(t, "calls")
+		s := newSamplerForProptest(2.0, 0.5, false)
+		t0 := time.Now()
+		s.now = func() time.Time { return t0 }
+		var elapsed time.Duration
+
+		for _, c := range calls {
+			emitted, outTags, _ := runOneCall(s, t0, &elapsed, c)
+			if !emitted {
+				continue
+			}
+			for _, inTag := range c.inputTags {
+				if !containsString(outTags, inTag) {
+					t.Fatalf("TagAugmentationOnly violated: input tag %q missing from emitted tags %v", inTag, outTags)
+				}
+			}
+			for _, outTag := range outTags {
+				if containsString(c.inputTags, outTag) {
+					continue
+				}
+				if !strings.HasPrefix(outTag, "adaptive_sampler_sampled_count:") {
+					t.Fatalf("TagAugmentationOnly violated: emitted tag %q is neither an input tag nor an adaptive_sampler_sampled_count tag", outTag)
+				}
+			}
+		}
+	})
+}
+
+// TestAdaptiveSampler_FlushAlwaysNil_Property anchors:
+//
+//	surface AdaptiveSampling (adaptive_sampler.allium)
+//	    @guarantee FlushNoop — flush always returns null.
+//
+// After any sequence of Process calls, Flush returns nil.
+// AdaptiveSampler has no buffer to drain.
+func TestAdaptiveSampler_FlushAlwaysNil_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genSamplerCall(), 0, 10).Draw(t, "calls")
+		s := newSamplerForProptest(3.0, 1.0, true)
+		t0 := time.Now()
+		s.now = func() time.Time { return t0 }
+		var elapsed time.Duration
+		for _, c := range calls {
+			runOneCall(s, t0, &elapsed, c)
+		}
+		if got := s.Flush(); got != nil {
+			t.Fatalf("FlushNoop violated: flush returned non-nil message (content=%q)", got.GetContent())
+		}
+	})
+}
+
+// TestAdaptiveSampler_ImportantLogProtection_Property anchors:
+//
+//	surface AdaptiveSampling (adaptive_sampler.allium)
+//	    @guarantee ImportantLogProtection — when protection is
+//	                                         enabled, important
+//	                                         logs always emit
+//	                                         regardless of pattern
+//	                                         table state.
+//
+// With protect_important_logs enabled, every call carrying an
+// important token sequence emits. Pattern entry count never
+// changes for important calls (the bypass is non-disruptive).
+func TestAdaptiveSampler_ImportantLogProtection_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		calls := rapid.SliceOfN(genSamplerCall(), 1, 8).Draw(t, "calls")
+		s := newSamplerForProptest(1.0, 0, true) // tight: burst=1 no refill
+		t0 := time.Now()
+		s.now = func() time.Time { return t0 }
+		var elapsed time.Duration
+
+		for i, c := range calls {
+			entryCountBefore := len(s.entries)
+			emitted, _, _ := runOneCall(s, t0, &elapsed, c)
+			if c.isImportantCall {
+				if !emitted {
+					t.Fatalf("ImportantLogProtection violated at call %d: important log dropped", i)
+				}
+				if len(s.entries) != entryCountBefore {
+					t.Fatalf("ImportantLogProtection violated at call %d: pattern table size changed (%d → %d) on important log",
+						i, entryCountBefore, len(s.entries))
+				}
+			}
+		}
+	})
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSlicesEqualAsSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for _, x := range a {
+		if !containsString(b, x) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/logs/internal/decoder/preprocessor/adaptive_sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/adaptive_sampler_test.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package preprocessor contains auto multiline detection and aggregation logic.
+package preprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// Anchoring unit tests for the AdaptiveSampling surface declared
+// in adaptive_sampler.allium. Each test names the spec construct
+// (@guarantee, rule, or @invariant) it anchors so that drift in
+// either direction is easy to spot during review.
+//
+// Property tests for the same surface live in
+// adaptive_sampler_proptest_test.go. The bulk of the scenario
+// coverage (per-rule behaviour, credit refill, eviction,
+// important-log protection) lives in sampler_test.go with its own
+// anchoring docstrings; the tests in THIS file cover Sampler
+// contract invariants those existing tests don't yet anchor.
+
+// TestAdaptiveSampler_ContentBytePassthrough_Emit anchors:
+//
+//	contract Sampler (sampler.allium)
+//	    @invariant ContentBytePassthrough — when process returns
+//	                                         a Message value, the
+//	                                         returned Message's
+//	                                         content bytes are
+//	                                         byte-equal to the
+//	                                         input msg's content
+//	                                         bytes.
+//
+// The sampler returns the input message pointer on emit (verified
+// via assert.Same — strictly stronger than byte equality, since
+// pointer identity implies the message's content is necessarily
+// preserved unless the sampler explicitly mutates it via
+// SetContent). AdaptiveSampler never calls SetContent.
+func TestAdaptiveSampler_ContentBytePassthrough_Emit(t *testing.T) {
+	s := newSampler(10, 5.0, 0)
+	msg := message.NewMessage([]byte("original content bytes"), nil, message.StatusInfo, 0)
+	out := s.Process(msg, patternA)
+	require.NotNil(t, out)
+	assert.Same(t, msg, out, "emitted message must be the input message pointer")
+	assert.Equal(t, []byte("original content bytes"), out.GetContent(),
+		"emitted content bytes must equal input content bytes")
+}
+
+// TestAdaptiveSampler_TagAugmentationOnly_PreservesInputTags anchors:
+//
+//	contract Sampler (sampler.allium)
+//	    @invariant TagAugmentationOnly — returned message's tags
+//	                                      are a superset of the
+//	                                      input msg's tags.
+//
+// Pre-existing tags on the input message survive sampling
+// unchanged. The sampler may APPEND adaptive_sampler_sampled_count
+// but never removes or modifies existing tags.
+func TestAdaptiveSampler_TagAugmentationOnly_PreservesInputTags(t *testing.T) {
+	s := newSampler(10, 5.0, 0)
+	msg := testMsg()
+	msg.ParsingExtra.Tags = []string{"upstream:tag1", "upstream:tag2"}
+
+	out := s.Process(msg, patternA)
+	require.NotNil(t, out)
+	assert.Contains(t, out.ParsingExtra.Tags, "upstream:tag1",
+		"existing tags must be preserved on emit")
+	assert.Contains(t, out.ParsingExtra.Tags, "upstream:tag2",
+		"existing tags must be preserved on emit")
+}
+
+// TestAdaptiveSampler_NoMessageFabrication anchors:
+//
+//	contract Sampler (sampler.allium)
+//	    @invariant NoMessageFabrication — every Message value
+//	                                       returned by process
+//	                                       originates from a
+//	                                       message previously
+//	                                       supplied to process.
+//
+// Every non-nil emission has pointer identity to the input message
+// of that specific process call. AdaptiveSampler never constructs
+// a Message value.
+func TestAdaptiveSampler_NoMessageFabrication(t *testing.T) {
+	s := newSampler(10, 5.0, 0)
+
+	for i := range 3 {
+		_ = i
+		msg := testMsg()
+		out := s.Process(msg, patternA)
+		if out != nil {
+			assert.Same(t, msg, out, "emitted message must be identical to the input of this process call")
+		}
+	}
+}
+
+// TestAdaptiveSampler_DropReturnsNil anchors:
+//
+//	contract Sampler (sampler.allium)
+//	    @invariant Totality — process returns either a Message
+//	                           or null.
+//	rule DropMatchingLog (adaptive_sampler.allium)
+//	    ensures: LogDropped(message)  →  null return from process
+//
+// A drop emission is exactly the null return — not a returned
+// message with is_dropped set, not an empty message. Pin the
+// null-return shape as a named anchor.
+func TestAdaptiveSampler_DropReturnsNil(t *testing.T) {
+	s := newSampler(10, 1.0, 0) // burst=1, no refill
+	require.NotNil(t, s.Process(testMsg(), patternA), "first message creates pattern, emits")
+	out := s.Process(testMsg(), patternA)
+	assert.Nil(t, out, "drop emission must be exactly nil")
+}

--- a/pkg/logs/internal/decoder/preprocessor/sampler_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/sampler_test.go
@@ -72,6 +72,17 @@ var (
 
 // --- NoopSampler ---
 
+// TestNoopSampler_AlwaysPassesThrough anchors:
+//
+//	contract Sampler (sampler.allium)
+//	    @invariant ContentBytePassthrough — returned message has
+//	                                         the same bytes as input.
+//	    @invariant NoMessageFabrication — output is either an input
+//	                                       message or null.
+//
+// NoopSampler is the trivial Sampler fulfiller: it returns the
+// input message pointer unchanged on every Process call. assert.Same
+// pins pointer identity, which is stronger than byte equality.
 func TestNoopSampler_AlwaysPassesThrough(t *testing.T) {
 	s := NewNoopSampler()
 	msg := testMsg()
@@ -79,13 +90,29 @@ func TestNoopSampler_AlwaysPassesThrough(t *testing.T) {
 	assert.Same(t, msg, s.Process(msg, nil))
 }
 
+// TestNoopSampler_FlushReturnsNil anchors:
+//
+//	contract Sampler (sampler.allium)
+//	    @invariant Totality — flush returns either a Message or null.
+//
+// NoopSampler doesn't buffer; flush returns null on every read.
 func TestNoopSampler_FlushReturnsNil(t *testing.T) {
 	assert.Nil(t, NewNoopSampler().Flush())
 }
 
 // --- AdaptiveSampler: new pattern ---
 
-// A new pattern is always allowed through regardless of credits.
+// TestAdaptiveSampler_NewPatternIsAllowed anchors:
+//
+//	surface AdaptiveSampling (adaptive_sampler.allium)
+//	    @guarantee FirstLogAlwaysEmitted
+//	rule RegisterNewPattern (adaptive_sampler.allium)
+//	    — fires when no existing pattern matches and table has
+//	    capacity; emits unconditionally.
+//
+// A new pattern is always emitted regardless of credit state. The
+// rule's `ensures: PatternEntry.created(...)` is verified via
+// s.entries having a single fresh entry with matchCount=1.
 func TestAdaptiveSampler_NewPatternIsAllowed(t *testing.T) {
 	s := newSampler(10, 1.0, 0)
 	out := s.Process(testMsg(), patternA)
@@ -96,8 +123,14 @@ func TestAdaptiveSampler_NewPatternIsAllowed(t *testing.T) {
 	requireNoSampledCountTag(t, out)
 }
 
-// A new pattern entry starts with BurstSize-1 credits so that the burst
-// allowance accounts for the first message already emitted.
+// TestAdaptiveSampler_NewPatternCredits anchors:
+//
+//	rule RegisterNewPattern (adaptive_sampler.allium)
+//	    ensures: PatternEntry.created(credits: config.burst_size - 1.0, ...)
+//
+// A new entry's initial credit budget is burst_size - 1: the first
+// message consumes one credit implicitly (the same message that
+// caused the entry to be created).
 func TestAdaptiveSampler_NewPatternCredits(t *testing.T) {
 	s := newSampler(10, 5.0, 0)
 	s.Process(testMsg(), patternA)
@@ -106,7 +139,16 @@ func TestAdaptiveSampler_NewPatternCredits(t *testing.T) {
 
 // --- AdaptiveSampler: rate limiting ---
 
-// After BurstSize messages the pattern is rate-limited.
+// TestAdaptiveSampler_RateLimitsAfterBurst anchors:
+//
+//	rule DropMatchingLog (adaptive_sampler.allium)
+//	    — fires when an existing pattern matches and credits are
+//	    insufficient.
+//	surface AdaptiveSampling
+//	    @guarantee SteadyStateRateBound — burst_size + rate_limit*T.
+//
+// With rate_limit=0 and burst=3, the 4th message of a matching
+// pattern is dropped. The dropped count increments on the entry.
 func TestAdaptiveSampler_RateLimitsAfterBurst(t *testing.T) {
 	const burst = 3.0
 	s := newSampler(10, burst, 0) // no credit refill
@@ -128,7 +170,18 @@ func TestAdaptiveSampler_RateLimitsAfterBurst(t *testing.T) {
 	assert.Equal(t, int64(1), s.entries[0].sampled, "dropped messages should increment the suppressed count")
 }
 
-// After being rate-limited, credits refill at RateLimit per second.
+// TestAdaptiveSampler_CreditsRefillOverTime anchors:
+//
+//	rule EmitMatchingLog (adaptive_sampler.allium)
+//	    let elapsed_seconds = seconds_elapsed(entry.last_seen, now)
+//	    let refill = elapsed_seconds * config.rate_limit
+//	    let capped_credits = min(entry.credits + refill, burst_size)
+//
+// After credits are exhausted, advancing the clock by N seconds
+// refills N * rate_limit credits (capped at burst_size). The first
+// re-emission after exhaustion also carries the adaptive_sampler_
+// sampled_count tag annotating the prior dropped message — see
+// TagAugmentationOnly on the AdaptiveSampling surface.
 func TestAdaptiveSampler_CreditsRefillOverTime(t *testing.T) {
 	s := newSampler(10, 3.0, 2.0) // 2 credits/sec
 	t0 := time.Now()
@@ -148,6 +201,21 @@ func TestAdaptiveSampler_CreditsRefillOverTime(t *testing.T) {
 	assert.Equal(t, int64(0), s.entries[0].sampled, "emitting should reset the suppressed count")
 }
 
+// TestAdaptiveSampler_TagsSuppressedMatchesAfterLongDelay anchors:
+//
+//	rule EmitMatchingLog (adaptive_sampler.allium)
+//	    let prior_sampled_count = entry.sampled_count
+//	    ensures: entry.sampled_count = 0
+//	    ensures: LogEmitted(message, sampled_count: prior_sampled_count)
+//	rule EmitMatchingLog @guidance — the tag attaches when
+//	    prior_sampled_count > 0.
+//	surface AdaptiveSampling
+//	    @guarantee TagAugmentationOnly
+//
+// The sampled-count tag carries the count from BEFORE the rule
+// reset sampled_count to 0. This requires capturing
+// prior_sampled_count as a let-binding before the ensures clauses
+// take effect.
 func TestAdaptiveSampler_TagsSuppressedMatchesAfterLongDelay(t *testing.T) {
 	s := newSampler(10, 1.0, 1.0) // 1 log/sec
 	t0 := time.Now()
@@ -169,7 +237,16 @@ func TestAdaptiveSampler_TagsSuppressedMatchesAfterLongDelay(t *testing.T) {
 	assert.Equal(t, int64(0), s.entries[0].sampled, "emitting should reset the suppressed count")
 }
 
-// Credits are capped at BurstSize even if a long time has passed.
+// TestAdaptiveSampler_CreditsCappedAtBurstSize anchors:
+//
+//	invariant CreditsCapped (adaptive_sampler.allium)
+//	    for entry in PatternEntries: entry.credits <= config.burst_size
+//	rule EmitMatchingLog
+//	    let capped_credits = min(entry.credits + refill, burst_size)
+//
+// The refill computation caps at burst_size — an hour of elapsed
+// time at rate_limit=100 would give 360000 credits without the cap;
+// the cap bounds it to burst_size, then the emission decrements by 1.
 func TestAdaptiveSampler_CreditsCappedAtBurstSize(t *testing.T) {
 	const burst = 3.0
 	s := newSampler(10, burst, 100.0)
@@ -185,7 +262,17 @@ func TestAdaptiveSampler_CreditsCappedAtBurstSize(t *testing.T) {
 
 // --- AdaptiveSampler: pattern isolation ---
 
-// Different structural patterns are tracked independently — each has its own credit pool.
+// TestAdaptiveSampler_PatternsTrackedIndependently anchors:
+//
+//	surface AdaptiveSampling (adaptive_sampler.allium)
+//	    @guarantee TokenAware — pattern classification uses tokens
+//	                             via is_match(...).
+//	rule EmitMatchingLog / DropMatchingLog
+//	    let matches = filter(PatternEntries, e => is_match(...))
+//
+// Pattern A's exhausted credit bucket has no effect on pattern B's
+// freshly-created bucket. Each pattern entry carries its own credit
+// state.
 func TestAdaptiveSampler_PatternsTrackedIndependently(t *testing.T) {
 	s := newSampler(10, 1.0, 0) // burst of exactly 1 per pattern
 	t0 := time.Now()
@@ -205,8 +292,17 @@ func TestAdaptiveSampler_PatternsTrackedIndependently(t *testing.T) {
 
 // --- AdaptiveSampler: bubbling ---
 
-// After multiple hits, a pattern bubbles toward the front of the sorted list
-// so it is found faster on the next scan.
+// TestAdaptiveSampler_HotPatternBubblesToFront anchors:
+//
+//	rule EmitMatchingLog @guidance (adaptive_sampler.allium) —
+//	    the entry is bubbled toward the front of the sorted table
+//	    to maintain descending match_count order via a swap chain.
+//
+// After patternC accumulates the highest matchCount it sits at
+// entries[0]. Remaining entries are in descending matchCount order.
+// This is a performance optimisation (hot patterns hit early in
+// the scan) but is documented in @guidance because it's
+// implementation-visible state ordering.
 func TestAdaptiveSampler_HotPatternBubblesToFront(t *testing.T) {
 	s := newSampler(10, 100.0, 0)
 	t0 := time.Now()
@@ -235,8 +331,19 @@ func TestAdaptiveSampler_HotPatternBubblesToFront(t *testing.T) {
 
 // --- AdaptiveSampler: eviction ---
 
-// When the table is full a new pattern evicts the least-frequently-matched one
-// (the last entry in the sorted list).
+// TestAdaptiveSampler_EvictsLeastFrequentWhenFull anchors:
+//
+//	rule EvictAndRegisterPattern (adaptive_sampler.allium)
+//	    let victim = min_by(PatternEntries, e => e.match_count)
+//	    ensures: not exists victim
+//	    ensures: PatternEntry.created(...)
+//	invariant TableBounded
+//	    PatternEntries.count <= config.max_patterns
+//
+// When max_patterns=2 and the table is full, the least-frequently-
+// matched entry is evicted to make room for a new pattern. The
+// table size remains at max_patterns; the high-frequency pattern A
+// is retained.
 func TestAdaptiveSampler_EvictsLeastFrequentWhenFull(t *testing.T) {
 	s := newSampler(2, 100.0, 0) // table holds at most 2 patterns
 	t0 := time.Now()
@@ -263,10 +370,19 @@ func TestAdaptiveSampler_EvictsLeastFrequentWhenFull(t *testing.T) {
 
 // --- AdaptiveSampler: bubbling aliasing ---
 
-// When a matched entry's incremented matchCount exceeds its predecessor's, the
-// entry bubbles forward via value swaps. All entry mutations (including
-// sampled_count) must complete before bubbling, otherwise the pointer aliases a
-// different entry after the swap.
+// TestAdaptiveSampler_BubblingAliasesSampledCount anchors:
+//
+//	rule EmitMatchingLog @guidance (adaptive_sampler.allium) —
+//	    "All entry mutations complete before bubbling to avoid
+//	    pointer aliasing."
+//
+// Regression test for a specific implementation bug: the bubble-
+// sort swap chain works on values, not pointers; the local pointer
+// `e := &s.entries[i]` aliases a different entry after the first
+// swap. All mutations to the matched entry (credits, sampled_count,
+// last_seen) MUST complete before the bubbling loop starts.
+// Failure mode: the sampled_count increment lands on the wrong
+// entry, so the carry-tag count drifts off the dropped count.
 func TestAdaptiveSampler_BubblingAliasesSampledCount(t *testing.T) {
 	s := newSampler(10, 1.0, 1.0) // burst=1, rate=1/sec
 	t0 := time.Now()
@@ -304,14 +420,34 @@ func TestAdaptiveSampler_BubblingAliasesSampledCount(t *testing.T) {
 
 // --- AdaptiveSampler: misc ---
 
+// TestAdaptiveSampler_FlushReturnsNil anchors:
+//
+//	surface AdaptiveSampling (adaptive_sampler.allium)
+//	    @guarantee FlushNoop — flush always returns null;
+//	                            AdaptiveSampler does not buffer.
+//
+// After processing a message (which makes an immediate emit-or-drop
+// decision), flush still returns nil. There is no pending state
+// to drain.
 func TestAdaptiveSampler_FlushReturnsNil(t *testing.T) {
 	s := newSampler(10, 10.0, 1.0)
 	s.Process(testMsg(), patternA)
 	assert.Nil(t, s.Flush())
 }
 
-// A message with no tokens (e.g. empty log line) never matches an existing entry
-// and is always treated as a new pattern.
+// TestAdaptiveSampler_EmptyTokensNewPattern anchors:
+//
+//	contract PatternMatching (adaptive_sampler.allium)
+//	    @invariant EmptySemantics — Two empty sequences match;
+//	                                 an empty and a non-empty
+//	                                 sequence never match.
+//
+// An empty-token input never matches a non-empty existing pattern,
+// so it falls through to RegisterNewPattern. The created entry
+// has an empty signature, which would only match a future empty
+// input. (Whether this is desirable is a separate concern;
+// EmptySemantics describes the predicate's mathematical
+// behaviour.)
 func TestAdaptiveSampler_EmptyTokensNewPattern(t *testing.T) {
 	s := newSampler(10, 5.0, 0)
 	msg := testMsg()
@@ -322,7 +458,19 @@ func TestAdaptiveSampler_EmptyTokensNewPattern(t *testing.T) {
 
 // --- AdaptiveSampler: important log protection ---
 
-// An important log is always returned even when credits are exhausted.
+// TestAdaptiveSampler_ImportantLogBypassesRateLimit anchors:
+//
+//	rule ImportantLogBypass (adaptive_sampler.allium) —
+//	    fires when config.protect_important_logs and
+//	    is_important(incoming); emits unconditionally.
+//	surface AdaptiveSampling
+//	    @guarantee ImportantLogProtection — important logs always
+//	                                         emit regardless of
+//	                                         pattern table state.
+//
+// With burst=1 and rate_limit=0, a normal pattern would be
+// drop-limited after the first message. An important pattern
+// (ERROR token) emits indefinitely.
 func TestAdaptiveSampler_ImportantLogBypassesRateLimit(t *testing.T) {
 	s := newSamplerWithProtect(10, 1.0, 0, true)
 	t0 := time.Now()
@@ -344,7 +492,20 @@ func TestAdaptiveSampler_ImportantLogBypassesRateLimit(t *testing.T) {
 	}
 }
 
-// Important logs bypass the pattern table entirely — no entry created.
+// TestAdaptiveSampler_ImportantLogDoesNotCreateEntry anchors:
+//
+//	surface AdaptiveSampling (adaptive_sampler.allium)
+//	    @guarantee ImportantLogProtection — "The bypass is
+//	                                          non-disruptive:
+//	                                          pattern table state
+//	                                          is entirely
+//	                                          unaffected."
+//
+// An important log under protection does NOT register a new
+// pattern entry. The pattern table is exactly as it was before
+// the call. (Implication: severity-classifying a log doesn't
+// poison the pattern table with shapes the sampler will never use
+// for rate limiting.)
 func TestAdaptiveSampler_ImportantLogDoesNotCreateEntry(t *testing.T) {
 	s := newSamplerWithProtect(10, 1.0, 0, true)
 	importantTokens := tokenize("FATAL: disk full")
@@ -353,7 +514,17 @@ func TestAdaptiveSampler_ImportantLogDoesNotCreateEntry(t *testing.T) {
 	assert.Empty(t, s.entries, "important logs should not create pattern table entries")
 }
 
-// Non-important logs are still rate-limited normally when protection is on.
+// TestAdaptiveSampler_NonImportantLogStillDropped anchors:
+//
+//	surface AdaptiveSampling (adaptive_sampler.allium)
+//	    @guarantee Totality — the 5 rules partition the input
+//	                           space; non-important logs fall to
+//	                           the pattern-table rules even when
+//	                           protect_important_logs is enabled.
+//
+// Enabling protection doesn't suppress the standard rate limiting
+// for ordinary logs — only the is_important branch is rerouted.
+// Pattern-table rules still apply to anything is_important rejects.
 func TestAdaptiveSampler_NonImportantLogStillDropped(t *testing.T) {
 	s := newSamplerWithProtect(10, 1.0, 0, true)
 	t0 := time.Now()
@@ -366,7 +537,19 @@ func TestAdaptiveSampler_NonImportantLogStillDropped(t *testing.T) {
 	assert.Nil(t, s.Process(testMsg(), normalTokens), "second message should be dropped — burst exhausted")
 }
 
-// When ProtectImportantLogs is false, important logs are rate-limited like any other.
+// TestAdaptiveSampler_ProtectDisabled anchors:
+//
+//	surface AdaptiveSampling (adaptive_sampler.allium)
+//	    @guarantee ImportantLogProtection (negative case) —
+//	                "When config.protect_important_logs is false,
+//	                 the predicate has no effect — the four
+//	                 pattern-table rules apply uniformly regardless
+//	                 of severity."
+//
+// With protection disabled, an ERROR log is rate-limited just like
+// any other. The is_important branch of the dispatch is unreachable
+// because ImportantLogBypass's first `requires:
+// config.protect_important_logs` clause fails.
 func TestAdaptiveSampler_ProtectDisabled(t *testing.T) {
 	s := newSamplerWithProtect(10, 1.0, 0, false)
 	t0 := time.Now()
@@ -509,6 +692,18 @@ func TestAdaptiveSampler_ExcludeTakesPrecedenceOverInclude(t *testing.T) {
 }
 
 // isImportant returns false for tokens that contain no critical keywords.
+// TestIsImportant anchors:
+//
+//	rule ImportantLogBypass @guidance (adaptive_sampler.allium) —
+//	    "The implementation checks for critical-severity keyword
+//	    tokens (FATAL, ERROR, PANIC, ALERT, SEVERE, CRITICAL,
+//	    EMERGENCY, WARN, EXCEPTION, CRASH, FAILURE, DEADLOCK,
+//	    TIMEOUT)."
+//
+// Verifies the is_important predicate's keyword list matches the
+// list documented in @guidance. Update both together when adding
+// a new severity keyword: the test grows a row; the @guidance
+// prose grows a name.
 func TestIsImportant(t *testing.T) {
 	assert.True(t, isImportant(tokenize("FATAL: disk full")))
 	assert.True(t, isImportant(tokenize("[ERROR] request failed")))


### PR DESCRIPTION
  What: Anchoring docstrings on 20 existing tests + 4 new gap unit tests + 5 property tests.

  Sampler contract @invariants:
  - ContentBytePassthrough — TestNoopSampler_AlwaysPassesThrough (Unit, existing, anchored) + TestAdaptiveSampler_ContentBytePassthrough_Emit (Unit) + _Property (Property)
  - Totality (flush returns null) — TestNoopSampler_FlushReturnsNil (Unit, existing, anchored)
  - TagAugmentationOnly (preserves input tags) — TestAdaptiveSampler_TagAugmentationOnly_PreservesInputTags (Unit) + _Property (Property)
  - NoMessageFabrication — TestAdaptiveSampler_NoMessageFabrication (Unit)
  - Totality (drop returns null) — TestAdaptiveSampler_DropReturnsNil (Unit)
  - Determinism — TestAdaptiveSampler_Determinism_Property (Property)

  AdaptiveSampling rules + surface:
  - RegisterNewPattern + FirstLogAlwaysEmitted — TestAdaptiveSampler_NewPatternIsAllowed (Unit, existing, anchored)
  - RegisterNewPattern ensures (burst_size - 1 initial credits) — TestAdaptiveSampler_NewPatternCredits (Unit, existing, anchored)
  - DropMatchingLog + SteadyStateRateBound — TestAdaptiveSampler_RateLimitsAfterBurst (Unit, existing, anchored)
  - EmitMatchingLog refill logic + TagAugmentationOnly — TestAdaptiveSampler_CreditsRefillOverTime (Unit, existing, anchored)
  - EmitMatchingLog prior_sampled_count let-binding + tag — TestAdaptiveSampler_TagsSuppressedMatchesAfterLongDelay (Unit, existing, anchored)
  - CreditsCapped invariant + EmitMatchingLog cap — TestAdaptiveSampler_CreditsCappedAtBurstSize (Unit, existing, anchored)
  - TokenAware — TestAdaptiveSampler_PatternsTrackedIndependently (Unit, existing, anchored)
  - EmitMatchingLog @guidance (bubble sort) — TestAdaptiveSampler_HotPatternBubblesToFront (Unit, existing, anchored)
  - EvictAndRegisterPattern + TableBounded — TestAdaptiveSampler_EvictsLeastFrequentWhenFull (Unit, existing, anchored)
  - EmitMatchingLog @guidance (aliasing regression) — TestAdaptiveSampler_BubblingAliasesSampledCount (Unit, existing, anchored)
  - FlushNoop — TestAdaptiveSampler_FlushReturnsNil (Unit, existing, anchored)
  - PatternMatching.EmptySemantics — TestAdaptiveSampler_EmptyTokensNewPattern (Unit, existing, anchored)
  - ImportantLogProtection (positive case) — TestAdaptiveSampler_ImportantLogBypassesRateLimit (Unit, existing, anchored)
  - ImportantLogProtection (non-disruptive: no entry created) — TestAdaptiveSampler_ImportantLogDoesNotCreateEntry (Unit, existing, anchored) + _Property (Property)
  - Totality (5-rule partition) — TestAdaptiveSampler_NonImportantLogStillDropped (Unit, existing, anchored)
  - ImportantLogProtection (negative case: protect disabled) — TestAdaptiveSampler_ProtectDisabled (Unit, existing, anchored)
  - ImportantLogBypass.@guidance keyword list — TestIsImportant (Unit, existing, anchored)
  - FlushNoop — TestAdaptiveSampler_FlushAlwaysNil_Property (Property)

  Stack: parent cmetz/adaptive_sampler_fulfils.
