### PR TITLE
[AGNTLOG-317] fix(logs): reject duplicate file tailers to prevent auditor corruption

### DIFF
--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -451,14 +451,17 @@ func (s *Launcher) launchTailers(source *sources.LogSource) {
 }
 
 // isFileAlreadyTailed returns true if any tailer currently tracked by the
-// launcher is already tailing the given file path. The TailerContainer is
-// keyed by scan key (e.g. <path>/<containerID> for container sources), so
-// two distinct scan keys can resolve to the same file path. Starting a
-// second tailer on the same path would race with the existing tailer when
-// updating auditor offsets/checkpoints, corrupting registry state. This
-// helper lets the spawn sites detect and reject such duplicates.
-func (s *Launcher) isFileAlreadyTailed(path string) bool {
-	identifier := "file:" + path
+// launcher is already tailing the same file (as determined by the tailer's
+// Identifier). The TailerContainer is keyed by scan key (e.g.
+// <path>/<containerID> for container sources), so two distinct scan keys
+// can resolve to the same file Identifier. Starting a second tailer on the
+// same file would race with the existing tailer when updating auditor
+// offsets/checkpoints, corrupting registry state. This helper lets the
+// spawn sites detect and reject such duplicates. Identifier construction
+// is owned by the tailer package (file.File.Identifier) so changes to the
+// identifier format only need to happen in one place.
+func (s *Launcher) isFileAlreadyTailed(file *tailer.File) bool {
+	identifier := file.Identifier()
 	for _, existing := range s.tailers.All() {
 		if existing.Identifier() == identifier {
 			return true
@@ -475,7 +478,7 @@ func (s *Launcher) startNewTailer(file *tailer.File, m config.TailingMode, finge
 		return false
 	}
 
-	if s.isFileAlreadyTailed(file.Path) {
+	if s.isFileAlreadyTailed(file) {
 		log.Warnf("file %q is already being tailed by another log source; skipping duplicate tailer to avoid auditor offset corruption", file.Path)
 		return false
 	}
@@ -510,7 +513,7 @@ func (s *Launcher) startNewTailerWithStoredInfo(file *tailer.File, m config.Tail
 		return false
 	}
 
-	if s.isFileAlreadyTailed(file.Path) {
+	if s.isFileAlreadyTailed(file) {
 		log.Warnf("file %q is already being tailed by another log source; skipping duplicate tailer to avoid auditor offset corruption", file.Path)
 		return false
 	}

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -8,6 +8,7 @@ package file
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"slices"
 	"sync"
@@ -68,6 +69,12 @@ type Launcher struct {
 	fileOpener    opener.FileOpener
 	fingerprinter tailer.Fingerprinter
 	stopOnce      sync.Once
+	// rejectedDuplicates tracks (sourceIdentifier, path) pairs that have already had their
+	// duplicate-rejection warning emitted. Without this cache the warning fires on every scan
+	// cycle (~1 s), producing ~3600 WARN/hr per duplicate. The key is built by
+	// duplicateRejectionKey. Entries are cleared when the offending source is removed so that a
+	// legitimate subsequent add still triggers the warning.
+	rejectedDuplicates map[string]struct{}
 }
 
 const (
@@ -124,6 +131,7 @@ func NewLauncher(
 		oldInfoMap:             make(map[string]*oldTailerInfo),
 		fileOpener:             fileOpener,
 		fingerprinter:          fingerprinter,
+		rejectedDuplicates:     make(map[string]struct{}),
 	}
 }
 
@@ -388,6 +396,30 @@ func (s *Launcher) removeSource(source *sources.LogSource) {
 			break
 		}
 	}
+	// Clear any cached duplicate-rejection keys associated with this source so that if
+	// the source is re-added later the warning fires again at that point.
+	identifier := source.Config.Identifier
+	prefix := identifier + "|"
+	for key := range s.rejectedDuplicates {
+		// Keys are built as "<identifier>|<path>"; delete all keys that belong to this source.
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			delete(s.rejectedDuplicates, key)
+		}
+		// Also handle the case where the *other* source (with a different identifier) was
+		// rejected because this source already owned the file.  We don't have a path-only
+		// index here, so we only clear exact-identifier matches; that is sufficient for
+		// the common case (the duplicate source is removed).
+	}
+}
+
+// duplicateRejectionKey returns the dedup key used to suppress repeated duplicate-tailer
+// warnings for the same (source identifier, file path) pair.
+func duplicateRejectionKey(file *tailer.File) string {
+	var identifier string
+	if file.Source != nil && file.Source.Config() != nil {
+		identifier = file.Source.Config().Identifier
+	}
+	return identifier + "|" + file.Path
 }
 
 // launch launches new tailers for a new source.
@@ -479,7 +511,17 @@ func (s *Launcher) startNewTailer(file *tailer.File, m config.TailingMode, finge
 	}
 
 	if s.isFileAlreadyTailed(file) {
-		log.Warnf("file %q is already being tailed by another log source; skipping duplicate tailer to avoid auditor offset corruption", file.Path)
+		key := duplicateRejectionKey(file)
+		err := fmt.Errorf("file %q is already being tailed by another log source; duplicate skipped to avoid auditor offset corruption", file.Path)
+		if _, seen := s.rejectedDuplicates[key]; !seen {
+			log.Warn(err)
+			s.rejectedDuplicates[key] = struct{}{}
+		} else {
+			log.Debugf("duplicate tailer rejection (suppressed repeat warning): %v", err)
+		}
+		if file.Source != nil {
+			file.Source.Status().Error(err)
+		}
 		return false
 	}
 
@@ -514,7 +556,17 @@ func (s *Launcher) startNewTailerWithStoredInfo(file *tailer.File, m config.Tail
 	}
 
 	if s.isFileAlreadyTailed(file) {
-		log.Warnf("file %q is already being tailed by another log source; skipping duplicate tailer to avoid auditor offset corruption", file.Path)
+		key := duplicateRejectionKey(file)
+		err := fmt.Errorf("file %q is already being tailed by another log source; duplicate skipped to avoid auditor offset corruption", file.Path)
+		if _, seen := s.rejectedDuplicates[key]; !seen {
+			log.Warn(err)
+			s.rejectedDuplicates[key] = struct{}{}
+		} else {
+			log.Debugf("duplicate tailer rejection (suppressed repeat warning): %v", err)
+		}
+		if file.Source != nil {
+			file.Source.Status().Error(err)
+		}
 		return false
 	}
 

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -422,6 +422,30 @@ func duplicateRejectionKey(file *tailer.File) string {
 	return identifier + "|" + file.Path
 }
 
+// rejectDuplicateIfTailed returns true if file is already tailed by another tailer.
+// It logs at Warn the first time a given (identifier, path) pair is rejected and at
+// Debug on subsequent calls for the same pair, and surfaces an error on the source's
+// Status so that `agent status` makes the rejection visible to operators.
+// Both startNewTailer and startNewTailerWithStoredInfo delegate to this method so the
+// rejection contract lives in exactly one place.
+func (s *Launcher) rejectDuplicateIfTailed(file *tailer.File) bool {
+	if !s.isFileAlreadyTailed(file) {
+		return false
+	}
+	key := duplicateRejectionKey(file)
+	err := fmt.Errorf("file %q is already being tailed by another log source; duplicate skipped to avoid auditor offset corruption", file.Path)
+	if _, seen := s.rejectedDuplicates[key]; !seen {
+		log.Warn(err)
+		s.rejectedDuplicates[key] = struct{}{}
+	} else {
+		log.Debugf("duplicate tailer rejection (suppressed repeat warning): %v", err)
+	}
+	if file.Source != nil {
+		file.Source.Status().Error(err)
+	}
+	return true
+}
+
 // launch launches new tailers for a new source.
 func (s *Launcher) launchTailers(source *sources.LogSource) {
 	// If we're at the limit already, no need to do a 'CollectFiles', just wait for the next 'scan'
@@ -510,18 +534,7 @@ func (s *Launcher) startNewTailer(file *tailer.File, m config.TailingMode, finge
 		return false
 	}
 
-	if s.isFileAlreadyTailed(file) {
-		key := duplicateRejectionKey(file)
-		err := fmt.Errorf("file %q is already being tailed by another log source; duplicate skipped to avoid auditor offset corruption", file.Path)
-		if _, seen := s.rejectedDuplicates[key]; !seen {
-			log.Warn(err)
-			s.rejectedDuplicates[key] = struct{}{}
-		} else {
-			log.Debugf("duplicate tailer rejection (suppressed repeat warning): %v", err)
-		}
-		if file.Source != nil {
-			file.Source.Status().Error(err)
-		}
+	if s.rejectDuplicateIfTailed(file) {
 		return false
 	}
 
@@ -555,18 +568,7 @@ func (s *Launcher) startNewTailerWithStoredInfo(file *tailer.File, m config.Tail
 		return false
 	}
 
-	if s.isFileAlreadyTailed(file) {
-		key := duplicateRejectionKey(file)
-		err := fmt.Errorf("file %q is already being tailed by another log source; duplicate skipped to avoid auditor offset corruption", file.Path)
-		if _, seen := s.rejectedDuplicates[key]; !seen {
-			log.Warn(err)
-			s.rejectedDuplicates[key] = struct{}{}
-		} else {
-			log.Debugf("duplicate tailer rejection (suppressed repeat warning): %v", err)
-		}
-		if file.Source != nil {
-			file.Source.Status().Error(err)
-		}
+	if s.rejectDuplicateIfTailed(file) {
 		return false
 	}
 

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -450,11 +450,33 @@ func (s *Launcher) launchTailers(source *sources.LogSource) {
 	}
 }
 
+// isFileAlreadyTailed returns true if any tailer currently tracked by the
+// launcher is already tailing the given file path. The TailerContainer is
+// keyed by scan key (e.g. <path>/<containerID> for container sources), so
+// two distinct scan keys can resolve to the same file path. Starting a
+// second tailer on the same path would race with the existing tailer when
+// updating auditor offsets/checkpoints, corrupting registry state. This
+// helper lets the spawn sites detect and reject such duplicates.
+func (s *Launcher) isFileAlreadyTailed(path string) bool {
+	identifier := "file:" + path
+	for _, existing := range s.tailers.All() {
+		if existing.Identifier() == identifier {
+			return true
+		}
+	}
+	return false
+}
+
 // startNewTailer creates a new tailer, making it tail from the last committed offset, the beginning or the end of the file,
 // returns true if the operation succeeded, false otherwise.
 func (s *Launcher) startNewTailer(file *tailer.File, m config.TailingMode, fingerprint *types.Fingerprint) bool {
 	if file == nil {
 		log.Debug("startNewTailer called with a nil file")
+		return false
+	}
+
+	if s.isFileAlreadyTailed(file.Path) {
+		log.Warnf("file %q is already being tailed by another log source; skipping duplicate tailer to avoid auditor offset corruption", file.Path)
 		return false
 	}
 
@@ -485,6 +507,11 @@ func (s *Launcher) startNewTailer(file *tailer.File, m config.TailingMode, finge
 func (s *Launcher) startNewTailerWithStoredInfo(file *tailer.File, m config.TailingMode, oldInfo *oldTailerInfo, fingerprint *types.Fingerprint) bool {
 	if file == nil {
 		log.Debug("startNewTailerWithStoredInfo called with a nil file")
+		return false
+	}
+
+	if s.isFileAlreadyTailed(file.Path) {
+		log.Warnf("file %q is already being tailed by another log source; skipping duplicate tailer to avoid auditor offset corruption", file.Path)
 		return false
 	}
 

--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -111,6 +111,59 @@ func TestLauncherFileDetectionSingleScan(t *testing.T) {
 	runLauncherFileDetectionSingleScanTest(t, []string{t.TempDir()})
 }
 
+// TestLauncherRejectsDuplicateFileTailer verifies that when two log sources
+// resolve to the same file path, the launcher refuses to start a second
+// tailer for that path. Two tailers on the same path would race when writing
+// to the auditor registry (offsets/checkpoints are keyed by file path via
+// Tailer.Identifier), which can corrupt registry state. See AGNTLOG-317.
+func TestLauncherRejectsDuplicateFileTailer(t *testing.T) {
+	testDir := t.TempDir()
+	path := testDir + "/shared.log"
+
+	f, err := os.Create(path)
+	assert.Nil(t, err)
+	defer f.Close()
+
+	launcher := createLauncher(t, launcherTestOptions{openFilesLimit: 5})
+	launcher.pipelineProvider = mock.NewMockProvider()
+	launcher.registry = auditorMock.NewMockRegistry()
+
+	// Two sources that resolve to the same file path. They differ only by
+	// container Identifier so the TailerContainer would otherwise key them
+	// under distinct scan keys, allowing both to be tracked and both to
+	// write to the same auditor entry.
+	firstSource := sources.NewLogSource("first", &config.LogsConfig{
+		Type: config.FileType, Path: path, TailingMode: "beginning", Identifier: "container-a",
+	})
+	secondSource := sources.NewLogSource("second", &config.LogsConfig{
+		Type: config.FileType, Path: path, TailingMode: "beginning", Identifier: "container-b",
+	})
+
+	launcher.addSource(firstSource)
+	assert.Equal(t, 1, launcher.tailers.Count(), "first source should start exactly one tailer")
+
+	// Sanity: helper reports the path as already tailed.
+	assert.True(t, launcher.isFileAlreadyTailed(path),
+		"after adding first source, isFileAlreadyTailed should return true for the path")
+
+	launcher.addSource(secondSource)
+	assert.Equal(t, 1, launcher.tailers.Count(),
+		"second source on the same file path must be rejected to avoid auditor offset races")
+
+	// And a third source that points at a different file in the same directory
+	// is still accepted, demonstrating the rejection is scoped to duplicate paths.
+	otherPath := testDir + "/other.log"
+	f2, err := os.Create(otherPath)
+	assert.Nil(t, err)
+	defer f2.Close()
+	thirdSource := sources.NewLogSource("third", &config.LogsConfig{
+		Type: config.FileType, Path: otherPath, TailingMode: "beginning", Identifier: "container-c",
+	})
+	launcher.addSource(thirdSource)
+	assert.Equal(t, 2, launcher.tailers.Count(),
+		"a source pointing at a distinct path must still produce its own tailer")
+}
+
 type TestSetupStrategy interface {
 	Setup(t *testing.T) TestSetupResult
 }
@@ -720,9 +773,11 @@ func runLauncherWithConcurrentContainerTailerTest(t *testing.T, testDirs []strin
 	msg = <-outputChan
 	assert.Equal(t, "Time", string(msg.GetContent()))
 
-	// Add a second source, same file, different container ID, tailing twice the same file is supported in that case
+	// Add a second source pointing at the same file (different container ID).
+	// Tailing the same file twice would race auditor offsets/checkpoints between
+	// the two tailers, so the launcher now rejects the duplicate (see AGNTLOG-317).
 	launcher.addSource(secondSource)
-	assert.Equal(t, 2, launcher.tailers.Count())
+	assert.Equal(t, 1, launcher.tailers.Count())
 }
 
 func runLauncherTailFromTheBeginningTest(t *testing.T, testDirs []string, chmodFileIfExists bool) {
@@ -737,8 +792,10 @@ func runLauncherTailFromTheBeginningTest(t *testing.T, testDirs []string, chmodF
 	sources := []*sources.LogSource{
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: testDir + "/test.log", TailingMode: "beginning"}),
 		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: testDir + "/container.log", TailingMode: "beginning", Identifier: "123456789"}),
-		// Same file different container ID
-		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: testDir + "/container.log", TailingMode: "beginning", Identifier: "987654321"}),
+		// Different file, different container ID. Two sources pointing at the same
+		// file path (regardless of container ID) are rejected by the launcher to
+		// prevent auditor offset races (see AGNTLOG-317), so use a distinct path here.
+		sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: testDir + "/container2.log", TailingMode: "beginning", Identifier: "987654321"}),
 	}
 
 	for i, source := range sources {

--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -242,6 +242,59 @@ func TestLauncherDuplicateRejectionSetsErrorStatus(t *testing.T) {
 		"error message must explain why the source was rejected")
 }
 
+// TestLauncherDuplicateRejectionStoredInfoPath verifies that startNewTailerWithStoredInfo
+// applies the same rejection contract as startNewTailer: a file that is already being tailed
+// must be rejected, its source Status must show an error, and the dedup cache must record the
+// pair so that repeated calls suppress the Warn log.
+func TestLauncherDuplicateRejectionStoredInfoPath(t *testing.T) {
+	testDir := t.TempDir()
+	path := testDir + "/shared.log"
+
+	f, err := os.Create(path)
+	assert.Nil(t, err)
+	defer f.Close()
+
+	launcher := createLauncher(t, launcherTestOptions{openFilesLimit: 5})
+	launcher.pipelineProvider = mock.NewMockProvider()
+	launcher.registry = auditorMock.NewMockRegistry()
+
+	firstSource := sources.NewLogSource("first", &config.LogsConfig{
+		Type: config.FileType, Path: path, TailingMode: "beginning", Identifier: "container-a",
+	})
+	secondSource := sources.NewLogSource("second", &config.LogsConfig{
+		Type: config.FileType, Path: path, TailingMode: "beginning", Identifier: "container-b",
+	})
+
+	// Establish the first tailer via the normal path.
+	launcher.addSource(firstSource)
+	assert.Equal(t, 1, launcher.tailers.Count())
+
+	// Attempt to start a second tailer for the same underlying file via the stored-info path.
+	file := filetailer.NewFile(path, secondSource, false)
+	oldInfo := &oldTailerInfo{Pattern: nil, InfoRegistry: nil}
+
+	result := launcher.startNewTailerWithStoredInfo(file, config.Beginning, oldInfo, nil)
+
+	assert.False(t, result, "startNewTailerWithStoredInfo must return false for a duplicate file")
+	assert.Equal(t, 1, launcher.tailers.Count(), "duplicate must not produce a second tailer")
+
+	// The rejected source's Status must expose an error for `agent status`.
+	assert.True(t, secondSource.Status.IsError(),
+		"rejected source must have its Status set to an error state")
+	assert.Contains(t, secondSource.Status.GetError(), "already being tailed",
+		"error message must explain why the source was rejected")
+
+	// The dedup cache must hold the entry so repeated calls suppress the Warn log.
+	assert.Len(t, launcher.rejectedDuplicates, 1,
+		"dedup cache should hold exactly one entry after the first rejection")
+
+	// A second call must still be rejected (dedup entry is still present).
+	result = launcher.startNewTailerWithStoredInfo(file, config.Beginning, oldInfo, nil)
+	assert.False(t, result, "startNewTailerWithStoredInfo must continue to return false on repeated calls")
+	assert.Len(t, launcher.rejectedDuplicates, 1,
+		"dedup cache must not grow on repeated rejections of the same key")
+}
+
 type TestSetupStrategy interface {
 	Setup(t *testing.T) TestSetupResult
 }

--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -143,7 +143,7 @@ func TestLauncherRejectsDuplicateFileTailer(t *testing.T) {
 	assert.Equal(t, 1, launcher.tailers.Count(), "first source should start exactly one tailer")
 
 	// Sanity: helper reports the path as already tailed.
-	assert.True(t, launcher.isFileAlreadyTailed(path),
+	assert.True(t, launcher.isFileAlreadyTailed(filetailer.NewFile(path, firstSource, false)),
 		"after adding first source, isFileAlreadyTailed should return true for the path")
 
 	launcher.addSource(secondSource)
@@ -778,6 +778,15 @@ func runLauncherWithConcurrentContainerTailerTest(t *testing.T, testDirs []strin
 	// the two tailers, so the launcher now rejects the duplicate (see AGNTLOG-317).
 	launcher.addSource(secondSource)
 	assert.Equal(t, 1, launcher.tailers.Count())
+
+	// Verify the surviving tailer is the one from the first source (keyed by
+	// the first source's container ID), not the rejected duplicate.
+	survivors := launcher.tailers.All()
+	if assert.Len(t, survivors, 1) {
+		expectedScanKey := path + "/" + firstSource.Config.Identifier
+		assert.Equal(t, expectedScanKey, survivors[0].GetID(),
+			"the originally-started tailer (first source) must survive the duplicate rejection")
+	}
 }
 
 func runLauncherTailFromTheBeginningTest(t *testing.T, testDirs []string, chmodFileIfExists bool) {

--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -164,6 +164,84 @@ func TestLauncherRejectsDuplicateFileTailer(t *testing.T) {
 		"a source pointing at a distinct path must still produce its own tailer")
 }
 
+// TestLauncherDuplicateRejectionWarnOnce verifies that the duplicate-tailer rejection
+// warning is emitted at most once per (source identifier, path) pair, even when
+// startNewTailer is called many times in successive scan cycles. After the source is
+// removed and re-added the warning should fire again.
+func TestLauncherDuplicateRejectionWarnOnce(t *testing.T) {
+	testDir := t.TempDir()
+	path := testDir + "/shared.log"
+
+	f, err := os.Create(path)
+	assert.Nil(t, err)
+	defer f.Close()
+
+	launcher := createLauncher(t, launcherTestOptions{openFilesLimit: 5})
+	launcher.pipelineProvider = mock.NewMockProvider()
+	launcher.registry = auditorMock.NewMockRegistry()
+
+	firstSource := sources.NewLogSource("first", &config.LogsConfig{
+		Type: config.FileType, Path: path, TailingMode: "beginning", Identifier: "container-a",
+	})
+	secondSource := sources.NewLogSource("second", &config.LogsConfig{
+		Type: config.FileType, Path: path, TailingMode: "beginning", Identifier: "container-b",
+	})
+
+	launcher.addSource(firstSource)
+	assert.Equal(t, 1, launcher.tailers.Count())
+
+	// Simulate N scan cycles: startNewTailer is called once per scan for the rejected file.
+	// The dedup cache must suppress repeated warnings so the map entry count stays at 1.
+	file := filetailer.NewFile(path, secondSource, false)
+	for i := 0; i < 5; i++ {
+		launcher.startNewTailer(file, config.Beginning, nil)
+	}
+	assert.Len(t, launcher.rejectedDuplicates, 1,
+		"dedup cache should hold exactly one entry for the rejected (identifier, path) pair")
+
+	// After removing the duplicate source the cache entry must be cleared so that a
+	// subsequent re-add triggers the warning once more.
+	launcher.removeSource(secondSource)
+	assert.Empty(t, launcher.rejectedDuplicates,
+		"cache entry must be cleared when the duplicate source is removed")
+}
+
+// TestLauncherDuplicateRejectionSetsErrorStatus verifies that the rejected source's
+// Status is set to an error state (visible in `agent status`) when startNewTailer
+// and startNewTailerWithStoredInfo refuse to start a duplicate tailer.
+func TestLauncherDuplicateRejectionSetsErrorStatus(t *testing.T) {
+	testDir := t.TempDir()
+	path := testDir + "/shared.log"
+
+	f, err := os.Create(path)
+	assert.Nil(t, err)
+	defer f.Close()
+
+	launcher := createLauncher(t, launcherTestOptions{openFilesLimit: 5})
+	launcher.pipelineProvider = mock.NewMockProvider()
+	launcher.registry = auditorMock.NewMockRegistry()
+
+	firstSource := sources.NewLogSource("first", &config.LogsConfig{
+		Type: config.FileType, Path: path, TailingMode: "beginning", Identifier: "container-a",
+	})
+	secondSource := sources.NewLogSource("second", &config.LogsConfig{
+		Type: config.FileType, Path: path, TailingMode: "beginning", Identifier: "container-b",
+	})
+
+	launcher.addSource(firstSource)
+	assert.Equal(t, 1, launcher.tailers.Count())
+
+	// The second source resolves to the same file; its tailer must be rejected.
+	launcher.addSource(secondSource)
+	assert.Equal(t, 1, launcher.tailers.Count(), "duplicate source must not produce a second tailer")
+
+	// R2: the rejected source's Status must show an error so that `agent status` surfaces it.
+	assert.True(t, secondSource.Status.IsError(),
+		"rejected source must have its Status set to an error state")
+	assert.Contains(t, secondSource.Status.GetError(), "already being tailed",
+		"error message must explain why the source was rejected")
+}
+
 type TestSetupStrategy interface {
 	Setup(t *testing.T) TestSetupResult
 }

--- a/releasenotes/notes/logs-reject-duplicate-file-tailer-1a2b3c4d5e6f7a8b.yaml
+++ b/releasenotes/notes/logs-reject-duplicate-file-tailer-1a2b3c4d5e6f7a8b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Logs Agent now rejects duplicate file tailers when two log sources resolve
+    to the same file path. Previously, two sources differing only by container
+    identifier could spawn two tailers for the same file, racing on the same
+    auditor registry entry and corrupting committed offsets/checkpoints. The
+    duplicate is now skipped with a warning and only the first tailer is kept.


### PR DESCRIPTION
## Summary

Jira: https://datadoghq.atlassian.net/browse/AGNTLOG-317

### Root cause

The file launcher's `TailerContainer` is keyed by `GetScanKey()`, which is
`<path>/<containerID>` for container sources and `<path>` otherwise. Two log
sources that point at the same file path but differ in container identifier
therefore produce two distinct scan keys, so the container happily tracks
both as separate tailers.

The auditor registry, however, is keyed by `Tailer.Identifier()` which is
just `"file:<path>"` (path-only — the existing `FIXME` on
`Tailer.Identifier` explicitly calls this out). When two tailers share an
Identifier, they race writing offsets and checkpoints to the same registry
entry, corrupting auditor state.

### Fix

Detect duplicates at the spawn site by file path. Before creating a new
file tailer in either `startNewTailer` or `startNewTailerWithStoredInfo`,
walk `s.tailers.All()` looking for an existing tailer with the same
`Identifier()`. If one is found, emit a `log.Warnf` explaining the
auditor-corruption hazard and return `false` without starting a duplicate
tailer.

This deliberately keeps the existing `TailerContainer` keying intact (one
entry per scan key) — that data structure is correct as-is. The duplicate
check is purely additive at the call site.

### What changed
- `pkg/logs/launchers/file/launcher.go`: new `isFileAlreadyTailed(path)`
  helper; both `startNewTailer` and `startNewTailerWithStoredInfo` consult
  it before creating a tailer.
- `pkg/logs/launchers/file/launcher_test.go`:
  - New `TestLauncherRejectsDuplicateFileTailer` exercising two
    same-path sources and a distinct-path control case.
  - `runLauncherWithConcurrentContainerTailerTest` and
    `runLauncherTailFromTheBeginningTest` updated: both previously
    asserted that two sources on the same path produce two tailers,
    which is the exact bug being fixed. The first now asserts the
    duplicate is rejected; the second now uses a distinct path for
    the third source.
- `releasenotes/notes/logs-reject-duplicate-file-tailer-*.yaml`: reno
  `fixes:` entry describing the auditor-corruption avoidance.

### Scope

This PR addresses **file tailers only**. Other launchers (journald,
container/docker, socket) have similar spawn paths and could benefit from
the same pattern, but each has its own keying semantics and deserves its
own scoped change in a follow-up.

## Test plan
- [x] `dda inv test --targets=./pkg/logs/launchers/file,./pkg/logs/tailers` — passes
- [x] `dda inv linter.go --targets=./pkg/logs/launchers/file,./pkg/logs/tailers` — clean
- [x] New unit test `TestLauncherRejectsDuplicateFileTailer` asserts:
  - two sources on the same path produce exactly one tailer
  - a third source on a distinct path still gets its own tailer
- [ ] Follow-up: apply the same pattern to other launchers (journald,
      container, socket) if duplicate-source races are observed there too.

## Manual QA

Built locally from commit `55a66f9450d` with `dda inv agent.build --build-exclude=systemd` on macOS arm64 (darwin 25.4.0, Go 1.25.10, Agent v7.81.0-devel) and exercised the dedup behavior end-to-end against a real agent binary. All scenarios behaved as expected.

### Important note on trigger paths

The `isFileAlreadyTailed` guard (the new code in this PR) fires when two sources have **different scan keys but the same `Identifier()`** — this is the container-source case where `GetScanKey()` returns `<path>/<containerID>` but `Identifier()` always returns `"file:<path>"`. For plain file sources with identical paths (no container ID), the existing `tailers.Get(file.GetScanKey())` check at `launchTailers:402` catches the duplicate before `startNewTailer` is reached and calls `tailer.ReplaceSource` instead. Both code paths produce the correct outcome: exactly one active tailer per physical file. The unit test `TestLauncherRejectsDuplicateFileTailer` directly exercises the new guard by setting distinct `Identifier` values on two sources with the same path.

### Risk-focused trace + verification

| # | Claim | Verified by |
|---|---|---|
| 1 | Two YAML configs at same path → only 1 active tailer (second source visible in status but no `Inputs:` entry — caught by scan-key dedup before reaching new guard) | Scenario A binary run |
| 2 | Two YAML configs at different paths → both get independent tailers, no false-positive rejection | Scenario B binary run |
| 3 | Single config baseline → one tailer, no warning, no regression | Scenario C binary run |
| 4 | Container-ID-differentiated sources at same path → second tailer rejected by new `isFileAlreadyTailed` guard with `Warnf` | `TestLauncherRejectsDuplicateFileTailer` unit test (1/1 PASS) |

### Concrete runs

**Scenario A** — Two YAML sources pointing at `/tmp/qa-317/shared.log`:

```
# Agent log (only one tailer started):
2026-05-19 09:39:44 EDT | CORE | INFO | (pkg/logs/launchers/file/launcher.go:486 in startNewTailer) | Starting a new tailer for: /tmp/qa-317/shared.log (offset: 0, whence: 2) for tailer key /tmp/qa-317/shared.log

# agent status (source_two has no Inputs: — no active tailer):
  source_one
  ----------
    - Type: file, Path: /tmp/qa-317/shared.log, Service: qa-one
      Status: OK
      Inputs:
        /tmp/qa-317/shared.log

  source_two
  ----------
    - Type: file, Path: /tmp/qa-317/shared.log, Service: qa-two
      Status: OK
      (no Inputs: entry — duplicate rejected)
```

**Scenario B** — Two sources, different paths (`shared.log` and `other.log`):

```
# Agent log (two tailers started, no dedup warning):
2026-05-19 09:37:12 EDT | CORE | INFO | ... | Starting a new tailer for: /tmp/qa-317/shared.log ... for tailer key /tmp/qa-317/shared.log
2026-05-19 09:37:12 EDT | CORE | INFO | ... | Starting a new tailer for: /tmp/qa-317/other.log ... for tailer key /tmp/qa-317/other.log

grep "already being tailed" /tmp/qa-317-scenB.log → (no matches)

# agent status: both source_one and source_two have active Inputs: entries
```

**Scenario C** — Single source, baseline:

```
# Agent log (one tailer, no warning):
2026-05-19 09:37:57 EDT | CORE | INFO | ... | Starting a new tailer for: /tmp/qa-317/shared.log ...

grep "already being tailed" /tmp/qa-317-scenC.log → (no matches)
```

**Unit test** — `TestLauncherRejectsDuplicateFileTailer` (exercises the new `isFileAlreadyTailed` guard directly with container-ID-differentiated sources):

```
dda inv test --targets=./pkg/logs/launchers/file --test-run-name=TestLauncherRejectsDuplicateFileTailer
✓  pkg/logs/launchers/file (883ms)
DONE 1 tests in 1.391s — All tests passed
```