### PR TITLE
Drop unneeded `exports_files` from BUILD.bazel files

### DIFF
--- a/deps/bzip2/overlay.BUILD.bazel
+++ b/deps/bzip2/overlay.BUILD.bazel
@@ -22,15 +22,7 @@ license(
     visibility = ["//visibility:public"],
 )
 
-exports_files([
-    "LICENSE",
-])
-
 VERSION = "1.0.8"
-
-exports_files([
-    "LICENSE",
-])
 
 # only for test cases in //deps/bzip
 exports_files([

--- a/deps/libffi.BUILD.bazel
+++ b/deps/libffi.BUILD.bazel
@@ -15,10 +15,6 @@ license(
     visibility = ["//visibility:public"],
 )
 
-exports_files([
-    "LICENSE",
-])
-
 VERSION = "3.4.8"
 
 # Base configuration shared by all platforms

--- a/deps/libseccomp/BUILD.bazel
+++ b/deps/libseccomp/BUILD.bazel
@@ -1,4 +1,0 @@
-exports_files([
-    "overlay.BUILD.bazel",
-    "configure.h",
-])

--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -2,10 +2,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("//bazel/rules/ebpf:cgo_godefs.bzl", "cgo_godefs")
 
-exports_files([
-    "types.go",
-    "types_windows.go",
-])
+exports_files(["types_windows.go"])
 
 cc_library(
     name = "ddnpmapi",

--- a/pkg/network/ebpf/c/prebuilt/BUILD.bazel
+++ b/pkg/network/ebpf/c/prebuilt/BUILD.bazel
@@ -83,9 +83,3 @@ ebpf_program_suite(
     visibility = ["//visibility:public"],
     deps = _COMMON_DEPS,
 )
-
-exports_files([
-    "conntrack.h",
-    "offsets.h",
-    "offset-guess.h",
-])

--- a/pkg/network/ebpf/c/runtime/BUILD.bazel
+++ b/pkg/network/ebpf/c/runtime/BUILD.bazel
@@ -52,8 +52,6 @@ ebpf_program_suite(
 )
 
 exports_files([
-    "conntrack-types.h",
-    "conntrack.h",
     "conntrack.c",
     "offsetguess-test.c",
     "shared-libraries.c",

--- a/pkg/windowsdriver/procmon/BUILD.bazel
+++ b/pkg/windowsdriver/procmon/BUILD.bazel
@@ -1,10 +1,7 @@
 load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/ebpf:cgo_godefs.bzl", "cgo_godefs")
 
-exports_files([
-    "types.go",
-    "types_windows.go",
-])
+exports_files(["types_windows.go"])
 
 cgo_godefs(
     name = "types_godefs",


### PR DESCRIPTION
### What does this PR do?
Remove vestigial `exports_files` declarations from BUILD.bazel files:
- deps/bzip2/overlay.BUILD.bazel: two duplicate `exports_files(["LICENSE"])` blocks (the `license(license_text = "LICENSE")` rule already covers it),
- deps/libffi.BUILD.bazel: same `exports_files(["LICENSE"])` redundancy,
- deps/libseccomp/BUILD.bazel: `exports_files` of `overlay.BUILD.bazel` and `configure.h`, only ever consumed by the `http_archive` repo rule via its `files` dict (repo rules have de facto access to these files).
- pkg/network/ebpf/c/prebuilt/BUILD.bazel: `*.h` files already exposed through the public `prebuilt_headers` (`cc_library`) and `prebuilt_headers_files` (`filegroup`) since no consumer references them directly,
- pkg/network/ebpf/c/runtime/BUILD.bazel: `*.h` files already exposed through `runtime_headers` (cc_library) - but the `*.c` entries are kept (referenced by `//pkg/ebpf/bytecode`).
- pkg/network/driver/BUILD.bazel and pkg/windowsdriver/procmon: the `types.go` source passed to `cgo_godefs` resolves through `attr.label` - contrarily to `*_windows` counterparts.

### Motivation
Reduce the noise in `BUILD.bazel` files, after realizing that Claude uses it as a source of inspiration to generate its own suggestions, which adds even more noise...
Each removed entry was either a duplicate, a same-package label that wasn't actually used as such, or a repo-rule input that has nothing to do with the build-graph visibility model.

### Describe how you validated your changes
- for each candidate, the entry was removed and the affected targets rebuilt,
- verified that `exports_files` of generated files used by `write_source_file*` is still required,
- force-refetched `@libseccomp` after wiping its external repo cache to exercise the `http_archive` overlay.

### Additional Notes
Claude did most of the job.