### PR TITLE
Improve documentation around manual qa tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,10 @@ Key Bazel macros:
 - Use `/write-e2e` skill or read those docs directly to write new E2E tests
 - Run locally: `dda inv new-e2e-tests.run --targets=./tests/<area>/...`
 
+### Manual QA
+- When the agent needs to be inspected in a given environment (e.g. EKS, ECS, a cloud VM) that is not easily reproducible locally, use the manual QA infrastructure.
+- Full guide (scenarios, commands, stack lifecycle): `docs/public/how-to/test/manual-qa/index.md`
+
 ### Linting
 - Go: golangci-lint via `dda inv linter.go`
 - Python: various linters via `dda inv linter.python`

--- a/docs/public/how-to/test/e2e.md
+++ b/docs/public/how-to/test/e2e.md
@@ -41,34 +41,6 @@ dda inv e2e.setup --with-azure --with-gcp
 
 The configuration is persisted to `~/.test_infra_config.yaml` (chmod `0600`, since it contains the auto-generated Pulumi passphrase). Re-running `dda inv e2e.setup` is idempotent — it prints `✓ already configured` checks and exits.
 
-## Setting Up the Development Environment
-
-E2E tests should be run within a [developer environment](../../tutorials/dev/env.md) to ensure consistency and proper isolation.
-
-### Start a Developer Environment
-
-1. **Clone the repository** (if using local checkout):
-   ```bash
-   git clone https://github.com/DataDog/datadog-agent.git
-   cd datadog-agent
-   ```
-
-2. **Start the environment** The following example is for an amd64 environment:
-   ```bash
-   dda env dev start --id devenv-amd --arch amd64
-   ```
-
-   Or use a remote clone for better isolation:
-   ```bash
-   dda env dev start --clone
-   ```
-
-3. **Enter the environment shell**:
-   ```bash
-   dda env dev shell --id devenv-amd
-   ```
-
-For detailed information about developer environments, see the [Using developer environments](../../tutorials/dev/env.md) tutorial.
 
 ## Running E2E Tests
 

--- a/docs/public/how-to/test/manual-qa/aws-docker.md
+++ b/docs/public/how-to/test/manual-qa/aws-docker.md
@@ -1,0 +1,51 @@
+# AWS Docker VM
+
+Provisions an EC2 instance with Docker installed and the Datadog Agent running
+as a container. Use this to test container-specific agent behavior or Docker
+integrations.
+
+## Create
+
+```bash
+dda inv aws.create-docker
+```
+
+### Key options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stack-name` | `aws-dockervm` | Suffix for the Pulumi stack name |
+| `--architecture` | `x86_64` | CPU architecture: `x86_64` or `arm64` |
+| `--agent-version` | latest | Container image tag (e.g. `7.58.0-rc.3`) |
+| `--full-image-path` | — | Full registry path to a custom agent image |
+| `--agent-flavor` | — | Agent flavor (e.g. `datadog-fips-agent`) |
+| `--agent-env` | — | Extra env vars for the agent container (`VAR1=val1,VAR2=val2`) |
+| `--use-fakeintake` | `false` | Deploy a local mock intake alongside the agent |
+| `--install-agent` | `true` | Set to `false` to provision a Docker host without the agent |
+
+### Examples
+
+```bash
+# Docker host with a custom image
+dda inv aws.create-docker --full-image-path=my-registry/agent:my-tag
+
+# ARM Docker host
+dda inv aws.create-docker --architecture=arm64
+```
+
+## Connect
+
+SSH connection details are printed after the stack is created. The agent runs
+as a container; use `docker ps` / `docker logs` once connected.
+
+## Destroy
+
+```bash
+dda inv aws.destroy-docker
+```
+
+## Limitations
+
+- The agent runs in a Docker container, not as a host package. Host-agent
+  behavior (systemd, OS-level checks) is not testable with this scenario — use
+  [AWS VM](aws-vm.md) instead.

--- a/docs/public/how-to/test/manual-qa/aws-ecs.md
+++ b/docs/public/how-to/test/manual-qa/aws-ecs.md
@@ -1,0 +1,59 @@
+# AWS ECS
+
+Provisions an ECS cluster with the Datadog Agent running as a container task.
+Use this to test ECS-specific agent behavior or Fargate integrations.
+
+## Create
+
+```bash
+dda inv aws.create-ecs
+```
+
+### Key options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stack-name` | `aws-ecs` | Suffix for the Pulumi stack name |
+| `--use-fargate` | `true` | Use Fargate as the capacity provider |
+| `--linux-node-group` | `true` | Add an ECS-optimized Linux node group (EC2-backed) |
+| `--linux-arm-node-group` | `false` | Add an ECS-optimized Linux ARM node group (EC2-backed) |
+| `--bottlerocket-node-group` | `true` | Add a Bottlerocket node group (EC2-backed) |
+| `--windows-node-group` | `false` | Add a Windows LTSC node group (EC2-backed) |
+| `--agent-version` | latest | Container image tag |
+| `--full-image-path` | — | Full registry path to a custom agent image |
+| `--agent-flavor` | — | Agent flavor (e.g. `datadog-fips-agent`) |
+| `--agent-env` | — | Extra env vars for the agent container (`VAR1=val1,VAR2=val2`) |
+| `--no-interactive` | — | Disable clipboard prompt and desktop notification |
+
+### Examples
+
+```bash
+# Fargate-only cluster (default)
+dda inv aws.create-ecs
+
+# ECS cluster with EC2-backed Windows nodes (no Fargate)
+dda inv aws.create-ecs --use-fargate=false --windows-node-group=true --linux-node-group=false --bottlerocket-node-group=false
+
+# ECS with a custom agent image
+dda inv aws.create-ecs --full-image-path=my-registry/agent:my-tag
+```
+
+## Connect
+
+The agent runs as an ECS task. Use the ECS console or the AWS CLI to inspect
+task logs and container status:
+
+```bash
+aws-vault exec sso-agent-sandbox-account-admin -- aws ecs list-tasks --cluster <cluster-name>
+```
+
+## Destroy
+
+```bash
+dda inv aws.destroy-ecs
+```
+
+## Limitations
+
+- The agent runs as a container task; host-agent behavior is not testable.
+- FakeIntake is not supported for ECS.

--- a/docs/public/how-to/test/manual-qa/aws-eks.md
+++ b/docs/public/how-to/test/manual-qa/aws-eks.md
@@ -1,0 +1,77 @@
+# AWS EKS
+
+Provisions a managed EKS cluster with the Datadog Agent deployed as a
+DaemonSet via Helm. Use this to test Kubernetes-specific agent behavior,
+the Cluster Agent, or Kubernetes integrations.
+
+/// admonition | Provisioning time
+    type: note
+
+EKS clusters take approximately 20 minutes to create.
+///
+
+## Prerequisites
+
+EKS requires both an API key and an **app key** in `~/.test_infra_config.yaml`
+(or via `E2E_APP_KEY`).
+
+## Create
+
+```bash
+dda inv aws.create-eks
+```
+
+### Key options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stack-name` | `aws-eks` | Suffix for the Pulumi stack name |
+| `--linux-node-group` | `true` | Include a Linux (x86_64) node group |
+| `--linux-arm-node-group` | `false` | Include a Linux ARM node group |
+| `--bottlerocket-node-group` | `true` | Include a Bottlerocket node group |
+| `--windows-node-group` | `false` | Include a Windows node group |
+| `--gpu-node-group` | `false` | Include a GPU node group (disables all other node groups) |
+| `--instance-type` | auto | EC2 instance type for cluster nodes |
+| `--agent-version` | latest | Container image tag (e.g. `7.58.0-rc.3`) |
+| `--full-image-path` | — | Full registry path to a custom agent image |
+| `--cluster-agent-full-image-path` | — | Full registry path to a custom Cluster Agent image |
+| `--helm-config` | — | Path to a custom Helm values file to merge with defaults |
+| `--local-chart-path` | — | Path to a local Helm chart |
+| `--kube-version` | latest | Kubernetes version (e.g. `1.31`) |
+| `--agent-flavor` | — | Agent flavor (e.g. `datadog-fips-agent`) |
+| `--no-interactive` | — | Disable clipboard prompt and desktop notification |
+
+### Examples
+
+```bash
+# EKS cluster with Windows nodes
+dda inv aws.create-eks --windows-node-group=true
+
+# EKS with a specific Kubernetes version and custom Helm values
+dda inv aws.create-eks --kube-version=1.31 --helm-config=./my-values.yaml
+
+# GPU-only cluster
+dda inv aws.create-eks --gpu-node-group=true
+```
+
+## Connect
+
+After the cluster is ready, `kubectl` is configured automatically.
+The task prints the cluster context name to use:
+
+```bash
+kubectl config use-context <context-name>
+kubectl get nodes
+```
+
+## Destroy
+
+```bash
+dda inv aws.destroy-eks
+```
+
+## Limitations
+
+- GPU node groups are x86_64 only; enabling `--gpu-node-group` disables all
+  other node groups automatically.
+- FakeIntake is not supported for EKS.

--- a/docs/public/how-to/test/manual-qa/aws-kind.md
+++ b/docs/public/how-to/test/manual-qa/aws-kind.md
@@ -1,0 +1,67 @@
+# AWS KinD
+
+Provisions an EC2 instance running KinD (Kubernetes in Docker) with the
+Datadog Agent deployed via Helm. A lighter-weight alternative to EKS when you
+need a Kubernetes environment but don't need a managed cluster.
+
+## Prerequisites
+
+KinD requires both an API key and an **app key** in `~/.test_infra_config.yaml`
+(or via `E2E_APP_KEY`).
+
+## Create
+
+```bash
+dda inv aws.create-kind
+```
+
+### Key options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stack-name` | `aws-kind` | Suffix for the Pulumi stack name |
+| `--architecture` | `x86_64` | CPU architecture: `x86_64` or `arm64` |
+| `--agent-version` | latest | Container image tag |
+| `--full-image-path` | — | Full registry path to a custom agent image |
+| `--cluster-agent-full-image-path` | — | Full registry path to a custom Cluster Agent image |
+| `--install-agent-with-operator` | `false` | Deploy the agent via the Datadog Operator instead of Helm |
+| `--helm-config` | — | Path to a custom Helm values file to merge with defaults |
+| `--kube-version` | latest | Kubernetes version (e.g. `1.31`) |
+| `--use-fakeintake` | `false` | Deploy a local mock intake alongside the agent |
+| `--agent-flavor` | — | Agent flavor (e.g. `datadog-fips-agent`) |
+
+### Examples
+
+```bash
+# KinD cluster on an ARM host
+dda inv aws.create-kind --architecture=arm64
+
+# KinD with a specific Kubernetes version
+dda inv aws.create-kind --kube-version=1.31
+
+# Deploy agent via Operator instead of Helm
+dda inv aws.create-kind --install-agent-with-operator=true
+```
+
+## Connect
+
+SSH connection details for the EC2 host are printed after creation. Once
+connected, `kubectl` is available on the host and the KinD cluster context is
+already configured:
+
+```bash
+# From inside the EC2 host
+kubectl get nodes
+kubectl get pods -n datadog
+```
+
+## Destroy
+
+```bash
+dda inv aws.destroy-kind
+```
+
+## Limitations
+
+- Single-node cluster — not suitable for testing multi-node Kubernetes behavior.
+- The EC2 instance type is fixed at `t3.xlarge`; this cannot be overridden.

--- a/docs/public/how-to/test/manual-qa/aws-vm.md
+++ b/docs/public/how-to/test/manual-qa/aws-vm.md
@@ -1,0 +1,71 @@
+# AWS VM
+
+Provisions an EC2 instance with the Datadog Agent installed. The most common
+scenario for testing agent behavior on a host.
+
+## Create
+
+```bash
+dda inv aws.create-vm
+```
+
+### Key options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stack-name` | `aws-vm` | Suffix for the Pulumi stack name |
+| `--os-family` | `ubuntu` | OS: `ubuntu`, `debian`, `centos`, `redhat`, `suse`, `windows`, `macos` |
+| `--os-version` | latest | OS version for the chosen family |
+| `--architecture` | `x86_64` | CPU architecture: `x86_64` or `arm64` |
+| `--instance-type` | auto | EC2 instance type (e.g. `t3.medium`) |
+| `--ami-id` | — | Use a specific AMI instead of the default for the OS family |
+| `--pipeline-id` | — | Deploy the agent build from a specific GitLab pipeline |
+| `--agent-version` | latest | Pin an agent version (e.g. `7.58.0-1`) |
+| `--agent-config-path` | — | Path to a local `datadog.yaml` to merge with defaults |
+| `--local-package` | — | Path to a local `.deb` / `.rpm` / `.msi` package to install |
+| `--use-fakeintake` | `false` | Deploy a local mock intake alongside the agent |
+| `--install-agent` | `true` | Set to `false` to provision a raw VM without the agent |
+
+### Examples
+
+```bash
+# Ubuntu ARM VM with a pipeline build
+dda inv aws.create-vm --os-family=ubuntu --architecture=arm64 --pipeline-id=12345678
+
+# Windows VM
+dda inv aws.create-vm --os-family=windows
+
+# VM with a local package
+dda inv aws.create-vm --local-package=./datadog-agent_7.58.0.deb
+
+# Two parallel environments
+dda inv aws.create-vm --stack-name=test-a
+dda inv aws.create-vm --stack-name=test-b
+```
+
+## Connect
+
+The task prints SSH connection details when the instance is ready.
+
+```bash
+# Print connection details again
+dda inv aws.show-vm --stack-name=<name>
+```
+
+For Windows VMs:
+
+```bash
+dda inv aws.get-vm-password --stack-name=<name>
+dda inv aws.rdp-vm          --stack-name=<name>
+```
+
+## Destroy
+
+```bash
+dda inv aws.destroy-vm [--stack-name=<name>]
+```
+
+## Limitations
+
+- FakeIntake cannot be deployed without the agent (`--install-agent=true` is required).
+- macOS VMs require access to macOS-compatible subnets in the `agent-sandbox` account; the required flags are applied automatically when `--os-family=macos` is used.

--- a/docs/public/how-to/test/manual-qa/azure-vm.md
+++ b/docs/public/how-to/test/manual-qa/azure-vm.md
@@ -1,0 +1,62 @@
+# Azure VM
+
+Provisions an Azure virtual machine with the Datadog Agent installed. Use this
+to test agent behavior on Azure infrastructure or Windows Server environments.
+
+## Prerequisites
+
+Azure support must be enabled during setup:
+
+```bash
+dda inv e2e.setup --with-azure
+```
+
+This adds an `azure.publicKeyPath` entry to `~/.test_infra_config.yaml`, which
+is required for all Azure VM tasks.
+
+## Create
+
+```bash
+dda inv az.create-vm
+```
+
+### Key options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stack-name` | `az-vm` | Suffix for the Pulumi stack name |
+| `--os-family` | `windows` | OS: `windows` or `ubuntu` |
+| `--os-version` | latest | OS version for the chosen family |
+| `--architecture` | `x86_64` | CPU architecture: `x86_64` or `arm64` |
+| `--instance-type` | `Standard_B4ms` | Azure VM size |
+| `--pipeline-id` | — | Deploy the agent build from a specific GitLab pipeline |
+| `--agent-version` | latest | Pin an agent version (e.g. `7.58.0-1`) |
+| `--agent-config-path` | — | Path to a local `datadog.yaml` to merge with defaults |
+| `--agent-flavor` | — | Agent flavor (e.g. `datadog-fips-agent`) |
+| `--install-agent` | `true` | Set to `false` to provision a raw VM without the agent |
+
+### Examples
+
+```bash
+# Ubuntu VM on Azure
+dda inv az.create-vm --os-family=ubuntu
+
+# Windows VM with a specific agent version
+dda inv az.create-vm --os-family=windows --agent-version=7.58.0-1
+```
+
+## Connect
+
+SSH connection details are printed after creation (Linux). For Windows, the
+task outputs RDP connection information.
+
+## Destroy
+
+```bash
+dda inv az.destroy-vm
+```
+
+## Limitations
+
+- Only `windows` and `ubuntu` OS families are supported.
+- FakeIntake is not supported for Azure VMs.

--- a/docs/public/how-to/test/manual-qa/gcp-vm.md
+++ b/docs/public/how-to/test/manual-qa/gcp-vm.md
@@ -1,0 +1,59 @@
+# GCP VM
+
+Provisions a Google Cloud virtual machine with the Datadog Agent installed.
+
+## Prerequisites
+
+GCP support must be enabled during setup:
+
+```bash
+dda inv e2e.setup --with-gcp
+```
+
+This adds a `gcp.publicKeyPath` entry to `~/.test_infra_config.yaml`.
+
+## Create
+
+```bash
+dda inv gcp.create-vm
+```
+
+### Key options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stack-name` | `gcp-vm` | Suffix for the Pulumi stack name |
+| `--os-family` | `ubuntu` | OS: `ubuntu` (only supported family) |
+| `--os-version` | latest | Ubuntu version |
+| `--architecture` | `x86_64` | CPU architecture: `x86_64` or `arm64` |
+| `--instance-type` | `e2-medium` | GCP machine type |
+| `--pipeline-id` | — | Deploy the agent build from a specific GitLab pipeline |
+| `--agent-version` | latest | Pin an agent version (e.g. `7.58.0-1`) |
+| `--agent-config-path` | — | Path to a local `datadog.yaml` to merge with defaults |
+| `--agent-flavor` | — | Agent flavor (e.g. `datadog-fips-agent`) |
+| `--install-agent` | `true` | Set to `false` to provision a raw VM without the agent |
+
+### Examples
+
+```bash
+# Ubuntu ARM VM on GCP
+dda inv gcp.create-vm --architecture=arm64
+
+# GCP VM with a pipeline build
+dda inv gcp.create-vm --pipeline-id=12345678
+```
+
+## Connect
+
+SSH connection details are printed after the instance is ready.
+
+## Destroy
+
+```bash
+dda inv gcp.destroy-vm
+```
+
+## Limitations
+
+- Only `ubuntu` is supported as an OS family.
+- FakeIntake is not supported for GCP VMs.

--- a/docs/public/how-to/test/manual-qa/index.md
+++ b/docs/public/how-to/test/manual-qa/index.md
@@ -1,0 +1,48 @@
+# Manual QA Infrastructure
+
+The E2E framework can provision real cloud infrastructure for manual QA without
+running automated tests. Environments stay alive until you explicitly destroy
+them (or our cleaner destroys it, every week), giving you direct access (SSH, kubectl, RDP) to inspect the agent in a
+realistic environment.
+
+## Prerequisites
+
+Complete the [one-time setup](../e2e.md#one-time-setup) from the E2E testing guide
+before creating any environment.
+
+If you do not want to rely on fake intake, and send data to the real Datadog backend, you should make sure you set a valid API in ~/.test_infra_config.yaml
+
+## Stack lifecycle
+
+Each environment is a named Pulumi stack. Stacks are automatically prefixed
+with your OS username:
+
+```
+<username>-<stack-name>
+# e.g.  alice-aws-vm    (default for the aws/vm scenario)
+#       alice-my-qa     (with --stack-name my-qa)
+```
+
+Stacks **persist until you destroy them**. Run the matching `destroy-*` task
+when you are done to avoid leaving cloud resources running.
+
+Agents are automatically tagged `stackid:<stack-name>` so you can filter
+metrics and logs in the Datadog UI to a specific environment.
+
+## Scenarios
+
+| Scenario | Command | What it creates |
+|----------|---------|-----------------|
+| [AWS VM](aws-vm.md) | `dda inv aws.create-vm` | EC2 instance + Agent |
+| [AWS Docker VM](aws-docker.md) | `dda inv aws.create-docker` | EC2 + Docker + containerized Agent |
+| [AWS EKS](aws-eks.md) | `dda inv aws.create-eks` | EKS cluster + Agent DaemonSet |
+| [AWS ECS](aws-ecs.md) | `dda inv aws.create-ecs` | ECS cluster + Agent |
+| [AWS KinD](aws-kind.md) | `dda inv aws.create-kind` | EC2 + KinD cluster + Agent |
+| [Azure VM](azure-vm.md) | `dda inv az.create-vm` | Azure VM + Agent |
+| [GCP VM](gcp-vm.md) | `dda inv gcp.create-vm` | GCP VM + Agent |
+
+Pass `--no-interactive` to any scenario to disable the clipboard prompt and desktop notification, which is useful when running from an AI agent or CI context.
+
+## See Also
+
+- [Running E2E tests](../e2e.md) — automated test execution against the same infrastructure

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,19 @@ nav:
     - Unit tests: how-to/test/unit.md
     - Static analysis: how-to/test/static-analysis.md
     - End-to-end tests: how-to/test/e2e.md
+    - Manual QA: 
+      - how-to/test/manual-qa/index.md
+      - AWS: 
+        - VM: how-to/test/manual-qa/aws-vm.md 
+        - Docker: how-to/test/manual-qa/aws-docker.md
+        - EKS: how-to/test/manual-qa/aws-eks.md
+        - ECS: how-to/test/manual-qa/aws-ecs.md
+        - Kind: how-to/test/manual-qa/aws-kind.md
+      - Azure: 
+        - VM: how-to/test/manual-qa/azure-vm.md
+      - GCP: 
+        - VM: how-to/test/manual-qa/gcp-vm.md
+      
   - Go:
     - Add nested modules: how-to/go/modules.md
   - Debug agents:

--- a/tasks/e2e_framework/aws/ecs.py
+++ b/tasks/e2e_framework/aws/ecs.py
@@ -27,6 +27,7 @@ scenario_name = "aws/ecs"
         "full_image_path": doc.full_image_path,
         "agent_flavor": doc.agent_flavor,
         "agent_env": doc.agent_env,
+        "interactive": doc.interactive,
     }
 )
 def create_ecs(
@@ -45,6 +46,7 @@ def create_ecs(
     full_image_path: str | None = None,
     agent_flavor: str | None = None,
     agent_env: str | None = None,
+    interactive: bool | None = True,
 ):
     """
     Create a new ECS environment.
@@ -72,13 +74,15 @@ def create_ecs(
         agent_env=agent_env,
     )
 
-    tool.notify(ctx, "Your ECS cluster is now created")
+    if interactive:
+        tool.notify(ctx, "Your ECS cluster is now created")
 
-    _show_connection_message(ctx, config_path, full_stack_name)
+    _show_connection_message(ctx, config_path, full_stack_name, interactive)
 
 
-def _show_connection_message(ctx: Context, config_path: str | None, full_stack_name: str):
-    import pyperclip
+def _show_connection_message(
+    ctx: Context, config_path: str | None, full_stack_name: str, interactive: bool | None = True
+):
     from pydantic import ValidationError
 
     from tasks.e2e_framework import config
@@ -94,8 +98,11 @@ def _show_connection_message(ctx: Context, config_path: str | None, full_stack_n
     command = f"{get_aws_wrapper(local_config.get_aws().get_account())} aws ecs list-tasks --cluster {cluster_name}"
     print(f"\nYou can run the following command to list tasks on the ECS cluster\n\n{command}\n")
 
-    input("Press a key to copy command to clipboard...")
-    pyperclip.copy(command)
+    if interactive:
+        import pyperclip
+
+        input("Press a key to copy command to clipboard...")
+        pyperclip.copy(command)
 
 
 @task(help={"stack_name": doc.stack_name})

--- a/tasks/e2e_framework/aws/eks.py
+++ b/tasks/e2e_framework/aws/eks.py
@@ -37,6 +37,7 @@ scenario_name = "aws/eks"
         "helm_config": doc.helm_config,
         "local_chart_path": doc.local_chart_path,
         "kube_version": doc.kubernetes_version,
+        "interactive": doc.interactive,
     }
 )
 def create_eks(
@@ -62,6 +63,7 @@ def create_eks(
     helm_config: str | None = None,
     local_chart_path: str | None = None,
     kube_version: str | None = None,
+    interactive: bool | None = True,
 ):
     """
     Create a new EKS environment. It lasts around 20 minutes.
@@ -111,13 +113,15 @@ def create_eks(
         helm_config=helm_config,
     )
 
-    tool.notify(ctx, "Your EKS cluster is now created")
+    if interactive:
+        tool.notify(ctx, "Your EKS cluster is now created")
 
-    _show_connection_message(ctx, full_stack_name, config_path)
+    _show_connection_message(ctx, full_stack_name, config_path, interactive)
 
 
-def _show_connection_message(ctx: Context, full_stack_name: str, config_path: str | None):
-    import pyperclip
+def _show_connection_message(
+    ctx: Context, full_stack_name: str, config_path: str | None, interactive: bool | None = True
+):
     from pydantic import ValidationError
 
     from tasks.e2e_framework import config
@@ -139,8 +143,11 @@ def _show_connection_message(ctx: Context, full_stack_name: str, config_path: st
 
     print(f"\nYou can run the following command to connect to the EKS cluster\n\n{command}\n")
 
-    input("Press a key to copy command to clipboard...")
-    pyperclip.copy(command)
+    if interactive:
+        import pyperclip
+
+        input("Press a key to copy command to clipboard...")
+        pyperclip.copy(command)
 
 
 @task(help={"stack_name": doc.stack_name})


### PR DESCRIPTION
### What does this PR do?

Improve documentation regarding our manual QA tasks, that allow spinning up environment with the agent installed on demand.
Add an entry in AGENTS.md so that AI Agent automatically uses those tasks to create environment to test the agent

### Motivation

Make those tasks easier to use for humans and AI agents

### Describe how you validated your changes

### Additional Notes
