### PR TITLE
fix(logs): bind logs_config.experimental_auto_multi_line_detection

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -640,13 +640,12 @@ func (c *LogsConfig) AutoMultiLineStatus(coreConfig pkgconfigmodel.Reader) (enab
 	if c.AutoMultiLine != nil {
 		return *c.AutoMultiLine, false
 	}
-	if coreConfig.GetBool("logs_config.experimental_auto_multi_line_detection") {
+	if coreConfig.IsConfigured("logs_config.experimental_auto_multi_line_detection") {
 		log.Warn("logs_config.experimental_auto_multi_line_detection is deprecated, use logs_config.auto_multi_line_detection instead")
-		return true, false
 	}
 	isDefault = !coreConfig.IsConfigured("logs_config.auto_multi_line_detection") &&
 		!coreConfig.IsConfigured("logs_config.experimental_auto_multi_line_detection")
-	return coreConfig.GetBool("logs_config.auto_multi_line_detection"), isDefault
+	return coreConfig.GetBool("logs_config.auto_multi_line_detection") || coreConfig.GetBool("logs_config.experimental_auto_multi_line_detection"), isDefault
 }
 
 // AutoMultiLineEnabled determines whether auto multi line detection is enabled for this config,

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1881,6 +1881,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 
 	// Auto multiline detection settings
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection", false)
+	config.BindEnvAndSetDefault("logs_config.experimental_auto_multi_line_detection", false)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_detection_custom_samples", []map[string]interface{}{})
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_json_detection", true)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line.enable_datetime_detection", true)

--- a/releasenotes/notes/bind-experimental-auto-multi-line-detection-ad02bf3fc54a910b.yaml
+++ b/releasenotes/notes/bind-experimental-auto-multi-line-detection-ad02bf3fc54a910b.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Binds ``logs_config.experimental_auto_multi_line_detection`` so the
+    deprecated setting no longer triggers "config key is unknown" warnings
+    in the Agent logs. The setting continues to behave as before and a
+    deprecation warning is logged when it is explicitly configured.

--- a/releasenotes/notes/bind-experimental-auto-multi-line-detection-ad02bf3fc54a910b.yaml
+++ b/releasenotes/notes/bind-experimental-auto-multi-line-detection-ad02bf3fc54a910b.yaml
@@ -1,7 +1,0 @@
----
-fixes:
-  - |
-    Binds ``logs_config.experimental_auto_multi_line_detection`` so the
-    deprecated setting no longer triggers "config key is unknown" warnings
-    in the Agent logs. The setting continues to behave as before and a
-    deprecation warning is logged when it is explicitly configured.


### PR DESCRIPTION
## Summary
- Registers `logs_config.experimental_auto_multi_line_detection` via `BindEnvAndSetDefault`, eliminating the recurring `config key "logs_config.experimental_auto_multi_line_detection" is unknown` warnings in the Agent logs.
- Reworks `AutoMultiLineStatus` so the deprecation warning fires when the setting is **explicitly** configured (`IsConfigured`), rather than only when the value happens to be `true`.
- `auto_multi_line_detection || experimental_auto_multi_line_detection` preserves the previous "either one true → enabled" behavior.

## Test plan / manual QA
Built the Agent locally (`dda inv agent.build --build-exclude=systemd`) and exercised both code paths against a real Agent run on macOS:

- **Experimental key unset** (`/tmp/dd-no-exp.yaml`):
  - Old behavior: `WARN ... config key "logs_config.experimental_auto_multi_line_detection" is unknown` appeared at startup (see e.g. `agent.log.1` lines 3636, 6657, ...).
  - New behavior: `grep -c experimental_auto_multi_line /tmp/agent-noexp.log` → **0** mentions. Both the "unknown key" warning and the deprecation warning are silent. ✅
- **Experimental key set to `true`** (`/tmp/dd-with-exp.yaml`, `logs_config.experimental_auto_multi_line_detection: true`):
  - No "unknown key" warning. ✅
  - Deprecation warning fires correctly: `logs_config.experimental_auto_multi_line_detection is deprecated, use logs_config.auto_multi_line_detection instead`. ✅
  - Auto multi-line detection is enabled (the `||` fall-through behaves as before). ✅
- Unit tests:
  - `dda inv test --targets=./comp/logs/agent/config` → 183/183 passed.
  - `go test -tags test -v -run TestAutoMultiLine ./comp/logs/agent/config/` → all 7 subtests pass, including the two `deprecated_experimental_*` cases that exercise the rebound key.
  - `go test -tags test -count=1 ./pkg/config/setup/` → ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)