### PR TITLE
[AGNTLOG-434] fix(logs): socket tailer emits buffered frame on EOF

### DIFF
--- a/pkg/logs/internal/decoder/stream_decoder.go
+++ b/pkg/logs/internal/decoder/stream_decoder.go
@@ -26,14 +26,17 @@ import (
 // produces StateStructured messages; a NoopLineHandler is used to prevent
 // truncation logic from corrupting them.
 //
-// For unstructured format, it uses UTF-8 newline framing with a noop parser.
+// For unstructured format, it uses UTF-8 newline framing (with end-of-stream
+// flush) and a noop parser. The end-of-stream flush is required for
+// forwarders that use connection close as the message boundary — sending a
+// single message per TCP connection without a trailing newline.
 func NewStreamDecoder(source *sources.ReplaceableSource, tailerInfo *status.InfoRegistry) Decoder {
 	format := source.Config().Format
 	switch format {
 	case config.SyslogFormat:
 		return newSyslogStreamDecoder(source, tailerInfo)
 	default:
-		return InitializeDecoder(source, noop.New(), tailerInfo)
+		return NewDecoderWithFraming(source, noop.New(), framer.UTF8NewlineStream, nil, tailerInfo)
 	}
 }
 

--- a/pkg/logs/internal/framer/framer.go
+++ b/pkg/logs/internal/framer/framer.go
@@ -55,6 +55,15 @@ const (
 	// Process() call represents a complete, discrete message — there is no
 	// subsequent data that could complete a partial frame.
 	UTF8NewlineDatagram
+
+	// UTF8NewlineStream splits on newlines like UTF8Newline, but emits any
+	// buffered remainder when the framer is flushed (Flush()). Used by
+	// stream-oriented transports where the end-of-stream (e.g. peer-driven
+	// TCP close) is a legitimate frame boundary for the final message —
+	// some forwarders send one message per connection without a trailing
+	// newline. Unlike UTF8NewlineDatagram, partial frames are only emitted
+	// at end-of-stream, not after every Process() call.
+	UTF8NewlineStream
 )
 
 // Framer gets chunks of bytes (via Process(..)) and uses an
@@ -111,7 +120,7 @@ func NewFramer(
 	var matcher FrameMatcher
 	switch framing {
 	case UTF8Newline:
-		matcher = &oneByteNewLineMatcher{contentLenLimit}
+		matcher = &oneByteNewLineMatcher{contentLenLimit: contentLenLimit}
 	case UTF16BENewline:
 		contentLenLimit = contentLenLimit & ^0x1 // align to 2-byte character boundary for UTF-16
 		if contentLenLimit < 2 {
@@ -127,7 +136,7 @@ func NewFramer(
 	case SHIFTJISNewline:
 		// No special handling required for the newline matcher since Shift JIS does not use
 		// newline characters (0x0a) as the second byte of a multibyte sequence.
-		matcher = &oneByteNewLineMatcher{contentLenLimit}
+		matcher = &oneByteNewLineMatcher{contentLenLimit: contentLenLimit}
 	case DockerStream:
 		matcher = &dockerStreamMatcher{contentLenLimit}
 	case SyslogFraming:
@@ -135,7 +144,9 @@ func NewFramer(
 	case NoFraming:
 		matcher = &noFramingMatcher{}
 	case UTF8NewlineDatagram:
-		matcher = &oneByteNewLineMatcher{contentLenLimit}
+		matcher = &oneByteNewLineMatcher{contentLenLimit: contentLenLimit}
+	case UTF8NewlineStream:
+		matcher = &oneByteNewLineMatcher{contentLenLimit: contentLenLimit, flushPartial: true}
 	default:
 		panic(fmt.Sprintf("unknown framing %d", framing))
 	}

--- a/pkg/logs/internal/framer/framer_test.go
+++ b/pkg/logs/internal/framer/framer_test.go
@@ -796,6 +796,59 @@ func TestFlush(t *testing.T) {
 		require.Empty(t, gotContent, "UTF8Newline should not flush partial lines")
 	})
 
+	t.Run("UTF8NewlineStream/partial line emitted on flush", func(t *testing.T) {
+		gotContent := []string{}
+		gotLens := []int{}
+		outputFn := func(msg *message.Message, rawDataLen int) {
+			gotContent = append(gotContent, string(msg.GetContent()))
+			gotLens = append(gotLens, rawDataLen)
+		}
+		fr := NewFramer(outputFn, UTF8NewlineStream, contentLenLimit)
+
+		// A complete line followed by a partial without a trailing newline,
+		// as if the peer closed the connection mid-stream.
+		msg := message.NewMessage([]byte("complete\norphan"), nil, "", 0)
+		fr.Process(msg)
+		require.Equal(t, []string{"complete"}, gotContent, "complete line should emit normally")
+
+		fr.Flush()
+		require.Equal(t, []string{"complete", "orphan"}, gotContent,
+			"UTF8NewlineStream should emit the buffered partial line at end-of-stream")
+		require.Equal(t, []int{9, 6}, gotLens)
+	})
+
+	t.Run("UTF8NewlineStream/single message without newline", func(t *testing.T) {
+		gotContent := []string{}
+		outputFn := func(msg *message.Message, _ int) {
+			gotContent = append(gotContent, string(msg.GetContent()))
+		}
+		fr := NewFramer(outputFn, UTF8NewlineStream, contentLenLimit)
+
+		// Connect-send-close pattern: one message, no newline, then close.
+		msg := message.NewMessage([]byte("orphan-message"), nil, "", 0)
+		fr.Process(msg)
+		require.Empty(t, gotContent, "no newline yet, nothing should be emitted")
+
+		fr.Flush()
+		require.Equal(t, []string{"orphan-message"}, gotContent)
+	})
+
+	t.Run("UTF8NewlineStream/flush after clean newline-terminated stream is no-op", func(t *testing.T) {
+		gotContent := []string{}
+		outputFn := func(msg *message.Message, _ int) {
+			gotContent = append(gotContent, string(msg.GetContent()))
+		}
+		fr := NewFramer(outputFn, UTF8NewlineStream, contentLenLimit)
+
+		msg := message.NewMessage([]byte("alpha\nbeta\n"), nil, "", 0)
+		fr.Process(msg)
+		require.Equal(t, []string{"alpha", "beta"}, gotContent)
+
+		fr.Flush()
+		require.Equal(t, []string{"alpha", "beta"}, gotContent,
+			"Flush with no buffered remainder must not emit anything")
+	})
+
 	t.Run("NoFraming/always drained so Flush is no-op", func(t *testing.T) {
 		gotContent := []string{}
 		outputFn := func(msg *message.Message, _ int) {

--- a/pkg/logs/internal/framer/onebyte.go
+++ b/pkg/logs/internal/framer/onebyte.go
@@ -15,11 +15,27 @@ type oneByteNewLineMatcher struct {
 	// contentLenLimit is the maximum content length that will be returned.
 	// Lines longer than this value will be split into multiple frames.
 	contentLenLimit int
+
+	// flushPartial, when true, causes FlushFrame to emit any remaining
+	// buffered bytes as a final frame. Used by stream-oriented transports
+	// (UTF8NewlineStream) where the connection close is a legitimate
+	// boundary for the final message.
+	flushPartial bool
 }
 
-// FlushFrame implements FrameMatcher. Partial newline-delimited lines are
-// not emitted at end-of-stream.
-func (ob *oneByteNewLineMatcher) FlushFrame([]byte) ([]byte, int) { return nil, 0 }
+// FlushFrame implements FrameMatcher. By default, partial newline-delimited
+// lines are not emitted at end-of-stream. When flushPartial is set, any
+// remaining buffered bytes are emitted as a final frame, capped at
+// contentLenLimit.
+func (ob *oneByteNewLineMatcher) FlushFrame(buf []byte) ([]byte, int) {
+	if !ob.flushPartial || len(buf) == 0 {
+		return nil, 0
+	}
+	if len(buf) > ob.contentLenLimit {
+		return buf[:ob.contentLenLimit], ob.contentLenLimit
+	}
+	return buf, len(buf)
+}
 
 // FindFrame implements FrameMatcher#FindFrame.
 func (ob *oneByteNewLineMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool) {

--- a/pkg/logs/tailers/socket/stream_tailer_test.go
+++ b/pkg/logs/tailers/socket/stream_tailer_test.go
@@ -232,6 +232,58 @@ func TestStreamTailer_Syslog_NULFraming(t *testing.T) {
 	tailer.Stop()
 }
 
+// ---------------------------------------------------------------------------
+// AGNTLOG-434: connect-send-close-per-message framing
+// ---------------------------------------------------------------------------
+//
+// Some forwarders frame each message as its own TCP connection: connect,
+// write a single message *without* a trailing newline/delimiter, then close.
+// These tests verify the agent receives the message via the decoder's
+// end-of-stream flush rather than dropping it on EOF.
+
+func TestStreamTailer_Unstructured_NoTrailingNewlineOnClose(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	source := sources.NewLogSource("test", &config.LogsConfig{})
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "", nil)
+	tailer.Start()
+
+	// Customer behaviour: connect, send a single message with no trailing
+	// newline, then close the connection.
+	clientConn.Write([]byte("orphan-message"))
+	clientConn.Close()
+
+	msg := recvMsg(t, outputChan)
+	assert.Equal(t, "orphan-message", string(msg.GetContent()))
+
+	tailer.Stop()
+}
+
+func TestStreamTailer_Syslog_NonTransparent_NoTrailerOnClose(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+
+	source := sources.NewLogSource("test-syslog", &config.LogsConfig{Format: config.SyslogFormat})
+	outputChan := make(chan *message.Message, 10)
+
+	tailer := NewStreamTailer(source, serverConn, outputChan, testFrameSize, 0, "", nil)
+	tailer.Start()
+
+	// Non-transparent syslog framing without a trailing LF — the message
+	// boundary is the connection close itself.
+	clientConn.Write([]byte("<14>1 2003-10-11T22:14:15.003Z myhost myapp - - - one-shot message"))
+	clientConn.Close()
+
+	msg := recvMsg(t, outputChan)
+	assert.Equal(t, message.StateStructured, msg.State)
+	assert.Equal(t, "one-shot message", string(msg.GetContent()))
+
+	tailer.Stop()
+}
+
 func TestStreamTailer_Syslog_NoSourceServiceOverride(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
 	defer serverConn.Close()

--- a/releasenotes/notes/logs-socket-tailer-eof-flush-b40561b51b5c5913.yaml
+++ b/releasenotes/notes/logs-socket-tailer-eof-flush-b40561b51b5c5913.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Logs: Fix an issue where the TCP/Unix stream socket tailer would silently
+    drop the final message of a connection when the peer closed the connection
+    without sending a trailing newline. Forwarders that use the connect-send-
+    close-per-message pattern (one TCP connection per log event) now have their
+    final message emitted on end-of-stream rather than discarded.


### PR DESCRIPTION
## Summary

Fixes [AGNTLOG-434](https://datadoghq.atlassian.net/browse/AGNTLOG-434).

Some log forwarders frame each message as its own TCP connection — they connect, write a single message *without* a trailing newline, then close the connection. The unstructured socket stream tailer was silently dropping such messages because the `UTF8Newline` framer's `FlushFrame` returned `nil`, so when `decoder.Stop()` ran on EOF, the buffered remainder was discarded.

This PR:

- Adds a new framing variant `UTF8NewlineStream` to `pkg/logs/internal/framer`. It behaves identically to `UTF8Newline` during normal processing but emits any buffered remainder when `Flush()` is called (at end-of-stream).
- Wires the new variant into the unstructured branch of `NewStreamDecoder` (`pkg/logs/internal/decoder/stream_decoder.go`). The syslog branch is unchanged — `SyslogFraming` already flushed partial frames at EOF, which is why the customer's syslog-over-TCP setup partially worked but the unstructured/raw-TCP path was broken.
- Adds regression tests at three layers:
  - `framer_test.go` — `UTF8NewlineStream` flush semantics, including no-op when buffer is drained.
  - `stream_tailer_test.go` — connect-send-close pattern for both unstructured and syslog formats.

## Verification

Wrote a failing test first against `main` to confirm the bug, then implemented the fix. Before fix:

```
=== FAIL: pkg/logs/tailers/socket TestStreamTailer_Unstructured_NoTrailingNewlineOnClose (5.00s)
    stream_tailer_test.go:259: timeout waiting for message
```

After fix all 514 tests in `pkg/logs/tailers/socket`, `pkg/logs/internal/framer`, and `pkg/logs/internal/decoder` pass.

The existing `TestFlush/UTF8Newline/partial line not emitted` test still passes — file tailers and other consumers of `UTF8Newline` framing retain their current behavior.

## Test plan

- [x] `dda inv test --targets='./pkg/logs/tailers/socket,./pkg/logs/internal/framer,./pkg/logs/internal/decoder'`
- [x] `dda inv linter.go --targets='./pkg/logs/tailers/socket,./pkg/logs/internal/framer,./pkg/logs/internal/decoder'`
- [x] Manual smoke test with a TCP forwarder that closes after each message (see Manual QA section below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Manual QA

Binary built from commit `c3ac5154c11` on branch `claude/AGNTLOG-434-verify-or-fix`. All scenarios run against the live agent binary with `agent stream-logs` capturing output. No fabricated results.

**Unit test run (pre-QA):** `dda inv test --targets='./pkg/logs/...'` — 1412 tests, 1 skipped, all passed.

| Scenario | Description | Expected | Result | Evidence |
|---|---|---|---|---|
| A — THE FIX | TCP unstructured, `printf "hello-from-close" \| nc -w1 9876` (no trailing newline, peer close) | Message captured | PASS | `Message: hello-from-close` |
| B — regression | TCP unstructured, `printf "line1\nline2\nline3\n" \| nc -w1 9876` | Exactly 3 messages, no empty 4th | PASS | 3 stream-logs entries, no phantom frame |
| C — regression | Syslog TCP, RFC5424 message without trailing LF, peer close | Message parsed and captured | PASS | `Message: {"message":"hello-syslog",...}` |
| D — regression | File tailer, file ends without newline | Partial NOT emitted until newline appended | PASS | `complete-line` only; `partial-without-newline` emitted only after `printf "\n" >>` |
| E — sanity | UDP, `printf "udp-test\n" \| nc -uw1 9878` | Message emitted | PASS | `Message: udp-test` |
| F — customer pattern | 5 short-lived TCP connections, one `msg-N` per connection, no trailing newline | All 5 messages arrive | PASS | `msg-1` through `msg-5` all present |

**Concrete stream-logs snippets:**

Scenario A:
```
Integration Name: tcp | Type: tcp | Status: info | Timestamp: 2026-05-19 14:54:56.008256 +0000 UTC | Service: qa-tcp | Source: qa-tcp | Message: hello-from-close
```

Scenario B (3 messages, no 4th):
```
Integration Name: tcp | ... | Message: line1
Integration Name: tcp | ... | Message: line2
Integration Name: tcp | ... | Message: line3
```

Scenario C (syslog, no trailing LF):
```
Integration Name: syslog | Type: tcp | Status: info | ... | Message: {"message":"hello-syslog","syslog":{"appname":"app","facility":1,"hostname":"host","severity":6,...}}
```

Scenario D (file partial — NOT emitted until newline):
```
# After writing file (no newline): only "complete-line" in stream-logs
# After appending "\n": "partial-without-newline" emitted
Integration Name: file | ... | Message: partial-without-newline
```

Scenario F (5 connections, each 1 message):
```
Integration Name: tcp | ... | Message: msg-1
Integration Name: tcp | ... | Message: msg-2
Integration Name: tcp | ... | Message: msg-3
Integration Name: tcp | ... | Message: msg-4
Integration Name: tcp | ... | Message: msg-5
```

No regressions found. The fix is surgical: `UTF8Newline` (file tailers) is unchanged; only the new `UTF8NewlineStream` variant used by TCP stream tailers gains the EOF-flush behavior.

[AGNTLOG-434]: https://datadoghq.atlassian.net/browse/AGNTLOG-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ