### PR TITLE
Increase timeout for CodeQL Scan

### DIFF
--- a/.gitlab/build/source_test/codeql_scan.yml
+++ b/.gitlab/build/source_test/codeql_scan.yml
@@ -4,6 +4,7 @@
 
 run_codeql_scan:
   image: registry.ddbuild.io/code-scanning:v89505840-d7f7832-datadog-agent
+  timeout: 5h
   tags: ["arch:amd64", "specific:true"]
   extends: .dd_octo_sts
   stage: source_test


### PR DESCRIPTION
### What does this PR do?

- Increase timeout for CodeQL Scan

### Motivation

We've been getting [timeout errors from CodeQL Scans](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40duration%3A%3E0%20%40ci.job.name%3Arun_codeql_scan%20-%40ci.status%3Arunning&agg_m=count&agg_m_source=base&agg_q=%40ci.status&agg_q_source=base&agg_t=count&buildLevel=job&cipipeline_explorer_sort=time%2Cdesc&colorBy=meta%5B%27ci.stage.name%27%5D&colorByAttr=meta%5B%27ci.stage.name%27%5D&currentTab=trace&fromUser=false&index=cipipeline&mode=sliding&refresh_mode=sliding&spanViewType=metadata&tab=overview&top_n=10&top_o=top&viz=timeseries&x_missing=true&start=1774014507564&end=1779198507564&paused=false)


### Describe how you validated your changes

### Additional Notes
