### PR TITLE
Drop ineffective `pbgo` nuke loop from `tasks/protobuf.py`

### DIFF
--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -1,4 +1,3 @@
-import glob
 import os
 import re
 from pathlib import Path
@@ -44,13 +43,6 @@ def generate(ctx, pre_commit=False):
     proto_root = os.path.join(repo_root, "pkg", "proto")
     protodep_root = os.path.join(proto_root, "protodep")
     pbgo_dir = os.path.join(proto_root, "pbgo")
-    print(f"nuking old definitions at: {proto_root}")
-    file_list = glob.glob(os.path.join(proto_root, "pbgo", "*.pb.go"))
-    for file_path in file_list:
-        try:
-            os.remove(file_path)
-        except OSError:
-            print("Error while deleting file : ", file_path)
 
     with ctx.cd(repo_root):
         # protobuf defs


### PR DESCRIPTION
### What does this PR do?
Remove the `pkg/proto/pbgo/*.pb.go` glob + delete-loop at the top of `protobuf.generate`.
The single-level `glob` matches nothing under the current per-package layout, so the loop has been a no-op for almost 3 years.

### Motivation
The loop was introduced with #8199 (2021) with the broader `glob` on `pbgo/*.go`, when generated files lived directly under `pbgo/`.
With #10650 (2023), every `.pb.go` was moved into a `pbgo/<pkg>/` subdirectory, and the `glob` was narrowed from `*.go` to `*.pb.go`, likely intended to be `**/*.pb.go`.
Since then, the cleanup has been silently inert.

I didn't want to make this cleanup part of the ongoing `bazel`ification happening in the present file (e.g., #50972) because it's orthogonal to it and can be merged/reverted independently.

### Describe how you validated your changes
`dda inv protobuf.generate` still succeeds.