### PR TITLE
Add Milvus E2E scenario for agent-sandbox

### DIFF
--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/README.md
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/README.md
@@ -1,0 +1,134 @@
+# Milvus Pulumi scenario
+
+Deployable e2e-framework scenario that stands up a Milvus stack with
+real traffic, a Datadog Agent reporting to a real Datadog org, and
+Autodiscovery-driven Milvus integration. Wrapped as a `go test` so it
+slots into the existing runner — but the test body is intentionally
+empty: this is a *deploy*, not a *check*.
+
+## What it deploys
+
+Built on the stock `awsdocker.Provisioner` (`environments.DockerHost`):
+a single AWS EC2 VM running a Docker Compose project that contains:
+
+| Service          | Image                                  | Role                                                       |
+|------------------|----------------------------------------|------------------------------------------------------------|
+| `datadog-agent`  | (framework default agent image)        | Runs the Milvus check via container-label Autodiscovery.   |
+| `milvus`         | `milvusdb/milvus:v2.4.13`              | Milvus standalone. Carries the Datadog AD labels.          |
+| `etcd`           | `coreos/etcd:v3.5.5`                   | Milvus metadata store.                                     |
+| `minio`          | `minio/minio:RELEASE.2023-03-20…`      | Milvus object store.                                       |
+| `milvus-traffic` | `python:3.11-slim`                     | Installs `pymilvus`, runs insert / search / query forever. |
+
+## Layout
+
+```
+milvus/
+├── provisioner.go              # awsdocker.Provisioner(...) wiring
+├── milvus_test.go              # Empty test that drives `pulumi up`
+├── testfixtures/
+│   ├── docker-compose.milvus.yaml  # Milvus + etcd + MinIO + traffic + AD labels
+│   └── traffic.py                  # pymilvus traffic generator
+└── README.md
+```
+
+## Framework primitives used
+
+Per `test/e2e-framework/AGENTS.md`, the stock typed environment with
+`With*` options is preferred over a custom Pulumi program:
+
+* `awsdocker.Provisioner` → `environments.DockerHost`.
+* `ec2docker.WithoutFakeIntake()` → Agent ships to the real intake.
+* `dockeragentparams.WithExtraComposeManifest("milvus", …)` → splices the
+  Milvus stack into the same compose project as the Agent so docker.sock
+  Autodiscovery picks it up.
+* `dockeragentparams.WithEnvironmentVariables(...)` → injects
+  `DD_E2E_TEST_ID` (interpolated into AD labels) and `DD_MILVUS_TRAFFIC_B64`
+  (the script, base64-encoded so the file is created inside the container
+  at boot).
+* `dockeragentparams.WithTags(...)` → host-level `DD_TAGS`.
+
+The Milvus integration is configured purely via Datadog Autodiscovery
+container labels on the milvus service — no `conf.d` file, no custom env.
+
+## Real intake
+
+Because `WithoutFakeIntake()` is set and `WithFakeintake(...)` is never
+called, the Agent uses the default intake (`datadoghq.com`) with the API
+key from the runner profile. Configure with `E2E_API_KEY` (and
+`E2E_APP_KEY` if you want to query the backend from any future test).
+
+## Deploying
+
+This scenario uses the default e2e-framework AWS environment (`agent-sandbox`).
+Run the standard local setup once, then authenticate with the generated AWS SSO
+profile before deploying:
+
+```bash
+dda inv e2e.setup --account=agent-sandbox
+aws-vault exec sso-agent-sandbox-account-admin -- aws sts get-caller-identity
+```
+
+The `scripts/` directory wraps the framework runner with sensible defaults
+and uses `dd-auth` to populate the Datadog API key. From the milvus directory:
+
+```bash
+./scripts/up.sh        # provision the stack (keeps it alive)
+./scripts/check.sh     # smoke-test the deployment (containers + agent + traffic)
+./scripts/test.sh      # up.sh -> wait -> check.sh   (use --teardown to also destroy)
+./scripts/down.sh      # destroy the stack
+```
+
+Each script sources `scripts/_lib.sh`, which runs `dd-auth --output`,
+exports `DD_API_KEY` / `DD_APP_KEY` / `DD_SITE`, and re-publishes them under
+the names the framework/provisioner read (`E2E_API_KEY`, `E2E_APP_KEY`,
+`MILVUS_DD_SITE`). To authenticate against a non-default org, set
+`DD_AUTH_DOMAIN` (native dd-auth env var) before calling the scripts:
+
+```bash
+DD_AUTH_DOMAIN=dddev.datadoghq.com ./scripts/up.sh
+```
+
+The provisioner sets `DD_SITE` on the agent container when
+`MILVUS_DD_SITE` is non-empty, so the agent ships to the same org that
+owns the key.
+
+Overrideable env vars:
+
+| Var                  | Default      | Effect                                                |
+|----------------------|--------------|-------------------------------------------------------|
+| `MILVUS_STACK_NAME`  | `milvus-dev` | Pulumi stack name; shared by all four scripts.        |
+| `MILVUS_E2E_TEST_ID` | stack name   | Stamped into AD labels, `DD_TAGS`, host tags.         |
+| `MILVUS_WAIT_SECS`   | `180`        | How long `test.sh` waits after `up.sh` before checking. |
+| `DDA`                | `dda`        | Path to the `dda` binary (use for non-PATH installs). |
+
+Underlying command (what `up.sh` runs):
+
+```bash
+E2E_DEV_MODE=true E2E_STACK_NAME=milvus-dev MILVUS_E2E_TEST_ID=milvus-dev \
+  dda inv new-e2e-tests.run \
+  --targets=./tests/agent-metric-pipelines/milvus \
+  --run=^TestMilvusEnv$
+```
+
+After deploy, look in Datadog for metrics filtered by
+`e2e_test_id:<id>` (e.g. `milvus.proxy.num_collections`,
+`milvus.proxy.search_latency`, `milvus.proxy.req_count`).
+
+## Inspecting on the VM
+
+The runner prints the EC2 host once provisioning is done:
+
+```bash
+ssh <printed host>
+sudo docker ps                                # datadog-agent, milvus-*, etc.
+sudo docker logs -f milvus-traffic            # "iteration=N ok"
+sudo docker exec -it datadog-agent agent status | sed -n '/milvus/,/^$/p'
+sudo docker exec -it datadog-agent agent check milvus
+```
+
+## References
+
+* Pattern this is based on:
+  `test/new-e2e/examples/dockerenv_with_extra_compose_test.go`
+* Framework docs: `test/e2e-framework/AGENTS.md`
+* Integration docs: <https://docs.datadoghq.com/integrations/milvus/>

--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/milvus_test.go
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/milvus_test.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package milvus
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+)
+
+// milvusEnv is a thin wrapper around the stock DockerHost so we can attach
+// suite methods if we ever want to.
+type milvusEnv struct {
+	e2e.BaseSuite[environments.DockerHost]
+}
+
+// TestProvisioned is a placeholder test method. It exists for one reason:
+// testify's Suite runner skips suites that have zero Test* methods
+// entirely — it never calls SetupSuite, which is where the e2e-framework
+// runs `pulumi up`. Without this method the test "passes" in tens of
+// milliseconds and provisions nothing. This method asserts the env was
+// initialized; the real assertion that matters is that we got here at
+// all (i.e. SetupSuite completed).
+func (s *milvusEnv) TestProvisioned() {
+	env := s.Env()
+	require.NotNil(s.T(), env, "environment should be provisioned")
+	require.NotNil(s.T(), env.RemoteHost, "RemoteHost should be provisioned")
+	s.T().Logf("provisioned host address = %s", env.RemoteHost.Address)
+}
+
+// TestMilvusEnv is intentionally a no-op test: its only purpose is to drive
+// the e2e-framework runner to `pulumi up` the Milvus scenario.
+//
+// Typical usage (deploy only, keep the stack alive for inspection / iteration):
+//
+//	E2E_DEV_MODE=true \
+//	E2E_STACK_NAME=milvus-dev \
+//	dda inv new-e2e-tests.run \
+//	    --targets=./tests/agent-metric-pipelines/milvus \
+//	    --run=^TestMilvusEnv$
+//
+// Without E2E_DEV_MODE the framework will tear the stack back down once
+// the (empty) test returns — useful as a CI-style smoke check that the
+// scenario provisions cleanly.
+func TestMilvusEnv(t *testing.T) {
+	testID := os.Getenv("MILVUS_E2E_TEST_ID")
+	if testID == "" {
+		testID = randomTestID()
+	}
+	t.Logf("milvus scenario testID = %s", testID)
+
+	stackName := os.Getenv("E2E_STACK_NAME")
+	if stackName == "" {
+		stackName = fmt.Sprintf("milvus-%s", testID)
+	}
+
+	e2e.Run(t, &milvusEnv{},
+		e2e.WithProvisioner(Provisioner(testID)),
+		e2e.WithStackName(stackName),
+	)
+}
+
+func randomTestID() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/provisioner.go
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/provisioner.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package milvus provides an E2E scenario that deploys Milvus, drives real
+// traffic against it, runs a Docker Agent configured with the Milvus
+// integration via Autodiscovery, and expects metrics to flow to a real
+// Datadog intake (no fakeintake).
+package milvus
+
+import (
+	_ "embed"
+	"encoding/base64"
+	"os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/dockeragentparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2docker"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+	awsdocker "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/docker"
+)
+
+//go:embed testfixtures/docker-compose.milvus.yaml
+var milvusComposeContent string
+
+//go:embed testfixtures/traffic.py
+var trafficScript string
+
+// Provisioner returns the stock AWS Docker host provisioner configured for
+// the Milvus E2E scenario:
+//
+//   - WithoutFakeIntake() — the Agent ships to the real Datadog intake
+//     using the runner's API key.
+//   - WithExtraComposeManifest() — adds Milvus standalone (etcd + MinIO +
+//     milvus) and a pymilvus traffic generator to the agent compose.
+//   - WithEnvironmentVariables() — injects per-run state into compose:
+//     a unique e2e_test_id (also surfaced via DD_TAGS / AD labels) and the
+//     base64-encoded traffic generator script.
+//   - WithTags() — host-level tags attached to all metrics from this run.
+//
+// The Milvus integration itself is configured via Datadog Autodiscovery
+// labels on the milvus service (see the embedded compose), so no host-side
+// conf.d file is needed.
+func Provisioner(testID string) provisioners.TypedProvisioner[environments.DockerHost] {
+	trafficB64 := base64.StdEncoding.EncodeToString([]byte(trafficScript))
+
+	agentOpts := []dockeragentparams.Option{
+		dockeragentparams.WithExtraComposeManifest(
+			"milvus",
+			pulumi.String(milvusComposeContent),
+		),
+		dockeragentparams.WithEnvironmentVariables(pulumi.StringMap{
+			"DD_E2E_TEST_ID":        pulumi.String(testID),
+			"DD_MILVUS_TRAFFIC_B64": pulumi.String(trafficB64),
+		}),
+		dockeragentparams.WithTags([]string{
+			"env:e2e",
+			"e2e_scenario:milvus",
+			"e2e_test_id:" + testID,
+		}),
+	}
+
+	// If the caller (typically scripts/_lib.sh after dd-auth) selected a
+	// non-default Datadog site, pin it on the agent container so the agent
+	// ships to the same org that owns the API key.
+	if site := os.Getenv("MILVUS_DD_SITE"); site != "" {
+		agentOpts = append(agentOpts,
+			dockeragentparams.WithAgentServiceEnvVariable("DD_SITE", pulumi.String(site)),
+		)
+	}
+
+	return awsdocker.Provisioner(
+		awsdocker.WithRunOptions(
+			ec2docker.WithoutFakeIntake(),
+			ec2docker.WithAgentOptions(agentOpts...),
+		),
+	)
+}

--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/_lib.sh
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/_lib.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Shared helpers for the Milvus scenario scripts.
+#
+# - Locates the repo root and the milvus test directory (works from any cwd).
+# - Authenticates to Datadog via `dd-auth --output` so the API key, app key
+#   and site are exported into the current shell, then re-exports them
+#   under the names the e2e-framework runner expects (E2E_API_KEY,
+#   E2E_APP_KEY, MILVUS_DD_SITE).
+# - Computes the stack name used by the test so up/down/check agree.
+#
+# Source this file; don't run it directly.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+MILVUS_DIR=$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)
+REPO_ROOT=$(cd -- "${MILVUS_DIR}/../../../../.." &>/dev/null && pwd)
+
+# Stack name: stable per checkout so up/down/check operate on the same env.
+# Override with MILVUS_STACK_NAME for ad-hoc runs.
+STACK_NAME=${MILVUS_STACK_NAME:-milvus-dev}
+
+# testID embedded in AD labels / DD_TAGS / agent host tags. Override with
+# MILVUS_E2E_TEST_ID to keep it stable across redeploys.
+TEST_ID=${MILVUS_E2E_TEST_ID:-${STACK_NAME//[^a-zA-Z0-9_-]/_}}
+
+log()  { printf '\033[1;34m[milvus]\033[0m %s\n' "$*" >&2; }
+fail() { printf '\033[1;31m[milvus]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Authenticate with dd-auth and surface the credentials under the names the
+# e2e-framework runner reads. Idempotent — safe to call from every script.
+#
+# dd-auth(1) is a no-arg-required CLI that prints KEY=VALUE pairs to stdout
+# when invoked with `--output`:
+#
+#   $ dd-auth --output
+#   DD_API_KEY=...
+#   DD_APP_KEY=...
+#   DD_SITE=datadoghq.com
+#
+# Honors `DD_AUTH_DOMAIN` (native dd-auth env var) for selecting a non-default
+# org, e.g. `DD_AUTH_DOMAIN=dddev.datadoghq.com`.
+ensure_dd_auth() {
+    if ! command -v dd-auth >/dev/null 2>&1; then
+        fail "dd-auth not found in PATH; install it or set DD_API_KEY/DD_SITE manually"
+    fi
+
+    log "running dd-auth --output${DD_AUTH_DOMAIN:+ (domain=${DD_AUTH_DOMAIN})}..."
+    local creds
+    creds=$(dd-auth --output) \
+        || fail "dd-auth failed; try \`dd-auth -v --output\` to debug"
+
+    # Export each KEY=VALUE line into our env.
+    while IFS= read -r line; do
+        [[ -z "${line}" || "${line}" == \#* ]] && continue
+        [[ "${line}" == *=* ]] || continue
+        export "${line?}"
+    done <<<"${creds}"
+
+    [[ -n "${DD_API_KEY:-}" ]] || fail "dd-auth output did not include DD_API_KEY"
+    [[ -n "${DD_SITE:-}"    ]] || fail "dd-auth output did not include DD_SITE"
+
+    # Map to the names the e2e-framework runner picks up.
+    export E2E_API_KEY="${DD_API_KEY}"
+    [[ -n "${DD_APP_KEY:-}" ]] && export E2E_APP_KEY="${DD_APP_KEY}"
+
+    # The Milvus provisioner reads MILVUS_DD_SITE at deploy time so the agent
+    # ships to the same org dd-auth authenticated against (otherwise it would
+    # default to datadoghq.com regardless of the auth target).
+    export MILVUS_DD_SITE="${DD_SITE}"
+
+    log "DD auth ok (site=${DD_SITE}, api key length=${#DD_API_KEY})"
+}
+
+# Print the path used to invoke dda. Honors DDA if set.
+dda_bin() { echo "${DDA:-dda}"; }
+
+require_dda() {
+    command -v "$(dda_bin)" >/dev/null 2>&1 \
+        || fail "$(dda_bin) not found in PATH (see docs/public/how-to/test/e2e.md)"
+}
+
+# Retrieve a single Pulumi stack output value (e.g. host address). Returns
+# empty string if the stack doesn't exist yet.
+stack_output() {
+    local key=$1
+    (cd "${REPO_ROOT}/test/new-e2e" \
+        && pulumi stack output -s "${STACK_NAME}" "${key}" 2>/dev/null) || true
+}

--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/check.sh
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/check.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Smoke-test the deployed Milvus scenario.
+#
+# Asserts:
+#   1. Pulumi stack exists.
+#   2. SSH to the VM works.
+#   3. The five expected containers (agent + milvus stack + traffic) are running.
+#   4. The Datadog Agent has scheduled the milvus check.
+#   5. The traffic container is producing iterations.
+#   6. The Milvus /metrics endpoint serves Prometheus output.
+#
+# Exit non-zero on the first failed check.
+
+source "$(dirname -- "${BASH_SOURCE[0]}")/_lib.sh"
+ensure_dd_auth   # not strictly required, but keeps env consistent
+
+# --- 1. stack exists -------------------------------------------------------
+
+cd "${REPO_ROOT}/test/new-e2e"
+pulumi stack -s "${STACK_NAME}" --non-interactive >/dev/null 2>&1 \
+    || fail "stack ${STACK_NAME} not found — did you run ./scripts/up.sh ?"
+
+# --- 2. resolve VM address from Pulumi outputs -----------------------------
+
+HOST_ADDRESS=$(stack_output dockervm-address)
+[[ -n "${HOST_ADDRESS}" ]] \
+    || HOST_ADDRESS=$(pulumi stack output -s "${STACK_NAME}" --json 2>/dev/null \
+        | python3 -c "import json,sys; d=json.load(sys.stdin)
+import re
+def walk(o):
+    if isinstance(o, dict):
+        for k,v in o.items():
+            if k == 'address' and isinstance(v, str): yield v
+            else: yield from walk(v)
+    elif isinstance(o, list):
+        for i in o: yield from walk(i)
+for a in walk(d):
+    print(a); break")
+[[ -n "${HOST_ADDRESS}" ]] || fail "could not locate VM address in pulumi outputs"
+log "VM address: ${HOST_ADDRESS}"
+
+SSH_KEY=${E2E_AWS_PRIVATE_KEY_PATH:-${HOME}/.ssh/id_rsa}
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10)
+[[ -f "${SSH_KEY}" ]] && SSH_OPTS+=(-i "${SSH_KEY}")
+SSH_USER=${SSH_USER:-ubuntu}
+
+ssh_run() {
+    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${HOST_ADDRESS}" "$@"
+}
+
+# --- 3. SSH works ----------------------------------------------------------
+
+log "checking SSH..."
+ssh_run true || fail "ssh to ${SSH_USER}@${HOST_ADDRESS} failed"
+
+# --- 4. containers ---------------------------------------------------------
+
+log "listing containers..."
+CONTAINERS=$(ssh_run "sudo docker ps --format '{{.Names}}'") \
+    || fail "docker ps failed on the VM"
+
+echo "${CONTAINERS}" | sed 's/^/    /' >&2
+
+for name in datadog-agent milvus-standalone milvus-etcd milvus-minio milvus-traffic; do
+    grep -qx "${name}" <<<"${CONTAINERS}" \
+        || fail "expected container ${name} not running"
+done
+log "all 5 containers running ✓"
+
+# --- 5. milvus check scheduled --------------------------------------------
+
+log "checking 'agent status' for milvus..."
+if ssh_run "sudo docker exec datadog-agent agent status 2>/dev/null | grep -E '^\s*milvus' -A 5" \
+    | tee /dev/stderr | grep -q "milvus"; then
+    log "milvus integration loaded ✓"
+else
+    fail "milvus integration not present in agent status"
+fi
+
+# --- 6. traffic generator producing iterations ----------------------------
+
+log "checking traffic generator logs..."
+TRAFFIC_LOG=$(ssh_run "sudo docker logs --tail 20 milvus-traffic 2>&1") \
+    || fail "could not fetch milvus-traffic logs"
+echo "${TRAFFIC_LOG}" | sed 's/^/    /' >&2
+grep -qE 'iteration=[0-9]+ ok' <<<"${TRAFFIC_LOG}" \
+    || fail "traffic generator has not produced a successful iteration yet"
+log "traffic generator producing iterations ✓"
+
+# --- 7. milvus /metrics endpoint live -------------------------------------
+
+log "fetching milvus /metrics..."
+METRICS_HEAD=$(ssh_run "sudo docker exec datadog-agent curl -fsS http://milvus:9091/metrics 2>/dev/null | head -5") \
+    || fail "agent could not reach milvus:9091/metrics"
+[[ -n "${METRICS_HEAD}" ]] || fail "milvus /metrics returned empty"
+echo "${METRICS_HEAD}" | sed 's/^/    /' >&2
+log "milvus metrics endpoint live ✓"
+
+log "all smoke checks passed"
+log "next: open Datadog and filter by e2e_test_id:${TEST_ID}"

--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/down.sh
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/down.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Tear down the Milvus scenario stack provisioned by up.sh.
+#
+# Usage: ./scripts/down.sh
+
+source "$(dirname -- "${BASH_SOURCE[0]}")/_lib.sh"
+ensure_dd_auth   # pulumi destroy still hits AWS; keep credentials wired up
+
+log "destroying stack=${STACK_NAME}"
+
+cd "${REPO_ROOT}/test/new-e2e"
+
+# Use pulumi directly so this works even if the test binary isn't around.
+# `--yes` skips the confirmation prompt; `--non-interactive` is safe to use
+# even when a TTY is attached.
+if ! pulumi stack -s "${STACK_NAME}" --non-interactive >/dev/null 2>&1; then
+    log "stack ${STACK_NAME} does not exist, nothing to do"
+    exit 0
+fi
+
+pulumi destroy -s "${STACK_NAME}" --yes --non-interactive
+pulumi stack rm -s "${STACK_NAME}" --yes --non-interactive
+
+log "stack ${STACK_NAME} destroyed"

--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/test.sh
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for the Milvus deployment.
+#
+#   1. up.sh        — provision the stack
+#   2. wait         — for Milvus to come up and the traffic loop to start
+#   3. check.sh     — verify containers, agent check, traffic, metrics
+#   4. (optional) down.sh — tear down the stack on success
+#
+# By default the stack is LEFT RUNNING after a successful smoke test so you
+# can inspect it. Pass --teardown to destroy it on success.
+
+set -euo pipefail
+
+TEARDOWN=0
+for arg in "$@"; do
+    case "${arg}" in
+        --teardown|-t) TEARDOWN=1 ;;
+        -h|--help)
+            sed -n '2,12p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *) echo "unknown arg: ${arg}" >&2; exit 2 ;;
+    esac
+done
+
+source "$(dirname -- "${BASH_SOURCE[0]}")/_lib.sh"
+
+log "===== 1/4 : up ====="
+"${SCRIPT_DIR}/up.sh"
+
+# Milvus standalone needs ~90s, pymilvus install + first iteration another
+# ~60-120s. Be generous; check.sh will retry the slow assertions itself.
+WAIT_SECS=${MILVUS_WAIT_SECS:-180}
+log "===== 2/4 : waiting ${WAIT_SECS}s for milvus + traffic to warm up ====="
+sleep "${WAIT_SECS}"
+
+log "===== 3/4 : check ====="
+if ! "${SCRIPT_DIR}/check.sh"; then
+    fail "smoke check failed — leaving the stack up for inspection (./scripts/down.sh to remove)"
+fi
+
+if (( TEARDOWN == 1 )); then
+    log "===== 4/4 : down ====="
+    "${SCRIPT_DIR}/down.sh"
+else
+    log "===== 4/4 : skipping teardown (pass --teardown to destroy) ====="
+fi
+
+log "milvus scenario smoke test PASSED"

--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/up.sh
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/scripts/up.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Deploy the Milvus scenario and leave it running.
+#
+# Usage: ./scripts/up.sh
+#
+# Honors:
+#   MILVUS_STACK_NAME   pulumi stack name (default: milvus-dev)
+#   MILVUS_E2E_TEST_ID  per-run tag stamped onto every Milvus metric
+#                       (default: <stack name>)
+
+source "$(dirname -- "${BASH_SOURCE[0]}")/_lib.sh"
+require_dda
+ensure_dd_auth
+
+log "deploying stack=${STACK_NAME} test_id=${TEST_ID}"
+
+cd "${REPO_ROOT}"
+
+# E2E_DEV_MODE=true keeps the stack alive after the test returns.
+# We point both E2E_STACK_NAME and MILVUS_E2E_TEST_ID at our chosen values
+# so the test code uses them verbatim.
+E2E_DEV_MODE=true \
+E2E_STACK_NAME="${STACK_NAME}" \
+MILVUS_E2E_TEST_ID="${TEST_ID}" \
+"$(dda_bin)" inv new-e2e-tests.run \
+    --targets=./tests/agent-metric-pipelines/milvus \
+    --run='^TestMilvusEnv$'
+
+log "stack ${STACK_NAME} provisioned"
+log "  Datadog filter:  e2e_test_id:${TEST_ID}"
+log "  Check status:    ./scripts/check.sh"
+log "  Tear down:       ./scripts/down.sh"

--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/testfixtures/docker-compose.milvus.yaml
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/testfixtures/docker-compose.milvus.yaml
@@ -1,0 +1,112 @@
+# Milvus standalone stack + traffic generator, designed to be merged into
+# the e2e-framework Docker Agent compose via
+# dockeragentparams.WithExtraComposeManifest.
+#
+# The Datadog Milvus integration is configured on the milvus service via
+# Autodiscovery container labels — the host Agent (running in the same
+# compose project) picks it up through docker.sock. No conf.d file needed.
+#
+# Variables interpolated by docker compose at deploy time (provided by the
+# provisioner through dockeragentparams.WithEnvironmentVariables):
+#   - DD_E2E_TEST_ID:        per-run tag used for metric scoping
+#   - DD_MILVUS_TRAFFIC_B64: base64-encoded traffic.py
+
+services:
+  etcd:
+    container_name: milvus-etcd
+    image: ${DD_REGISTRY:-quay.io}/coreos/etcd:v3.5.5
+    environment:
+      ETCD_AUTO_COMPACTION_MODE: revision
+      ETCD_AUTO_COMPACTION_RETENTION: "1000"
+      ETCD_QUOTA_BACKEND_BYTES: "4294967296"
+      ETCD_SNAPSHOT_COUNT: "50000"
+    command: etcd -advertise-client-urls=http://etcd:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  minio:
+    container_name: milvus-minio
+    image: ${DD_REGISTRY:-docker.io}/minio/minio:RELEASE.2023-03-20T20-16-18Z
+    environment:
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+    command: minio server /minio_data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  milvus:
+    container_name: milvus-standalone
+    image: ${DD_REGISTRY:-docker.io}/milvusdb/milvus:v2.4.13
+    command: ["milvus", "run", "standalone"]
+    environment:
+      ETCD_ENDPOINTS: etcd:2379
+      MINIO_ADDRESS: minio:9000
+    depends_on:
+      - "etcd"
+      - "minio"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      interval: 30s
+      start_period: 90s
+      timeout: 20s
+      retries: 5
+    # Datadog Autodiscovery: the host Agent (in the same compose project)
+    # uses docker.sock to discover this container and schedule the milvus
+    # OpenMetrics check against it.
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "milvus": {
+            "init_config": {},
+            "instances": [
+              {
+                "openmetrics_endpoint": "http://%%host%%:9091/metrics",
+                "min_collection_interval": 15,
+                "tags": [
+                  "env:e2e",
+                  "e2e_scenario:milvus",
+                  "e2e_test_id:${DD_E2E_TEST_ID}"
+                ]
+              }
+            ]
+          }
+        }
+
+  # Real traffic against Milvus: insert + search + query in a loop. The
+  # pymilvus script is injected as a base64-encoded env var by the
+  # provisioner so this compose stays self-contained on the VM.
+  milvus-traffic:
+    container_name: milvus-traffic
+    image: ${DD_REGISTRY:-docker.io}/library/python:3.11-slim
+    depends_on:
+      - "milvus"
+    environment:
+      MILVUS_HOST: milvus
+      MILVUS_PORT: "19530"
+      DD_MILVUS_TRAFFIC_B64: ${DD_MILVUS_TRAFFIC_B64}
+    command:
+      - bash
+      - -lc
+      - |
+        set -e
+        mkdir -p /app
+        echo "$$DD_MILVUS_TRAFFIC_B64" | base64 -d > /app/traffic.py
+        pip install --no-cache-dir 'pymilvus==2.4.9' >/tmp/pip.log 2>&1
+        # Wait for Milvus to accept connections before starting the workload.
+        python - <<'PY'
+        import socket, time
+        for _ in range(120):
+            try:
+                with socket.create_connection(("milvus", 19530), timeout=2):
+                    break
+            except OSError:
+                time.sleep(2)
+        PY
+        exec python /app/traffic.py
+    restart: unless-stopped

--- a/test/new-e2e/tests/agent-metric-pipelines/milvus/testfixtures/traffic.py
+++ b/test/new-e2e/tests/agent-metric-pipelines/milvus/testfixtures/traffic.py
@@ -1,0 +1,100 @@
+"""Continuously exercise a Milvus instance to produce realistic metrics.
+
+This is the workload used by the E2E scenario in
+``test/new-e2e/tests/agent-metric-pipelines/milvus``. It connects to a
+Milvus standalone deployment, creates (or reuses) a small collection,
+and runs an unbounded insert/search/query loop. The goal is not
+correctness of the data but to keep proxy / query node / data node
+metrics non-zero so the Datadog integration has something to report.
+"""
+
+import os
+import random
+import time
+
+from pymilvus import (
+    Collection,
+    CollectionSchema,
+    DataType,
+    FieldSchema,
+    connections,
+    utility,
+)
+
+HOST = os.environ.get("MILVUS_HOST", "milvus")
+PORT = os.environ.get("MILVUS_PORT", "19530")
+COLLECTION = "e2e_traffic"
+DIM = 16
+
+
+def get_or_create_collection() -> Collection:
+    if utility.has_collection(COLLECTION):
+        return Collection(COLLECTION)
+
+    fields = [
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
+        FieldSchema(name="embedding", dtype=DataType.FLOAT_VECTOR, dim=DIM),
+    ]
+    schema = CollectionSchema(fields, description="E2E traffic collection")
+    collection = Collection(COLLECTION, schema)
+    collection.create_index(
+        field_name="embedding",
+        index_params={
+            "index_type": "IVF_FLAT",
+            "metric_type": "L2",
+            "params": {"nlist": 16},
+        },
+    )
+    return collection
+
+
+def random_vectors(n: int) -> list[list[float]]:
+    return [[random.random() for _ in range(DIM)] for _ in range(n)]
+
+
+def main() -> None:
+    connections.connect(alias="default", host=HOST, port=PORT)
+    collection = get_or_create_collection()
+    collection.load()
+
+    iteration = 0
+    while True:
+        iteration += 1
+        try:
+            # Insert a small batch so the writer path is exercised.
+            collection.insert([random_vectors(32)])
+
+            # Flush occasionally to drive data node metrics.
+            if iteration % 10 == 0:
+                collection.flush()
+
+            # Search to drive query node + proxy metrics.
+            collection.search(
+                data=random_vectors(4),
+                anns_field="embedding",
+                param={"metric_type": "L2", "params": {"nprobe": 8}},
+                limit=5,
+            )
+
+            # Lightweight query to add variety.
+            if iteration % 5 == 0:
+                collection.query(expr="id >= 0", limit=1, output_fields=["id"])
+
+            print(f"iteration={iteration} ok", flush=True)
+        except Exception as exc:  # noqa: BLE001 - keep the loop alive
+            print(f"iteration={iteration} error={exc!r}", flush=True)
+            time.sleep(5)
+            # Re-connect on hard errors.
+            try:
+                connections.disconnect("default")
+            except Exception:  # noqa: BLE001
+                pass
+            connections.connect(alias="default", host=HOST, port=PORT)
+            collection = get_or_create_collection()
+            collection.load()
+
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What does this PR do?

Adds a deployable Milvus E2E scenario under `test/new-e2e/tests/agent-metric-pipelines/milvus`.

The scenario uses the stock AWS Docker Host provisioner (`awsdocker.Provisioner` / `ec2docker`) on the default `agent-sandbox` E2E account. It deploys:

- Datadog Agent Docker container
- Milvus standalone (`milvusdb/milvus:v2.4.13`)
- etcd
- MinIO
- a Python `pymilvus` traffic generator

The Agent is configured through Docker Autodiscovery labels on the Milvus container and sends metrics to a real Datadog intake (`ec2docker.WithoutFakeIntake()`).

The scenario intentionally has only a provisioning smoke test. Helper scripts are included for deploy / inspect / teardown workflows:

- `scripts/up.sh`
- `scripts/check.sh`
- `scripts/test.sh`
- `scripts/down.sh`

### Motivation

Provide a reproducible Milvus workload that Agent / integrations developers can deploy through the standard E2E framework to validate the Milvus integration and metric pipeline against a real intake.

This branch intentionally starts from the default `agent-sandbox` tooling path. It does not include the earlier `agent-integrations-dev` environment bootstrap or Pulumi override workarounds.

### Describe how you validated your changes

- Built this branch from latest `origin/main` as a single clean commit.
- Verified the branch contains no `agent-integrations-dev`, `E2E_ENVIRONMENTS`, or `E2E_STACK_PARAMS` overrides.
- Ran `gofmt` on the new Go files.
- Local pre-commit Go formatting hooks passed.

Not yet deployed end-to-end locally because access to `sso-agent-sandbox-account-admin` is pending. Once access is granted, validation command is:

```bash
cd test/new-e2e/tests/agent-metric-pipelines/milvus
dda inv e2e.setup --account=agent-sandbox
./scripts/test.sh --teardown
```

### Additional Notes

This scenario uses real intake, not fakeintake, by design.
