### PR TITLE
fix: close HTTP response body on all return paths

### DIFF
--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -558,6 +558,7 @@ func downloadPolicy(log log.Component, config config.Component, _ secrets.Compon
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	resBytes, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -567,7 +568,6 @@ func downloadPolicy(log log.Component, config config.Component, _ secrets.Compon
 	if res.StatusCode != 200 {
 		return fmt.Errorf("failed to download policies: %s (error code %d)", string(resBytes), res.StatusCode)
 	}
-	defer res.Body.Close()
 
 	// Unzip the downloaded file containing both default and custom policies
 	reader, err := zip.NewReader(bytes.NewReader(resBytes), int64(len(resBytes)))

--- a/pkg/fleet/daemon/local_api.go
+++ b/pkg/fleet/daemon/local_api.go
@@ -593,6 +593,7 @@ func (c *localAPIClientImpl) PromoteConfigExperiment(pkg string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	var response APIResponse
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
@@ -601,7 +602,6 @@ func (c *localAPIClientImpl) PromoteConfigExperiment(pkg string) error {
 	if response.Error != nil {
 		return fmt.Errorf("error promoting config experiment: %s", response.Error.Message)
 	}
-	defer resp.Body.Close()
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Moves `defer resp.Body.Close()` to immediately after the successful `Do` call in two functions where it was placed too late, causing body leaks on error return paths:

- `pkg/fleet/daemon/local_api.go` — `PromoteConfigExperiment`: defer was after JSON decode and error check returns
- `cmd/system-probe/subcommands/runtime/command.go` — `downloadPolicies`: defer was after `io.ReadAll` and status check returns

### Motivation

Resource leak: `resp.Body` was left open whenever the function returned early due to a decode error or non-200 status.

### Describe how you validated your changes

One-line move in each function, matching the pattern used consistently by all sibling functions in the codebase.

### Additional Notes

Spotted in https://github.com/DataDog/datadog-agent/pull/50380#discussion_r3258098102. Scanned all Go files in `comp`, `cmd`, and `pkg` for the same pattern — these are the only two occurrences.