### PR TITLE
test(e2e): add xperf tracing to service-test start/stop loops

### DIFF
--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -666,10 +666,83 @@ func (s *baseStartStopSuite) BeforeTest(suiteName, testName string) {
 	s.T().Logf("Clearing dump folder")
 	err = windowsCommon.CleanDirectory(host, s.dumpFolder)
 	s.Require().NoError(err, "should clean dump folder")
+
+	// Start xperf tracing to capture service start/stop timing under Driver Verifier.
+	// Two ETW sessions run concurrently (circular buffers, merged on stop):
+	//   - NT Kernel Logger: scheduler, loader, CPU profile, context switch with stacks
+	//   - scm-trace: Microsoft-Windows-Services SCM events (SetServiceStatus transitions)
+	// The merged .etl is only downloaded on test failure. See AfterTest -> collectXperf.
+	s.startXperf(host)
+}
+
+// xperfSCMSessionName is the user-mode ETW session name that captures Microsoft-Windows-Services
+// SCM events (matches the name in the MS-published TSS xperf recipe).
+const xperfSCMSessionName = "scm-trace"
+
+// startXperf starts xperf tracing on the remote host with two concurrent sessions
+// (NT Kernel Logger + scm-trace user session for the SCM provider). Both use circular
+// FileMode so that for tests with multiple start/stop iterations the trace captures
+// the tail of activity around whichever iteration fails.
+func (s *baseStartStopSuite) startXperf(host *components.RemoteHost) {
+	err := host.HostArtifactClient.Get("windows-products/xperf-5.0.8169.zip", "C:/xperf.zip")
+	if !s.Assert().NoError(err, "should fetch xperf artifact") {
+		return
+	}
+
+	// Extract if C:/xperf dir does not exist.
+	_, err = host.Execute("if (-Not (Test-Path -Path C:/xperf)) { Expand-Archive -Path C:/xperf.zip -DestinationPath C:/xperf }")
+	if !s.Assert().NoError(err, "should expand xperf archive") {
+		return
+	}
+
+	// Single xperf invocation starts both the NT Kernel Logger (-on <KernelGroups> -f kernel.etl ...)
+	// and a named user-mode session (-start scm-trace -on Microsoft-Windows-Services) per the
+	// MS TSS xperf SCM-tracing recipe. -d on stop will merge both into a single .etl.
+	xperfPath := "C:/xperf/xperf.exe"
+	cmd := fmt.Sprintf(
+		`& "%s" -on Base+Latency+CSwitch+PROC_THREAD+LOADER+Profile+DISPATCHER -stackWalk CSwitch+Profile+ReadyThread+ThreadCreate -f C:/kernel.etl -MaxBuffers 1024 -BufferSize 1024 -MaxFile 1024 -FileMode Circular -start %s -on Microsoft-Windows-Services`,
+		xperfPath, xperfSCMSessionName,
+	)
+	_, err = host.Execute(cmd)
+	s.Assert().NoError(err, "should start xperf tracing (kernel + scm-trace)")
+}
+
+// collectXperf stops both xperf sessions, merges them, and downloads the resulting
+// .etl to the session output dir if the test failed.
+func (s *baseStartStopSuite) collectXperf(host *components.RemoteHost) {
+	xperfPath := "C:/xperf/xperf.exe"
+	outputPath := "C:/full_host_profiles.etl"
+
+	// Stop kernel logger (-stop) and the named SCM user session (-stop scm-trace), then -d
+	// merges both into outputPath. Matches the MS TSS recipe.
+	_, err := host.Execute(fmt.Sprintf(`& "%s" -stop -stop %s -d %s`, xperfPath, xperfSCMSessionName, outputPath))
+	if !s.Assert().NoError(err, "should stop and merge xperf trace") {
+		return
+	}
+
+	// Only collect the trace artifact if the test failed. Use a tempfile pattern in the
+	// session output dir so multiple failing tests in the same suite don't overwrite each
+	// other's traces.
+	if s.T().Failed() {
+		outDir := s.SessionOutputDir()
+		f, err := os.CreateTemp(outDir, "xperf-*.etl")
+		if !s.Assert().NoError(err, "should create local xperf trace file") {
+			return
+		}
+		localPath := f.Name()
+		_ = f.Close()
+		err = host.GetFile(outputPath, localPath)
+		s.Assert().NoError(err, "should download xperf trace")
+	}
 }
 
 func (s *baseStartStopSuite) AfterTest(suiteName, testName string) {
 	s.BaseSuite.AfterTest(suiteName, testName)
+
+	// Stop xperf and merge to .etl as early as possible after the test body, so the
+	// circular trace is preserved before any subsequent diagnostic collection further
+	// perturbs system state. .etl is only downloaded if the test failed.
+	s.collectXperf(s.Env().RemoteHost)
 
 	// look for and download crashdumps. Dumps from processes in
 	// DefaultIgnoredCrashDumpImages are still downloaded as artifacts but do

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -737,8 +737,6 @@ func (s *baseStartStopSuite) collectXperf(host *components.RemoteHost) {
 }
 
 func (s *baseStartStopSuite) AfterTest(suiteName, testName string) {
-	s.BaseSuite.AfterTest(suiteName, testName)
-
 	// Stop xperf and merge to .etl as early as possible after the test body, so the
 	// circular trace is preserved before any subsequent diagnostic collection further
 	// perturbs system state. .etl is only downloaded if the test failed.
@@ -800,6 +798,11 @@ func (s *baseStartStopSuite) AfterTest(suiteName, testName string) {
 
 	// check if the host crashed.
 	s.Require().False(s.collectSystemCrashDump(), "should not have system crash dump")
+
+	// Run BaseSuite.AfterTest last: on failure it invokes environment diagnose,
+	// which may call require (aborting anything after it) and perturbs system
+	// state. Our collection above must complete first.
+	s.BaseSuite.AfterTest(suiteName, testName)
 }
 
 func (s *baseStartStopSuite) collectAgentLogs() {


### PR DESCRIPTION
### What does this PR do?

Wraps each test in `baseStartStopSuite` (and its descendant suites under `test/new-e2e/tests/windows/service-test`) with an xperf trace started in `BeforeTest` and stopped/merged in `AfterTest`.

Two concurrent ETW sessions are started in a single xperf invocation:

- **NT Kernel Logger** — `Base+Latency+CSwitch+PROC_THREAD+LOADER+Profile+DISPATCHER` with stacks on `CSwitch+Profile+ReadyThread+ThreadCreate`. Matches the existing xperf helpers in `test/new-e2e/tests/windows/install-test/base.go` and `test/new-e2e/tests/installer/windows/base_suite.go`.
- **`scm-trace` user session** — `Microsoft-Windows-Services` ETW provider, so SCM `SetServiceStatus` transitions land on the same timeline as kernel activity. Two-session invocation follows the MS TSS SCM-tracing recipe.

Both sessions use circular ring buffers; the merged `full_host_profiles.etl` is only downloaded on test failure. Each failed test gets its own `xperf-*.etl` via `os.CreateTemp(outDir, "xperf-*.etl")` so multiple failures in a suite don't overwrite each other's traces.

### Motivation

The DriverVerifier service-test cluster ([WINA-2645](https://datadoghq.atlassian.net/browse/WINA-2645), and the wider family of WINA "Failed agent CI test" tickets it represents) has been hitting SCM `ServicesPipeTimeout` failures at a steady rate — **57 occurrences over 30 days across 11 distinct service-test jobs**, with 18 of those in `TestDriverVerifierOnServiceBehaviorPowerShell` alone.

The on-VM signature is Application event log entries from `Service Control Manager`:

- Event ID 7000: `The <service> service failed to start due to the following error: The service did not respond to the start or control request in a timely fashion.`
- Event ID 7009: `A timeout was reached (30000 milliseconds) while waiting for the <service> service to connect.`

…meaning the agent service process is launched but never calls `SetServiceStatus(SERVICE_START_PENDING)` within SCM's 30s pipe timeout. Without kernel-level visibility we can only guess what's consuming CPU during agent startup; the xperf trace will give us that visibility.

### Describe how you validated your changes

Ran `TestDriverVerifierOnServiceBehaviorWhenDisabledTraceAgent` end-to-end against a freshly-provisioned Windows test VM with `agent 7.81.0-devel` from the latest main pipeline:

- All 6 subtests passed; no spurious failures introduced by the xperf overhead.
- xperf started and stopped cleanly in every `BeforeTest`/`AfterTest`.
- Merged `full_host_profiles.etl` was ~60 MB after a ~10-iteration `TestAgentStopsAllServices` run (well within the 1 GB circular cap).
- Manually pulled the trace and opened with `xperf -a profile -detail` — confirmed the per-process CPU breakdown was useful.

[WINA-2645]: https://datadoghq.atlassian.net/browse/WINA-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ