### PR TITLE
Revert "Stop building internal images when Dockerfiles are modified"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -585,25 +585,13 @@ workflow:
   - <<: *if_deploy
     variables:
       RELEASE_PROD: "true"
-  # TODO: Agent Delivery. We stop building all the internal images when one of them is modified.
-  # We currently have issues with internal registries because we hit the max number of images.
-  # There's currently no easy way to specify `target:none` and override this: https://github.com/DataDog/images/blob/master/datadog-agent/build_metadata.yaml#L1
-  # at runtime if we actually don't need the image to be replicated (which is the case here because
-  # we only need the image to be built to validate it's still working). This is a short-term solution to reduce
-  # the number of issues we see in production.
-  # https://datadoghq.atlassian.net/browse/BARX-1766.
-  # Several things we should/could do:
-  # 1. Be able to force the `target` annotation to `none` in this case (to discuss with dependency-management and implement in the images repository)
-  # 2. Only build the images that was modified in the PR, not all of them to reduce the amount of images.
-  # 3. There's a bug with the just-in-time replication that will be fixed once https://github.com/google/go-containerregistry/pull/2267 lands.
-  #    That will allow us to stop relying on the `target` annotation. Orchestration Systems is on it, see https://datadoghq.atlassian.net/browse/ARTM-185.
-  # - changes:
-  #     paths:
-  #       - .gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
-  #       - Dockerfiles/**/*
-  #     compare_to: $COMPARE_TO_BRANCH
-  #   variables:
-  #     RELEASE_PROD: "false"
+  - changes:
+      paths:
+        - .gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+        - Dockerfiles/**/*
+      compare_to: $COMPARE_TO_BRANCH
+    variables:
+      RELEASE_PROD: "false"
   - when: manual
     allow_failure: true
     variables:


### PR DESCRIPTION
Reverts DataDog/datadog-agent#50352 following https://github.com/DataDog/datadog-agent/commit/7973456a9c3ea016ecd0a62185ac59374ccccc72. This PR was a temporary measure to reduce the number of images that were pushed internally (as explained in the previous PR). We managed to fix the replication issues mentioned in the comments so we can now bring this back and start building the images again. They will only be pushed to staging repositories, not impacting our production repositories anymore.