### PR TITLE
fix(aggregator): prevent uint16 overflow in FuzzTagFilterCacheHighChurn

### DIFF
--- a/pkg/aggregator/tagfilter_cache_test.go
+++ b/pkg/aggregator/tagfilter_cache_test.go
@@ -380,8 +380,11 @@ func FuzzTagFilterCacheHighChurn(f *testing.F) {
 		sc := newTagFilterCache(defaultReverseCacheCapacity)
 		postKey := ckey.ContextKey(999)
 
-		for i := start; i < start+count; i++ {
-			sc.add(ckey.ContextKey(i), tagFilterCacheEntry{contextKey: postKey, removedTags: int(i)})
+		// Widen to int to avoid uint16 overflow: start+count could wrap around
+		// to a value smaller than start, making the loop body never execute.
+		end := int(start) + int(count)
+		for i := int(start); i < end; i++ {
+			sc.add(ckey.ContextKey(i), tagFilterCacheEntry{contextKey: postKey, removedTags: i})
 			assertTagFilterCacheConsistent(t, sc)
 		}
 


### PR DESCRIPTION
### What does this PR do?
Widens the loop bounds from `uint16` to `int` in `FuzzTagFilterCacheHighChurn`.

### Motivation

`start + count` was evaluated as `uint16`. When the sum exceeds 65535 it wraps to a small value less than `start`, making the loop body never execute — the intended high-churn scenario is silently skipped.

### Describe how you validated your changes
The fuzz corpus entry that triggered the failure now passes.

### Additional Notes
Production `tagFilterCache` uses `uint` throughout; there is no overflow risk in non-test code.