### PR TITLE
chore(deps): replace github.com/golang/protobuf with google.golang.org/protobuf

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -390,9 +390,6 @@ linters:
       text: "name will be used as .* by other packages, and that stutters"
     - path: pkg/util/containerd
       text: "name will be used as .* by other packages, and that stutters"
-    # Should be replaced by google.golang.org/protobuf but is not a drop-in replacement
-    - text: "\"github.com/golang/protobuf/proto\" is deprecated"
-      linters: [staticcheck]
     # Can't rely on getting the same elements after calling Seed because dependencies could be using
     # it too. Should be replaced by using a local source, but there are too many uses in the repo.
     - text: "rand.Seed has been deprecated since Go 1.20"

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/BUILD.bazel
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/BUILD.bazel
@@ -20,11 +20,11 @@ go_library(
         "//pkg/util/grpc",
         "//pkg/util/log",
         "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
-        "@com_github_golang_protobuf//proto",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//credentials",
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//grpclog",
+        "@org_golang_google_protobuf//proto",
         "@org_uber_go_fx//:fx",
     ],
 )

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -32,7 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 const (

--- a/pkg/network/encoding/encoding_linux_test.go
+++ b/pkg/network/encoding/encoding_linux_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // SA1019: agent-payload/v5/process types are gogo-generated and do not implement protoreflect.ProtoMessage
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // SA1019: agent-payload/v5/process types are gogo-generated and do not implement protoreflect.ProtoMessage
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/network/encoding/marshal/usm_http_test.go
+++ b/pkg/network/encoding/marshal/usm_http_test.go
@@ -15,7 +15,7 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck // SA1019: agent-payload/v5/process types are gogo-generated and do not implement protoreflect.ProtoMessage
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/network/encoding/marshal/usm_latency_encoding_test.go
+++ b/pkg/network/encoding/marshal/usm_latency_encoding_test.go
@@ -9,8 +9,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"


### PR DESCRIPTION
### What does this PR do?

Replaces `github.com/golang/protobuf/proto` with `google.golang.org/protobuf/proto`.

### Motivation

`golang/protobuf` is officially deprecated.

### Describe how you validated your changes

Import path change only, same API.

### Additional Notes

No functional change.