### PR TITLE
[CWS] Match attach_recursive_mnt.isra.0 kprobe symbol

### DIFF
--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -249,7 +249,10 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 
 			// Mount probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				hookFunc("hook_attach_recursive_mnt"),
+				&manager.OneOf{Selectors: []manager.ProbesSelector{
+					hookFunc("hook_attach_recursive_mnt"),
+					hookFunc("hook_attach_recursive_mnt", withUID(SecurityAgentUID+"_isra")),
+				}},
 				hookFunc("hook_propagate_mnt"),
 				hookFunc("hook_security_sb_umount"),
 				hookFunc("hook_clone_mnt"),

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -17,6 +17,7 @@ func getMountProbes(fentry bool) []*manager.Probe {
 				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_attach_recursive_mnt",
 			},
+			MatchFuncName: `^attach_recursive_mnt(\.isra\.0)?$`,
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -17,7 +17,14 @@ func getMountProbes(fentry bool) []*manager.Probe {
 				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_attach_recursive_mnt",
 			},
-			MatchFuncName: `^attach_recursive_mnt(\.isra\.0)?$`,
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID + "_isra",
+				EBPFFuncName: "hook_attach_recursive_mnt",
+			},
+			CopyProgram:   true,
+			MatchFuncName: `^attach_recursive_mnt\.isra\.0$`,
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/releasenotes/notes/cws-attach-recursive-mnt-isra-b70762d10b767ae8.yaml
+++ b/releasenotes/notes/cws-attach-recursive-mnt-isra-b70762d10b767ae8.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix CWS event_monitor failing to load on kernels that export
+    ``attach_recursive_mnt`` as ``attach_recursive_mnt.isra.0`` (the result of
+    GCC's IPA-SRA optimization, observed on Talos Linux with kernel 6.18).
+    The kprobe now matches both the unsuffixed and ``.isra.0`` symbol names.


### PR DESCRIPTION
### What does this PR do?

`hook_attach_recursive_mnt` now matches both `attach_recursive_mnt` and `attach_recursive_mnt.isra.0`.

### Motivation

On Talos Linux 1.12.5 (kernel 6.18.15), GCC's IPA-SRA pass renames `attach_recursive_mnt` to `attach_recursive_mnt.isra.0`. The kernel exports only the suffixed name. CWS attaches the kprobe by exact name, so attachment fails:

```
symbol 'attach_recursive_mnt' not found: invalid argument
```

The probe is in an `AllOf` group in `pkg/security/ebpf/probes/event_types.go`, so ebpf-manager tears down the mount probe group when this selector fails. sysprobe never opens `/var/run/sysprobe/runtime-security.sock`, and security-agent loops on socket connection errors.

Fixes #48510.

### Describe how you validated your changes

The conntracker already uses the same regex form for `ctnetlink_fill_info(\.constprop\.0)?` at `pkg/network/tracer/ebpf_conntracker.go:432`, covering the analogous `.constprop.0` suffix. I have not run this on a Talos 6.18 kernel; agent-security reviewers should sanity-check that `manager.Probe` parses the regex as expected.

### Additional Notes

Added a release note under `releasenotes/notes/`.