### PR TITLE
Ignore .phoenix/ worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,6 @@ AUTO_JIRA.md
 .python-nix-home
 .venv-nix
 flake.lock
+
+# Phoenix worktrees
+.phoenix/


### PR DESCRIPTION
### What does this PR do?

Adds `.phoenix/` to `.gitignore`.

### Motivation

[Phoenix](https://github.com/scottopell/phoenix-ide) (an AI-coding-agent
host) creates per-task worktrees under `.phoenix/worktrees/<name>/` in
the repo root. They're local-only scratch space — each is a working
copy of some branch, but the `.phoenix/` directory itself isn't anything
the repo cares about. Today it shows up as an untracked directory in
`git status` for anyone using Phoenix, which gets noisy.

### Describe how you validated your changes

Single-line ignore change. Manually verified: `find . -name AGENTS.md`
and similar listings stop including paths under `.phoenix/worktrees/...`
once this is applied locally.

### Possible Drawbacks / Trade-offs

None — `.phoenix/` is a Phoenix-specific path and isn't used by any
build, CI step or check in this repo.
