### PR TITLE
[FA] feat(installer): add Heartbeat field to PackageState proto

### DIFF
--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -827,7 +827,6 @@ func (d *daemonImpl) refreshState(ctx context.Context) {
 	runningConfigVersions := map[string]string{
 		"datadog-agent": d.env.ConfigID,
 	}
-	heartbeat, _ := json.Marshal(map[string]int64{"last_seen": time.Now().Unix()})
 	var packages []*pbgo.PackageState
 	for pkg, s := range configAndPackageStates.States {
 		p := &pbgo.PackageState{
@@ -838,7 +837,7 @@ func (d *daemonImpl) refreshState(ctx context.Context) {
 			ExperimentConfigVersion: configAndPackageStates.ConfigStates[pkg].Experiment,
 			RunningVersion:          runningVersions[pkg],
 			RunningConfigVersion:    runningConfigVersions[pkg],
-			Heartbeat:               heartbeat,
+			HeartbeatTimestamp:      uint64(time.Now().Unix()),
 		}
 
 		requestState, ok := tasksState[pkg]

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -827,6 +827,7 @@ func (d *daemonImpl) refreshState(ctx context.Context) {
 	runningConfigVersions := map[string]string{
 		"datadog-agent": d.env.ConfigID,
 	}
+	heartbeat, _ := json.Marshal(map[string]int64{"last_seen": time.Now().Unix()})
 	var packages []*pbgo.PackageState
 	for pkg, s := range configAndPackageStates.States {
 		p := &pbgo.PackageState{
@@ -837,6 +838,7 @@ func (d *daemonImpl) refreshState(ctx context.Context) {
 			ExperimentConfigVersion: configAndPackageStates.ConfigStates[pkg].Experiment,
 			RunningVersion:          runningVersions[pkg],
 			RunningConfigVersion:    runningConfigVersions[pkg],
+			Heartbeat:               heartbeat,
 		}
 
 		requestState, ok := tasksState[pkg]

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -129,7 +129,8 @@ message PackageState {
   string experiment_config_version = 12;
   string running_version = 13;
   string running_config_version = 14;
-  bytes heartbeat = 15;
+  uint64 heartbeat_timestamp = 15;
+  float  completion           = 16;
 }
 
 message PackageStateTask {

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -130,7 +130,7 @@ message PackageState {
   string running_version = 13;
   string running_config_version = 14;
   uint64 heartbeat_timestamp = 15;
-  float  completion           = 16;
+  float  completion = 16;
 }
 
 message PackageStateTask {

--- a/pkg/proto/datadog/remoteconfig/remoteconfig.proto
+++ b/pkg/proto/datadog/remoteconfig/remoteconfig.proto
@@ -129,6 +129,7 @@ message PackageState {
   string experiment_config_version = 12;
   string running_version = 13;
   string running_config_version = 14;
+  bytes heartbeat = 15;
 }
 
 message PackageStateTask {

--- a/pkg/proto/pbgo/core/remoteconfig.pb.go
+++ b/pkg/proto/pbgo/core/remoteconfig.pb.go
@@ -1236,7 +1236,8 @@ type PackageState struct {
 	ExperimentConfigVersion string                 `protobuf:"bytes,12,opt,name=experiment_config_version,json=experimentConfigVersion,proto3" json:"experiment_config_version,omitempty"`
 	RunningVersion          string                 `protobuf:"bytes,13,opt,name=running_version,json=runningVersion,proto3" json:"running_version,omitempty"`
 	RunningConfigVersion    string                 `protobuf:"bytes,14,opt,name=running_config_version,json=runningConfigVersion,proto3" json:"running_config_version,omitempty"`
-	Heartbeat               []byte                 `protobuf:"bytes,15,opt,name=heartbeat,proto3" json:"heartbeat,omitempty"`
+	HeartbeatTimestamp      uint64                 `protobuf:"varint,15,opt,name=heartbeat_timestamp,json=heartbeatTimestamp,proto3" json:"heartbeat_timestamp,omitempty"`
+	Completion              float32                `protobuf:"fixed32,16,opt,name=completion,proto3" json:"completion,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -1327,11 +1328,18 @@ func (x *PackageState) GetRunningConfigVersion() string {
 	return ""
 }
 
-func (x *PackageState) GetHeartbeat() []byte {
+func (x *PackageState) GetHeartbeatTimestamp() uint64 {
 	if x != nil {
-		return x.Heartbeat
+		return x.HeartbeatTimestamp
 	}
-	return nil
+	return 0
+}
+
+func (x *PackageState) GetCompletion() float32 {
+	if x != nil {
+		return x.Completion
+	}
+	return 0
 }
 
 type PackageStateTask struct {
@@ -2494,7 +2502,7 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x04tags\x18\x01 \x03(\tR\x04tags\x128\n" +
 	"\bpackages\x18\x02 \x03(\v2\x1c.datadog.config.PackageStateR\bpackages\x120\n" +
 	"\x14available_disk_space\x18\x03 \x01(\x04R\x12availableDiskSpace\x12&\n" +
-	"\x0fsecrets_pub_key\x18\x04 \x01(\tR\rsecretsPubKey\"\xc5\x03\n" +
+	"\x0fsecrets_pub_key\x18\x04 \x01(\tR\rsecretsPubKey\"\xf8\x03\n" +
 	"\fPackageState\x12\x18\n" +
 	"\apackage\x18\x01 \x01(\tR\apackage\x12%\n" +
 	"\x0estable_version\x18\x02 \x01(\tR\rstableVersion\x12-\n" +
@@ -2503,8 +2511,11 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x15stable_config_version\x18\v \x01(\tR\x13stableConfigVersion\x12:\n" +
 	"\x19experiment_config_version\x18\f \x01(\tR\x17experimentConfigVersion\x12'\n" +
 	"\x0frunning_version\x18\r \x01(\tR\x0erunningVersion\x124\n" +
-	"\x16running_config_version\x18\x0e \x01(\tR\x14runningConfigVersion\x12\x1c\n" +
-	"\theartbeat\x18\x0f \x01(\fR\theartbeatJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"\x16running_config_version\x18\x0e \x01(\tR\x14runningConfigVersion\x12/\n" +
+	"\x13heartbeat_timestamp\x18\x0f \x01(\x04R\x12heartbeatTimestamp\x12\x1e\n" +
+	"\n" +
+	"completion\x18\x10 \x01(\x02R\n" +
+	"completionJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
 	"\x10\v\"\x84\x01\n" +
 	"\x10PackageStateTask\x12\x0e\n" +

--- a/pkg/proto/pbgo/core/remoteconfig.pb.go
+++ b/pkg/proto/pbgo/core/remoteconfig.pb.go
@@ -1236,6 +1236,7 @@ type PackageState struct {
 	ExperimentConfigVersion string                 `protobuf:"bytes,12,opt,name=experiment_config_version,json=experimentConfigVersion,proto3" json:"experiment_config_version,omitempty"`
 	RunningVersion          string                 `protobuf:"bytes,13,opt,name=running_version,json=runningVersion,proto3" json:"running_version,omitempty"`
 	RunningConfigVersion    string                 `protobuf:"bytes,14,opt,name=running_config_version,json=runningConfigVersion,proto3" json:"running_config_version,omitempty"`
+	Heartbeat               []byte                 `protobuf:"bytes,15,opt,name=heartbeat,proto3" json:"heartbeat,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -1324,6 +1325,13 @@ func (x *PackageState) GetRunningConfigVersion() string {
 		return x.RunningConfigVersion
 	}
 	return ""
+}
+
+func (x *PackageState) GetHeartbeat() []byte {
+	if x != nil {
+		return x.Heartbeat
+	}
+	return nil
 }
 
 type PackageStateTask struct {
@@ -2486,7 +2494,7 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x04tags\x18\x01 \x03(\tR\x04tags\x128\n" +
 	"\bpackages\x18\x02 \x03(\v2\x1c.datadog.config.PackageStateR\bpackages\x120\n" +
 	"\x14available_disk_space\x18\x03 \x01(\x04R\x12availableDiskSpace\x12&\n" +
-	"\x0fsecrets_pub_key\x18\x04 \x01(\tR\rsecretsPubKey\"\xa7\x03\n" +
+	"\x0fsecrets_pub_key\x18\x04 \x01(\tR\rsecretsPubKey\"\xc5\x03\n" +
 	"\fPackageState\x12\x18\n" +
 	"\apackage\x18\x01 \x01(\tR\apackage\x12%\n" +
 	"\x0estable_version\x18\x02 \x01(\tR\rstableVersion\x12-\n" +
@@ -2495,7 +2503,8 @@ const file_datadog_remoteconfig_remoteconfig_proto_rawDesc = "" +
 	"\x15stable_config_version\x18\v \x01(\tR\x13stableConfigVersion\x12:\n" +
 	"\x19experiment_config_version\x18\f \x01(\tR\x17experimentConfigVersion\x12'\n" +
 	"\x0frunning_version\x18\r \x01(\tR\x0erunningVersion\x124\n" +
-	"\x16running_config_version\x18\x0e \x01(\tR\x14runningConfigVersionJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"\x16running_config_version\x18\x0e \x01(\tR\x14runningConfigVersion\x12\x1c\n" +
+	"\theartbeat\x18\x0f \x01(\fR\theartbeatJ\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
 	"\x10\v\"\x84\x01\n" +
 	"\x10PackageStateTask\x12\x0e\n" +

--- a/pkg/proto/pbgo/core/remoteconfig_gen.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen.go
@@ -3874,9 +3874,9 @@ func (z OrgStatusResponse) Msgsize() (s int) {
 // MarshalMsg implements msgp.Marshaler
 func (z *PackageState) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 9
+	// map header, size 10
 	// string "Package"
-	o = append(o, 0x89, 0xa7, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65)
+	o = append(o, 0x8a, 0xa7, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65)
 	o = msgp.AppendString(o, z.Package)
 	// string "StableVersion"
 	o = append(o, 0xad, 0x53, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
@@ -3907,9 +3907,12 @@ func (z *PackageState) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "RunningConfigVersion"
 	o = append(o, 0xb4, 0x52, 0x75, 0x6e, 0x6e, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
 	o = msgp.AppendString(o, z.RunningConfigVersion)
-	// string "Heartbeat"
-	o = append(o, 0xa9, 0x48, 0x65, 0x61, 0x72, 0x74, 0x62, 0x65, 0x61, 0x74)
-	o = msgp.AppendBytes(o, z.Heartbeat)
+	// string "HeartbeatTimestamp"
+	o = append(o, 0xb2, 0x48, 0x65, 0x61, 0x72, 0x74, 0x62, 0x65, 0x61, 0x74, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70)
+	o = msgp.AppendUint64(o, z.HeartbeatTimestamp)
+	// string "Completion"
+	o = append(o, 0xaa, 0x43, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x69, 0x6f, 0x6e)
+	o = msgp.AppendFloat32(o, z.Completion)
 	return
 }
 
@@ -3990,10 +3993,16 @@ func (z *PackageState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "RunningConfigVersion")
 				return
 			}
-		case "Heartbeat":
-			z.Heartbeat, bts, err = msgp.ReadBytesBytes(bts, z.Heartbeat)
+		case "HeartbeatTimestamp":
+			z.HeartbeatTimestamp, bts, err = msgp.ReadUint64Bytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "Heartbeat")
+				err = msgp.WrapError(err, "HeartbeatTimestamp")
+				return
+			}
+		case "Completion":
+			z.Completion, bts, err = msgp.ReadFloat32Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Completion")
 				return
 			}
 		default:
@@ -4016,7 +4025,7 @@ func (z *PackageState) Msgsize() (s int) {
 	} else {
 		s += z.Task.Msgsize()
 	}
-	s += 20 + msgp.StringPrefixSize + len(z.StableConfigVersion) + 24 + msgp.StringPrefixSize + len(z.ExperimentConfigVersion) + 15 + msgp.StringPrefixSize + len(z.RunningVersion) + 21 + msgp.StringPrefixSize + len(z.RunningConfigVersion) + 10 + msgp.BytesPrefixSize + len(z.Heartbeat)
+	s += 20 + msgp.StringPrefixSize + len(z.StableConfigVersion) + 24 + msgp.StringPrefixSize + len(z.ExperimentConfigVersion) + 15 + msgp.StringPrefixSize + len(z.RunningVersion) + 21 + msgp.StringPrefixSize + len(z.RunningConfigVersion) + 19 + msgp.Uint64Size + 11 + msgp.Float32Size
 	return
 }
 

--- a/pkg/proto/pbgo/core/remoteconfig_gen.go
+++ b/pkg/proto/pbgo/core/remoteconfig_gen.go
@@ -3874,9 +3874,9 @@ func (z OrgStatusResponse) Msgsize() (s int) {
 // MarshalMsg implements msgp.Marshaler
 func (z *PackageState) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 8
+	// map header, size 9
 	// string "Package"
-	o = append(o, 0x88, 0xa7, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65)
+	o = append(o, 0x89, 0xa7, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65)
 	o = msgp.AppendString(o, z.Package)
 	// string "StableVersion"
 	o = append(o, 0xad, 0x53, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
@@ -3907,6 +3907,9 @@ func (z *PackageState) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "RunningConfigVersion"
 	o = append(o, 0xb4, 0x52, 0x75, 0x6e, 0x6e, 0x69, 0x6e, 0x67, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e)
 	o = msgp.AppendString(o, z.RunningConfigVersion)
+	// string "Heartbeat"
+	o = append(o, 0xa9, 0x48, 0x65, 0x61, 0x72, 0x74, 0x62, 0x65, 0x61, 0x74)
+	o = msgp.AppendBytes(o, z.Heartbeat)
 	return
 }
 
@@ -3987,6 +3990,12 @@ func (z *PackageState) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "RunningConfigVersion")
 				return
 			}
+		case "Heartbeat":
+			z.Heartbeat, bts, err = msgp.ReadBytesBytes(bts, z.Heartbeat)
+			if err != nil {
+				err = msgp.WrapError(err, "Heartbeat")
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -4007,7 +4016,7 @@ func (z *PackageState) Msgsize() (s int) {
 	} else {
 		s += z.Task.Msgsize()
 	}
-	s += 20 + msgp.StringPrefixSize + len(z.StableConfigVersion) + 24 + msgp.StringPrefixSize + len(z.ExperimentConfigVersion) + 15 + msgp.StringPrefixSize + len(z.RunningVersion) + 21 + msgp.StringPrefixSize + len(z.RunningConfigVersion)
+	s += 20 + msgp.StringPrefixSize + len(z.StableConfigVersion) + 24 + msgp.StringPrefixSize + len(z.ExperimentConfigVersion) + 15 + msgp.StringPrefixSize + len(z.RunningVersion) + 21 + msgp.StringPrefixSize + len(z.RunningConfigVersion) + 10 + msgp.BytesPrefixSize + len(z.Heartbeat)
 	return
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a `heartbeat` field (`bytes`, field 15) to the `PackageState` protobuf message and populates it in the installer daemon with a JSON payload on every `refreshState()` call.

The heartbeat value is: `{"last_seen": <unix_seconds>}`

This allows the RC backend to observe when the installer last reported its state — useful for detecting silent failures or stale agents without requiring a separate mechanism.

## Motivation

The RC backend currently has no way to distinguish between an installer that is running and idle vs. one that has stopped reporting. The `last_seen` timestamp in the heartbeat payload fills this gap.

## Changes

- `pkg/proto/datadog/remoteconfig/remoteconfig.proto`: add `bytes heartbeat = 15` to `PackageState`
- `pkg/proto/pbgo/core/remoteconfig.pb.go`: regenerated
- `pkg/proto/pbgo/core/remoteconfig_gen.go`: regenerated
- `pkg/fleet/daemon/daemon.go`: populate `Heartbeat` in `refreshState()`

## Test plan

- [ ] All existing `pkg/fleet/daemon` unit tests pass (`dda inv test --targets=./pkg/fleet/daemon/...`)
- [ ] Proto generated files validated by pre-push hook (`validate-protocol-buffer-generated-files`)