### PR TITLE
fix(clusteragent/appsec): use oldObject for DELETE match conditions

### DIFF
--- a/pkg/clusteragent/admission/mutate/appsec/webhook.go
+++ b/pkg/clusteragent/admission/mutate/appsec/webhook.go
@@ -105,20 +105,32 @@ func (w *Webhook) MatchConditions() []admissionregistrationv1.MatchCondition {
 		return nil
 	}
 
+	objectExpression := w.patternsExpression(false)
+	oldObjectExpression := w.patternsExpression(true)
+	finalExpression := fmt.Sprintf("(request.operation == 'DELETE' && (%s)) || (request.operation != 'DELETE' && (%s))", oldObjectExpression, objectExpression)
+
+	return []admissionregistrationv1.MatchCondition{{
+		Name:       webhookName,
+		Expression: finalExpression,
+	}}
+}
+
+func (w *Webhook) patternsExpression(useOldObject bool) string {
 	var finalExpression strings.Builder
 	for i, pattern := range w.patterns {
+		expression := pattern.MatchCondition().Expression
+		if useOldObject {
+			expression = strings.ReplaceAll(expression, "object.", "oldObject.")
+		}
 		finalExpression.WriteRune('(')
-		finalExpression.WriteString(pattern.MatchCondition().Expression)
+		finalExpression.WriteString(expression)
 		finalExpression.WriteRune(')')
 		if i != len(w.patterns)-1 {
 			finalExpression.WriteString("||")
 		}
 	}
 
-	return []admissionregistrationv1.MatchCondition{{
-		Name:       webhookName,
-		Expression: finalExpression.String(),
-	}}
+	return finalExpression.String()
 }
 
 // Timeout returns the timeout for the webhook

--- a/pkg/clusteragent/admission/mutate/appsec/webhook_integration_test.go
+++ b/pkg/clusteragent/admission/mutate/appsec/webhook_integration_test.go
@@ -10,6 +10,7 @@ package appsec
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -476,14 +477,14 @@ func TestAppsecWebhookMatchConditions(t *testing.T) {
 			patterns: []*mockSidecarPattern{
 				{matchExpression: "'label1' in object.metadata.labels"},
 			},
-			expectedOrCount: 0,
+			expectedOrCount: 1,
 		},
 		"two patterns": {
 			patterns: []*mockSidecarPattern{
 				{matchExpression: "'label1' in object.metadata.labels"},
 				{matchExpression: "'label2' in object.metadata.labels"},
 			},
-			expectedOrCount: 1,
+			expectedOrCount: 3,
 		},
 		"three patterns": {
 			patterns: []*mockSidecarPattern{
@@ -491,7 +492,7 @@ func TestAppsecWebhookMatchConditions(t *testing.T) {
 				{matchExpression: "'label2' in object.metadata.labels"},
 				{matchExpression: "'label3' in object.metadata.labels"},
 			},
-			expectedOrCount: 2,
+			expectedOrCount: 5,
 		},
 	}
 
@@ -522,7 +523,10 @@ func TestAppsecWebhookMatchConditions(t *testing.T) {
 			// Verify each pattern's expression is included
 			for _, p := range test.patterns {
 				assert.Contains(t, expression, p.matchExpression, "Expression should contain pattern's match expression")
+				assert.Contains(t, expression, strings.ReplaceAll(p.matchExpression, "object.", "oldObject."), "Expression should contain DELETE-safe oldObject expression")
 			}
+			assert.Contains(t, expression, "request.operation == 'DELETE'", "Expression should branch for DELETE requests")
+			assert.Contains(t, expression, "request.operation != 'DELETE'", "Expression should keep object-based matching for non-DELETE requests")
 
 			t.Logf("Generated expression: %s", expression)
 		})

--- a/pkg/clusteragent/admission/mutate/appsec/webhook_test.go
+++ b/pkg/clusteragent/admission/mutate/appsec/webhook_test.go
@@ -100,6 +100,10 @@ func TestWebhookMatchConditions(t *testing.T) {
 	assert.NotEmpty(t, conditions[0].Expression)
 
 	// The expression should be valid CEL (at minimum it should not be empty)
+	assert.Contains(t, conditions[0].Expression, "request.operation == 'DELETE'")
+	assert.Contains(t, conditions[0].Expression, "oldObject.metadata.labels['gateway'] == 'istio'")
+	assert.Contains(t, conditions[0].Expression, "request.operation != 'DELETE'")
+	assert.Contains(t, conditions[0].Expression, "object.metadata.labels['gateway'] == 'istio'")
 	t.Logf("Generated CEL expression: %s", conditions[0].Expression)
 }
 
@@ -227,6 +231,10 @@ func TestWebhook_MatchConditions_MultiplePatterns(t *testing.T) {
 	assert.Contains(t, expression, pattern1.matchExpression)
 	assert.Contains(t, expression, pattern2.matchExpression)
 	assert.Contains(t, expression, pattern3.matchExpression)
+	assert.Contains(t, expression, "request.operation == 'DELETE'")
+	assert.Contains(t, expression, "oldObject.metadata.labels['gateway-type'] == 'istio')||(oldObject.metadata.labels['gateway-type'] == 'envoy'")
+	assert.Contains(t, expression, "request.operation != 'DELETE'")
+	assert.Contains(t, expression, "object.metadata.labels['gateway-type'] == 'istio')||(object.metadata.labels['gateway-type'] == 'envoy'")
 
 	// Expression should be wrapped in parentheses
 	assert.Contains(t, expression, "(", "Patterns should be wrapped in parentheses")

--- a/releasenotes-dca/notes/appsec-delete-oldobject-matchconditions-b430a54055e0c41b.yaml
+++ b/releasenotes-dca/notes/appsec-delete-oldobject-matchconditions-b430a54055e0c41b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Cluster Agent: Evaluate AppSec sidecar admission webhook match conditions
+    against the deleted object for pod deletion requests.


### PR DESCRIPTION
### What does this PR do?

Generates operation-aware AppSec proxy webhook match conditions.

For DELETE requests, sidecar pattern predicates are evaluated against `oldObject`. For other operations, they keep using `object`.

### Motivation

Fixes #50864

Kubernetes admission requests expose the deleted resource through `oldObject` on DELETE. Reading `object` in a DELETE match condition can make evaluation fail before the webhook is called.

### Describe how you validated your changes

`go test -tags 'kubeapiserver test' ./pkg/clusteragent/admission/mutate/appsec`

---
https://datadoghq.atlassian.net/browse/APPSEC-63712