### PR TITLE
Isolates proxy config tests from CI proxy environment variables

### DIFF
--- a/pkg/config/setup/config_secret_test.go
+++ b/pkg/config/setup/config_secret_test.go
@@ -146,6 +146,7 @@ func TestProxyWithSecret(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			unsetProxyEnvForTest(t)
 
 			config := newTestConf(t)
 			config.SetWithoutSource("use_proxy_for_cloud_metadata", true)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -33,6 +33,26 @@ func confFromYAML(t *testing.T, yamlConfig string) pkgconfigmodel.BuildableConfi
 	return conf
 }
 
+// can be used to ensure proxy tests are isolated from proxy env vars set by CI
+func unsetProxyEnvForTest(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		"DD_PROXY_HTTP",
+		"DD_PROXY_HTTPS",
+		"DD_PROXY_NO_PROXY",
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"NO_PROXY",
+		"http_proxy",
+		"https_proxy",
+		"no_proxy",
+	} {
+		t.Setenv(key, "")
+		require.NoError(t, os.Unsetenv(key))
+	}
+}
+
 func TestDefaults(t *testing.T) {
 	config := newTestConf(t)
 
@@ -433,6 +453,7 @@ func TestProxy(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			unsetProxyEnvForTest(t)
 
 			config := newTestConf(t)
 			config.SetWithoutSource("use_proxy_for_cloud_metadata", c.proxyForCloudMetadata)


### PR DESCRIPTION
### What does this PR do?
Isolates proxy config tests from CI proxy environment variables

### Motivation
proxy env vars in CI can override test config and cause false E2E failures

### Describe how you validated your changes
Ran go test -tags test ./pkg/config/setup -count=1 with proxy env vars injected

### Additional Notes