### PR TITLE
Drop no-op `default_visibility` declarations from BUILD.bazel files

### DIFF
--- a/bazel/rules/rewrite_rpath/BUILD.bazel
+++ b/bazel/rules/rewrite_rpath/BUILD.bazel
@@ -1,13 +1,4 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
-package(default_visibility = ["//visibility:public"])
-
 exports_files([
     "macos.sh",
     "macos_dir.sh",
 ])
-
-bzl_library(
-    name = "rewrite_rpath_bzl",
-    srcs = ["rewrite_rpath.bzl"],
-)

--- a/deps/nghttp2/BUILD.bazel
+++ b/deps/nghttp2/BUILD.bazel
@@ -1,1 +1,0 @@
-package(default_visibility = ["//visibility:public"])

--- a/deps/openssl/BUILD.bazel
+++ b/deps/openssl/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
-package(default_visibility = ["//visibility:public"])
-
 sh_test(
     name = "check_no_sandbox_paths",
     srcs = ["check_no_sandbox_paths.sh"],

--- a/deps/openssl_fips/BUILD.bazel
+++ b/deps/openssl_fips/BUILD.bazel
@@ -1,1 +1,0 @@
-package(default_visibility = ["//visibility:public"])

--- a/deps/unixodbc/aarch64/BUILD.bazel
+++ b/deps/unixodbc/aarch64/BUILD.bazel
@@ -1,1 +1,0 @@
-package(default_visibility = ["//visibility:public"])

--- a/deps/unixodbc/x86_64/BUILD.bazel
+++ b/deps/unixodbc/x86_64/BUILD.bazel
@@ -1,1 +1,0 @@
-package(default_visibility = ["//visibility:public"])

--- a/deps/xz/BUILD.bazel
+++ b/deps/xz/BUILD.bazel
@@ -1,1 +1,0 @@
-package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
### What does this PR do?
Drops `package(default_visibility = ["//visibility:public"])` from BUILD.bazel files where the declaration was governing nothing:
- empty single-line placeholder BUILD.bazel files whose only content was the `package()` call:
  - deps/nghttp2/BUILD.bazel
  - deps/openssl_fips/BUILD.bazel
  - deps/unixodbc/aarch64/BUILD.bazel
  - deps/unixodbc/x86_64/BUILD.bazel
  - deps/xz/BUILD.bazel
- deps/openssl/BUILD.bazel: holds a single `sh_test` target with no consumers (tests aren't depended on) => drop the `package()` line,
- bazel/rules/rewrite_rpath/BUILD.bazel: remove the dead `bzl_library(:rewrite_rpath_bzl)` target (zero references in the repo) and drops the `package()` line since `exports_files()` itself already defaults to `public` visibility, so no explicit visibility attribute is needed on the surviving call.

### Motivation
Reduce the noise in `BUILD.bazel` files, after realizing that Claude inspires from it to generate its own suggestions, which adds even more noise...

Each placeholder `package` contains no targets: the BUILD.bazel file exists solely to mark a package boundary for repo-rule label resolution from MODULE.bazel `http_archive(files = {...})` entries.

For the two non-placeholder cases, the default was either guarding a target nobody depends on (`sh_test`) or made redundant by `exports_files` defaulting to public on its own.

### Describe how you validated your changes
`bazel test //...` passes.

### Additional Notes
Claude did most of the job.