### PR TITLE
[ABLD-387] Complete `bazel`ification of generated `.pb.go` files

### DIFF
--- a/bazel/rules/protoc_go_inject_tag/add-outputdir-flag.patch
+++ b/bazel/rules/protoc_go_inject_tag/add-outputdir-flag.patch
@@ -1,0 +1,59 @@
+diff --git a/file.go b/file.go
+index 5a7ef80..4bfc3cb 100644
+--- a/file.go
++++ b/file.go
+@@ -131,6 +131,10 @@ func parseFile(inputPath string, src interface{}, xxxSkip []string) (areas []tex
+ }
+ 
+ func writeFile(inputPath string, areas []textArea, removeTagComment bool) (err error) {
++	return writeFileTo(inputPath, inputPath, areas, removeTagComment)
++}
++
++func writeFileTo(inputPath, outputPath string, areas []textArea, removeTagComment bool) (err error) {
+ 	f, err := os.Open(inputPath)
+ 	if err != nil {
+ 		return
+@@ -151,12 +155,12 @@ func writeFile(inputPath string, areas []textArea, removeTagComment bool) (err e
+ 		logf("inject custom tag %q to expression %q", area.InjectTag, string(contents[area.Start-1:area.End-1]))
+ 		contents = injectTag(contents, area, removeTagComment)
+ 	}
+-	if err = os.WriteFile(inputPath, contents, 0o644); err != nil {
++	if err = os.WriteFile(outputPath, contents, 0o644); err != nil {
+ 		return
+ 	}
+ 
+ 	if len(areas) > 0 {
+-		logf("file %q is injected with custom tags", inputPath)
++		logf("file %q is injected with custom tags", outputPath)
+ 	}
+ 	return
+ }
+diff --git a/main.go b/main.go
+index 68f6161..d67d555 100644
+--- a/main.go
++++ b/main.go
+@@ -9,9 +9,10 @@ import (
+ )
+ 
+ func main() {
+-	var inputFiles, xxxTags string
++	var inputFiles, outputDir, xxxTags string
+ 	var removeTagComment bool
+ 	flag.StringVar(&inputFiles, "input", "", "pattern to match input file(s)")
++	flag.StringVar(&outputDir, "outputdir", "", "if set, write tagged copies into this directory instead of overwriting input in place")
+ 	flag.StringVar(&xxxTags, "XXX_skip", "", "tags that should be skipped (applies 'tag:\"-\"') for unknown fields (deprecated since protoc-gen-go v1.4.0)")
+ 	flag.BoolVar(&removeTagComment, "remove_tag_comment", false, "removes tag comments from the generated file(s)")
+ 	flag.BoolVar(&verbose, "verbose", false, "verbose logging")
+@@ -57,7 +58,11 @@ func main() {
+ 		if err != nil {
+ 			log.Fatal(err)
+ 		}
+-		if err = writeFile(path, areas, removeTagComment); err != nil {
++		outputPath := path
++		if outputDir != "" {
++			outputPath = filepath.Join(outputDir, filepath.Base(path))
++		}
++		if err = writeFileTo(path, outputPath, areas, removeTagComment); err != nil {
+ 			log.Fatal(err)
+ 		}
+ 	}

--- a/bazel/rules/protoc_go_inject_tag/defs.bzl
+++ b/bazel/rules/protoc_go_inject_tag/defs.bzl
@@ -1,0 +1,28 @@
+"""Apply `protoc-go-inject-tag` to a go_proto_library's outputs.
+
+Relies on `add-outputdir-flag.patch` (pending https://github.com/favadi/protoc-go-inject-tag/pull/73): the tool gains
+`-outputdir=DIR`, so the rule runs a single hermetic action that writes tagged copies to the rule's output directory.
+"""
+
+def _impl(ctx):
+    inputs = ctx.attr.go_proto_library[OutputGroupInfo].go_generated_srcs.to_list()
+    outputs = [ctx.actions.declare_file(f.basename) for f in inputs]
+    ctx.actions.run(
+        arguments = [
+            "-input={}/*.go".format(inputs[0].dirname),
+            "-outputdir={}".format(outputs[0].dirname),
+        ],
+        executable = ctx.executable._tool,
+        inputs = inputs,
+        mnemonic = "ProtocGoInjectTag",
+        outputs = outputs,
+    )
+    return [OutputGroupInfo(go_generated_srcs = depset(outputs))]
+
+protoc_go_inject_tag = rule(
+    implementation = _impl,
+    attrs = {
+        "go_proto_library": attr.label(mandatory = True),
+        "_tool": attr.label(cfg = "exec", default = "@com_github_favadi_protoc_go_inject_tag//:protoc-go-inject-tag", executable = True),
+    },
+)

--- a/bazel/rules/write_pb_go/_gazelle_extension.go
+++ b/bazel/rules/write_pb_go/_gazelle_extension.go
@@ -119,11 +119,12 @@ func goProtoLibraries(args language.GenerateArgs) map[string][]goProtoLibrary {
 
 // generateResult emits a write_pb_go rule when the current directory holds a go_library whose
 // importpath matches an accumulated go_proto_library, or deletes a stale one otherwise.
+// Any `gazelle:write_pb_go <go_proto_library> <override>` directive substitutes the former label with the latter.
 func generateResult(args language.GenerateArgs, goProtoLibraries map[string][]goProtoLibrary) language.GenerateResult {
 	if importPath := goLibraryImportPath(args.File); importPath != "" {
 		srcs := map[string][]string{}
 		for _, lib := range goProtoLibraries[importPath] {
-			srcs[lib.label.Rel("", args.Rel).String()] = lib.generatedSrcs
+			srcs[override(args, lib.label.Rel("", args.Rel).String())] = lib.generatedSrcs
 		}
 		if len(srcs) > 0 {
 			r := rule.NewRule(name, name)
@@ -208,4 +209,17 @@ func goLibraryImportPath(f *rule.File) string {
 		}
 	}
 	return ""
+}
+
+// override returns any label overridden by `gazelle:write_pb_go <orig> <overridden>` or orig.
+func override(args language.GenerateArgs, label string) string {
+	for _, d := range args.File.Directives {
+		if d.Key != name {
+			continue
+		}
+		if parts := strings.Fields(d.Value); len(parts) == 2 && parts[0] == label {
+			return parts[1]
+		}
+	}
+	return label
 }

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -471,6 +471,13 @@ use_repo(
     "tools_gotest_gotestsum",
 )
 
+# https://github.com/favadi/protoc-go-inject-tag/pull/73
+go_deps.module_override(
+    patch_strip = 1,
+    patches = ["//bazel/rules/protoc_go_inject_tag:add-outputdir-flag.patch"],
+    path = "github.com/favadi/protoc-go-inject-tag",
+)
+
 use_repo_rule("//bazel/rules/go_fast:repo.bzl", "go_fast")(name = "go_fast")
 
 use_repo_rule("//bazel/rules/go_sdk_overrides:repo.bzl", "go_sdk_overrides")(name = "go_sdk_overrides")

--- a/pkg/proto/datadog/dogstatsdhttp/BUILD.bazel
+++ b/pkg/proto/datadog/dogstatsdhttp/BUILD.bazel
@@ -12,8 +12,8 @@ proto_library(
 go_proto_library(
     name = "pb_go_proto",
     compilers = [
-        "//bazel/rules/go_proto_compiler:go_vtproto_full",
         "@rules_go//proto:go_proto",
+        "//bazel/rules/go_proto_compiler:go_vtproto_full",
     ],
     importpath = "pkg/proto/pbgo/dogstatsdhttp",
     proto = ":pb_proto",

--- a/pkg/proto/datadog/trace/BUILD.bazel
+++ b/pkg/proto/datadog/trace/BUILD.bazel
@@ -1,5 +1,7 @@
+# gazelle:go_proto_compilers @rules_go//proto:go_proto,//bazel/rules/go_proto_compiler:go_vtproto_serde
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
+load("//bazel/rules/protoc_go_inject_tag:defs.bzl", "protoc_go_inject_tag")
 
 proto_library(
     name = "trace_proto",
@@ -16,8 +18,18 @@ proto_library(
 
 go_proto_library(
     name = "trace_go_proto",
+    compilers = [
+        "@rules_go//proto:go_proto",
+        "//bazel/rules/go_proto_compiler:go_vtproto_serde",
+    ],
     importpath = "pkg/proto/pbgo/trace",
     proto = ":trace_proto",
     visibility = ["//visibility:public"],
     deps = ["//pkg/proto/datadog/trace/idx:idx_go_proto"],
+)
+
+protoc_go_inject_tag(
+    name = "trace_go_proto_tagged",
+    go_proto_library = ":trace_go_proto",
+    visibility = ["//visibility:public"],
 )

--- a/pkg/proto/datadog/trace/idx/BUILD.bazel
+++ b/pkg/proto/datadog/trace/idx/BUILD.bazel
@@ -1,3 +1,4 @@
+# gazelle:go_proto_compilers @rules_go//proto:go_proto
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 
@@ -13,6 +14,7 @@ proto_library(
 
 go_proto_library(
     name = "idx_go_proto",
+    compilers = ["@rules_go//proto:go_proto"],
     importpath = "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx",
     proto = ":idx_proto",
     visibility = ["//visibility:public"],

--- a/pkg/proto/pbgo/trace/BUILD.bazel
+++ b/pkg/proto/pbgo/trace/BUILD.bazel
@@ -1,6 +1,22 @@
-# TODO(regis): remove this once protoc-go-inject-tag and msgp are plugged into //pkg/proto/datadog/trace:trace_go_proto
-# gazelle:write_pb_go off
+# gazelle:write_pb_go //pkg/proto/datadog/trace:trace_go_proto //pkg/proto/datadog/trace:trace_go_proto_tagged
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//bazel/rules/write_pb_go:defs.bzl", "write_pb_go")
+
+write_pb_go(
+    name = "write_pb_go",
+    srcs = {
+        "//pkg/proto/datadog/trace:trace_go_proto_tagged": [
+            "agent_payload.pb.go",
+            "agent_payload_vtproto.pb.go",
+            "span.pb.go",
+            "span_vtproto.pb.go",
+            "stats.pb.go",
+            "stats_vtproto.pb.go",
+            "tracer_payload.pb.go",
+            "tracer_payload_vtproto.pb.go",
+        ],
+    },
+)
 
 go_library(
     name = "trace",

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -141,16 +141,7 @@ class BazelTools:
 
     def __new__(cls, ctx):
         if not cls._paths:
-            labels = (
-                "//bazel/toolchains/protoc",
-                "@com_github_favadi_protoc_go_inject_tag//:protoc-go-inject-tag",
-                "@com_github_golang_mock//mockgen",
-                "@com_github_planetscale_vtprotobuf//cmd/protoc-gen-go-vtproto",
-                "@com_github_tinylib_msgp//:msgp",
-                "@org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc",
-                "@org_golang_google_protobuf//cmd/protoc-gen-go",
-                "@rules_go//go",
-            )
+            labels = ("@com_github_golang_mock//mockgen", "@com_github_tinylib_msgp//:msgp", "@rules_go//go")
             bazel(ctx, "build", *labels)
             root = bazel(ctx, "info", "execution_root", capture_output=True).strip()
             for line in bazel(
@@ -166,11 +157,8 @@ class BazelTools:
         return super().__new__(cls)
 
     def __getattr__(self, name):
-        return self._paths[name.replace("_", "-")]
+        return self._paths[name]
 
     @property
     def go_env(self):
         return {"PATH": f"{self._paths['go_bin_runner'].parent}{os.pathsep}{os.getenv('PATH', '')}"}
-
-    def protoc_plugin(self, name):
-        return f"--plugin={name}={self._paths[name]}"

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -8,24 +8,6 @@ from tasks.libs.build.bazel import BazelTools, bazel
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import get_unstaged_files, get_untracked_files
 
-PROTO_PKGS = {
-    'trace': True,
-}
-
-# maybe put this in a separate function
-PKG_PLUGINS = {
-    'trace': '--go-vtproto_out=',
-}
-
-PKG_CLI_EXTRAS = {
-    'trace': '--go-vtproto_opt=features=marshal+unmarshal+size',
-}
-
-# protoc-go-inject-tag targets
-INJECT_TAG_TARGETS = {
-    'trace': ['span.pb.go', 'stats.pb.go', 'tracer_payload.pb.go', 'agent_payload.pb.go'],
-}
-
 
 @task
 def generate(ctx, pre_commit=False):
@@ -41,7 +23,6 @@ def generate(ctx, pre_commit=False):
     base = os.path.dirname(os.path.abspath(__file__))
     repo_root = os.path.abspath(os.path.join(base, ".."))
     proto_root = os.path.join(repo_root, "pkg", "proto")
-    protodep_root = os.path.join(proto_root, "protodep")
     pbgo_dir = os.path.join(proto_root, "pbgo")
 
     with ctx.cd(repo_root):
@@ -56,34 +37,7 @@ def generate(ctx, pre_commit=False):
         bazel(ctx, "run", "//pkg/proto/pbgo/process:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/sbom:write_pb_go")
         bazel(ctx, "run", "//pkg/proto/pbgo/trace/idx:write_pb_go")
-        for pkg, inject_tags in PROTO_PKGS.items():
-            files = []
-            pkg_root = Path(proto_root, "datadog", pkg)
-            for path in pkg_root.rglob('*.proto'):
-                if len(path.parts) == len(pkg_root.parts) + 1:
-                    files.append(path.as_posix())
-
-            targets = ' '.join(files)
-
-            # Generate Go code with protoc-gen-go and protoc-gen-go-grpc
-            # Note: The new protoc-gen-go doesn't support plugins=grpc, so we use separate outputs
-            # This generates *.pb.go (messages) and *_grpc.pb.go (gRPC stubs) in a single protoc call
-            ctx.run(
-                f"{bt.protoc} {bt.protoc_plugin("protoc-gen-go")} {bt.protoc_plugin("protoc-gen-go-grpc")} -I{proto_root} -I{protodep_root} --go_out={repo_root} --go-grpc_out={repo_root} {targets}"
-            )
-
-            if pkg in PKG_PLUGINS:
-                output_generator = PKG_PLUGINS[pkg]
-                cli_extras = PKG_CLI_EXTRAS.get(pkg, '')
-                ctx.run(
-                    f"{bt.protoc} {bt.protoc_plugin("protoc-gen-go-vtproto")} -I{proto_root} -I{protodep_root} {output_generator}{repo_root} {cli_extras} {targets}"
-                )
-
-            if inject_tags:
-                inject_path = os.path.join(proto_root, "pbgo", pkg)
-                # inject_tags logic
-                for target in INJECT_TAG_TARGETS[pkg]:
-                    ctx.run(f"{bt.protoc_go_inject_tag} -input={os.path.join(inject_path, target)}")
+        bazel(ctx, "run", "//pkg/proto/pbgo/trace:write_pb_go")
 
         # Mockgen (not done in pre-commit as it is slow)
         if not pre_commit:


### PR DESCRIPTION
### What does this PR do?
The last gap was `protoc-go-inject-tag` for `pkg/proto/pbgo/trace`: it now runs as a regular `bazel` action wired by `gazelle`.

The change introduces three pieces:
- a `protoc_go_inject_tag` rule wrapping a `go_proto_library` and exposing the tagged outputs through the same `go_generated_srcs` output group as the bare library,
- a local patch adding `-outputdir=DIR` to `github.com/favadi/protoc-go-inject-tag`, pending upstream as favadi/protoc-go-inject-tag#73,
- a cumulative `gazelle:write_pb_go <go_proto_library> <override>` directive that redirects a `write_pb_go` default source label to a custom one, superseding the need for an harmful `# keep` anchor.

`tasks/protobuf.py` drops the `PROTO_PKGS`, `PKG_PLUGINS`, `PKG_CLI_EXTRAS` and `INJECT_TAG_TARGETS` mappings plus the `protoc`/`vtproto`/`inject_tag` loop they parameterized, in favor of just:
```
bazel run //pkg/proto/pbgo/trace:write_pb_go
```

The `protodep_root` local goes with it, and `BazelTools` sheds the `protoc_plugin` helper, the 5 `protoc`-toolchain labels it resolved, and the `_`-to-`-` attribute translation they required.

### Motivation
*After this change every committed `.pb.go` file in the repository is managed by `gazelle` and built+verified by `bazel`.*

### Describe how you validated your changes
- `bazel run //:gazelle` is stable,
- `bazel test //...` passes (covers all `.pb.go` + `_vtproto.pb.go`),
- `dda inv protobuf.generate` is a no-op on a clean tree and restores any hand-mutated `.pb.go`.

### Additional Notes
`msgp` and the `span_gen.go` patches stay legacy-owned for now, follow-up work for `_gen.go` (i.e. *not* `.pb.go`).