### PR TITLE
[AGNTLOG-317] fix(logs): status shows duplicate tailers on same file

### DIFF
--- a/pkg/logs/tailers/tailer_tracker.go
+++ b/pkg/logs/tailers/tailer_tracker.go
@@ -43,46 +43,82 @@ type AnyTailerContainer interface {
 }
 
 // TailerContainer is a container for a concrete tailer type.
+//
+// Multiple tailers may share the same GetID() (for instance, when two log
+// configurations accidentally point at the same file path). To make sure each
+// tailer instance remains observable through the status endpoint, the
+// container stores all tailers sharing an ID under a slice keyed by that ID.
+// Get/Contains return the first tailer registered for an ID, and Remove
+// removes the specific instance provided by the caller.
 type TailerContainer[T Tailer] struct {
 	sync.RWMutex
-	tailers map[string]T
+	tailers map[string][]T
 }
 
 // NewTailerContainer creates a new TailerContainer instance.
 func NewTailerContainer[T Tailer]() *TailerContainer[T] {
 	return &TailerContainer[T]{
-		tailers: make(map[string]T),
+		tailers: make(map[string][]T),
 	}
 }
 
-// Get returns a tailer with the provided id if it exists.
+// Get returns a tailer with the provided id if it exists. If multiple tailers
+// share the same id, the first one added is returned.
 func (t *TailerContainer[T]) Get(id string) (T, bool) {
 	t.RLock()
 	defer t.RUnlock()
-	tailer, ok := t.tailers[id]
-	return tailer, ok
+	tailers, ok := t.tailers[id]
+	if !ok || len(tailers) == 0 {
+		var zero T
+		return zero, false
+	}
+	return tailers[0], true
 }
 
-// Contains returns true if the key exists.
+// Contains returns true if at least one tailer with the provided id exists.
 func (t *TailerContainer[T]) Contains(id string) bool {
 	t.RLock()
 	defer t.RUnlock()
-	_, ok := t.tailers[id]
-	return ok
+	tailers, ok := t.tailers[id]
+	return ok && len(tailers) > 0
 }
 
-// Add adds a new tailer to the container.
+// Add adds a new tailer to the container. If another tailer with the same ID
+// is already present, both are retained so that both remain visible in the
+// agent status.
 func (t *TailerContainer[T]) Add(tailer T) {
 	t.Lock()
 	defer t.Unlock()
-	t.tailers[tailer.GetID()] = tailer
+	id := tailer.GetID()
+	t.tailers[id] = append(t.tailers[id], tailer)
 }
 
-// Remove removes a tailer from the container.
+// Remove removes the given tailer instance from the container. Only the
+// matching instance is removed; other tailers sharing the same ID are kept.
 func (t *TailerContainer[T]) Remove(tailer T) {
 	t.Lock()
 	defer t.Unlock()
-	delete(t.tailers, tailer.GetID())
+	id := tailer.GetID()
+	tailers, ok := t.tailers[id]
+	if !ok {
+		return
+	}
+	// Tailer is an interface type, so its type set is not statically
+	// comparable; compare instance identity via the empty interface, which
+	// uses the underlying dynamic type's == operator at runtime (pointer
+	// equality for the concrete tailer pointer types this container holds).
+	target := any(tailer)
+	for i, existing := range tailers {
+		if any(existing) == target {
+			tailers = append(tailers[:i], tailers[i+1:]...)
+			break
+		}
+	}
+	if len(tailers) == 0 {
+		delete(t.tailers, id)
+	} else {
+		t.tailers[id] = tailers
+	}
 }
 
 // All returns a slice of all tailers in the container.
@@ -90,8 +126,8 @@ func (t *TailerContainer[T]) All() []T {
 	t.RLock()
 	defer t.RUnlock()
 	tailers := make([]T, 0, len(t.tailers))
-	for _, tailer := range t.tailers {
-		tailers = append(tailers, tailer)
+	for _, bucket := range t.tailers {
+		tailers = append(tailers, bucket...)
 	}
 	return tailers
 }
@@ -100,7 +136,11 @@ func (t *TailerContainer[T]) All() []T {
 func (t *TailerContainer[T]) Count() int {
 	t.RLock()
 	defer t.RUnlock()
-	return len(t.tailers)
+	count := 0
+	for _, bucket := range t.tailers {
+		count += len(bucket)
+	}
+	return count
 }
 
 // Tailers returns a slice of all tailers in the container without their concrete types.
@@ -108,8 +148,10 @@ func (t *TailerContainer[T]) Tailers() []Tailer {
 	t.RLock()
 	defer t.RUnlock()
 	tailers := make([]Tailer, 0, len(t.tailers))
-	for _, tailer := range t.tailers {
-		tailers = append(tailers, tailer)
+	for _, bucket := range t.tailers {
+		for _, tailer := range bucket {
+			tailers = append(tailers, tailer)
+		}
 	}
 	return tailers
 }

--- a/pkg/logs/tailers/tailer_tracker_test.go
+++ b/pkg/logs/tailers/tailer_tracker_test.go
@@ -98,3 +98,65 @@ func TestCollectAllTailers(t *testing.T) {
 	}
 
 }
+
+// TestDuplicateTailerIDsAreAllPreserved is a regression test for AGNTLOG-317.
+// When two tailers share the same GetID() (for example, two log configurations
+// accidentally tailing the same file path) both must remain observable from
+// the TailerTracker so the agent status surfaces every active tailer.
+func TestDuplicateTailerIDsAreAllPreserved(t *testing.T) {
+	container := NewTailerContainer[*TestTailer1]()
+
+	t1 := NewTestTailer1("/var/log/app.log")
+	t2 := NewTestTailer1("/var/log/app.log")
+	t3 := NewTestTailer1("/var/log/other.log")
+
+	container.Add(t1)
+	container.Add(t2)
+	container.Add(t3)
+
+	// Count and All must reflect every instance even when IDs collide.
+	assert.Equal(t, 3, container.Count())
+	assert.Equal(t, 3, len(container.All()))
+
+	// The status path consumes the tracker view; it must surface both
+	// duplicate-ID tailers, not just one of them.
+	tracker := NewTailerTracker()
+	tracker.Add(container)
+
+	tailers := tracker.All()
+	assert.Equal(t, 3, len(tailers))
+
+	seen := make(map[*TestTailer1]bool)
+	for _, item := range tailers {
+		tt, ok := item.(*TestTailer1)
+		assert.True(t, ok)
+		seen[tt] = true
+	}
+	assert.True(t, seen[t1], "first duplicate-id tailer must remain visible")
+	assert.True(t, seen[t2], "second duplicate-id tailer must remain visible")
+	assert.True(t, seen[t3])
+
+	// Contains is true while at least one duplicate-id tailer remains.
+	assert.True(t, container.Contains("/var/log/app.log"))
+
+	// Get returns one of the duplicates (the implementation returns the
+	// first one registered).
+	got, ok := container.Get("/var/log/app.log")
+	assert.True(t, ok)
+	assert.Equal(t, t1, got)
+
+	// Removing one duplicate keeps the other discoverable; Contains stays true.
+	container.Remove(t1)
+	assert.True(t, container.Contains("/var/log/app.log"))
+	assert.Equal(t, 2, container.Count())
+	got, ok = container.Get("/var/log/app.log")
+	assert.True(t, ok)
+	assert.Equal(t, t2, got)
+
+	// Removing the last duplicate clears the entry entirely.
+	container.Remove(t2)
+	assert.False(t, container.Contains("/var/log/app.log"))
+	_, ok = container.Get("/var/log/app.log")
+	assert.False(t, ok)
+	assert.Equal(t, 1, container.Count())
+}

--- a/releasenotes/notes/logs-status-duplicate-tailers-8ee9989bd9ace7da.yaml
+++ b/releasenotes/notes/logs-status-duplicate-tailers-8ee9989bd9ace7da.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes the log agent status output so that when multiple tailers share
+    the same identifier (for example, when two log configurations accidentally
+    point at the same file path), all instances are displayed instead of
+    silently overwriting one another.


### PR DESCRIPTION
## JIRA
https://datadoghq.atlassian.net/browse/AGNTLOG-317

## Root cause
`TailerContainer` (in `pkg/logs/tailers/tailer_tracker.go`) stored tailers as `map[string]T` keyed by `tailer.GetID()`. When two tailers produced the same ID — for example, two log configurations accidentally tailing the same file path — `Add` would silently overwrite the previous entry. The agent status surfaces tailers through `TailerTracker.All() -> container.Tailers()`, so the overwritten tailer disappeared from the status output even though it was still running. This made it impossible to diagnose the "two tailers on the same file" misconfiguration from the agent status.

## Fix
- Change the container's internal storage to `map[string][]T` so multiple tailers sharing an ID can coexist.
- Preserve the existing single-tailer semantics on the read paths: `Get` and `Contains` return the first tailer registered for an ID.
- `Remove` removes the specific tailer instance handed in by the caller (matched by underlying-pointer identity via `any`), and only deletes the map entry when no duplicates remain.
- `All`, `Count`, and `Tailers` (the status path) now surface every active tailer.

The change is internal to `TailerContainer`; no callers needed updates. The file launcher continues to use unique scan keys, so its `Get`/`Remove`/`Contains` semantics are unchanged.

## Tests
- New regression test `TestDuplicateTailerIDsAreAllPreserved` in `pkg/logs/tailers/tailer_tracker_test.go` registers two tailers with the same ID plus a third, then asserts both duplicates appear in `TailerTracker.All()` (the status code path). It also covers `Count`, `Contains`, `Get`, and one-by-one `Remove` of the duplicates.
- Existing `TestCollectAllTailers` still passes.

## Verification
- `dda inv test --targets=./pkg/logs/tailers` — all tests pass (95 tests).
- `dda inv test --targets=./pkg/logs/status,./pkg/logs/launchers/file` — all tests pass; downstream consumers of `TailerContainer` (the file launcher) are unaffected.
- `dda inv linter.go --targets=./pkg/logs/tailers,./pkg/logs/status` — 0 issues.