### PR TITLE
feat(win32_event_log): detect invalid channel via EvtSubscribe error, not a separate startup check

### DIFF
--- a/comp/checks/windowseventlog/impl/check/check.go
+++ b/comp/checks/windowseventlog/impl/check/check.go
@@ -18,6 +18,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/checks/windowseventlog/impl/check/eventdatafilter"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	windowseventlogchannels "github.com/DataDog/datadog-agent/comp/healthplatform/issues/windowseventlogchannels"
+	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	publishermetadatacache "github.com/DataDog/datadog-agent/comp/publishermetadatacache/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -71,6 +73,8 @@ type Check struct {
 	userRenderContext      evtapi.EventRenderContextHandle
 	bookmarkManager        evtbookmark.Manager
 	publisherMetadataCache publishermetadatacache.Component
+
+	healthPlatform healthplatformdef.Component
 }
 
 // Run updates sender stats, restarts the subscription if it failed, and saves the bookmark.
@@ -90,11 +94,26 @@ func (c *Check) Run() error {
 		// starts the event collection in the background.
 		err := c.startSubscription()
 		if err != nil {
+			if c.healthPlatform != nil && errors.Is(err, windows.ERROR_EVT_CHANNEL_NOT_FOUND) {
+				channelPath, _ := c.getChannelPath()
+				instanceID := fmt.Sprintf("%s:%s", windowseventlogchannels.IssueID, string(c.ID()))
+				_ = c.healthPlatform.ReportIssue(healthplatformdef.IssueReport{
+					IssueID:   instanceID,
+					IssueType: windowseventlogchannels.IssueID,
+					Source:    CheckName,
+					Context:   map[string]string{"channelPath": channelPath},
+				})
+			}
 			err = fmt.Errorf("subscription is not running, failed to start: %w", err)
 			if c.sub.Error() != nil {
 				err = fmt.Errorf("%w, last stop reason: %w", err, c.sub.Error())
 			}
 			return err
+		}
+		// Subscription started successfully; resolve any previously recorded channel issue.
+		if c.healthPlatform != nil {
+			instanceID := fmt.Sprintf("%s:%s", windowseventlogchannels.IssueID, string(c.ID()))
+			c.healthPlatform.ResolveIssue(instanceID)
 		}
 	}
 
@@ -304,7 +323,7 @@ func (c *Check) Cancel() {
 }
 
 // Factory creates a new check factory
-func Factory(logsAgent option.Option[logsAgent.Component], config configComponent.Component, publisherMetadataCache publishermetadatacache.Component) option.Option[func() check.Check] {
+func Factory(logsAgent option.Option[logsAgent.Component], config configComponent.Component, publisherMetadataCache publishermetadatacache.Component, healthPlatform healthplatformdef.Component) option.Option[func() check.Check] {
 	return option.New(func() check.Check {
 		return &Check{
 			CheckBase:              core.NewCheckBase(CheckName),
@@ -312,6 +331,7 @@ func Factory(logsAgent option.Option[logsAgent.Component], config configComponen
 			agentConfig:            config,
 			evtapi:                 winevtapi.New(),
 			publisherMetadataCache: publisherMetadataCache,
+			healthPlatform:         healthPlatform,
 		}
 	})
 }

--- a/comp/checks/windowseventlog/impl/windows_event_log.go
+++ b/comp/checks/windowseventlog/impl/windows_event_log.go
@@ -16,6 +16,7 @@ import (
 	windowseventlog "github.com/DataDog/datadog-agent/comp/checks/windowseventlog/def"
 	check "github.com/DataDog/datadog-agent/comp/checks/windowseventlog/impl/check"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/store/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	publishermetadatacache "github.com/DataDog/datadog-agent/comp/publishermetadatacache/def"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -30,6 +31,8 @@ type Requires struct {
 	LogsComponent          option.Option[logsAgent.Component]
 	Config                 configComponent.Component
 	PublisherMetadataCache publishermetadatacache.Component
+	// HealthPlatform is optional; absent in builds that omit the health platform bundle.
+	HealthPlatform healthplatformdef.Component `optional:"true"`
 }
 
 // Provides defines the output of the windowseventlog component.
@@ -41,7 +44,7 @@ type Provides struct {
 func NewComponent(reqs Requires) Provides {
 	reqs.Lifecycle.Append(compdef.Hook{
 		OnStart: func(_ context.Context) error {
-			core.RegisterCheck(check.CheckName, check.Factory(reqs.LogsComponent, reqs.Config, reqs.PublisherMetadataCache))
+			core.RegisterCheck(check.CheckName, check.Factory(reqs.LogsComponent, reqs.Config, reqs.PublisherMetadataCache, reqs.HealthPlatform))
 			return nil
 		},
 	})

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/windowseventlogchannels"
 )
 
 // team: agent-health

--- a/comp/healthplatform/issues/windowseventlogchannels/BUILD.bazel
+++ b/comp/healthplatform/issues/windowseventlogchannels/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "windowseventlogchannels",
+    srcs = [
+        "issue.go",
+        "module.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/windowseventlogchannels",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/windowseventlogchannels/issue.go
+++ b/comp/healthplatform/issues/windowseventlogchannels/issue.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package windowseventlogchannels provides an issue module for invalid Windows
+// Event Log channel configurations. The issue is detected by the win32_event_log
+// check itself when EvtSubscribe fails with ERROR_EVT_CHANNEL_NOT_FOUND.
+package windowseventlogchannels
+
+import (
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// WindowsEventLogChannelIssue provides the issue template for an invalid Windows Event Log channel.
+type WindowsEventLogChannelIssue struct{}
+
+// NewWindowsEventLogChannelIssue creates a new issue template.
+func NewWindowsEventLogChannelIssue() *WindowsEventLogChannelIssue {
+	return &WindowsEventLogChannelIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation steps.
+// Expected context keys:
+//   - "channelPath": the configured channel name that was not found on the host
+func (t *WindowsEventLogChannelIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	channelPath := context["channelPath"]
+	if channelPath == "" {
+		channelPath = "unknown"
+	}
+
+	extra, err := structpb.NewStruct(map[string]any{
+		"channelPath": channelPath,
+		"impact":      "Events from this channel will not be collected.",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error building Windows Event Log channel issue: %w", err)
+	}
+
+	return &healthplatform.Issue{
+		IssueName:   "windows_eventlog_channel_not_found",
+		Title:       "Windows Event Log Channel Not Found",
+		Description: fmt.Sprintf("The configured Windows Event Log channel %q does not exist on this host.", channelPath),
+		Category:    "configuration",
+		Location:    "win32-event-log",
+		Severity:    "warning",
+		Source:      "win32_event_log",
+		Extra:       extra,
+		Remediation: &healthplatform.Remediation{
+			Summary: "Verify the channel name and update the integration configuration.",
+			Steps: []*healthplatform.RemediationStep{
+				{Order: 1, Text: "List available channels: run `wevtutil el` in PowerShell"},
+				{Order: 2, Text: fmt.Sprintf("Verify that %q appears in the output", channelPath)},
+				{Order: 3, Text: "Update `channel_path` in win32_event_log.d/conf.yaml to a valid channel name"},
+				{Order: 4, Text: "Restart the Datadog Agent to apply the change"},
+			},
+		},
+		Tags: []string{"windows-event-log", "configuration", "win32_event_log"},
+	}, nil
+}

--- a/comp/healthplatform/issues/windowseventlogchannels/module.go
+++ b/comp/healthplatform/issues/windowseventlogchannels/module.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package windowseventlogchannels
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique type identifier for Windows Event Log channel-not-found issues.
+	IssueID = "windows-eventlog-channel-not-found"
+)
+
+type windowsEventLogChannelModule struct {
+	template *WindowsEventLogChannelIssue
+}
+
+// NewModule creates a new Windows Event Log channel issue module.
+func NewModule(config.Component) issues.Module {
+	return &windowsEventLogChannelModule{
+		template: NewWindowsEventLogChannelIssue(),
+	}
+}
+
+func (m *windowsEventLogChannelModule) IssueID() string {
+	return IssueID
+}
+
+func (m *windowsEventLogChannelModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns nil — the issue is reported by the win32_event_log
+// check itself when EvtSubscribe fails with ERROR_EVT_CHANNEL_NOT_FOUND.
+func (m *windowsEventLogChannelModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Replaces the separate startup `BuiltInHealthCheck` approach (PR #49838) with inline detection inside the existing `win32_event_log` check.

When `EvtSubscribe` fails with `ERROR_EVT_CHANNEL_NOT_FOUND`, the check's `Run()` method calls `healthPlatform.ReportIssue(...)` directly. When the subscription starts successfully (e.g. after the channel is created or the config is fixed), it calls `ResolveIssue(...)`.

**Changes:**
- `comp/healthplatform/issues/windowseventlogchannels/` — new issue module (`issue.go` + `module.go`) that registers the `windows-eventlog-channel-not-found` issue type; `BuiltInHealthCheck()` returns `nil` since detection is done by the check itself, not a scheduler-driven probe
- `comp/healthplatform/bundle.go` — blank import to trigger `init()` registration
- `comp/checks/windowseventlog/impl/windows_event_log.go` — adds `HealthPlatform healthplatformdef.Component` (optional via `optional:"true"`) to `Requires`
- `comp/checks/windowseventlog/impl/check/check.go` — adds `healthPlatform` field; `Factory` threads it through; `Run()` detects `ERROR_EVT_CHANNEL_NOT_FOUND` and reports/resolves the issue

### Motivation

The separate startup check approach in #49838 duplicates the channel path it already has: it re-parses every YAML file in `win32_event_log.d/` and shells out to `wevtutil gl` to validate channels. The check itself already calls `EvtSubscribe` with the exact channel and receives the precise Windows error code when it doesn't exist — so the check is the natural place to report the issue, with no extra work.

### Describe how you validated your changes

- `go build ./comp/healthplatform/... ./comp/checks/windowseventlog/...` passes on non-Windows (noop path)
- `healthPlatform` is `optional:"true"` — nil when the health platform bundle is absent, guarded before use

### Additional Notes

- `ERROR_EVT_CHANNEL_NOT_FOUND` (`windows.Errno(15007)`) is defined in `golang.org/x/sys/windows`
- The issue instance ID is `"windows-eventlog-channel-not-found:<checkID>"`, unique per check instance, so multiple win32_event_log instances watching different channels each get their own issue entry
- The health platform field is `nil` in existing tests (created via `new(Check)`) — no test changes needed