### PR TITLE
fix(e2e): assert config stop experiment outside WaitForDaemonToStop closure

### DIFF
--- a/test/new-e2e/tests/installer/windows/agent_config_test.go
+++ b/test/new-e2e/tests/installer/windows/agent_config_test.go
@@ -150,8 +150,8 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 	s.WaitForDaemonToStop(func() {
 		_, err := s.Installer().StopConfigExperiment(consts.AgentPackage)
 		s.Require().NoError(err, "daemon should stop cleanly")
-		s.AssertSuccessfulConfigStopExperiment()
 	}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second)), backoff.WithMaxTries(10))
+	s.AssertSuccessfulConfigStopExperiment()
 
 	// assert that the config dir permissions have not changed
 	perms, err = windowscommon.GetSecurityInfoForPath(s.Env().RemoteHost, configRoot)
@@ -264,8 +264,8 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 	s.WaitForDaemonToStop(func() {
 		_, err := s.Installer().StopConfigExperiment(consts.AgentPackage)
 		s.Require().NoError(err, "daemon should respond to request")
-		s.AssertSuccessfulConfigStopExperiment()
 	}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second)), backoff.WithMaxTries(10))
+	s.AssertSuccessfulConfigStopExperiment()
 }
 
 // TestRevertsConfigExperimentWhenTimeout tests that the watchdog will revert
@@ -310,8 +310,8 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 	s.WaitForDaemonToStop(func() {
 		_, err := s.Installer().StopConfigExperiment(consts.AgentPackage)
 		s.Require().NoError(err, "daemon should respond to request")
-		s.AssertSuccessfulConfigStopExperiment()
 	}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second)), backoff.WithMaxTries(10))
+	s.AssertSuccessfulConfigStopExperiment()
 }
 
 // TestManagedConfigActiveAfterUpgrade tests that the Agent's config is preserved after a package update.


### PR DESCRIPTION
### What does this PR do?

Moves `s.AssertSuccessfulConfigStopExperiment()` out of the `WaitForDaemonToStop`
closure in three `testAgentConfigSuite` tests, so the assertion runs after the
helper returns rather than during the in-progress service restart cycle.

### Motivation

Fixes [WINA-2582](https://datadoghq.atlassian.net/browse/WINA-2582).

Asserting inside the closure runs the agent-status check while the restart
cycle is still in progress, racing against the brief window when
`datadogagent` is Stopped. After `WaitForDaemonToStop` returns, the installer
has restarted — which (since the agent starts the installer) implies the agent
is back up. The first `WaitForDaemonToStop` call in the same test already
follows this pattern; this PR makes the rest consistent.

[WINA-2582]: https://datadoghq.atlassian.net/browse/WINA-2582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ