### PR TITLE
pkg/clusteragent/autoscaling/cluster/spot: track pods once per workload in processItem

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/spot/README.md
+++ b/pkg/clusteragent/autoscaling/cluster/spot/README.md
@@ -192,7 +192,7 @@ nginx-6f8f465d8c-sn6dw   1/1     Running   0          5m29s
 ## Scheduler components
 
 - `scheduler` — admission decisions, fallback, rebalancing
-- `workloadController` — watches workloads, syncs config and pods
+- `workloadController` — watches workloads, syncs config and pods (once)
 - `podTracker` — counts spot / on-demand pods per workload
 - `spotConfigStore` — per-workload spot config key-value store
 - `podLister` — lists pods from workloadmeta store
@@ -216,7 +216,7 @@ graph TD
     end
 
     Webhook -->|"CREATE / DELETE Pod"| S
-    WLM -->|"Pod set / unset events"| PT
+    WLM -->|"addedOrUpdated, deleted"| PT
 
     S -->|"getConfig, disable"| CS
     S -->|"admitNewPod, deletePod"| PT
@@ -228,7 +228,7 @@ graph TD
     K8sAPI -->|"WATCH workloads"| WC
 
     WC -->|"setConfig, deleteConfig"| CS
-    WC -->|"addedOrUpdated, untrack"| PT
+    WC -->|"untrack, addedOrUpdated (once)"| PT
     WC -->|"listPods"| PL
 
     PL -->|"ListKubernetesPods"| WLM

--- a/pkg/clusteragent/autoscaling/cluster/spot/scheduler.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/scheduler.go
@@ -141,10 +141,10 @@ func (s *scheduler) rebalance(ctx context.Context) {
 				continue
 			}
 			if err := s.evictor.evictPod(ctx, namespace, name, ""); err != nil {
-				log.Errorf("Failed to evict pod %s/%s for rebalancing: %v", namespace, name, err)
+				log.Errorf("Failed to evict pod %s/%s (%s) for rebalancing: %v", namespace, name, uid, err)
 				continue
 			}
-			log.Infof("Evicted pod %s/%s for spot rebalancing", namespace, name)
+			log.Infof("Evicted pod %s/%s (%s) for rebalancing", namespace, name, uid)
 		}
 	}
 }
@@ -252,10 +252,10 @@ func (s *scheduler) checkOnDemandFallbackOnce(ctx context.Context, now time.Time
 		}
 		for uid, pod := range pods {
 			if err := s.evictor.evictPod(ctx, pod.topLevelOwner.Namespace, pod.name, corev1.PodPending); err != nil {
-				log.Errorf("Failed to evict timed-out pending spot pod %s of %s: %v", pod.name, pod.topLevelOwner, err)
+				log.Errorf("Failed to evict timed-out pending spot pod %s (%s) of %s: %v", pod.name, uid, pod.topLevelOwner, err)
 				continue
 			}
-			log.Infof("Evicted timed-out pending spot pod %s of %s for on-demand fallback", pod.name, pod.topLevelOwner)
+			log.Infof("Evicted timed-out pending spot pod %s (%s) of %s for on-demand fallback", pod.name, uid, pod.topLevelOwner)
 			s.tracker.deletePendingSpotPod(uid)
 		}
 	}

--- a/pkg/clusteragent/autoscaling/cluster/spot/workload_controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/spot/workload_controller.go
@@ -183,12 +183,19 @@ func (c *workloadController) processItem(ctx context.Context, key objectRef) err
 	}
 
 	// Update config store
+	_, exists := c.store.getConfig(key)
+
 	cfg := c.defaultConfig
 	overrideFromAnnotations(&cfg, u.GetAnnotations())
 	c.store.setConfig(key, cfg)
 	log.Debugf("Spot workload config updated %s: %#v", key, cfg)
 
-	// List and track pods
+	// List and track pods.
+	// Do it once per enabled workload to avoid race with pod updates arriving via WLM through scheduler.trackPodUpdates.
+	if exists {
+		return nil
+	}
+
 	selector, ok := getPodSelector(key.Kind, u.Object)
 	if !ok {
 		return nil


### PR DESCRIPTION
### What does this PR do?

List and track pods once per workload to avoid race with pod updates arriving via WLM through scheduler.trackPodUpdates.

### Motivation

processItem is triggered on every Deployment/StatefulSet change, including the disabledUntil patch written by the fallback handler. Each run was calling wlm.ListKubernetesPods(), which returns a point-in-time snapshot that may lag behind the live pod state maintained by scheduler.trackPodUpdates via the WLM subscription.

When spot fallback fires it might happen that:
  1. WLM delivers delete events for evicted spot pods → tracker removes them.
  2. Deployment is updated e.g. due to disabledUntil annotation patch → workload controller re-queues.
  3. processItem takes a stale WLM snapshot that still shows the evicted pods as Pending.
  4. addedOrUpdated re-inserts them into spotUIDs and pendingSpotPods.
  5. hasPending() returns true indefinitely → getPodToDelete() is blocked → rebalancer stalls and does not recover workload from a fallback.

### Describe how you validated your changes

### Additional Notes

The issue is detected by flaky e2e fallback test (test/new-e2e/tests/autoscaling/spot.TestSpotSchedulingKindCI/TestDeploymentFallbackWhenSpotUnavailable)
The change also logs evicted pod ids to simplify correlation with debug logs.

Updates https://datadoghq.atlassian.net/browse/CASCL-1362

