### PR TITLE
Fix race condition in TestContainerIDRaceCondition

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -883,7 +883,7 @@ func TestContainerIDRaceCondition(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait for cycle 1 to complete: process exists but without container ID
-	assert.EventuallyWithT(t, func(cT *assert.CollectT) {
+	require.EventuallyWithT(t, func(cT *assert.CollectT) {
 		actualProc, err := c.mockStore.GetProcess(pid1)
 		require.NoError(cT, err)
 		assert.Empty(cT, actualProc.ContainerID)

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -885,7 +885,7 @@ func TestContainerIDRaceCondition(t *testing.T) {
 	// Wait for cycle 1 to complete: process exists but without container ID
 	assert.EventuallyWithT(t, func(cT *assert.CollectT) {
 		actualProc, err := c.mockStore.GetProcess(pid1)
-		assert.NoError(cT, err)
+		require.NoError(cT, err)
 		assert.Empty(cT, actualProc.ContainerID)
 	}, time.Second, time.Millisecond*100)
 
@@ -895,7 +895,7 @@ func TestContainerIDRaceCondition(t *testing.T) {
 	// After cycle 2: process should have the container ID
 	assert.EventuallyWithT(t, func(cT *assert.CollectT) {
 		actualProc, err := c.mockStore.GetProcess(pid1)
-		assert.NoError(cT, err)
+		require.NoError(cT, err)
 		assert.Equal(cT, "container-abc", actualProc.ContainerID)
 		assert.Equal(cT, &workloadmeta.EntityID{
 			Kind: workloadmeta.KindContainer,

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -882,10 +882,17 @@ func TestContainerIDRaceCondition(t *testing.T) {
 	err := c.collector.Start(ctx, c.mockStore)
 	assert.NoError(t, err)
 
+	// Wait for cycle 1 to complete: process exists but without container ID
+	assert.EventuallyWithT(t, func(cT *assert.CollectT) {
+		actualProc, err := c.mockStore.GetProcess(pid1)
+		assert.NoError(cT, err)
+		assert.Empty(cT, actualProc.ContainerID)
+	}, time.Second, time.Millisecond*100)
+
 	// Advance clock to trigger cycle 2
 	c.mockClock.Add(collectionInterval)
 
-	// After both cycles: process should have the container ID from cycle 2
+	// After cycle 2: process should have the container ID
 	assert.EventuallyWithT(t, func(cT *assert.CollectT) {
 		actualProc, err := c.mockStore.GetProcess(pid1)
 		assert.NoError(cT, err)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"c8ec5d1e-86db-4a77-83a6-5ecf70891070","source":"chat","resourceId":"65cbd822-48fa-4581-9a90-6b2455c8c735","workflowId":"4d73ed48-f03b-41ee-8b4a-d74e5693a53d","codeChangeId":"4d73ed48-f03b-41ee-8b4a-d74e5693a53d","sourceType":"slack"} -->
### Summary

`TestContainerIDRaceCondition` panics with a nil pointer dereference when `GetProcess` returns nil because the process hasn't been stored yet. `assert.NoError` inside `EventuallyWithT` records the failure but doesn't halt execution, so the callback continues and dereferences nil, panicking and preventing retries.

Separately, the test advanced the mock clock immediately after `Start()` without confirming cycle 1 had completed, forcing both collection cycles into a single 1-second polling window.

### Jira Ticket / Incident

https://datadoghq.atlassian.net/browse/CXP-3336

### Test Plan

Ran individual test and full suite multiple times and ensured it did not flake.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/65cbd822-48fa-4581-9a90-6b2455c8c735)

Comment @datadog to request changes