### PR TITLE
[clusteragent/cloudfoundry] Remove unused workloadmeta catalog import

### DIFF
--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -53,7 +53,6 @@ import (
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadfilterfx "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx"
-	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	workloadmetainit "github.com/DataDog/datadog-agent/comp/core/workloadmeta/init"
@@ -116,10 +115,12 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				eventplatformreceiverimpl.Module(),
 
 				// setup workloadmeta
-				wmcatalog.GetCatalog(),
 				workloadmetafx.Module(workloadmeta.Params{
 					InitHelper: workloadmetainit.GetWorkloadmetaInit(),
-				}), // TODO(components): check what this must be for cluster-agent-cloudfoundry
+					// Default AgentType does not match any collector. This is
+					// OK, because DCA CloudFoundry does not need to run any
+					// collector.
+				}),
 				localTaggerfx.Module(),
 				workloadfilterfx.Module(),
 				collectorimpl.Module(),


### PR DESCRIPTION
### What does this PR do?

This PR removes an unused workloadmeta catalog import in the DCA CloudFoundry.

I was trying to simplify the workloadmeta catalogs that we have and noticed that the DCA CloudFoundry was importing a catalog but not using any collectors in it. The reason is that it sets an empty `AgentType` in `workloadmeta.Params`. The default AgentType (value 0) doesn't match any collectors, so this can be safely deleted.

I think there might be more things that could be simplified, but I'll leave that for the owner team. For example, I think the `proccontainers.InitSharedContainerProvider` call is not needed here.

### Describe how you validated your changes

Just CI. I don't have access to a cloud foundry cluster. I'll leave to the owner team to decide if there's something else that needs to be tested for this.