### PR TITLE
[ AGNTLOG-619 ] Replace ubuntu with alpine in k8s log pipeline E2E tests

### DIFF
--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
@@ -7,8 +7,10 @@ package k8sfiletailing
 
 import (
 	"context"
-	kindfilelogger "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/kindfilelogging"
 	"testing"
+
+	apps "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps"
+	kindfilelogger "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/kindfilelogging"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -54,7 +56,7 @@ func (v *k8sCCAOffSuite) TestADAnnotations() {
 					Containers: []corev1.Container{
 						{
 							Name:  "annotations-job",
-							Image: "ubuntu",
+							Image: "ghcr.io/datadog/apps-alpine:" + apps.Version,
 							// Sleep is added here so k8s doesn't kill the container before
 							// the agent container can detect it.
 							Command: []string{"sh", "-c", "echo '" + testLogMessage + "' && sleep 10"},
@@ -74,8 +76,8 @@ func (v *k8sCCAOffSuite) TestADAnnotations() {
 		logsServiceNames, err := v.Env().FakeIntake.Client().GetLogServiceNames()
 		assert.NoError(c, err, "Error starting job")
 
-		if assert.Contains(c, logsServiceNames, "ubuntu", "Ubuntu service not found") {
-			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("ubuntu")
+		if assert.Contains(c, logsServiceNames, "apps-alpine", "Alpine service not found") {
+			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("apps-alpine")
 			assert.NoError(c, err, "Error filtering logs")
 			if assert.NotEmpty(c, filteredLogs, "Fake Intake returned no logs even though log service name exists") {
 				assert.Equal(c, testLogMessage, filteredLogs[0].Message, "Test log doesn't match")
@@ -101,7 +103,7 @@ func (v *k8sCCAOffSuite) TestCCAOff() {
 					Containers: []corev1.Container{
 						{
 							Name:  "cca-off-job",
-							Image: "ubuntu",
+							Image: "ghcr.io/datadog/apps-alpine:" + apps.Version,
 							// Sleep is added here so k8s doesn't kill the container before
 							// the agent container can detect it.
 							Command: []string{"sh", "-c", "echo '" + testLogMessage + "' && sleep 10"},
@@ -120,6 +122,6 @@ func (v *k8sCCAOffSuite) TestCCAOff() {
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		logsServiceNames, err := v.Env().FakeIntake.Client().GetLogServiceNames()
 		assert.NoError(c, err, "Error starting job")
-		assert.NotContains(c, logsServiceNames, "ubuntu", "Ubuntu service found with container collect all off")
+		assert.NotContains(c, logsServiceNames, "apps-alpine", "Alpine service found with container collect all off")
 	}, 1*time.Minute, 10*time.Second)
 }

--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	apps "github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps"
 	kindfilelogger "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-log-pipelines/kindfilelogging"
 
 	"github.com/stretchr/testify/assert"
@@ -50,7 +51,7 @@ func (v *k8sSuite) TestSingleLogAndMetadata() {
 					Containers: []corev1.Container{
 						{
 							Name:  "query-job-1",
-							Image: "ubuntu",
+							Image: "ghcr.io/datadog/apps-alpine:" + apps.Version,
 							// Sleep is added here so k8s doesn't kill the container before
 							// the agent container can detect it.
 							Command: []string{"sh", "-c", "echo '" + testLogMessage + "' && sleep 10"},
@@ -73,8 +74,8 @@ func (v *k8sSuite) TestSingleLogAndMetadata() {
 			return
 		}
 
-		if assert.Contains(c, logsServiceNames, "ubuntu", "Ubuntu service not found") {
-			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("ubuntu")
+		if assert.Contains(c, logsServiceNames, "apps-alpine", "Alpine service not found") {
+			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("apps-alpine")
 			assert.NoError(c, err, "Error filtering logs")
 			if err != nil {
 				return
@@ -82,7 +83,7 @@ func (v *k8sSuite) TestSingleLogAndMetadata() {
 			if assert.NotEmpty(c, filteredLogs, "Fake Intake returned no logs even though log service name exists") {
 				assert.Equal(c, testLogMessage, filteredLogs[0].Message, "Test log doesn't match")
 				// Check container metatdata
-				assert.Equal(c, filteredLogs[0].Service, "ubuntu", "Could not find service")
+				assert.Equal(c, filteredLogs[0].Service, "apps-alpine", "Could not find service")
 				assert.NotNil(c, filteredLogs[0].HostName, "Hostname not found")
 				assert.NotNil(c, filteredLogs[0].Tags, "Log tags not found")
 			}
@@ -110,7 +111,7 @@ func (v *k8sSuite) TestLongLogLine() {
 					Containers: []corev1.Container{
 						{
 							Name:  "long-line-job",
-							Image: "ubuntu",
+							Image: "ghcr.io/datadog/apps-alpine:" + apps.Version,
 							// Sleep is added here so k8s doesn't kill the container before
 							// the agent container can detect it.
 							Command: []string{"sh", "-c", "echo '" + longLineLog + "' && sleep 10"},
@@ -133,8 +134,8 @@ func (v *k8sSuite) TestLongLogLine() {
 			return
 		}
 
-		if assert.Contains(c, logsServiceNames, "ubuntu", "Ubuntu service not found") {
-			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("ubuntu")
+		if assert.Contains(c, logsServiceNames, "apps-alpine", "Alpine service not found") {
+			filteredLogs, err := v.Env().FakeIntake.Client().FilterLogs("apps-alpine")
 			assert.NoError(c, err, "Error filtering logs")
 			if err != nil {
 				return
@@ -175,7 +176,7 @@ func (v *k8sSuite) TestContainerExclude() {
 					Containers: []corev1.Container{
 						{
 							Name:  "exclude-job",
-							Image: "alpine",
+							Image: "ghcr.io/datadog/apps-alpine:" + apps.Version,
 							// Sleep is added here so k8s doesn't kill the container before
 							// the agent container can detect it.
 							Command: []string{"sh", "-c", "echo '" + testLogMessage + "' && sleep 10"},
@@ -197,6 +198,6 @@ func (v *k8sSuite) TestContainerExclude() {
 		if err != nil {
 			return
 		}
-		assert.NotContains(c, logsServiceNames, "alpine", "Alpine service found after excluded")
+		assert.NotContains(c, logsServiceNames, "apps-alpine", "Alpine service found after excluded")
 	}, 1*time.Minute, 10*time.Second)
 }


### PR DESCRIPTION
### What does this PR do?

Replaces the bare `ubuntu` container image with `ghcr.io/datadog/apps-alpine` in the k8s log pipeline E2E test jobs.

### Motivation

The k8s-logs E2E tests pull the bare `ubuntu` image from Docker Hub without authentication. In CI, this hits the unauthenticated pull rate limit (`429 Too Many Requests`), causing spurious `ErrImagePull` / `ImagePullBackOff` failures.

`ghcr.io/datadog/apps-alpine` is an existing internal alpine image already used by other E2E tests (e.g. etcd). It is hosted on GitHub Container Registry and not subject to Docker Hub rate limits. All four test jobs only need `sh`, `echo`, and `sleep`, which alpine supports identically.

### Describe how you validated your changes

- All four test jobs use only `sh`, `echo`, and `sleep` — all available in the apps-alpine image
- Service name assertions updated to match the new image name
- Human-readable assertion messages updated correspondingly