### PR TITLE
[PROF-14100 & PROF-14155] Configuration tweaks and cleanups

### DIFF
--- a/cmd/host-profiler/README.md
+++ b/cmd/host-profiler/README.md
@@ -106,22 +106,22 @@ The component is configured via an OpenTelemetry Collector YAML file. See [`dist
 
 - **`receivers.profiling`**: eBPF profiling parameters, tracers, symbol upload settings
 - **`processors.infraattributes`**: Infrastructure metadata enrichment (Agent mode only)
-- **`processors.k8sattributes`**: Kubernetes metadata enrichment (standalone mode)
-- **`exporters.otlphttp`**: Datadog profiling intake endpoint configuration
+- **`processors.k8s_attributes`**: Kubernetes metadata enrichment (standalone mode)
+- **`exporters.otlp_http`**: Datadog profiling intake endpoint configuration
 - **`extensions.ddprofiling`**: Datadog profiling extension (Agent mode only)
 
 ### Configuration Inference
 
-Configuration inference is enabled by default in bundled mode when symbol_endpoints and otlphttp exporters are not explicitly configured.
+Configuration inference is enabled by default in bundled mode when symbol_endpoints and otlp_http exporters are not explicitly configured.
 
 The host profiler searches for the following nodes in the core agent's configuration file:
 - **`apm_config`**:
     - **`profiling_dd_url`**: URL from which the site is extracted (takes priority)
     - **`profiling_additional_endpoints`**: additional endpoints with a url to extract `site` and `n` number of api keys
-- **`site`**: secondary site (if `profiling_dd_url` isn't configured) for symbol endpoints and otlphttp's `profiles_endpoint`
+- **`site`**: secondary site (if `profiling_dd_url` isn't configured) for symbol endpoints and otlp_http's `profiles_endpoint`
 - **`api_key`**: main api key for `site`
 
-This inference will create as many symbol endpoints and otlphttp exporters as there are site+key combinations.
+This inference will create as many symbol endpoints and otlp_http exporters as there are site+key combinations.
 
 ## CLI Flags
 

--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -10,17 +10,10 @@ receivers:
         - site: ${env:DD_SITE}
           api_key: ${env:DD_API_KEY}
 processors:
-# infraattributes/default is automatically removed when the Agent Core is not available
-  infraattributes/default:
-    cardinality: 2 # HighCardinality
-    allow_hostname_override: true
   cumulativetodelta: {}
-# resourcedetection is automatically removed when the Agent Core is available
   resourcedetection:
     detectors: ["system"]
     system:
-      # TODO: which resource attributes do we want as default?
-      # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/system/documentation.md
       resource_attributes:
         host.arch:
           enabled: true
@@ -30,8 +23,7 @@ processors:
           enabled: false
 
 exporters:
-  debug: {}
-  otlphttp:
+  otlp_http:
     endpoint: https://otlp.${env:DD_SITE}
     headers:
       dd-api-key: ${env:DD_API_KEY}
@@ -40,12 +32,9 @@ service:
   pipelines:
     profiles:
       receivers: [profiling]
-      # infraattributes/default is automatically removed when the Agent Core is not available
-      # resourcedetection is automatically removed when the Agent Core is available
-      processors: [infraattributes/default, resourcedetection]
-      exporters: [debug, otlphttp]
+      processors: [resourcedetection]
+      exporters: [otlp_http]
     metrics:
       receivers: [otlp]
-      # infraattributes/default is automatically removed when the Agent Core is not available
-      processors: [cumulativetodelta, infraattributes/default]
-      exporters: [otlphttp]
+      processors: [cumulativetodelta]
+      exporters: [otlp_http]

--- a/cmd/host-profiler/dist_test.go
+++ b/cmd/host-profiler/dist_test.go
@@ -6,18 +6,3 @@
 //go:build linux
 
 package main
-
-import (
-	_ "embed"
-	"strings"
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
-
-//go:embed dist/host-profiler-config.yaml
-var config string
-
-func TestConverterInfraAttributesName(t *testing.T) {
-	require.Equal(t, 6, strings.Count(config, "infraattributes/default"))
-}

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -19,6 +19,12 @@ import (
 
 type confMap = map[string]any
 
+const (
+	infraAttributesName = "infraattributes"
+	hpflareName         = "hpflare"
+	ddprofilingName     = "ddprofiling"
+)
+
 func buildReceivers(conf confMap, agent configManager) []any {
 	receivers := make(confMap)
 
@@ -103,7 +109,7 @@ func buildProcessors(conf confMap) []any {
 		"allow_hostname_override": true,
 		"cardinality":             2,
 	}
-	_ = converters.Set(processors, "infraattributes/default", infraattributes)
+	_ = converters.Set(processors, infraAttributesName, infraattributes)
 
 	metadata := confMap{
 		"attributes": []any{
@@ -122,7 +128,7 @@ func buildProcessors(conf confMap) []any {
 	_ = converters.Set(processors, "resource/dd-profiler-internal-metadata", metadata)
 
 	conf["processors"] = processors
-	return []any{"infraattributes/default", "resource/dd-profiler-internal-metadata"}
+	return []any{infraAttributesName, "resource/dd-profiler-internal-metadata"}
 }
 
 func buildMetricsTelemetry(conf confMap, healthMetrics healthMetricsConfig) {
@@ -184,15 +190,15 @@ func buildConfig(agent configManager, p params.CollectorParams) confMap {
 	buildMetricsPipeline(config, p.GetGoRuntimeMetrics(), agent.hostProfilerConfig.HealthMetrics, profilesProcessors, profilesExporters)
 
 	hpflareConf := confMap{"endpoint": fmt.Sprintf("localhost:%d", hpflareextension.EffectivePort(agent.hostProfilerConfig.HPFlare.Port))}
-	_ = converters.Set(config, "extensions::hpflare/default", hpflareConf)
-	serviceExtensions := []any{"hpflare/default"}
+	_ = converters.Set(config, "extensions::"+hpflareName, hpflareConf)
+	serviceExtensions := []any{hpflareName}
 	if agent.hostProfilerConfig.DDProfiling.Enabled {
 		ddprofilingConf := make(confMap)
 		if agent.hostProfilerConfig.DDProfiling.Period > 0 {
 			_ = converters.Set(ddprofilingConf, "profiler_options::period", agent.hostProfilerConfig.DDProfiling.Period)
 		}
-		_ = converters.Set(config, "extensions::ddprofiling/default", ddprofilingConf)
-		serviceExtensions = append(serviceExtensions, "ddprofiling/default")
+		_ = converters.Set(config, "extensions::"+ddprofilingName, ddprofilingConf)
+		serviceExtensions = append(serviceExtensions, ddprofilingName)
 	}
 	_ = converters.Set(config, "service::extensions", serviceExtensions)
 

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -45,7 +45,7 @@ func buildReceivers(conf confMap, agent configManager) []any {
 func buildExporters(conf confMap, agent configManager) []any {
 	const (
 		endpointFormat     = "https://otlp.%s"
-		otlpHTTPNameFormat = "otlphttp/%s_%d"
+		otlpHTTPNameFormat = "otlp_http/%s_%d"
 		debugExporterName  = "debug"
 	)
 

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
@@ -80,7 +80,7 @@ func TestBuildConfigDDProfilingEnabled(t *testing.T) {
 
 	extensions, ok := conf["extensions"].(confMap)
 	require.True(t, ok)
-	ddprofiling, ok := extensions["ddprofiling/default"].(confMap)
+	ddprofiling, ok := extensions[ddprofilingName].(confMap)
 	require.True(t, ok)
 	assert.Empty(t, ddprofiling, "ddprofiling config should be empty when period is not set")
 
@@ -88,8 +88,8 @@ func TestBuildConfigDDProfilingEnabled(t *testing.T) {
 	require.True(t, ok)
 	svcExtensions, ok := service["extensions"].([]any)
 	require.True(t, ok)
-	assert.Contains(t, svcExtensions, "ddprofiling/default")
-	assert.Contains(t, svcExtensions, "hpflare/default")
+	assert.Contains(t, svcExtensions, ddprofilingName)
+	assert.Contains(t, svcExtensions, hpflareName)
 }
 
 func TestBuildConfigDDProfilingEnabledWithPeriod(t *testing.T) {
@@ -107,7 +107,7 @@ func TestBuildConfigDDProfilingEnabledWithPeriod(t *testing.T) {
 
 	extensions, ok := conf["extensions"].(confMap)
 	require.True(t, ok)
-	ddprofiling, ok := extensions["ddprofiling/default"].(confMap)
+	ddprofiling, ok := extensions[ddprofilingName].(confMap)
 	require.True(t, ok)
 	profilerOptions, ok := ddprofiling["profiler_options"].(confMap)
 	require.True(t, ok)
@@ -117,7 +117,7 @@ func TestBuildConfigDDProfilingEnabledWithPeriod(t *testing.T) {
 	require.True(t, ok)
 	svcExtensions, ok := service["extensions"].([]any)
 	require.True(t, ok)
-	assert.Contains(t, svcExtensions, "ddprofiling/default")
+	assert.Contains(t, svcExtensions, ddprofilingName)
 }
 
 func TestBuildConfigDDProfilingDisabled(t *testing.T) {
@@ -132,15 +132,15 @@ func TestBuildConfigDDProfilingDisabled(t *testing.T) {
 
 	extensions, ok := conf["extensions"].(confMap)
 	require.True(t, ok)
-	_, ok = extensions["ddprofiling/default"]
+	_, ok = extensions[ddprofilingName]
 	assert.False(t, ok, "ddprofiling extension should not be present when disabled")
 
 	service, ok := conf["service"].(confMap)
 	require.True(t, ok)
 	svcExtensions, ok := service["extensions"].([]any)
 	require.True(t, ok)
-	assert.NotContains(t, svcExtensions, "ddprofiling/default")
-	assert.Contains(t, svcExtensions, "hpflare/default")
+	assert.NotContains(t, svcExtensions, ddprofilingName)
+	assert.Contains(t, svcExtensions, hpflareName)
 }
 
 func TestBuildConfigHPFlareCustomPort(t *testing.T) {
@@ -158,7 +158,7 @@ func TestBuildConfigHPFlareCustomPort(t *testing.T) {
 
 	extensions, ok := conf["extensions"].(confMap)
 	require.True(t, ok)
-	hpflare, ok := extensions["hpflare/default"].(confMap)
+	hpflare, ok := extensions[hpflareName].(confMap)
 	require.True(t, ok)
 	assert.Equal(t, "localhost:9999", hpflare["endpoint"])
 }
@@ -175,7 +175,7 @@ func TestBuildConfigHPFlareDefaultPort(t *testing.T) {
 
 	extensions, ok := conf["extensions"].(confMap)
 	require.True(t, ok)
-	hpflare, ok := extensions["hpflare/default"].(confMap)
+	hpflare, ok := extensions[hpflareName].(confMap)
 	require.True(t, ok)
 	assert.Equal(t, "localhost:7778", hpflare["endpoint"])
 }

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
@@ -33,7 +33,7 @@ func TestBuildExportersAdditionalHTTPHeaders(t *testing.T) {
 
 	exporters, ok := conf["exporters"].(confMap)
 	require.True(t, ok)
-	exporter, ok := exporters["otlphttp/datadoghq.com_0"].(confMap)
+	exporter, ok := exporters["otlp_http/datadoghq.com_0"].(confMap)
 	require.True(t, ok)
 	headers, ok := exporter["headers"].(confMap)
 	require.True(t, ok)
@@ -56,7 +56,7 @@ func TestBuildExportersNoAdditionalHTTPHeaders(t *testing.T) {
 
 	exporters, ok := conf["exporters"].(confMap)
 	require.True(t, ok)
-	exporter, ok := exporters["otlphttp/datadoghq.com_0"].(confMap)
+	exporter, ok := exporters["otlp_http/datadoghq.com_0"].(confMap)
 	require.True(t, ok)
 	headers, ok := exporter["headers"].(confMap)
 	require.True(t, ok)
@@ -198,7 +198,7 @@ func TestBuildExportersAdditionalHTTPHeadersDoNotOverrideRequired(t *testing.T) 
 
 	exporters, ok := conf["exporters"].(confMap)
 	require.True(t, ok)
-	exporter, ok := exporters["otlphttp/datadoghq.com_0"].(confMap)
+	exporter, ok := exporters["otlp_http/datadoghq.com_0"].(confMap)
 	require.True(t, ok)
 	headers, ok := exporter["headers"].(confMap)
 	require.True(t, ok)

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
@@ -1,7 +1,7 @@
 exporters:
     debug:
         verbosity: detailed
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -59,7 +59,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
                 - debug
             processors:
                 - filter
@@ -70,7 +70,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
                 - debug
             processors:
                 - infraattributes/default

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers-debug/otel.yaml
@@ -10,7 +10,7 @@ exporters:
             dd-evp-origin-version: 7.0.0-test
             x-datadog-profiling-metadata: workspace:peterg17
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -22,7 +22,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -55,7 +55,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -64,7 +64,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -73,7 +73,7 @@ service:
                 - otlp_http/datadoghq.com_0
                 - debug
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -58,7 +58,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -68,7 +68,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/add-headers/otel.yaml
@@ -9,7 +9,7 @@ exporters:
             x-custom-routing: some-value
             x-datadog-profiling-metadata: workspace:peterg17,env:staging
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -21,7 +21,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -54,7 +54,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -62,7 +62,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -70,7 +70,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.eu_0:
+    otlp_http/datadoghq.eu_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
         headers:
@@ -56,7 +56,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlp_http/datadoghq.eu_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +66,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlp_http/datadoghq.eu_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -19,7 +19,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -52,7 +52,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -60,7 +60,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -68,7 +68,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.eu_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -56,7 +56,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +66,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -19,7 +19,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -52,7 +52,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -60,7 +60,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -68,7 +68,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -58,7 +58,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -68,7 +68,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-enabled/otel.yaml
@@ -7,8 +7,8 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    ddprofiling/default: {}
-    hpflare/default:
+    ddprofiling: {}
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -20,7 +20,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -53,8 +53,8 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
-        - ddprofiling/default
+        - hpflare
+        - ddprofiling
     pipelines:
         metrics:
             exporters:
@@ -62,7 +62,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -70,7 +70,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
@@ -7,10 +7,10 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    ddprofiling/default:
+    ddprofiling:
         profiler_options:
             period: 30
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -22,7 +22,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -55,8 +55,8 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
-        - ddprofiling/default
+        - hpflare
+        - ddprofiling
     pipelines:
         metrics:
             exporters:
@@ -64,7 +64,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -72,7 +72,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/ddprofiling-period/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -60,7 +60,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -70,7 +70,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -56,7 +56,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +66,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-disabled/otel.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -19,7 +19,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -52,7 +52,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -60,7 +60,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -68,7 +68,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
@@ -9,7 +9,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -21,7 +21,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -54,7 +54,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -63,7 +63,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -72,7 +72,7 @@ service:
                 - otlp_http/datadoghq.com_0
                 - debug
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/debug-enabled/otel.yaml
@@ -1,7 +1,7 @@
 exporters:
     debug:
         verbosity: detailed
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -58,7 +58,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
                 - debug
             processors:
                 - filter
@@ -69,7 +69,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
                 - debug
             processors:
                 - infraattributes/default

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
@@ -14,7 +14,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -26,7 +26,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -61,7 +61,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -70,7 +70,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -79,7 +79,7 @@ service:
                 - otlp_http/datadoghq.com_0
                 - otlp_http/datadoghq.com_1
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
@@ -1,12 +1,12 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
             dd-api-key: additional_api_key
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
-    otlphttp/datadoghq.com_1:
+    otlp_http/datadoghq.com_1:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -65,8 +65,8 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
-                - otlphttp/datadoghq.com_1
+                - otlp_http/datadoghq.com_0
+                - otlp_http/datadoghq.com_1
             processors:
                 - filter
                 - cumulativetodelta
@@ -76,8 +76,8 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
-                - otlphttp/datadoghq.com_1
+                - otlp_http/datadoghq.com_0
+                - otlp_http/datadoghq.com_1
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-custom/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-custom/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -56,7 +56,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +66,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-custom/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-custom/otel.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -19,7 +19,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -52,7 +52,7 @@ receivers:
                         - 127.0.0.1:9090
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -60,7 +60,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -68,7 +68,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-disabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-disabled/otel.yaml
@@ -7,10 +7,10 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -30,13 +30,13 @@ receivers:
                   site: datadoghq.com
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         profiles:
             exporters:
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-disabled/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/health-metrics-disabled/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -34,7 +34,7 @@ service:
     pipelines:
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/hpflare-custom-port/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/hpflare-custom-port/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -56,7 +56,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +66,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/hpflare-custom-port/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/hpflare-custom-port/otel.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:9999
 processors:
     cumulativetodelta: {}
@@ -19,7 +19,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -52,7 +52,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -60,7 +60,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -68,7 +68,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
@@ -1,12 +1,12 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
             dd-api-key: test_api_key_123
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
-    otlphttp/us3.datadoghq.com_0:
+    otlp_http/us3.datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.us3.datadoghq.com
         headers:
@@ -65,8 +65,8 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/us3.datadoghq.com_0
-                - otlphttp/datadoghq.com_0
+                - otlp_http/us3.datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -76,8 +76,8 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/us3.datadoghq.com_0
-                - otlphttp/datadoghq.com_0
+                - otlp_http/us3.datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
@@ -14,7 +14,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -26,7 +26,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -61,7 +61,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -70,7 +70,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -79,7 +79,7 @@ service:
                 - otlp_http/us3.datadoghq.com_0
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/us3.datadoghq.com_0:
+    otlp_http/us3.datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.us3.datadoghq.com
         headers:
@@ -56,7 +56,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/us3.datadoghq.com_0
+                - otlp_http/us3.datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +66,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/us3.datadoghq.com_0
+                - otlp_http/us3.datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -19,7 +19,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -52,7 +52,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -60,7 +60,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -68,7 +68,7 @@ service:
             exporters:
                 - otlp_http/us3.datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
@@ -1,12 +1,12 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
             dd-api-key: main_key
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
-    otlphttp/datadoghq.eu_0:
+    otlp_http/datadoghq.eu_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
         headers:
@@ -65,8 +65,8 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.eu_0
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.eu_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -76,8 +76,8 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.eu_0
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.eu_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
@@ -14,7 +14,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -26,7 +26,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -61,7 +61,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -70,7 +70,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -79,7 +79,7 @@ service:
                 - otlp_http/datadoghq.eu_0
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
@@ -1,26 +1,26 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
             dd-api-key: main_key
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
-    otlphttp/datadoghq.eu_0:
+    otlp_http/datadoghq.eu_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
         headers:
             dd-api-key: eu_key_1
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
-    otlphttp/datadoghq.eu_1:
+    otlp_http/datadoghq.eu_1:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
         headers:
             dd-api-key: eu_key_2
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
-    otlphttp/datadoghq.eu_2:
+    otlp_http/datadoghq.eu_2:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
         headers:
@@ -83,10 +83,10 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.eu_0
-                - otlphttp/datadoghq.eu_1
-                - otlphttp/datadoghq.eu_2
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.eu_0
+                - otlp_http/datadoghq.eu_1
+                - otlp_http/datadoghq.eu_2
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -96,10 +96,10 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.eu_0
-                - otlphttp/datadoghq.eu_1
-                - otlphttp/datadoghq.eu_2
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.eu_0
+                - otlp_http/datadoghq.eu_1
+                - otlp_http/datadoghq.eu_2
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
@@ -28,7 +28,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -40,7 +40,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -79,7 +79,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -90,7 +90,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -101,7 +101,7 @@ service:
                 - otlp_http/datadoghq.eu_2
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multiple-endpoints/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multiple-endpoints/otel.yaml
@@ -1,15 +1,15 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         headers:
             dd-api-key: main_api_key
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
-    otlphttp/datadoghq.eu_0:
+    otlp_http/datadoghq.eu_0:
         headers:
             dd-api-key: eu_key_1
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
-    otlphttp/datadoghq.eu_1:
+    otlp_http/datadoghq.eu_1:
         headers:
             dd-api-key: eu_key_2
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
@@ -38,10 +38,10 @@ service:
     pipelines:
         profiles:
             exporters:
-                - otlphttp/datadoghq.eu_0
-                - otlphttp/datadoghq.eu_1
-                - otlphttp/datadoghq.com_0
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.eu_0
+                - otlp_http/datadoghq.eu_1
+                - otlp_http/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
             receivers:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.com_0:
+    otlp_http/datadoghq.com_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.com
         headers:
@@ -56,7 +56,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +66,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.com_0
+                - otlp_http/datadoghq.com_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -19,7 +19,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -52,7 +52,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -60,7 +60,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -68,7 +68,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.com_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.eu_0:
+    otlp_http/datadoghq.eu_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
         headers:
@@ -56,7 +56,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlp_http/datadoghq.eu_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +66,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlp_http/datadoghq.eu_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -19,7 +19,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -52,7 +52,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -60,7 +60,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -68,7 +68,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.eu_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp/datadoghq.eu_0:
+    otlp_http/datadoghq.eu_0:
         compression: zstd
         endpoint: https://otlp.datadoghq.eu
         headers:
@@ -56,7 +56,7 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlp_http/datadoghq.eu_0
             processors:
                 - filter
                 - cumulativetodelta
@@ -66,7 +66,7 @@ service:
                 - prometheus
         profiles:
             exporters:
-                - otlphttp/datadoghq.eu_0
+                - otlp_http/datadoghq.eu_0
             processors:
                 - infraattributes/default
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin: host-profiler-bundled
             dd-evp-origin-version: 7.0.0-test
 extensions:
-    hpflare/default:
+    hpflare:
         endpoint: localhost:7778
 processors:
     cumulativetodelta: {}
@@ -19,7 +19,7 @@ processors:
                     - ^scrape_.*$
                     - ^up$
                     - ^promhttp_metric_handler_errors_total$
-    infraattributes/default:
+    infraattributes:
         allow_hostname_override: true
         cardinality: 2
     resource/dd-profiler-internal-metadata:
@@ -52,7 +52,7 @@ receivers:
                         - 127.0.0.1:8889
 service:
     extensions:
-        - hpflare/default
+        - hpflare
     pipelines:
         metrics:
             exporters:
@@ -60,7 +60,7 @@ service:
             processors:
                 - filter
                 - cumulativetodelta
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus
@@ -68,7 +68,7 @@ service:
             exporters:
                 - otlp_http/datadoghq.eu_0
             processors:
-                - infraattributes/default
+                - infraattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -199,12 +199,12 @@ func TestConverterWithoutAgent(t *testing.T) {
 			expected: "no_agent/conv-nonstr-key-exp/out.yaml",
 		},
 		{
-			name:     "multiple-otlphttp-exporters",
+			name:     "multiple-otlp_http-exporters",
 			provided: "no_agent/multi-otlp-exp/in.yaml",
 			expected: "no_agent/multi-otlp-exp/out.yaml",
 		},
 		{
-			name:     "ignores-non-otlphttp",
+			name:     "ignores-non-otlp_http",
 			provided: "no_agent/ignore-non-otlp/in.yaml",
 			expected: "no_agent/ignore-non-otlp/out.yaml",
 		},
@@ -306,14 +306,14 @@ func TestConverterWithoutAgentErrors(t *testing.T) {
 			expectedError: "symbol_endpoints cannot be empty",
 		},
 		{
-			name:          "errors-when-no-otlphttp",
+			name:          "errors-when-no-otlp_http",
 			provided:      "no_agent/error-no-otlp/in.yaml",
-			expectedError: "no otlphttp exporter configured",
+			expectedError: "no otlp_http exporter configured",
 		},
 		{
 			name:          "empty-pipeline",
 			provided:      "no_agent/empty-pipeline/in.yaml",
-			expectedError: "no otlphttp exporter configured",
+			expectedError: "no otlp_http exporter configured",
 		},
 		{
 			name:          "non-string-processor-name-in-pipeline",

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -283,6 +283,11 @@ func TestConverterWithoutAgent(t *testing.T) {
 			provided: "no_agent/int-metrics-mixed/in.yaml",
 			expected: "no_agent/int-metrics-mixed/out.yaml",
 		},
+		{
+			name:     "deprecated-otlphttp-name-accepted",
+			provided: "no_agent/deprecated-otlphttp/in.yaml",
+			expected: "no_agent/deprecated-otlphttp/out.yaml",
+		},
 	}
 
 	runSuccessTests(t, newConverterWithoutAgent(confmap.ConverterSettings{Logger: zap.NewNop()}), tests)

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -42,8 +42,8 @@ var resourceDetectionDefaultConfig = confMap{
 //   - If no resourcedetection processor used, declare & use a minimal resourcedetection processor
 //   - No infraattributes processor configured nor declared
 //   - remove infraattributes processor from metrics processors pipeline
-//   - At least one otlphttpexporter with dd-api-key declared & used
-//   - Check if used otlphttpexporter has dd-api-key as string, if not string convert it, if not at all notify user
+//   - At least one otlp_http exporter with dd-api-key declared & used
+//   - Check if used otlp_http exporter has dd-api-key as string, if not string convert it, if not at all notify user
 //   - If profiling::symbol_uploader::enabled == true, convert api_key/app_key to strings in each endpoint
 //   - If no profiling is used & configured, add minimal one with symbol_uploader: false
 //   - remove hpflare extensions
@@ -80,7 +80,7 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 		return err
 	}
 
-	// If there's no otlphttpexporter configured. We can't infer necessary configurations as it needs URLs and API keys
+	// If there's no otlp_http exporter configured. We can't infer necessary configurations as it needs URLs and API keys
 	// so if nothing is found, notify user
 	if err := c.ensureOtlpHTTPExporterConfig(confStringMap, exporterNames); err != nil {
 		return err
@@ -349,7 +349,7 @@ func (c *converterWithoutAgent) checkProfilingReceiverConfig(profiling confMap) 
 }
 
 func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, exporterNames []any) error {
-	// for each otlphttpexporter used, check if necessary api key is present
+	// for each otlp_http exporter used, check if necessary api key is present
 	hasOtlpHTTP := false
 	for _, nameAny := range exporterNames {
 		if name, ok := nameAny.(string); ok && isComponentType(name, componentTypeOtlpHTTP) {
@@ -377,7 +377,7 @@ func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, expor
 	}
 
 	if !hasOtlpHTTP {
-		return errors.New("no otlphttp exporter configured in profiles pipeline")
+		return errors.New("no otlp_http exporter configured in profiles pipeline")
 	}
 
 	return nil
@@ -501,7 +501,7 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 
 		profilesEndpoint, ok := Get[string](exporterConf, "profiles_endpoint")
 		if !ok {
-			slog.Warn("otlphttp exporter missing endpoint and profiles_endpoint, cannot infer metrics endpoint",
+			slog.Warn("otlp_http exporter missing endpoint and profiles_endpoint, cannot infer metrics endpoint",
 				slog.String("exporter", exporterName))
 			continue
 		}

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -352,7 +352,7 @@ func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, expor
 	// for each otlp_http exporter used, check if necessary api key is present
 	hasOtlpHTTP := false
 	for _, nameAny := range exporterNames {
-		if name, ok := nameAny.(string); ok && isComponentType(name, componentTypeOtlpHTTP) {
+		if name, ok := nameAny.(string); ok && isComponentTypeOtlpHTTP(name) {
 			hasOtlpHTTP = true
 
 			if _, err := SetDefault(conf, pathPrefixExporters+name+"::compression", "zstd"); err != nil {
@@ -474,7 +474,7 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 			continue
 		}
 
-		if !isComponentType(exporterName, componentTypeOtlpHTTP) {
+		if !isComponentTypeOtlpHTTP(exporterName) {
 			continue
 		}
 

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -34,7 +34,7 @@ const (
 	componentTypeResourceDetection   = "resourcedetection"
 	componentTypeDDHostNameProcessor = "ddhostname"
 	componentTypeProfiling           = "profiling"
-	componentTypeOtlpHTTP            = "otlphttp"
+	componentTypeOtlpHTTP            = "otlp_http"
 	componentTypeDDProfiling         = "ddprofiling"
 	componentTypeHPFlare             = "hpflare"
 )
@@ -79,7 +79,7 @@ const (
 
 // isComponentType checks if a component name matches a specific type.
 // OTEL components follow the naming convention: "type" or "type/id"
-// Examples: "otlphttp", "otlphttp/prod", "profiling/custom"
+// Examples: "otlp_http", "otlp_http/prod", "profiling/custom"
 func isComponentType(name, componentType string) bool {
 	return name == componentType || strings.HasPrefix(name, componentType+"/")
 }

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -39,9 +39,14 @@ const (
 	componentTypeResourceDetection   = "resourcedetection"
 	componentTypeDDHostNameProcessor = "ddhostname"
 	componentTypeProfiling           = "profiling"
-	componentTypeOtlpHTTP            = "otlp_http"
 	componentTypeDDProfiling         = "ddprofiling"
 	componentTypeHPFlare             = "hpflare"
+)
+
+// Component type names for otlp_http
+const (
+	componentTypeOtlpHTTP           = "otlp_http"
+	componentTypeOtlpHTTPDeprecated = "otlphttp"
 )
 
 // Default component names
@@ -87,6 +92,11 @@ const (
 // Examples: "otlp_http", "otlp_http/prod", "profiling/custom"
 func isComponentType(name, componentType string) bool {
 	return name == componentType || strings.HasPrefix(name, componentType+"/")
+}
+
+// isComponentTypeOtlpHTTP checks for both the current ("otlp_http") and deprecated ("otlphttp") component names.
+func isComponentTypeOtlpHTTP(name string) bool {
+	return isComponentType(name, componentTypeOtlpHTTP) || isComponentType(name, componentTypeOtlpHTTPDeprecated)
 }
 
 // Get retrieves a value of type T from the confMap at the given path.

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -28,6 +28,11 @@ func NewFactoryWithoutAgent() confmap.ConverterFactory {
 
 type confMap = map[string]any
 
+// AutoConfiguredID is the OTEL component name suffix used for all components
+// that are automatically injected by the host profiler (as opposed to components
+// explicitly declared by the user).
+const AutoConfiguredID = "dd-autoconfigured"
+
 // Component type names for OTEL configuration
 const (
 	componentTypeInfraAttributes     = "infraattributes"
@@ -41,9 +46,9 @@ const (
 
 // Default component names
 const (
-	defaultInfraAttributesName     = "infraattributes/default"
-	defaultResourceDetectionName   = "resourcedetection/default"
-	defaultDDHostNameProcessorName = "ddhostname/default"
+	defaultInfraAttributesName     = componentTypeInfraAttributes + "/" + AutoConfiguredID
+	defaultResourceDetectionName   = componentTypeResourceDetection + "/" + AutoConfiguredID
+	defaultDDHostNameProcessorName = componentTypeDDHostNameProcessor + "/" + AutoConfiguredID
 	defaultProfilingName           = "profiling"
 )
 

--- a/comp/host-profiler/collector/impl/converters/converters_test.go
+++ b/comp/host-profiler/collector/impl/converters/converters_test.go
@@ -133,7 +133,7 @@ func TestGetIntermediateNodeNotMap(t *testing.T) {
 	require.False(t, ok)
 
 	// Intermediate node is array
-	_, ok = Get[string](cm, "exporters::otlphttp::headers")
+	_, ok = Get[string](cm, "exporters::otlp_http::headers")
 	require.False(t, ok)
 }
 
@@ -348,12 +348,12 @@ func TestConverterWithoutAgentPreservesExpandedValues(t *testing.T) {
 				"profiles": confMap{
 					"receivers":  []any{"profiling"},
 					"processors": []any{},
-					"exporters":  []any{"otlphttp"},
+					"exporters":  []any{"otlp_http"},
 				},
 			},
 		},
 		"exporters": confMap{
-			"otlphttp": confMap{
+			"otlp_http": confMap{
 				"headers": confMap{
 					"dd-api-key": xconfmap.ExpandedValue{Value: 6.7, Original: "6.7"},
 				},
@@ -373,7 +373,7 @@ func TestConverterWithoutAgentPreservesExpandedValues(t *testing.T) {
 	require.NoError(t, err)
 
 	convertedMap := xconfmap.ToStringMapRaw(conf)
-	headers, _ := Get[confMap](convertedMap, "exporters::otlphttp::headers")
+	headers, _ := Get[confMap](convertedMap, "exporters::otlp_http::headers")
 	expandedVal, ok := headers["dd-api-key"].(xconfmap.ExpandedValue)
 	require.True(t, ok, "dd-api-key should still be an ExpandedValue, got type: %T", headers["dd-api-key"])
 	require.Equal(t, 6.7, expandedVal.Value)

--- a/comp/host-profiler/collector/impl/converters/testdata/adds_resource_processor.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/adds_resource_processor.yaml
@@ -3,7 +3,7 @@ service:
     profiles:
       receivers: [profiling]
       processors: [batch, infraattributes]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 receivers:
   profiling:
     symbol_uploader:
@@ -14,6 +14,6 @@ processors:
   infraattributes:
     allow_hostname_override: true
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/in.yaml
@@ -7,8 +7,8 @@ service:
       receivers:
       - otlp
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -37,7 +37,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-missing/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -39,8 +39,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/in.yaml
@@ -7,8 +7,8 @@ service:
       receivers:
       - otlp
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -37,7 +37,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/add-prof-to-pipe/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -39,8 +39,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-err-from-ensure/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-err-from-ensure/in.yaml
@@ -1,6 +1,6 @@
 service:
   pipelines: not-a-map
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/in.yaml
@@ -12,8 +12,8 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -41,8 +41,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-apikey/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -39,7 +39,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/in.yaml
@@ -12,8 +12,8 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -41,8 +41,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-appkey/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -39,7 +39,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/in.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: 12345
 service:
@@ -7,4 +7,4 @@ service:
     profiles:
       processors: []
       receivers: []
-      exporters: [otlphttp]
+      exporters: [otlp_http]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -38,8 +38,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/conv-nonstr-key-exp/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: "12345"
@@ -36,7 +36,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/in.yaml
@@ -4,8 +4,8 @@ service:
       processors: []
       receivers: []
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -38,8 +38,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/create-default-prof/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -36,7 +36,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/deprecated-otlphttp/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/deprecated-otlphttp/in.yaml
@@ -1,0 +1,11 @@
+exporters:
+  otlphttp/prod:
+    headers:
+      dd-api-key: test-api-key
+    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: [otlphttp/prod]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/deprecated-otlphttp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/deprecated-otlphttp/out.yaml
@@ -1,0 +1,80 @@
+exporters:
+    otlphttp/prod:
+        compression: zstd
+        headers:
+            dd-api-key: test-api-key
+            dd-evp-origin: host-profiler-standalone
+            dd-evp-origin-version: 7.0.0-test
+        metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+processors:
+    cumulativetodelta/dd-hp-internal: {}
+    ddhostname/dd-autoconfigured: {}
+    filter/dd-hp-drop-internal:
+        metrics:
+            exclude:
+                match_type: regexp
+                metric_names:
+                    - ^scrape_.*$
+                    - ^up$
+                    - ^promhttp_metric_handler_errors_total$
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: telemetry.distro.name
+              value: host-profiler-standalone
+            - action: upsert
+              key: telemetry.distro.version
+              value: 7.0.0-test
+    resourcedetection/dd-autoconfigured:
+        detectors:
+            - system
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: true
+                host.name:
+                    enabled: false
+                os.type:
+                    enabled: false
+receivers:
+    profiling:
+        symbol_uploader:
+            enabled: false
+    prometheus/dd-hp-internal:
+        config:
+            scrape_configs:
+                - fallback_scrape_protocol: PrometheusText0.0.4
+                  job_name: host-profiler-internal
+                  metric_name_escaping_scheme: underscores
+                  metric_name_validation_scheme: legacy
+                  scrape_interval: 60s
+                  scrape_protocols:
+                    - PrometheusText0.0.4
+                  static_configs:
+                    - targets:
+                        - 127.0.0.1:8889
+service:
+    pipelines:
+        metrics:
+            processors: []
+        metrics/profiler-internal-health:
+            exporters:
+                - otlphttp/prod
+            processors:
+                - filter/dd-hp-drop-internal
+                - cumulativetodelta/dd-hp-internal
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - prometheus/dd-hp-internal
+        profiles:
+            exporters:
+                - otlphttp/prod
+            processors:
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/in.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key
 service:
@@ -8,4 +8,4 @@ service:
       processors: []
       receivers: []
       exporters:
-      - otlphttp
+      - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -38,8 +38,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ensures-headers/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -36,7 +36,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/in.yaml
@@ -1,7 +1,7 @@
 processors: "not a map"
 
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-key
 
@@ -11,4 +11,4 @@ service:
       processors:
         - batch
       exporters:
-        - otlphttp
+        - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-key
@@ -36,7 +36,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - batch
                 - resourcedetection/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/global-procs-notmap/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -39,8 +39,8 @@ service:
                 - otlp_http
             processors:
                 - batch
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/in.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key
 service:
@@ -8,4 +8,4 @@ service:
       processors: []
       receivers: []
       exporters:
-      - otlphttp
+      - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -38,8 +38,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/headers-wrong-type/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -36,7 +36,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/in.yaml
@@ -1,7 +1,7 @@
 exporters:
   logging: {}
   debug: {}
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key
 service:
@@ -12,4 +12,4 @@ service:
       exporters:
       - logging
       - debug
-      - otlphttp
+      - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/out.yaml
@@ -1,7 +1,7 @@
 exporters:
     debug: {}
     logging: {}
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -40,7 +40,7 @@ service:
             exporters:
                 - logging
                 - debug
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/ignore-non-otlp/out.yaml
@@ -8,7 +8,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -17,7 +17,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -42,8 +42,8 @@ service:
                 - debug
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-bare-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-bare-ep/out.yaml
@@ -8,7 +8,7 @@ exporters:
             dd-evp-origin-version: 7.0.0-test
 processors:
     cumulativetodelta/dd-hp-internal: {}
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     filter/dd-hp-drop-internal:
         metrics:
             exclude:
@@ -25,7 +25,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -63,8 +63,8 @@ service:
             processors:
                 - filter/dd-hp-drop-internal
                 - cumulativetodelta/dd-hp-internal
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus/dd-hp-internal
@@ -72,8 +72,8 @@ service:
             exporters:
                 - otlphttp
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-existing-ep/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-existing-ep/in.yaml
@@ -9,9 +9,9 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key
     profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-existing-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-existing-ep/out.yaml
@@ -9,7 +9,7 @@ exporters:
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     cumulativetodelta/dd-hp-internal: {}
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     filter/dd-hp-drop-internal:
         metrics:
             exclude:
@@ -26,7 +26,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -64,8 +64,8 @@ service:
             processors:
                 - filter/dd-hp-drop-internal
                 - cumulativetodelta/dd-hp-internal
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus/dd-hp-internal
@@ -73,8 +73,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-existing-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-existing-ep/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -60,7 +60,7 @@ service:
             processors: []
         metrics/profiler-internal-health:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - filter/dd-hp-drop-internal
                 - cumulativetodelta/dd-hp-internal
@@ -71,7 +71,7 @@ service:
                 - prometheus/dd-hp-internal
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-infer-ep/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-infer-ep/in.yaml
@@ -9,9 +9,9 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key
     profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-infer-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-infer-ep/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -60,7 +60,7 @@ service:
             processors: []
         metrics/profiler-internal-health:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - filter/dd-hp-drop-internal
                 - cumulativetodelta/dd-hp-internal
@@ -71,7 +71,7 @@ service:
                 - prometheus/dd-hp-internal
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-infer-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-infer-ep/out.yaml
@@ -9,7 +9,7 @@ exporters:
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 processors:
     cumulativetodelta/dd-hp-internal: {}
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     filter/dd-hp-drop-internal:
         metrics:
             exclude:
@@ -26,7 +26,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -64,8 +64,8 @@ service:
             processors:
                 - filter/dd-hp-drop-internal
                 - cumulativetodelta/dd-hp-internal
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus/dd-hp-internal
@@ -73,8 +73,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-level-none/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-level-none/in.yaml
@@ -12,9 +12,9 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key
     profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-level-none/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-level-none/out.yaml
@@ -7,7 +7,7 @@ exporters:
             dd-evp-origin-version: 7.0.0-test
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -16,7 +16,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -39,8 +39,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-level-none/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-level-none/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -37,7 +37,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-mixed/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-mixed/in.yaml
@@ -9,13 +9,13 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp/with-ep
-      - otlphttp/no-ep
+      - otlp_http/with-ep
+      - otlp_http/no-ep
 exporters:
-  otlphttp/with-ep:
+  otlp_http/with-ep:
     headers:
       dd-api-key: test-api-key-1
     profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
-  otlphttp/no-ep:
+  otlp_http/no-ep:
     headers:
       dd-api-key: test-api-key-2

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-mixed/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-mixed/out.yaml
@@ -1,11 +1,11 @@
 exporters:
-    otlphttp/no-ep:
+    otlp_http/no-ep:
         compression: zstd
         headers:
             dd-api-key: test-api-key-2
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
-    otlphttp/with-ep:
+    otlp_http/with-ep:
         compression: zstd
         headers:
             dd-api-key: test-api-key-1
@@ -66,7 +66,7 @@ service:
             processors: []
         metrics/profiler-internal-health:
             exporters:
-                - otlphttp/with-ep
+                - otlp_http/with-ep
             processors:
                 - filter/dd-hp-drop-internal
                 - cumulativetodelta/dd-hp-internal
@@ -77,8 +77,8 @@ service:
                 - prometheus/dd-hp-internal
         profiles:
             exporters:
-                - otlphttp/with-ep
-                - otlphttp/no-ep
+                - otlp_http/with-ep
+                - otlp_http/no-ep
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-mixed/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-mixed/out.yaml
@@ -15,7 +15,7 @@ exporters:
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
     cumulativetodelta/dd-hp-internal: {}
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     filter/dd-hp-drop-internal:
         metrics:
             exclude:
@@ -32,7 +32,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -70,8 +70,8 @@ service:
             processors:
                 - filter/dd-hp-drop-internal
                 - cumulativetodelta/dd-hp-internal
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus/dd-hp-internal
@@ -80,8 +80,8 @@ service:
                 - otlp_http/with-ep
                 - otlp_http/no-ep
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-prefer-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/int-metrics-prefer-ep/out.yaml
@@ -9,7 +9,7 @@ exporters:
         profiles_endpoint: https://otlp.datadoghq.com/v1development/profiles
 processors:
     cumulativetodelta/dd-hp-internal: {}
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     filter/dd-hp-drop-internal:
         metrics:
             exclude:
@@ -26,7 +26,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -64,8 +64,8 @@ service:
             processors:
                 - filter/dd-hp-drop-internal
                 - cumulativetodelta/dd-hp-internal
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus/dd-hp-internal
@@ -73,8 +73,8 @@ service:
             exporters:
                 - otlphttp
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/in.yaml
@@ -1,8 +1,8 @@
 exporters:
-  otlphttp/prod:
+  otlp_http/prod:
     headers:
       dd-api-key: 11111
-  otlphttp/staging:
+  otlp_http/staging:
     headers:
       dd-api-key: staging-key
   logging: {}
@@ -11,4 +11,4 @@ service:
     profiles:
       processors: []
       receivers: []
-      exporters: [otlphttp/prod, otlphttp/staging, logging]
+      exporters: [otlp_http/prod, otlp_http/staging, logging]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/out.yaml
@@ -1,12 +1,12 @@
 exporters:
     logging: {}
-    otlphttp/prod:
+    otlp_http/prod:
         compression: zstd
         headers:
             dd-api-key: "11111"
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
-    otlphttp/staging:
+    otlp_http/staging:
         compression: zstd
         headers:
             dd-api-key: staging-key
@@ -43,8 +43,8 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp/prod
-                - otlphttp/staging
+                - otlp_http/prod
+                - otlp_http/staging
                 - logging
             processors:
                 - resourcedetection/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-otlp-exp/out.yaml
@@ -13,7 +13,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -22,7 +22,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -47,8 +47,8 @@ service:
                 - otlp_http/staging
                 - logging
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/in.yaml
@@ -19,8 +19,8 @@ service:
       - profiling
       - profiling/custom
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -45,7 +45,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-profiling-recv/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -47,8 +47,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/in.yaml
@@ -14,8 +14,8 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -41,7 +41,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-symbol-ep/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -43,8 +43,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/nonstr-proc-pipeline/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/nonstr-proc-pipeline/in.yaml
@@ -10,8 +10,8 @@ service:
       - infraattributes
       receivers: []
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/nonstr-recv-pipeline/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/nonstr-recv-pipeline/in.yaml
@@ -6,8 +6,8 @@ service:
       - 123
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/in.yaml
@@ -14,7 +14,7 @@ processors:
         os.type:
           enabled: true
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: "test-key"
 service:
@@ -22,4 +22,4 @@ service:
     profiles:
       receivers: [profiling]
       processors: [resourcedetection]
-      exporters: [otlphttp]
+      exporters: [otlp_http]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -39,7 +39,7 @@ service:
                 - otlp_http
             processors:
                 - resourcedetection
-                - ddhostname/default
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-all-res-attrs/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-key
@@ -36,7 +36,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/in.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key
       dd-evp-origin: custom-origin
@@ -9,4 +9,4 @@ service:
     profiles:
       processors: []
       receivers: []
-      exporters: [otlphttp]
+      exporters: [otlp_http]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: custom-origin
             dd-evp-origin-version: custom-version
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -38,8 +38,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-evp-headers/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -36,7 +36,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/in.yaml
@@ -10,7 +10,7 @@ processors:
         host.arch:
           enabled: false
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: "test-key"
 service:
@@ -18,4 +18,4 @@ service:
     profiles:
       receivers: [profiling]
       processors: [resourcedetection]
-      exporters: [otlphttp]
+      exporters: [otlp_http]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-key
@@ -32,7 +32,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-arch/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -35,7 +35,7 @@ service:
                 - otlp_http
             processors:
                 - resourcedetection
-                - ddhostname/default
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/in.yaml
@@ -10,7 +10,7 @@ processors:
         host.name:
           enabled: true
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: "test-key"
 service:
@@ -18,4 +18,4 @@ service:
     profiles:
       receivers: [profiling]
       processors: [resourcedetection]
-      exporters: [otlphttp]
+      exporters: [otlp_http]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-key
@@ -34,7 +34,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-host-name/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -37,7 +37,7 @@ service:
                 - otlp_http
             processors:
                 - resourcedetection
-                - ddhostname/default
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/in.yaml
@@ -10,7 +10,7 @@ processors:
         os.type:
           enabled: true
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: "test-key"
 service:
@@ -18,4 +18,4 @@ service:
     profiles:
       receivers: [profiling]
       processors: [resourcedetection]
-      exporters: [otlphttp]
+      exporters: [otlp_http]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-key
@@ -34,7 +34,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-os-type/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -37,7 +37,7 @@ service:
                 - otlp_http
             processors:
                 - resourcedetection
-                - ddhostname/default
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/in.yaml
@@ -9,8 +9,8 @@ service:
       processors: []
       receivers: []
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -42,8 +42,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-otlp-proto/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -40,7 +40,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/in.yaml
@@ -12,7 +12,7 @@ processors:
         host.name:
           enabled: true
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: "test-key"
 service:
@@ -20,4 +20,4 @@ service:
     profiles:
       receivers: [profiling]
       processors: [resourcedetection]
-      exporters: [otlphttp]
+      exporters: [otlp_http]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-key
@@ -37,7 +37,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/preserve-res-no-sys/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -40,7 +40,7 @@ service:
                 - otlp_http
             processors:
                 - resourcedetection
-                - ddhostname/default
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/in.yaml
@@ -7,7 +7,7 @@ processors:
     timeout: 10s
 
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-key
 
@@ -19,4 +19,4 @@ service:
         - infraattributes_custom
         - batch
       exporters:
-        - otlphttp
+        - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/out.yaml
@@ -8,7 +8,7 @@ exporters:
 processors:
     batch:
         timeout: 10s
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     infraattributes_custom:
         other_config: value
     myinfraat tributes:
@@ -21,7 +21,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -47,8 +47,8 @@ service:
                 - myinfraattributes
                 - infraattributes_custom
                 - batch
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/proc-name-similar/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-key
@@ -42,7 +42,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - myinfraattributes
                 - infraattributes_custom

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-proc-empty/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-proc-empty/in.yaml
@@ -3,7 +3,7 @@ service:
     profiles:
       receivers: [profiling]
       processors: [resource/dd-profiler-internal-metadata]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 receivers:
   profiling:
     symbol_uploader:
@@ -11,6 +11,6 @@ receivers:
 processors:
   resource/dd-profiler-internal-metadata: {}
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-proc-exists/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-proc-exists/in.yaml
@@ -3,7 +3,7 @@ service:
     profiles:
       receivers: [profiling]
       processors: [resource/dd-profiler-internal-metadata]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 receivers:
   profiling:
     symbol_uploader:
@@ -15,6 +15,6 @@ processors:
         value: some_value
         action: upsert
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-proc-in-pipeline/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/reserved-proc-in-pipeline/in.yaml
@@ -3,12 +3,12 @@ service:
     profiles:
       receivers: [profiling]
       processors: [resource/dd-profiler-internal-metadata]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 receivers:
   profiling:
     symbol_uploader:
       enabled: false
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/in.yaml
@@ -3,7 +3,7 @@ service:
     profiles:
       receivers: [profiling]
       processors: [batch]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
   extensions:
     - ddprofiling
     - hpflare
@@ -33,7 +33,7 @@ receivers:
       enabled: false
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: http://localhost:4318
     headers:
       dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
@@ -17,7 +17,7 @@ processors:
     batch:
         timeout: 10s
     cumulativetodelta/dd-hp-internal: {}
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     filter/dd-hp-drop-internal:
         metrics:
             exclude:
@@ -34,7 +34,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -72,13 +72,13 @@ service:
             processors: []
         metrics/profiler-internal-health:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - filter/dd-hp-drop-internal
                 - cumulativetodelta/dd-hp-internal
                 - batch
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - prometheus/dd-hp-internal
@@ -87,8 +87,8 @@ service:
                 - otlp_http
             processors:
                 - batch
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         endpoint: http://localhost:4318
         headers:
@@ -84,7 +84,7 @@ service:
                 - prometheus/dd-hp-internal
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - batch
                 - resourcedetection/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-infraattr-metrics/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-infraattr-metrics/in.yaml
@@ -7,7 +7,7 @@ processors:
     timeout: 10s
 
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-key
 
@@ -17,11 +17,11 @@ service:
       processors:
         - batch
       exporters:
-        - otlphttp
+        - otlp_http
     metrics:
       processors:
         - infraattributes
         - infraattributes/custom
         - batch
       exporters:
-        - otlphttp
+        - otlp_http

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-infraattr-metrics/out.yaml
@@ -8,7 +8,7 @@ exporters:
 processors:
     batch:
         timeout: 10s
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -17,7 +17,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -44,8 +44,8 @@ service:
                 - otlp_http
             processors:
                 - batch
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-infraattr-metrics/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-key
@@ -36,12 +36,12 @@ service:
     pipelines:
         metrics:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - batch
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - batch
                 - resourcedetection/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/in.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key
 service:
@@ -7,4 +7,4 @@ service:
     profiles:
       processors: []
       receivers: []
-      exporters: [otlphttp]
+      exporters: [otlp_http]

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -38,8 +38,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/str-key-exporter/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -36,7 +36,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-ep-wrongtype/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-ep-wrongtype/in.yaml
@@ -10,8 +10,8 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/in.yaml
@@ -9,8 +9,8 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -38,8 +38,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-disabled/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -36,7 +36,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-empty-ep/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-empty-ep/in.yaml
@@ -10,8 +10,8 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/in.yaml
@@ -12,8 +12,8 @@ service:
       receivers:
       - profiling
       exporters:
-      - otlphttp
+      - otlp_http
 exporters:
-  otlphttp:
+  otlp_http:
     headers:
       dd-api-key: test-api-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/out.yaml
@@ -6,7 +6,7 @@ exporters:
             dd-evp-origin: host-profiler-standalone
             dd-evp-origin-version: 7.0.0-test
 processors:
-    ddhostname/default: {}
+    ddhostname/dd-autoconfigured: {}
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -15,7 +15,7 @@ processors:
             - action: upsert
               key: telemetry.distro.version
               value: 7.0.0-test
-    resourcedetection/default:
+    resourcedetection/dd-autoconfigured:
         detectors:
             - system
         system:
@@ -41,8 +41,8 @@ service:
             exporters:
                 - otlp_http
             processors:
-                - resourcedetection/default
-                - ddhostname/default
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - profiling

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/symbol-up-str-keys/out.yaml
@@ -1,5 +1,5 @@
 exporters:
-    otlphttp:
+    otlp_http:
         compression: zstd
         headers:
             dd-api-key: test-api-key
@@ -39,7 +39,7 @@ service:
             processors: []
         profiles:
             exporters:
-                - otlphttp
+                - otlp_http
             processors:
                 - resourcedetection/default
                 - ddhostname/default


### PR DESCRIPTION
### What does this PR do?

  - renamed every deprecated otlphttp to otlp_http
  - renamed every deprecated k8sattributes to k8s_attributes
  - cleaned up host-profiler-config.yaml
  - normalized autoconfigured components to the same name as DDOT

### Motivation

### Describe how you validated your changes
Tested locally, verified on [rel-env](https://ddstaging.datadoghq.com/profiling/explorer?query=telemetry.distro.version%3A7.81.0-devel_git.232.173f7ed.theomagellan-config-cleanup%20OR%20profiler_version%3A7.81.0-devel_git.232.173f7ed.theomagellan-config-cleanup&agg_m=%40prof_ebpf_cpu_cores&agg_m_source=base&agg_t=sum&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&fromUser=true&my_code=disabled&refresh_mode=sliding&viz=stream&from_ts=1779089322882&to_ts=1779092922882&live=true)

### Additional Notes
