### PR TITLE
[AGNTLOG-323] fix(logs): nil-guard stream-logs filter on shutdown

### DIFF
--- a/comp/api/api/utils/stream/stream.go
+++ b/comp/api/api/utils/stream/stream.go
@@ -86,7 +86,12 @@ func GetStreamFunc(messageReceiverFunc func() MessageReceiver, streamType, agent
 				return
 			case <-r.Context().Done():
 				return
-			case line := <-logChan:
+			case line, ok := <-logChan:
+				if !ok {
+					// Filter channel closed by the receiver — usually agent
+					// shutdown. Exit so we don't spin reading zero values.
+					return
+				}
 				fmt.Fprint(w, line)
 			case <-flushTimer.C:
 				// The buffer will flush on its own most of the time, but when we run out of logs flush so the client is up to date.

--- a/pkg/logs/diagnostic/message_receiver.go
+++ b/pkg/logs/diagnostic/message_receiver.go
@@ -114,7 +114,14 @@ func (b *BufferedMessageReceiver) Filter(filters *Filters, done <-chan struct{})
 		defer close(out)
 		for {
 			select {
-			case msgPair := <-b.inputChan:
+			case msgPair, ok := <-b.inputChan:
+				if !ok {
+					// inputChan was closed (e.g. agent shutdown). Stop the
+					// goroutine instead of formatting the zero-value
+					// messagePair, which would dereference a nil
+					// *message.Message and panic.
+					return
+				}
 				if shouldHandleMessage(&msgPair, filters) {
 					out <- b.formatter.Format(msgPair.msg, msgPair.eventType, msgPair.rendered)
 				}

--- a/pkg/logs/diagnostic/message_receiver_test.go
+++ b/pkg/logs/diagnostic/message_receiver_test.go
@@ -219,6 +219,31 @@ func TestNoFilters(t *testing.T) {
 	readFilteredLines(t, b, &filters, 15)
 }
 
+// TestFilterStopWhileStreaming verifies that calling Stop() on the message
+// receiver while a consumer is reading from Filter() does not panic. Stop()
+// closes inputChan; the Filter goroutine must detect the closed channel and
+// exit rather than calling the formatter with a zero-value (nil-msg)
+// messagePair. Regression test for AGNTLOG-323.
+func TestFilterStopWhileStreaming(t *testing.T) {
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b.SetEnabled(true)
+
+	done := make(chan struct{})
+	defer close(done)
+	lineChan := b.Filter(nil, done)
+
+	// Simulate agent shutdown: close the input channel out from under the
+	// Filter goroutine. Before the fix this caused the goroutine to read a
+	// zero-value messagePair and panic on a nil *message.Message in the
+	// formatter.
+	b.Stop()
+
+	// The output channel should be closed cleanly without any spurious values.
+	for msg := range lineChan {
+		assert.Equal(t, "", msg, "unexpected message after shutdown: %q", msg)
+	}
+}
+
 func newMessage(name, typ, source, service string) *message.Message {
 	cfg := &config.LogsConfig{
 		Type:    typ,

--- a/releasenotes/notes/fix-stream-logs-shutdown-segfault-e24997b35b4abb47.yaml
+++ b/releasenotes/notes/fix-stream-logs-shutdown-segfault-e24997b35b4abb47.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a segmentation fault that occurred when the Agent was shut down while
+    ``agent stream-logs`` was running. The diagnostic message receiver's filter
+    goroutine now detects a closed input channel during shutdown instead of
+    dereferencing a nil message.


### PR DESCRIPTION
## Summary

Fixes [AGNTLOG-323](https://datadoghq.atlassian.net/browse/AGNTLOG-323): Agent segfaults when shut down while `agent stream-logs` is running.

**Root cause:** `BufferedMessageReceiver.Filter` reads from the input channel without checking the close indicator. When `Stop()` closes the channel during shutdown, the goroutine loops on a zero-value `messagePair{}` (with a nil `*message.Message`), and the formatter then dereferences `m.Origin`, panicking with SIGSEGV.

**Fix:** Use the two-value receive form to detect the closed channel and exit the goroutine cleanly. The deferred `close(out)` then signals consumers (e.g. `exportStreamLogs`) to terminate without panicking.

## Changes
- \`pkg/logs/diagnostic/message_receiver.go\` — two-value receive, exit on closed channel.
- \`pkg/logs/diagnostic/message_receiver_test.go\` — regression test that closes input mid-Filter and asserts no panic.
- Release note added.

## Verification
- \`dda inv linter.go --targets=./pkg/logs/diagnostic\` — passed
- \`dda inv test --targets=./pkg/logs/diagnostic\` — passed (incl. new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGNTLOG-323]: https://datadoghq.atlassian.net/browse/AGNTLOG-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ