### PR TITLE
fix(obfuscate): skip NaN/Inf in FuzzTokenizeFloatStrings

### DIFF
--- a/pkg/obfuscate/sql_tokenizer_test.go
+++ b/pkg/obfuscate/sql_tokenizer_test.go
@@ -79,6 +79,13 @@ func FuzzTokenizeFloatStrings(f *testing.F) {
 	f.Add(float64(-12.3456789))
 
 	f.Fuzz(func(t *testing.T, f float64) {
+		// NaN and Inf are not valid SQL numeric literals; strconv.FormatFloat
+		// renders them as "NaN", "+Inf", or "-Inf", which the tokenizer correctly
+		// does not classify as Number tokens.  Skip them rather than asserting
+		// a property they cannot satisfy.
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return
+		}
 		for _, format := range []byte{'e', 'E', 'f'} {
 			value := strconv.FormatFloat(f, format, -1, 64)
 			testTokenizeNumber(t, value)


### PR DESCRIPTION
### What does this PR do?
Skips `NaN` and `Inf` inputs in `FuzzTokenizeFloatStrings`.

### Motivation

`strconv.FormatFloat` renders NaN and Inf as `"NaN"`, `"+Inf"`, `"-Inf"` — none of which are valid SQL numeric literals. The tokenizer correctly rejects them, but the test was asserting that *all* `float64` values format as `Number` tokens.

### Describe how you validated your changes
The fuzz corpus entry that triggered the failure now passes.