### PR TITLE
fix(clusteragent/appsec): do not expose disabled sidecar patterns

### DIFF
--- a/pkg/clusteragent/appsec/cleanup.go
+++ b/pkg/clusteragent/appsec/cleanup.go
@@ -25,8 +25,8 @@ import (
 // Needs to be called as the leader instance to avoid conflicts.
 func Cleanup(ctx context.Context, logger log.Component, datadogConfig config.Component, leaderSub leaderNotifier) {
 	logger.Info("Cleaning up appsec injections from cluster resources because proxy injection is disabled")
-	injector = newSecurityInjector(ctx, logger, appsecconfig.FromComponent(datadogConfig, logger), leaderSub)
-	if injector == nil {
+	cleanupInjector := newSecurityInjector(ctx, logger, appsecconfig.FromComponent(datadogConfig, logger), leaderSub)
+	if cleanupInjector == nil {
 		return
 	}
 
@@ -44,7 +44,7 @@ func Cleanup(ctx context.Context, logger log.Component, datadogConfig config.Com
 			<-leaderNotifChange
 		}
 
-		for _, pattern := range injector.patterns {
+		for _, pattern := range cleanupInjector.patterns {
 			cleanupPattern(ctx, logger, apiClient.DynamicCl, pattern)
 		}
 	}()

--- a/pkg/clusteragent/appsec/injector.go
+++ b/pkg/clusteragent/appsec/injector.go
@@ -363,6 +363,9 @@ func GetSidecarPatterns() []appsecconfig.SidecarInjectionPattern {
 		log.Error("Appsec Injector not initialized, cannot setup sidecar patterns")
 		return nil
 	}
+	if !injector.config.Injection.Enabled || !injector.config.Product.Enabled {
+		return nil
+	}
 
 	var sidecarPatterns []appsecconfig.SidecarInjectionPattern
 

--- a/pkg/clusteragent/appsec/injector_test.go
+++ b/pkg/clusteragent/appsec/injector_test.go
@@ -26,6 +26,9 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	appsecconfig "github.com/DataDog/datadog-agent/pkg/clusteragent/appsec/config"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // mockInjectionPattern implements the InjectionPattern interface for testing
@@ -63,6 +66,34 @@ func (m *mockInjectionPattern) Added(context.Context, *unstructured.Unstructured
 func (m *mockInjectionPattern) Deleted(context.Context, *unstructured.Unstructured) error {
 	m.deletedCalls++
 	return m.deletedErr
+}
+
+type mockSidecarInjectionPattern struct {
+	mockInjectionPattern
+}
+
+func (m *mockSidecarInjectionPattern) Mode() appsecconfig.InjectionMode {
+	return appsecconfig.InjectionModeSidecar
+}
+
+func (m *mockSidecarInjectionPattern) MatchCondition() admissionregistrationv1.MatchCondition {
+	return admissionregistrationv1.MatchCondition{Expression: "object.metadata.labels['app'] == 'gateway'"}
+}
+
+func (m *mockSidecarInjectionPattern) ShouldMutatePod(*corev1.Pod) bool {
+	return true
+}
+
+func (m *mockSidecarInjectionPattern) IsNamespaceEligible(string) bool {
+	return true
+}
+
+func (m *mockSidecarInjectionPattern) MutatePod(*corev1.Pod, string, dynamic.Interface) (bool, error) {
+	return true, nil
+}
+
+func (m *mockSidecarInjectionPattern) PodDeleted(*corev1.Pod, string, dynamic.Interface) (bool, error) {
+	return true, nil
 }
 
 func newMockSecurityInjector(_ context.Context, mockClient dynamic.Interface, mockLogger log.Component, mockConfig appsecconfig.Config) *securityInjector {
@@ -334,6 +365,66 @@ func TestCompilePatterns(t *testing.T) {
 	// Verify the pattern is configured correctly
 	pattern := patterns[appsecconfig.ProxyTypeEnvoyGateway]
 	assert.NotNil(t, pattern, "Pattern should not be nil")
+}
+
+func TestGetSidecarPatterns(t *testing.T) {
+	previousInjector := injector
+	t.Cleanup(func() { injector = previousInjector })
+
+	tests := []struct {
+		name             string
+		injectionEnabled bool
+		productEnabled   bool
+		expectPatterns   bool
+	}{
+		{
+			name:             "returns sidecar patterns when product and injection are enabled",
+			injectionEnabled: true,
+			productEnabled:   true,
+			expectPatterns:   true,
+		},
+		{
+			name:             "returns no sidecar patterns when injection is disabled",
+			injectionEnabled: false,
+			productEnabled:   true,
+			expectPatterns:   false,
+		},
+		{
+			name:             "returns no sidecar patterns when product is disabled",
+			injectionEnabled: true,
+			productEnabled:   false,
+			expectPatterns:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxyType := appsecconfig.ProxyTypeEnvoyGateway
+			injector = &securityInjector{
+				logger: logmock.New(t),
+				config: appsecconfig.Config{
+					Injection: appsecconfig.Injection{Enabled: tt.injectionEnabled},
+					Product: appsecconfig.Product{
+						Enabled: tt.productEnabled,
+						Proxies: map[appsecconfig.ProxyType]struct{}{proxyType: {}},
+					},
+				},
+				patterns: map[appsecconfig.ProxyType]appsecconfig.InjectionPattern{
+					proxyType: &mockSidecarInjectionPattern{mockInjectionPattern: mockInjectionPattern{
+						resource:  schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+						namespace: metav1.NamespaceAll,
+					}},
+				},
+			}
+
+			patterns := GetSidecarPatterns()
+			if tt.expectPatterns {
+				require.Len(t, patterns, 1)
+				return
+			}
+			assert.Empty(t, patterns)
+		})
+	}
 }
 
 // Note: TestNewSecurityInjector tests are skipped as they require full APIClient mock

--- a/releasenotes-dca/notes/appsec-disabled-sidecar-patterns-b1a48de025ae9c6b.yaml
+++ b/releasenotes-dca/notes/appsec-disabled-sidecar-patterns-b1a48de025ae9c6b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Cluster Agent: Prevent disabled AppSec proxy injection cleanup from enabling
+    the AppSec sidecar admission webhook.


### PR DESCRIPTION
### What does this PR do?

Keeps AppSec cleanup from publishing sidecar patterns through the package-level injector when proxy injection is disabled.

`GetSidecarPatterns()` also now returns no patterns unless both the AppSec product and injector are enabled.

### Motivation

Fixes #50864

Cleanup still needs pattern definitions so it can remove existing AppSec resources, but that local cleanup state should not make admission registration treat the injector as running.

Without that separation, the AppSec proxy webhook can be registered even though injection is disabled.

### Describe how you validated your changes

`go test -tags 'kubeapiserver test' ./pkg/clusteragent/appsec`

---
https://datadoghq.atlassian.net/browse/APPSEC-63712