### PR TITLE
bazel: check parity between dda inv test and bazel per-flavor test runs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -810,6 +810,7 @@
 /tasks/macos.py                         @DataDog/windows-products
 /tasks/msi.py                           @DataDog/windows-products
 /tasks/agent.py                         @DataDog/agent-runtimes
+/tasks/bazel.py                         @DataDog/agent-build
 /tasks/build_tags.py                    @DataDog/agent-build
 /tasks/build_tags.bzl                   @DataDog/agent-build
 /tasks/anomalydetection.py              @DataDog/q-branch
@@ -864,6 +865,7 @@
 /tasks/release_metrics/                 @DataDog/agent-delivery
 /tasks/libs/releasing/                  @DataDog/agent-delivery
 /tasks/schema/                          @DataDog/agent-configuration
+/tasks/unit_tests/bazel_tests.py        @DataDog/agent-build
 /tasks/unit_tests/components_tests.py   @DataDog/agent-runtimes
 /tasks/unit_tests/build_tags_tests.py   @DataDog/agent-build
 /tasks/unit_tests/libs/build/           @DataDog/agent-build

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -79,6 +79,7 @@ bazel:test:windows-amd64:
   script:
     - !reference [.bazel:test:reporting:ci_links]
     - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
+    - dda inv -- -e bazel.ensure-test-parity --bep $BEP_FILE --flavor-name $FLAVOR
 
 # macOS flavor variant: re-installs dda in both script and after_script since
 # macOS shell executors run each phase in a fresh shell.
@@ -86,8 +87,8 @@ bazel:test:windows-amd64:
   extends: .bazel:test:flavor
   script:
     - !reference [.install_python_dependencies]
-    - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
+    - !reference [.macos_setup_go]
+    - !reference [.bazel:test:flavor, script]
   after_script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting, after_script]
@@ -160,4 +161,5 @@ bazel:test:windows-amd64:base:
   variables:
     POWERSHELL_SCRIPT: >-
       bazel test --keep_going --build_tests_only --config=base
+      --build_event_json_file=$CI_PROJECT_DIR/bazel-bep-base.json
       //pkg/... //comp/... //cmd/...

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -79,7 +79,7 @@ bazel:test:windows-amd64:
   script:
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
+    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
     - dda inv -- -e bazel.ensure-test-parity --bep $BEP_FILE --flavor-name $FLAVOR --emit-metrics
 
 # macOS flavor variant: re-installs dda in both script and after_script since
@@ -161,7 +161,7 @@ bazel:test:windows-amd64:base:
   extends: [ .bazel:test, .bazel:runner:windows-amd64 ]
   variables:
     POWERSHELL_SCRIPT: >-
-      bazel test --keep_going --build_tests_only --config=base
+      bazel test --keep_going --build_tests_only --config=base --test_arg=-test.v
       --build_event_json_file=$CI_PROJECT_DIR/bazel-bep-base.json
       //pkg/... //comp/... //cmd/...;
       dda inv -- -e bazel.ensure-test-parity

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -77,7 +77,7 @@ bazel:test:windows-amd64:
 .bazel:test:flavor:
   extends: [ .bazel:test, .bazel:test:reporting ]
   script:
-    - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
+    - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || echo 'Failed to fetch an API key, no metrics will be emitted'; export DD_API_KEY
     - !reference [.bazel:test:reporting:ci_links]
     - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
     - dda inv -- -e bazel.ensure-test-parity --bep $BEP_FILE --flavor-name $FLAVOR --emit-metrics

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -163,4 +163,12 @@ bazel:test:windows-amd64:base:
     POWERSHELL_SCRIPT: >-
       bazel test --keep_going --build_tests_only --config=base
       --build_event_json_file=$CI_PROJECT_DIR/bazel-bep-base.json
-      //pkg/... //comp/... //cmd/...
+      //pkg/... //comp/... //cmd/...;
+      dda inv -- -e bazel.ensure-test-parity
+      --bep $CI_PROJECT_DIR/bazel-bep-base.json
+      --flavor-name base
+  artifacts:
+    when: always
+    paths:
+      - bazel-bep-*.json
+    expire_in: 1 week

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -77,9 +77,10 @@ bazel:test:windows-amd64:
 .bazel:test:flavor:
   extends: [ .bazel:test, .bazel:test:reporting ]
   script:
+    - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
     - !reference [.bazel:test:reporting:ci_links]
     - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v=test2json --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
-    - dda inv -- -e bazel.ensure-test-parity --bep $BEP_FILE --flavor-name $FLAVOR
+    - dda inv -- -e bazel.ensure-test-parity --bep $BEP_FILE --flavor-name $FLAVOR --emit-metrics
 
 # macOS flavor variant: re-installs dda in both script and after_script since
 # macOS shell executors run each phase in a fresh shell.

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -29,44 +29,69 @@ _IMPORT_PREFIX = AGENT_MODULE_PATH_PREFIX.rstrip("/")
 _DD_AGENT_GO_TEST_TAG = "dd_agent_go_test"
 
 
+# cmd.exe on Windows caps command lines at 8191 chars; stay safely under that
+# per 'go list' invocation so the command line doesn't grow unbounded with
+# the tracked package set.
+_MAX_CMDLINE_CHARS = 6000
+
+
+def _chunk_import_paths(import_paths: list[str]) -> list[list[str]]:
+    """Split import paths into batches that keep each 'go list' command line
+    under the Windows cmd.exe length limit."""
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    current_len = 0
+    for path in import_paths:
+        if current and current_len + len(path) + 1 > _MAX_CMDLINE_CHARS:
+            chunks.append(current)
+            current, current_len = [], 0
+        current.append(path)
+        current_len += len(path) + 1
+    if current:
+        chunks.append(current)
+    return chunks
+
+
 def _go_test_packages(tags: list[str], import_paths: set[str]) -> dict[str, set[str]]:
     """Return {import_path: {Test* func names}} for the given import paths
     compiled under the given build tags."""
     if not import_paths:
         return {}
-    # Query the whole module and filter below rather than passing import_paths on
-    # the command line, which can exceed the OS command-line length limit.
-    result = subprocess.run(
-        ["go", "list", "-json", "-e", f"-tags={','.join(sorted(tags))}", "./..."],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-    )
-    if result.returncode != 0:
-        # -e reports per-package errors inside the JSON output without failing the
-        # command; a non-zero exit means `go list` itself failed to run at all.
-        raise ChildProcessError(f"go list failed with exit code {result.returncode}: {result.stderr}")
     pkgs: dict[str, set[str]] = {}
     decoder = json.JSONDecoder()
-    text, pos = result.stdout, 0
-    while pos < len(text):
-        pos = _JSON_WHITESPACE_RE.match(text, pos).end()
-        if pos >= len(text):
-            break
-        obj, pos = decoder.raw_decode(text, pos)
-        import_path = obj["ImportPath"]
-        if import_path not in import_paths:
-            continue
-        pkg_dir = Path(obj["Dir"])
-        test_files = obj.get("TestGoFiles", []) + obj.get("XTestGoFiles", [])
-        funcs: set[str] = set()
-        for f in test_files:
-            funcs.update(_TEST_FUNC_RE.findall((pkg_dir / f).read_text()))
-        # TestMain is Go's test harness entry point, never dispatched as a test case.
-        funcs.discard("TestMain")
-        if funcs:
-            pkgs[import_path] = funcs
+    for chunk in _chunk_import_paths(sorted(import_paths)):
+        # shell=False (the default value, which we still pass explicitly) is
+        # required: cmd.exe on Windows has an 8191-char command-line limit.
+        result = subprocess.run(
+            ["go", "list", "-json", "-e", f"-tags={','.join(sorted(tags))}", *chunk],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            shell=False,
+        )
+        if result.returncode != 0:
+            # -e reports per-package errors inside the JSON output without failing the
+            # command; a non-zero exit means `go list` itself failed to run at all.
+            raise ChildProcessError(f"go list failed with exit code {result.returncode}: {result.stderr}")
+        text, pos = result.stdout, 0
+        while pos < len(text):
+            pos = _JSON_WHITESPACE_RE.match(text, pos).end()
+            if pos >= len(text):
+                break
+            obj, pos = decoder.raw_decode(text, pos)
+            import_path = obj["ImportPath"]
+            if import_path not in import_paths:
+                continue
+            pkg_dir = Path(obj["Dir"])
+            test_files = obj.get("TestGoFiles", []) + obj.get("XTestGoFiles", [])
+            funcs: set[str] = set()
+            for f in test_files:
+                funcs.update(_TEST_FUNC_RE.findall((pkg_dir / f).read_text()))
+            # TestMain is Go's test harness entry point, never dispatched as a test case.
+            funcs.discard("TestMain")
+            if funcs:
+                pkgs[import_path] = funcs
     return pkgs
 
 

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -34,15 +34,14 @@ def _go_test_packages(tags: list[str], import_paths: set[str]) -> dict[str, set[
     compiled under the given build tags."""
     if not import_paths:
         return {}
-    # shell=False (the default value, which we still pass explicitly) is
-    # required: cmd.exe on Windows has an 8191-char command-line limit.
+    # Query the whole module and filter below rather than passing import_paths on
+    # the command line, which can exceed the OS command-line length limit.
     result = subprocess.run(
-        ["go", "list", "-json", "-e", f"-tags={','.join(sorted(tags))}", *sorted(import_paths)],
+        ["go", "list", "-json", "-e", f"-tags={','.join(sorted(tags))}", "./..."],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
         encoding="utf-8",
-        shell=False,
     )
     if result.returncode != 0:
         # -e reports per-package errors inside the JSON output without failing the

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -34,14 +34,20 @@ def _go_test_packages(tags: list[str], import_paths: set[str]) -> dict[str, set[
     compiled under the given build tags."""
     if not import_paths:
         return {}
-    # shell=False is required: cmd.exe on Windows has an 8191-char command-line limit.
+    # shell=False (the default value, which we still pass explicitly) is
+    # required: cmd.exe on Windows has an 8191-char command-line limit.
     result = subprocess.run(
         ["go", "list", "-json", "-e", f"-tags={','.join(sorted(tags))}", *sorted(import_paths)],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
         encoding="utf-8",
+        shell=False,
     )
+    if result.returncode != 0:
+        # -e reports per-package errors inside the JSON output without failing the
+        # command; a non-zero exit means `go list` itself failed to run at all.
+        raise ChildProcessError(f"go list failed with exit code {result.returncode}: {result.stderr}")
     pkgs: dict[str, set[str]] = {}
     decoder = json.JSONDecoder()
     text, pos = result.stdout, 0

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
+import platform
 import re
 import subprocess
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
+from datetime import datetime
 from pathlib import Path
 
 from invoke import task
@@ -185,15 +188,36 @@ def _bazel_test_funcs_from_bep(bep_path: Path) -> dict[str, set[str]]:
     return covered
 
 
+def _emit_test_count_metric(flavor: str, count: int) -> None:
+    """Send a datadog.agent.bazel_tests.executed gauge for one flavor job."""
+    from tasks.libs.common.datadog_api import create_gauge
+    from tasks.libs.common.datadog_api import send_metrics as _send_metrics
+
+    if not os.environ.get("DD_API_KEY"):
+        print("DD_API_KEY not set, skipping test count metric", file=sys.stderr)
+        return
+
+    tags = [
+        f"flavor:{flavor}",
+        f"platform:{platform.system().lower()}",
+        f"pipeline_id:{os.environ.get('CI_PIPELINE_ID', 'unknown')}",
+        "repository:datadog-agent",
+    ]
+    timestamp = int(datetime.now().timestamp())
+    _send_metrics([create_gauge("datadog.agent.bazel_tests.executed", timestamp, count, tags)], warn=True)
+    print(f"Sent metric: datadog.agent.bazel_tests.executed={count} (flavor={flavor})")
+
+
 @task(
     help={
         "flavor_name": f"Agent flavor to check ({', '.join(f.name for f in AgentFlavor)}).",
         "bep": "Path to the build_event_json_file produced by the preceding "
         "'bazel test --config=<flavor> ...' invocation.",
         "verbose": "Print passing packages.",
+        "emit_metrics": "Send a datadog.agent.bazel_tests.executed gauge to Datadog (requires DD_API_KEY).",
     },
 )
-def ensure_test_parity(ctx, bep, flavor_name, verbose=False):
+def ensure_test_parity(ctx, bep, flavor_name, verbose=False, emit_metrics=False):
     """
     Verify every Go test visible to 'dda inv test --flavor=<f>' is also
     present and executed in the matching Bazel per-flavor run.
@@ -228,10 +252,12 @@ def ensure_test_parity(ctx, bep, flavor_name, verbose=False):
     extra_in_bazel = {p for p, funcs in coverage.items() if funcs} - go_pkgs
 
     failed = False
+    test_count = 0
     for import_path in sorted(go_pkgs):
         go_funcs = test_pkgs[import_path]
         bazel_funcs = coverage[import_path]
         missing_funcs = go_funcs - bazel_funcs
+        test_count += len(bazel_funcs)
         if missing_funcs:
             sample = ", ".join(sorted(missing_funcs)[:3]) + (", ..." if len(missing_funcs) > 3 else "")
             print(f"[FAIL] {import_path} [{flavor_name}] -- tests missing from Bazel: {sample}")
@@ -243,6 +269,8 @@ def ensure_test_parity(ctx, bep, flavor_name, verbose=False):
     if extra_in_bazel:
         failed = True
 
+    if emit_metrics:
+        _emit_test_count_metric(flavor_name, test_count)
     if failed:
         sys.exit(1)
 

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -20,6 +20,8 @@ from tasks.libs.common.gomodules import AGENT_MODULE_PATH_PREFIX
 REPO_ROOT = Path(__file__).parent.parent
 # Top-level Test* declarations in Go source files — Go side of the parity comparison.
 _TEST_FUNC_RE = re.compile(r'^func (Test\w*)\(', re.MULTILINE)
+# Matches json.decoder.WHITESPACE, an undocumented/unstubbed cpython internal.
+_JSON_WHITESPACE_RE = re.compile(r"[ \t\n\r]*")
 _IMPORT_PREFIX = AGENT_MODULE_PATH_PREFIX.rstrip("/")
 # Tag the dd_agent_go_test macro stamps on every variant it emits
 # (bazel/rules/go/dd_agent_go_test.bzl). Used to distinguish its generated
@@ -44,24 +46,18 @@ def _go_test_packages(tags: list[str], import_paths: set[str]) -> dict[str, set[
     decoder = json.JSONDecoder()
     text, pos = result.stdout, 0
     while pos < len(text):
-        try:
-            obj, end = decoder.raw_decode(text, pos)
-        except json.JSONDecodeError:
+        pos = _JSON_WHITESPACE_RE.match(text, pos).end()
+        if pos >= len(text):
             break
-        pos = end
-        while pos < len(text) and text[pos].isspace():
-            pos += 1
-        import_path = obj.get("ImportPath", "")
+        obj, pos = decoder.raw_decode(text, pos)
+        import_path = obj["ImportPath"]
         if import_path not in import_paths:
             continue
-        pkg_dir = Path(obj.get("Dir", ""))
+        pkg_dir = Path(obj["Dir"])
         test_files = obj.get("TestGoFiles", []) + obj.get("XTestGoFiles", [])
         funcs: set[str] = set()
         for f in test_files:
-            try:
-                funcs.update(_TEST_FUNC_RE.findall((pkg_dir / f).read_text()))
-            except OSError:
-                continue
+            funcs.update(_TEST_FUNC_RE.findall((pkg_dir / f).read_text()))
         # TestMain is Go's test harness entry point, never dispatched as a test case.
         funcs.discard("TestMain")
         if funcs:
@@ -114,17 +110,13 @@ def _test_xml_funcs(paths: list[Path]) -> set[str]:
             continue
         if not content.strip():
             continue
-        try:
-            root = ET.fromstring(content)
-        except ET.ParseError:
-            continue
-        funcs = {
-            tc.get("name", "")
+        root = ET.fromstring(content)
+        return {
+            tc.attrib["name"]
             for tc in root.iter("testcase")
-            if tc.get("name", "").startswith("Test") and "/" not in tc.get("name", "")
+            if tc.attrib["name"].startswith("Test") and "/" not in tc.attrib["name"]
         }
-        return funcs
-    return set()
+    raise FileNotFoundError(f"no readable test.xml found among candidates: {paths}")
 
 
 def _bazel_test_funcs_from_bep(bep_path: Path) -> dict[str, set[str]]:
@@ -178,10 +170,9 @@ def _bazel_test_funcs_from_bep(bep_path: Path) -> dict[str, set[str]]:
 
     covered: dict[str, set[str]] = {}
     for label in dd_agent_labels:
-        action = test_action.get(label)
-        if action is None:
+        if label not in test_action:
             continue
-        uri, cfg_id = action
+        uri, cfg_id = test_action[label]
         funcs = _test_xml_funcs(_test_xml_candidates(label, uri, cfg_id, local_exec_root, config_testlogs))
         covered.setdefault(_label_to_import_path(label), set()).update(funcs)
 
@@ -204,7 +195,11 @@ def _emit_test_count_metric(flavor: str, count: int) -> None:
         "repository:datadog-agent",
     ]
     timestamp = int(datetime.now().timestamp())
-    _send_metrics([create_gauge("datadog.agent.bazel_tests.executed", timestamp, count, tags)], warn=True)
+    try:
+        _send_metrics([create_gauge("datadog.agent.bazel_tests.executed", timestamp, count, tags)])
+    except Exception as e:
+        print(f"Failed to send test count metric: {e}", file=sys.stderr)
+        return
     print(f"Sent metric: datadog.agent.bazel_tests.executed={count} (flavor={flavor})")
 
 

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import re
+import subprocess
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
@@ -8,15 +10,241 @@ from pathlib import Path
 
 from invoke import task
 
+from tasks.build_tags import compute_build_tags_for_flavor
 from tasks.flavor import AgentFlavor
 from tasks.libs.common.gomodules import AGENT_MODULE_PATH_PREFIX
 
+REPO_ROOT = Path(__file__).parent.parent
+# Top-level Test* declarations in Go source files — Go side of the parity comparison.
+_TEST_FUNC_RE = re.compile(r'^func (Test\w*)\(', re.MULTILINE)
 _IMPORT_PREFIX = AGENT_MODULE_PATH_PREFIX.rstrip("/")
+# Tag the dd_agent_go_test macro stamps on every variant it emits
+# (bazel/rules/go/dd_agent_go_test.bzl). Used to distinguish its generated
+# go_test rules from other custom wrappers (rtloader_go_test, ...).
+_DD_AGENT_GO_TEST_TAG = "dd_agent_go_test"
+
+
+def _go_test_packages(tags: list[str], import_paths: set[str]) -> dict[str, set[str]]:
+    """Return {import_path: {Test* func names}} for the given import paths
+    compiled under the given build tags."""
+    if not import_paths:
+        return {}
+    # shell=False is required: cmd.exe on Windows has an 8191-char command-line limit.
+    result = subprocess.run(
+        ["go", "list", "-json", "-e", f"-tags={','.join(sorted(tags))}", *sorted(import_paths)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    pkgs: dict[str, set[str]] = {}
+    decoder = json.JSONDecoder()
+    text, pos = result.stdout, 0
+    while pos < len(text):
+        try:
+            obj, end = decoder.raw_decode(text, pos)
+        except json.JSONDecodeError:
+            break
+        pos = end
+        while pos < len(text) and text[pos].isspace():
+            pos += 1
+        import_path = obj.get("ImportPath", "")
+        if import_path not in import_paths:
+            continue
+        pkg_dir = Path(obj.get("Dir", ""))
+        test_files = obj.get("TestGoFiles", []) + obj.get("XTestGoFiles", [])
+        funcs: set[str] = set()
+        for f in test_files:
+            try:
+                funcs.update(_TEST_FUNC_RE.findall((pkg_dir / f).read_text()))
+            except OSError:
+                continue
+        # TestMain is Go's test harness entry point, never dispatched as a test case.
+        funcs.discard("TestMain")
+        if funcs:
+            pkgs[import_path] = funcs
+    return pkgs
 
 
 def _label_to_import_path(label: str) -> str:
+    """Convert a Bazel label like '//pkg/util/kernel:kernel_test_iot' into the
+    Go import path of the package the test lives in."""
     pkg_part = label.lstrip("/").split(":", 1)[0]
     return _IMPORT_PREFIX if not pkg_part else f"{_IMPORT_PREFIX}/{pkg_part}"
+
+
+def _test_xml_candidates(
+    label: str,
+    uri: str,
+    cfg_id: str,
+    local_exec_root: str | None,
+    config_testlogs: dict[str, Path],
+) -> list[Path]:
+    """Candidate paths for test.xml, in priority order.
+
+    BEP URIs are file:// for local actions and bytestream:// for remote-cache
+    hits; for the latter Bazel still materializes test.xml on disk at
+    <localExecRoot>/<testlogs-dir>/<label>/test.xml.
+    """
+    paths: list[Path] = []
+    if uri.startswith("file://"):
+        paths.append(Path(uri.removeprefix("file://")))
+    testlogs_dir = config_testlogs.get(cfg_id)
+    if local_exec_root and testlogs_dir:
+        # Label "//pkg/foo:bar_test" -> "pkg/foo/bar_test/test.xml".
+        label_rel = label.lstrip("/").replace(":", "/")
+        paths.append(Path(local_exec_root) / testlogs_dir / label_rel / "test.xml")
+    return paths
+
+
+def _test_xml_funcs(paths: list[Path]) -> set[str]:
+    """Return top-level Test* functions from the first readable test.xml.
+
+    Subtests appear as name="TestFoo/Sub"; filtering to names without '/'
+    gives top-level functions. Requires --test_arg=-test.v (or
+    --test_env=GO_TEST_WRAP_TESTV=1) for a complete XML.
+    """
+    for path in paths:
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if not content.strip():
+            continue
+        try:
+            root = ET.fromstring(content)
+        except ET.ParseError:
+            continue
+        funcs = {
+            tc.get("name", "")
+            for tc in root.iter("testcase")
+            if tc.get("name", "").startswith("Test") and "/" not in tc.get("name", "")
+        }
+        return funcs
+    return set()
+
+
+def _bazel_test_funcs_from_bep(bep_path: Path) -> dict[str, set[str]]:
+    """Parse a Build Event Protocol JSON stream into {import_path: {Test* funcs}}.
+
+    Selects dd_agent_go_test targets that had a testResult event and whose
+    test.xml records at least one Test* function. Plain go_test rules (no
+    `dd_agent_go_test` tag) are ignored.
+    """
+    dd_agent_labels: set[str] = set()
+    # (uri, config_id) per label so we can recover test.xml even when Bazel
+    # writes only a bytestream:// URI to the BEP. The convenience symlink
+    # `bazel-testlogs` doesn't exist on CI (--noexperimental_convenience_symlinks),
+    # so we reconstruct the absolute path from `localExecRoot` and the
+    # configuration's BINDIR.
+    test_action: dict[str, tuple[str, str]] = {}
+    local_exec_root: str | None = None
+    config_testlogs: dict[str, Path] = {}
+
+    with open(bep_path) as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            event = json.loads(line)
+            eid = event.get("id", {})
+            if "workspace" in eid:
+                local_exec_root = event.get("workspaceInfo", {}).get("localExecRoot")
+            elif "configuration" in eid:
+                cfg_id = eid["configuration"].get("id", "")
+                bindir = event.get("configuration", {}).get("makeVariable", {}).get("BINDIR", "")
+                # BINDIR is "bazel-out/<config-mnemonic>/bin"; testlogs lives
+                # alongside as "bazel-out/<config-mnemonic>/testlogs".
+                bindir_path = Path(bindir)
+                if bindir_path.name == "bin":
+                    config_testlogs[cfg_id] = bindir_path.parent / "testlogs"
+            elif "targetConfigured" in eid:
+                label = eid["targetConfigured"].get("label", "")
+                cfg = event.get("configured", {})
+                if cfg.get("targetKind") != "go_test rule":
+                    continue
+                tags = set(cfg.get("tag") or [])
+                if _DD_AGENT_GO_TEST_TAG in tags:
+                    dd_agent_labels.add(label)
+            elif "testResult" in eid:
+                label = eid["testResult"].get("label", "")
+                cfg_id = eid["testResult"].get("configuration", {}).get("id", "")
+                for out in event["testResult"].get("testActionOutput") or []:
+                    if out.get("name") == "test.xml":
+                        test_action[label] = (out.get("uri", ""), cfg_id)
+                        break
+
+    covered: dict[str, set[str]] = {}
+    for label in dd_agent_labels:
+        action = test_action.get(label)
+        if action is None:
+            continue
+        uri, cfg_id = action
+        funcs = _test_xml_funcs(_test_xml_candidates(label, uri, cfg_id, local_exec_root, config_testlogs))
+        covered.setdefault(_label_to_import_path(label), set()).update(funcs)
+
+    return covered
+
+
+@task(
+    help={
+        "flavor_name": f"Agent flavor to check ({', '.join(f.name for f in AgentFlavor)}).",
+        "bep": "Path to the build_event_json_file produced by the preceding "
+        "'bazel test --config=<flavor> ...' invocation.",
+        "verbose": "Print passing packages.",
+    },
+)
+def ensure_test_parity(ctx, bep, flavor_name, verbose=False):
+    """
+    Verify every Go test visible to 'dda inv test --flavor=<f>' is also
+    present and executed in the matching Bazel per-flavor run.
+
+    Reads test execution from a Bazel Build Event Protocol JSON stream
+    (--build_event_json_file). The BEP determines scope (dd_agent_go_test
+    packages that produced test results); 'go list' is then queried for just
+    those packages to obtain the expected Test* function set. A package
+    compiled with wrong build tags (running a different set of functions) is
+    also reported as a failure.
+
+    Exits 1 if any gap is found.
+    """
+    bep_path = Path(bep)
+    if not bep_path.is_file():
+        print(f"error: BEP file not found: {bep}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        flavor = AgentFlavor[flavor_name]
+    except KeyError:
+        print(f"Unknown flavor '{flavor_name}'. Options: {[f.name for f in AgentFlavor]}", file=sys.stderr)
+        sys.exit(1)
+
+    # bazel test runs systematically pass the "race" build tag, so files guarded
+    # by `!race` must be excluded from the expected test set too.
+    tags = [*compute_build_tags_for_flavor("unit-tests", None, None, flavor), "race"]
+    coverage = _bazel_test_funcs_from_bep(bep_path)
+    test_pkgs = _go_test_packages(tags, set(coverage))
+
+    go_pkgs = set(test_pkgs)
+    extra_in_bazel = {p for p, funcs in coverage.items() if funcs} - go_pkgs
+
+    failed = False
+    for import_path in sorted(go_pkgs):
+        go_funcs = test_pkgs[import_path]
+        bazel_funcs = coverage[import_path]
+        missing_funcs = go_funcs - bazel_funcs
+        if missing_funcs:
+            sample = ", ".join(sorted(missing_funcs)[:3]) + (", ..." if len(missing_funcs) > 3 else "")
+            print(f"[FAIL] {import_path} [{flavor_name}] -- tests missing from Bazel: {sample}")
+            failed = True
+        elif verbose:
+            print(f"[PASS] {import_path} [{flavor_name}] ({len(bazel_funcs)} tests)")
+    for import_path in sorted(extra_in_bazel):
+        print(f"[FAIL] {import_path} [{flavor_name}] -- Bazel target exists but not in dda inv test")
+    if extra_in_bazel:
+        failed = True
+
+    if failed:
+        sys.exit(1)
 
 
 def _parse_bep(bep_path: Path) -> tuple[list[Path], dict[str, bool]]:

--- a/tasks/libs/common/datadog_api.py
+++ b/tasks/libs/common/datadog_api.py
@@ -52,9 +52,6 @@ def create_gauge(metric_name, timestamp, value, tags, unit=None, metric_origin=N
 
 
 def send_metrics(series):
-    """
-    Send series of metrics to Datadog
-    """
     from datadog_api_client import ApiClient, Configuration
     from datadog_api_client.v2.api.metrics_api import MetricsApi
     from datadog_api_client.v2.model.metric_payload import MetricPayload

--- a/tasks/libs/common/datadog_api.py
+++ b/tasks/libs/common/datadog_api.py
@@ -51,20 +51,33 @@ def create_gauge(metric_name, timestamp, value, tags, unit=None, metric_origin=N
     return create_metric(MetricIntakeType.GAUGE, metric_name, timestamp, value, tags, unit, metric_origin)
 
 
-def send_metrics(series):
+def send_metrics(series, warn=False):
+    """
+    Send series of metrics to Datadog
+    Args:
+        series: The metrics to send
+        warn: If true, failures will be logged but the process will continue
+    """
     from datadog_api_client import ApiClient, Configuration
     from datadog_api_client.v2.api.metrics_api import MetricsApi
     from datadog_api_client.v2.model.metric_payload import MetricPayload
 
     with ApiClient(Configuration(enable_retry=True)) as api_client:
         api_instance = MetricsApi(api_client)
-        response = api_instance.submit_metrics(body=MetricPayload(series=series))
+        try:
+            response = api_instance.submit_metrics(body=MetricPayload(series=series))
+        except Exception as e:
+            print(f"Error while sending pipeline metrics to the Datadog backend: {e}", file=sys.stderr)
+            if not warn:
+                raise Exit(code=1) from e
+            return None
 
         if response["errors"]:
             print(
                 f"Error(s) while sending pipeline metrics to the Datadog backend: {response['errors']}", file=sys.stderr
             )
-            raise Exit(code=1)
+            if not warn:
+                raise Exit(code=1)
 
         return response
 

--- a/tasks/libs/common/datadog_api.py
+++ b/tasks/libs/common/datadog_api.py
@@ -51,12 +51,9 @@ def create_gauge(metric_name, timestamp, value, tags, unit=None, metric_origin=N
     return create_metric(MetricIntakeType.GAUGE, metric_name, timestamp, value, tags, unit, metric_origin)
 
 
-def send_metrics(series, warn=False):
+def send_metrics(series):
     """
     Send series of metrics to Datadog
-    Args:
-        series: The metrics to send
-        warn: If true, failures will be logged but the process will continue
     """
     from datadog_api_client import ApiClient, Configuration
     from datadog_api_client.v2.api.metrics_api import MetricsApi
@@ -64,20 +61,13 @@ def send_metrics(series, warn=False):
 
     with ApiClient(Configuration(enable_retry=True)) as api_client:
         api_instance = MetricsApi(api_client)
-        try:
-            response = api_instance.submit_metrics(body=MetricPayload(series=series))
-        except Exception as e:
-            print(f"Error while sending pipeline metrics to the Datadog backend: {e}", file=sys.stderr)
-            if not warn:
-                raise Exit(code=1) from e
-            return None
+        response = api_instance.submit_metrics(body=MetricPayload(series=series))
 
         if response["errors"]:
             print(
                 f"Error(s) while sending pipeline metrics to the Datadog backend: {response['errors']}", file=sys.stderr
             )
-            if not warn:
-                raise Exit(code=1)
+            raise Exit(code=1)
 
         return response
 

--- a/tasks/unit_tests/bazel_tests.py
+++ b/tasks/unit_tests/bazel_tests.py
@@ -1,0 +1,204 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tasks.bazel import (
+    _IMPORT_PREFIX,
+    _bazel_test_funcs_from_bep,
+    _go_test_packages,
+    _label_to_import_path,
+    _test_xml_candidates,
+    _test_xml_funcs,
+)
+
+
+class TestLabelToImportPath(unittest.TestCase):
+    def test_regular_package(self):
+        self.assertEqual(
+            _label_to_import_path("//pkg/util/kernel:kernel_test_iot"),
+            f"{_IMPORT_PREFIX}/pkg/util/kernel",
+        )
+
+    def test_root_package(self):
+        self.assertEqual(_label_to_import_path("//:root_test"), _IMPORT_PREFIX)
+
+
+class TestTestXmlCandidates(unittest.TestCase):
+    def test_file_uri_only(self):
+        paths = _test_xml_candidates("//pkg/foo:bar_test", "file:///tmp/test.xml", "cfg1", None, {})
+        self.assertEqual(paths, [Path("/tmp/test.xml")])
+
+    def test_bytestream_uri_reconstructed_from_testlogs(self):
+        paths = _test_xml_candidates(
+            "//pkg/foo:bar_test",
+            "bytestream://example/blobs/abc/123",
+            "cfg1",
+            "/exec/root",
+            {"cfg1": Path("bazel-out/k8-fastbuild/testlogs")},
+        )
+        self.assertEqual(paths, [Path("/exec/root/bazel-out/k8-fastbuild/testlogs/pkg/foo/bar_test/test.xml")])
+
+    def test_both_candidates_in_priority_order(self):
+        paths = _test_xml_candidates(
+            "//pkg/foo:bar_test",
+            "file:///tmp/test.xml",
+            "cfg1",
+            "/exec/root",
+            {"cfg1": Path("bazel-out/k8-fastbuild/testlogs")},
+        )
+        self.assertEqual(
+            paths,
+            [
+                Path("/tmp/test.xml"),
+                Path("/exec/root/bazel-out/k8-fastbuild/testlogs/pkg/foo/bar_test/test.xml"),
+            ],
+        )
+
+    def test_no_candidates_when_config_unknown(self):
+        paths = _test_xml_candidates(
+            "//pkg/foo:bar_test", "bytestream://example/blobs/abc/123", "cfg1", "/exec/root", {}
+        )
+        self.assertEqual(paths, [])
+
+
+_JUNIT_XML = """<?xml version="1.0"?>
+<testsuite name="pkg/foo" tests="3">
+  <testcase name="TestFoo"></testcase>
+  <testcase name="TestFoo/SubCase"></testcase>
+  <testcase name="TestBar"></testcase>
+</testsuite>
+"""
+
+
+class TestTestXmlFuncs(unittest.TestCase):
+    def test_top_level_funcs_only(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xml_path = Path(tmpdir) / "test.xml"
+            xml_path.write_text(_JUNIT_XML)
+            self.assertEqual(_test_xml_funcs([xml_path]), {"TestFoo", "TestBar"})
+
+    def test_falls_through_unreadable_and_empty_candidates(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = Path(tmpdir) / "missing.xml"
+            empty = Path(tmpdir) / "empty.xml"
+            empty.write_text("")
+            real = Path(tmpdir) / "test.xml"
+            real.write_text(_JUNIT_XML)
+            self.assertEqual(_test_xml_funcs([missing, empty, real]), {"TestFoo", "TestBar"})
+
+    def test_raises_when_nothing_readable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = Path(tmpdir) / "missing.xml"
+            with self.assertRaises(FileNotFoundError):
+                _test_xml_funcs([missing])
+
+
+def _bep_line(event: dict) -> str:
+    return json.dumps(event) + "\n"
+
+
+class TestBazelTestFuncsFromBep(unittest.TestCase):
+    def test_extracts_funcs_for_dd_agent_go_test_targets_only(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xml_path = Path(tmpdir) / "test.xml"
+            xml_path.write_text(_JUNIT_XML)
+
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(
+                "".join(
+                    [
+                        _bep_line({"id": {"workspace": {}}, "workspaceInfo": {"localExecRoot": "/exec/root"}}),
+                        _bep_line(
+                            {
+                                "id": {"targetConfigured": {"label": "//pkg/foo:foo_test"}},
+                                "configured": {"targetKind": "go_test rule", "tag": ["dd_agent_go_test"]},
+                            }
+                        ),
+                        _bep_line(
+                            {
+                                "id": {"targetConfigured": {"label": "//pkg/foo:foo_other_test"}},
+                                "configured": {"targetKind": "go_test rule", "tag": []},
+                            }
+                        ),
+                        _bep_line(
+                            {
+                                "id": {"targetConfigured": {"label": "//pkg/foo:not_a_go_binary"}},
+                                "configured": {"targetKind": "sh_test rule", "tag": ["dd_agent_go_test"]},
+                            }
+                        ),
+                        _bep_line(
+                            {
+                                "id": {"testResult": {"label": "//pkg/foo:foo_test", "configuration": {"id": "cfg1"}}},
+                                "testResult": {"testActionOutput": [{"name": "test.xml", "uri": xml_path.as_uri()}]},
+                            }
+                        ),
+                    ]
+                )
+            )
+
+            covered = _bazel_test_funcs_from_bep(bep_path)
+            self.assertEqual(covered, {f"{_IMPORT_PREFIX}/pkg/foo": {"TestFoo", "TestBar"}})
+
+    def test_configured_but_never_run_is_skipped(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(
+                _bep_line(
+                    {
+                        "id": {"targetConfigured": {"label": "//pkg/foo:foo_test"}},
+                        "configured": {"targetKind": "go_test rule", "tag": ["dd_agent_go_test"]},
+                    }
+                )
+            )
+            self.assertEqual(_bazel_test_funcs_from_bep(bep_path), {})
+
+
+class TestGoTestPackages(unittest.TestCase):
+    def test_empty_import_paths_skips_subprocess(self):
+        with patch("tasks.bazel.subprocess.run") as mock_run:
+            self.assertEqual(_go_test_packages(["race"], set()), {})
+            mock_run.assert_not_called()
+
+    def test_nonzero_returncode_raises(self):
+        with patch("tasks.bazel.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+            with self.assertRaises(ChildProcessError):
+                _go_test_packages(["race"], {"example.com/pkg/foo"})
+
+    def test_parses_concatenated_json_and_filters_by_import_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_dir = Path(tmpdir) / "foo"
+            pkg_dir.mkdir()
+            (pkg_dir / "foo_test.go").write_text(
+                "package foo\nfunc TestFoo(t *testing.T) {}\nfunc TestMain(m *testing.M) {}\n"
+            )
+
+            stdout = "".join(
+                [
+                    json.dumps(
+                        {
+                            "ImportPath": "example.com/pkg/foo",
+                            "Dir": str(pkg_dir),
+                            "TestGoFiles": ["foo_test.go"],
+                        }
+                    ),
+                    "\n",
+                    json.dumps({"ImportPath": "example.com/pkg/bar", "Dir": str(tmpdir)}),
+                    "\n",
+                ]
+            )
+
+            with patch("tasks.bazel.subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+                result = _go_test_packages(["race"], {"example.com/pkg/foo"})
+
+            # "example.com/pkg/bar" is filtered out: not in import_paths.
+            # TestMain is discarded even though it matched the Test* pattern.
+            self.assertEqual(result, {"example.com/pkg/foo": {"TestFoo"}})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What does this PR do?

Add a `dda inv bazel.ensure-test-parity` task and wire it into each per-flavor
Bazel test job. After a successful `bazel test --config=<flavor> //...`, the
task reads the Build Event Protocol (BEP) JSON produced by the run and confirms
that every Go test package `dda inv test --flavor=<flavor>` would discover has a
matching `dd_agent_go_test` variant that actually executed for the same flavor.
A metric containing the number of tests ran is also sent to DD so that we can check the coverage progress

### Motivation

We now run per-flavor tests, but we want to ensure that our test targets don't contain empty test suites, or that some tests aren't excluded due to a mistake in the build tags.

 The parity step relies on each `bazel test` invocation producing a BEP JSON (`--build_event_json_file=$BEP_FILE`). The CI wiring adds the flag and  publishes the BEP as a job artifact (`bazel-bep-*.json`)
We might leverage the BEP artifacts to provide more observability in the future

### Describe how you validated your changes

- Ran each per-flavor job locally against a fresh BEP and confirmed `[PASS]`
  count matches what `dda inv test --flavor=<f>` discovers.
- The number of tests ran metric is used into a WIP dashboard to monitor our migration progresses 

### Additional Notes

