### PR TITLE
[EXPERIMENTAL] feat(discovery): config-file sender for DSCVR-438 PoC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -491,6 +491,7 @@
 /comp/core/autodiscovery/providers/remote_config*.go  @DataDog/fleet
 /comp/core/autodiscovery/providers/datastreams @DataDog/data-streams-monitoring
 /comp/core/gui/guiimpl/systray/ @DataDog/windows-products @DataDog/agent-configuration
+/comp/discovery/                                @DataDog/agent-discovery
 /comp/healthplatform/issues/admisconfig @DataDog/container-platform @DataDog/agent-health
 /comp/healthplatform/issues/rofspermissions @DataDog/container-platform @DataDog/agent-health
 /pkg/cloudfoundry                       @DataDog/agent-integrations

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -108,6 +108,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/defaults"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
+	configsenderfx "github.com/DataDog/datadog-agent/comp/discovery/configsender/fx"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd"
 	dogstatsdhttp "github.com/DataDog/datadog-agent/comp/dogstatsd/http/def"
 	dogstatsdhttpfx "github.com/DataDog/datadog-agent/comp/dogstatsd/http/fx"
@@ -565,6 +566,7 @@ func getSharedFxOption() fx.Option {
 		networkpath.Bundle(),
 		syntheticsTestsfx.Module(),
 		remoteagentregistryfx.Module(),
+		configsenderfx.Module(),
 		haagentfx.Module(),
 		doqueryactionsfx.Module(),
 		metricscompressorfx.Module(),

--- a/comp/discovery/configsender/def/BUILD.bazel
+++ b/comp/discovery/configsender/def/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/discovery/configsender/def",
+    visibility = ["//visibility:public"],
+)

--- a/comp/discovery/configsender/def/component.go
+++ b/comp/discovery/configsender/def/component.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package configsender ships discovered config-file contents to the EvP
+// staging intake (demoalpha track) as part of the DSCVR-438 PoC.
+//
+// The component polls the system-probe discovery module's /services endpoint
+// and, for each Service.ConfigFiles entry it can recognise, reads the file
+// and POSTs the envelope expected by the demoalpha-worker.
+//
+// Opt-in via discovery.config_files_sender.enabled. Linux only.
+package configsender
+
+// team: agent-discovery
+
+// Component is the marker interface for the configsender component. The
+// component exposes no public methods — instantiation through fx starts the
+// background goroutine via a lifecycle hook, and consumption is implicit.
+type Component interface{}

--- a/comp/discovery/configsender/fx/BUILD.bazel
+++ b/comp/discovery/configsender/fx/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fx",
+    srcs = ["fx.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/discovery/configsender/fx",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/discovery/configsender/def",
+        "//comp/discovery/configsender/impl",
+        "//pkg/util/fxutil",
+    ],
+)

--- a/comp/discovery/configsender/fx/fx.go
+++ b/comp/discovery/configsender/fx/fx.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package fx provides the fx module for the configsender component.
+package fx
+
+import (
+	configsender "github.com/DataDog/datadog-agent/comp/discovery/configsender/def"
+	configsenderimpl "github.com/DataDog/datadog-agent/comp/discovery/configsender/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			configsenderimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[configsender.Component](),
+	)
+}

--- a/comp/discovery/configsender/impl/BUILD.bazel
+++ b/comp/discovery/configsender/impl/BUILD.bazel
@@ -1,0 +1,137 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "impl",
+    srcs = [
+        "configsender_linux.go",
+        "configsender_nonlinux.go",
+        "content_type.go",
+        "dedup.go",
+        "envelope.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/discovery/configsender/impl",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:aix": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:android": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/def",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/discovery/core",
+            "//pkg/discovery/model",
+            "//pkg/system-probe/api/client",
+            "//pkg/util/log",
+            "@//pkg/system-probe/config",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:js": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/def",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/discovery/core",
+            "//pkg/discovery/model",
+            "//pkg/system-probe/api/client",
+            "//pkg/util/log",
+            "@//pkg/system-probe/config",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:osx": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "@rules_go//go/platform:windows": [
+            "//comp/core/hostname/hostnameinterface",
+            "//comp/discovery/configsender/def",
+            "//pkg/config/model",
+            "//pkg/util/log",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "impl_test",
+    srcs = [
+        "content_type_test.go",
+        "envelope_test.go",
+    ],
+    embed = [":impl"],
+    gotags = ["test"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/comp/discovery/configsender/impl/configsender_linux.go
+++ b/comp/discovery/configsender/impl/configsender_linux.go
@@ -1,0 +1,223 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux
+
+package configsenderimpl
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	configsender "github.com/DataDog/datadog-agent/comp/discovery/configsender/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	"github.com/DataDog/datadog-agent/pkg/discovery/core"
+	"github.com/DataDog/datadog-agent/pkg/discovery/model"
+	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
+	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+)
+
+const (
+	configFlag    = "discovery.config_files_sender.enabled"
+	intakeURL     = "https://all-internal-intake-logs.staging.dog/v2/track/demoalpha/org/47653"
+	pollInterval  = 30 * time.Second
+	httpTimeout   = 10 * time.Second
+	maxFileSize   = 256 * 1024
+	configSource  = "app_native"
+)
+
+// Requires defines the dependencies for the configsender component.
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+	Config    pkgconfigmodel.Reader
+	Hostname  hostnameinterface.Component
+}
+
+// Provides defines the output of the configsender component.
+type Provides struct {
+	Comp configsender.Component
+}
+
+// NewComponent wires the configsender component. When the feature flag is
+// off this is a no-op — no goroutine is spawned, no socket is opened.
+func NewComponent(reqs Requires) Provides {
+	if !reqs.Config.GetBool(configFlag) {
+		log.Infof("configsender disabled (set %s: true to enable)", configFlag)
+		return Provides{Comp: &sender{}}
+	}
+
+	apiKey := strings.TrimSpace(reqs.Config.GetString("api_key"))
+	s := &sender{
+		hostname:  reqs.Hostname,
+		apiKey:    apiKey,
+		sysProbe:  sysprobeclient.GetCheckClient(),
+		intake:    &http.Client{Timeout: httpTimeout},
+		stopCh:    make(chan struct{}),
+	}
+
+	reqs.Lifecycle.Append(compdef.Hook{
+		OnStart: func(context.Context) error {
+			log.Infof("configsender enabled, posting to %s", intakeURL)
+			go s.run()
+			return nil
+		},
+		OnStop: func(context.Context) error {
+			close(s.stopCh)
+			return nil
+		},
+	})
+
+	return Provides{Comp: s}
+}
+
+type sender struct {
+	hostname hostnameinterface.Component
+	apiKey   string
+	sysProbe *sysprobeclient.CheckClient
+	intake   *http.Client
+	seen     dedupSet
+	stopCh   chan struct{}
+}
+
+func (s *sender) run() {
+	s.tick() // first tick immediately so we don't wait 30s on startup
+	t := time.NewTicker(pollInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-t.C:
+			s.tick()
+		}
+	}
+}
+
+func (s *sender) tick() {
+	pids, err := listProcPIDs()
+	if err != nil {
+		log.Debugf("configsender: listProcPIDs: %v", err)
+		return
+	}
+	if len(pids) == 0 {
+		return
+	}
+	resp, err := sysprobeclient.Post[model.ServicesResponse](
+		s.sysProbe, "/services",
+		core.Params{NewPids: pids},
+		sysconfig.DiscoveryModule,
+	)
+	if err != nil {
+		log.Debugf("configsender: fetch /services: %v", err)
+		return
+	}
+	host, err := s.hostname.Get(context.Background())
+	if err != nil || host == "" {
+		log.Warnf("configsender: no hostname, skipping tick: %v", err)
+		return
+	}
+	for _, svc := range resp.Services {
+		integration := strings.ToLower(svc.GeneratedName)
+		if integration == "" {
+			continue
+		}
+		for _, path := range svc.ConfigFiles {
+			s.process(host, integration, path)
+		}
+	}
+}
+
+func (s *sender) process(host, integration, path string) {
+	ct := detectContentType(integration, path)
+	if ct == "" {
+		return
+	}
+	raw, err := readCapped(path, maxFileSize)
+	if err != nil {
+		log.Debugf("configsender: read %s: %v", path, err)
+		return
+	}
+	if !utf8.Valid(raw) {
+		log.Debugf("configsender: skip non-utf8 file %s", path)
+		return
+	}
+	body, hash, err := buildEnvelope(host, integration, configSource, path, ct, raw)
+	if err != nil {
+		log.Warnf("configsender: build envelope for %s: %v", path, err)
+		return
+	}
+	if !s.seen.addIfNew(host, integration, hash) {
+		return
+	}
+	if err := s.post(body); err != nil {
+		log.Warnf("configsender: post %s: %v", path, err)
+		s.seen.forget(host, integration, hash)
+		return
+	}
+	log.Infof("configsender: config sent host=%s integration=%s file=%s hash=%s", host, integration, path, hash[:12])
+}
+
+func (s *sender) post(body []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, intakeURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if s.apiKey != "" {
+		req.Header.Set("DD-API-KEY", s.apiKey)
+	}
+	resp, err := s.intake.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		excerpt, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, excerpt)
+	}
+	return nil
+}
+
+func readCapped(path string, max int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(io.LimitReader(f, max))
+}
+
+func listProcPIDs() ([]int32, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+	pids := make([]int32, 0, 256)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		n, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		pids = append(pids, int32(n))
+	}
+	return pids, nil
+}

--- a/comp/discovery/configsender/impl/configsender_nonlinux.go
+++ b/comp/discovery/configsender/impl/configsender_nonlinux.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !linux
+
+package configsenderimpl
+
+import (
+	configsender "github.com/DataDog/datadog-agent/comp/discovery/configsender/def"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+// Requires defines the dependencies for the configsender component.
+// On non-linux platforms the component is a no-op; the discovery rust
+// module only runs on linux.
+type Requires struct {
+	Config   pkgconfigmodel.Reader
+	Hostname hostnameinterface.Component
+}
+
+// Provides defines the output of the configsender component.
+type Provides struct {
+	Comp configsender.Component
+}
+
+type noopSender struct{}
+
+// NewComponent returns a no-op component on non-linux builds.
+func NewComponent(_ Requires) Provides {
+	log.Info("configsender: noop on non-linux platforms")
+	return Provides{Comp: &noopSender{}}
+}

--- a/comp/discovery/configsender/impl/content_type.go
+++ b/comp/discovery/configsender/impl/content_type.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package configsenderimpl
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// detectContentType returns one of the three content_type values the
+// demoalpha-worker recognises ("yaml", "json", "redis_conf"), or "" when the
+// (integration, path) combination is not safe to ship.
+//
+// We are deliberately restrictive: the worker's parseRedisConf is a
+// line-based key/value parser tailored to redis.conf — feeding it
+// nginx.conf or postgresql.conf produces noise. Restricting redis_conf to
+// integration=redis keeps the demo honest until per-integration parsers
+// exist on the worker side.
+func detectContentType(integration, path string) string {
+	base := strings.ToLower(filepath.Base(path))
+	switch filepath.Ext(base) {
+	case ".yaml", ".yml":
+		return "yaml"
+	case ".json":
+		return "json"
+	}
+	if integration == "redis" && (base == "redis.conf" || strings.HasSuffix(base, ".conf")) {
+		return "redis_conf"
+	}
+	return ""
+}

--- a/comp/discovery/configsender/impl/content_type_test.go
+++ b/comp/discovery/configsender/impl/content_type_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package configsenderimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectContentType(t *testing.T) {
+	cases := []struct {
+		name        string
+		integration string
+		path        string
+		want        string
+	}{
+		{"redis conf canonical", "redis", "/etc/redis/redis.conf", "redis_conf"},
+		{"redis conf uppercased", "redis", "/etc/REDIS/Redis.Conf", "redis_conf"},
+		{"redis other .conf", "redis", "/etc/redis/extra.conf", "redis_conf"},
+		{"redis yaml integration", "redis", "/etc/datadog-agent/conf.d/redis.d/conf.yaml", "yaml"},
+		{"yml extension", "redis", "/tmp/x.yml", "yaml"},
+		{"json extension", "anything", "/tmp/x.json", "json"},
+
+		// Restriction: only redis is allowed to ship `.conf` files as redis_conf.
+		{"nginx conf rejected", "nginx", "/etc/nginx/nginx.conf", ""},
+		{"postgres conf rejected", "postgres", "/etc/postgresql/postgresql.conf", ""},
+		{"empty integration with conf rejected", "", "/etc/redis/redis.conf", ""},
+
+		// Unknown extensions return empty.
+		{"no extension", "redis", "/etc/redis/redis", ""},
+		{"unknown ext", "redis", "/etc/redis/redis.ini", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, detectContentType(tc.integration, tc.path))
+		})
+	}
+}

--- a/comp/discovery/configsender/impl/dedup.go
+++ b/comp/discovery/configsender/impl/dedup.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package configsenderimpl
+
+import "sync"
+
+// dedupSet tracks (host_id, integration, content_hash) tuples already shipped
+// successfully so we do not re-send the same config every tick. The set is
+// process-local and lost on restart — that is acceptable because the worker
+// overwrites within the 1-day TTL of config_facts_v1.
+type dedupSet struct{ m sync.Map }
+
+func dedupKey(host, integration, hash string) string {
+	return host + "|" + integration + "|" + hash
+}
+
+// addIfNew returns true when the tuple was not previously present and has
+// now been recorded. Returns false (and is a no-op) when the tuple was
+// already in the set.
+func (d *dedupSet) addIfNew(host, integration, hash string) bool {
+	_, loaded := d.m.LoadOrStore(dedupKey(host, integration, hash), struct{}{})
+	return !loaded
+}
+
+// forget removes a tuple — used on POST failure so the next tick retries.
+func (d *dedupSet) forget(host, integration, hash string) {
+	d.m.Delete(dedupKey(host, integration, hash))
+}

--- a/comp/discovery/configsender/impl/envelope.go
+++ b/comp/discovery/configsender/impl/envelope.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package configsenderimpl implements the configsender component interface.
+package configsenderimpl
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// envelope mirrors the EvP intake envelope consumed by the demoalpha-worker.
+// See DataDog/experimental#9989 (phase3/sender/send-demoalpha.sh) for the
+// canonical wire shape.
+type envelope struct {
+	Service string  `json:"service"`
+	Project string  `json:"project"`
+	Tags    string  `json:"ddtags"`
+	Message string  `json:"message"`
+	Data    payload `json:"data"`
+}
+
+// payload carries the per-config fields the worker reads from data.*.
+// All five fields below must be non-empty for the worker to write into
+// config_facts_v1 (host_id, integration, config_source, content_type, raw).
+type payload struct {
+	HostID       string `json:"host_id"`
+	Integration  string `json:"integration"`
+	ConfigSource string `json:"config_source"`
+	Filename     string `json:"filename"`
+	ContentType  string `json:"content_type"`
+	Raw          string `json:"raw"`
+}
+
+// buildEnvelope returns the serialized envelope and a sha256 hex digest of
+// the raw file content. The digest is used by the caller for in-memory
+// deduplication.
+func buildEnvelope(hostID, integration, source, filename, contentType string, raw []byte) ([]byte, string, error) {
+	sum := sha256.Sum256(raw)
+	hash := hex.EncodeToString(sum[:])
+	e := envelope{
+		Service: "demoalpha-worker",
+		Project: "config-ingestion-poc",
+		Tags:    fmt.Sprintf("config-ingestion-poc,source:agent,host:%s", hostID),
+		Message: fmt.Sprintf("%s %s config from %s (%s)", integration, source, hostID, filename),
+		Data: payload{
+			HostID:       hostID,
+			Integration:  integration,
+			ConfigSource: source,
+			Filename:     filename,
+			ContentType:  contentType,
+			Raw:          string(raw),
+		},
+	}
+	b, err := json.Marshal(e)
+	return b, hash, err
+}

--- a/comp/discovery/configsender/impl/envelope_test.go
+++ b/comp/discovery/configsender/impl/envelope_test.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package configsenderimpl
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEnvelopeMatchesWireShape(t *testing.T) {
+	raw := []byte("bind 127.0.0.1\nport 6379\n")
+
+	body, hash, err := buildEnvelope("host-7", "redis", "app_native", "/etc/redis/redis.conf", "redis_conf", raw)
+	require.NoError(t, err)
+
+	expected := sha256.Sum256(raw)
+	assert.Equal(t, hex.EncodeToString(expected[:]), hash)
+
+	var got envelope
+	require.NoError(t, json.Unmarshal(body, &got))
+
+	assert.Equal(t, "demoalpha-worker", got.Service)
+	assert.Equal(t, "config-ingestion-poc", got.Project)
+	assert.Equal(t, "config-ingestion-poc,source:agent,host:host-7", got.Tags)
+	assert.Equal(t, "redis app_native config from host-7 (/etc/redis/redis.conf)", got.Message)
+	assert.Equal(t, "host-7", got.Data.HostID)
+	assert.Equal(t, "redis", got.Data.Integration)
+	assert.Equal(t, "app_native", got.Data.ConfigSource)
+	assert.Equal(t, "/etc/redis/redis.conf", got.Data.Filename)
+	assert.Equal(t, "redis_conf", got.Data.ContentType)
+	assert.Equal(t, string(raw), got.Data.Raw)
+}
+
+func TestBuildEnvelopeRawPreservedExactly(t *testing.T) {
+	// The worker re-parses data.raw byte-for-byte, so any mutation here
+	// (e.g. trimming, normalising newlines) would silently break parsing.
+	raw := []byte("bind 127.0.0.1  \r\nport\t6379\n\n# trailing\n")
+
+	body, _, err := buildEnvelope("h", "redis", "app_native", "/etc/redis/redis.conf", "redis_conf", raw)
+	require.NoError(t, err)
+
+	var got envelope
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, string(raw), got.Data.Raw)
+}
+
+func TestBuildEnvelopeJSONFieldNames(t *testing.T) {
+	// The worker reads exact field names from data.*. A typo in a JSON tag
+	// would silently drop the field on the wire — guard against that.
+	body, _, err := buildEnvelope("h", "redis", "app_native", "/etc/redis/redis.conf", "redis_conf", []byte("x"))
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &raw))
+	for _, key := range []string{"service", "project", "ddtags", "message", "data"} {
+		_, ok := raw[key]
+		assert.True(t, ok, "top-level key %q missing", key)
+	}
+
+	var data map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw["data"], &data))
+	for _, key := range []string{"host_id", "integration", "config_source", "filename", "content_type", "raw"} {
+		_, ok := data[key]
+		assert.True(t, ok, "data key %q missing", key)
+	}
+}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -830,6 +830,12 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	// Service discovery configuration
 	bindEnvAndSetLogsConfigKeys(config, "service_discovery.forwarder.")
 
+	// Config-file sender — experimental, DSCVR-438 PoC.
+	// When enabled, the agent reads config files discovered by the
+	// system-probe discovery module (Service.ConfigFiles) and ships their
+	// contents to the EvP staging intake on the demoalpha track. Linux only.
+	config.BindEnvAndSetDefault("discovery.config_files_sender.enabled", false)
+
 	// Orchestrator Explorer - process agent
 	// DEPRECATED in favor of `orchestrator_explorer.orchestrator_dd_url` setting. If both are set `orchestrator_explorer.orchestrator_dd_url` will take precedence.
 	config.BindEnv("process_config.orchestrator_dd_url", "DD_PROCESS_CONFIG_ORCHESTRATOR_DD_URL", "DD_PROCESS_AGENT_ORCHESTRATOR_DD_URL") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'


### PR DESCRIPTION
## Status: internal-demo PoC — not for review, not for merge

Pairs with #50811 (Rust-side cmdline parsing, this PR is stacked on its
branch) and the backend PoC at DataDog/experimental#9989.

This PR exists in draft form purely as a code-review surface for myself.
It is not seeking review.

## What it does

Adds \`comp/discovery/configsender\`, an opt-in agent-side component that
ships config files discovered via \`Service.ConfigFiles\` (added by #50811)
to the EvP staging intake on the \`demoalpha\` track.

- Linux only (no-op stub on other platforms).
- Disabled by default (\`discovery.config_files_sender.enabled\`).
- 30s poll against system-probe \`/services\`.
- 256 KiB file-size cap, in-memory dedup by \`(host, integration, sha256)\`.
- Restrictive content_type detection: \`yaml\` / \`json\` for those
  extensions; \`redis_conf\` only for \`integration=redis\`.

## Out of scope (intentionally — this is a demo)

- workloadmeta plumbing.
- Production auth via the forwarder (uses staging intake URL directly).
- Retries / persistent dedup.
- E2E coverage with fakeintake.

## How to try

\`\`\`yaml
api_key: <staging-key>
discovery:
  config_files_sender:
    enabled: true
system_probe_config:
  enabled: true
\`\`\`

Then \`tail -f /var/log/datadog/agent.log | grep configsender\`.