### PR TITLE
[CWS] Add size on disk metric for activity dumps

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -302,6 +302,11 @@ var (
 	// Tags: -
 	MetricActivityDumpLocalStorageDeleted = newAgentMetric(".activity_dump.local_storage.deleted")
 
+	// MetricActivityDumpLocalStorageSizeOnDisk is the name of the metric used to track the size that the profiles are
+	// using on disk
+	// Tags: -
+	MetricActivityDumpLocalStorageSizeOnDisk = newAgentMetric(".activity_dump.local_storage.size_on_disk")
+
 	// SBOM resolver metrics
 
 	// MetricSBOMResolverActiveSBOMs is the name of the metric used to report the count of SBOMs kept in memory

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -305,7 +305,7 @@ var (
 	// MetricActivityDumpLocalStorageSizeOnDisk is the name of the metric used to track the size that the profiles are
 	// using on disk
 	// Tags: -
-	MetricActivityDumpLocalStorageSizeOnDisk = newAgentMetric(".activity_dump.local_storage.size_on_disk")
+	MetricActivityDumpLocalStorageSizeOnDisk = newRuntimeMetric(".activity_dump.local_storage.size_on_disk")
 
 	// SBOM resolver metrics
 

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -89,21 +89,17 @@ type Profile struct {
 
 	// V2
 	// First has been sent
-	hasAlreadyBeenSent bool
+	hasAlreadyBeenSent *atomic.Bool
 }
 
 // HasAlreadyBeenSent returns true if the profile has already been sent
 func (p *Profile) HasAlreadyBeenSent() bool {
-	p.Lock()
-	defer p.Unlock()
-	return p.hasAlreadyBeenSent
+	return p.hasAlreadyBeenSent.Load()
 }
 
 // SetHasAlreadyBeenSent sets the hasAlreadyBeenSent flag to true
 func (p *Profile) SetHasAlreadyBeenSent() {
-	p.Lock()
-	defer p.Unlock()
-	p.hasAlreadyBeenSent = true
+	p.hasAlreadyBeenSent.Store(true)
 }
 
 // Opts defines the options to create a new profile
@@ -150,10 +146,11 @@ func New(opts ...Opts) *Profile {
 		Header: ActivityDumpHeader{
 			DNSNames: utils.NewStringKeys(nil),
 		},
-		LoadedInKernel:  atomic.NewBool(false),
-		LoadedNano:      atomic.NewUint64(0),
-		versionContexts: make(map[string]*VersionContext),
-		profileCookie:   utils.RandNonZeroUint64(),
+		LoadedInKernel:     atomic.NewBool(false),
+		LoadedNano:         atomic.NewUint64(0),
+		hasAlreadyBeenSent: atomic.NewBool(false),
+		versionContexts:    make(map[string]*VersionContext),
+		profileCookie:      utils.RandNonZeroUint64(),
 	}
 
 	for _, opt := range opts {

--- a/pkg/security/security_profile/storage/directory.go
+++ b/pkg/security/security_profile/storage/directory.go
@@ -255,6 +255,36 @@ func (d *Directory) Load(wls *cgroupModel.WorkloadSelector, p *profile.Profile) 
 	return false, nil
 }
 
+func (d *Directory) getProfilesSizeOnDisk() uint64 {
+	var ret uint64
+
+	files, err := os.ReadDir(d.directoryPath)
+	if err != nil {
+		seclog.Warnf("couldn't list the files in %s. The %s metric is reporting incorrect data for this host", d.directoryPath, metrics.MetricActivityDumpLocalStorageSizeOnDisk)
+		return 0
+	}
+
+	for _, file := range files {
+		fullpath := filepath.Join(d.directoryPath, file.Name())
+
+		_, err := config.ParseStorageFormat(filepath.Ext(fullpath))
+		// skip files that don't have any of our storage formats
+		if err != nil {
+			continue
+		}
+
+		s, err := os.Stat(fullpath)
+		if err != nil {
+			seclog.Warnf("couldn't stat the file %s. The %s metric is likely to be reporting incorrect data for this host", fullpath, metrics.MetricActivityDumpLocalStorageSizeOnDisk)
+			continue
+		}
+
+		ret += uint64(s.Size())
+	}
+
+	return ret
+}
+
 // GetStorageType returns the storage type
 func (d *Directory) GetStorageType() config.StorageType {
 	return config.LocalStorage
@@ -273,6 +303,10 @@ func (d *Directory) SendTelemetry(sender statsd.ClientInterface) {
 	if count := d.deletedCount.Swap(0); count > 0 {
 		_ = sender.Count(metrics.MetricActivityDumpLocalStorageDeleted, int64(count), nil, 1.0)
 	}
+
+	// send the total size on disk used by the profiles
+	sizeOnDisk := d.getProfilesSizeOnDisk()
+	_ = sender.Gauge(metrics.MetricActivityDumpLocalStorageSizeOnDisk, float64(sizeOnDisk), nil, 1.0)
 }
 
 func compressWithGZip(filename string, rawBuf []byte) (*bytes.Buffer, error) {


### PR DESCRIPTION
### What does this PR do?

Adds a new metric to show exactly how much disk space is taken by the activity dumps

### Motivation

We have no idea how much is being used right now

### Describe how you validated your changes


### Additional Notes
