### PR TITLE
[ACIX-1620] Wire RC inside E2E tests

### DIFF
--- a/test/e2e-framework/components/datadog/agent/ecs.go
+++ b/test/e2e-framework/components/datadog/agent/ecs.go
@@ -26,6 +26,11 @@ func ECSLinuxDaemonDefinition(e aws.Environment, name string, apiKeySSMParamName
 		return nil, err
 	}
 
+	containerDef, err := ecsLinuxAgentSingleContainerDefinition(&e, apiKeySSMParamName, fakeintake, params)
+	if err != nil {
+		return nil, err
+	}
+
 	return ecs.NewEC2Service(e.Ctx(), e.Namer.ResourceName(name), &ecs.EC2ServiceArgs{
 		Name:               e.CommonNamer().DisplayName(255, pulumi.String(name)),
 		Cluster:            clusterArn,
@@ -39,7 +44,7 @@ func ECSLinuxDaemonDefinition(e aws.Environment, name string, apiKeySSMParamName
 		EnableExecuteCommand: pulumi.BoolPtr(true),
 		TaskDefinitionArgs: &ecs.EC2ServiceTaskDefinitionArgs{
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
-				"datadog-agent": ecsLinuxAgentSingleContainerDefinition(&e, apiKeySSMParamName, fakeintake, params),
+				"datadog-agent": containerDef,
 			},
 			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
 				RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
@@ -80,7 +85,11 @@ func ECSLinuxDaemonDefinition(e aws.Environment, name string, apiKeySSMParamName
 	}, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
 }
 
-func ecsLinuxAgentSingleContainerDefinition(e config.Env, apiKeySSMParamName pulumi.StringInput, fakeintake *fakeintake.Fakeintake, params *ecsagentparams.Params) ecs.TaskDefinitionContainerDefinitionArgs {
+func ecsLinuxAgentSingleContainerDefinition(e config.Env, apiKeySSMParamName pulumi.StringInput, fi *fakeintake.Fakeintake, params *ecsagentparams.Params) (ecs.TaskDefinitionContainerDefinitionArgs, error) {
+	fiEnv, err := ecsFakeintakeAdditionalEndpointsEnv(fi)
+	if err != nil {
+		return ecs.TaskDefinitionContainerDefinitionArgs{}, err
+	}
 	return ecs.TaskDefinitionContainerDefinitionArgs{
 		Cpu:       pulumi.IntPtr(200),
 		Memory:    pulumi.IntPtr(512),
@@ -151,7 +160,7 @@ func ecsLinuxAgentSingleContainerDefinition(e config.Env, apiKeySSMParamName pul
 				Name:  pulumi.StringPtr("DD_TELEMETRY_CHECKS"),
 				Value: pulumi.StringPtr("*"),
 			},
-		}, ecsAgentAdditionalEndpointsEnv(params)...), ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...), ecsAgentAdditionalEnvFromConfig(e)...),
+		}, ecsAgentAdditionalEndpointsEnv(params)...), fiEnv...), ecsAgentAdditionalEnvFromConfig(e)...),
 		Secrets: ecs.TaskDefinitionSecretArray{
 			ecs.TaskDefinitionSecretArgs{
 				Name:      pulumi.String("DD_API_KEY"),
@@ -227,7 +236,7 @@ func ecsLinuxAgentSingleContainerDefinition(e config.Env, apiKeySSMParamName pul
 				},
 			)),
 		},
-	}
+	}, nil
 }
 
 func ecsAgentAdditionalEndpointsEnv(params *ecsagentparams.Params) []ecs.TaskDefinitionKeyValuePairInput {
@@ -242,9 +251,13 @@ func ecsAgentAdditionalEndpointsEnv(params *ecsagentparams.Params) []ecs.TaskDef
 	return taskDefArray
 }
 
-func ecsFakeintakeAdditionalEndpointsEnv(fakeintake *fakeintake.Fakeintake) []ecs.TaskDefinitionKeyValuePairInput {
-	if fakeintake == nil {
-		return []ecs.TaskDefinitionKeyValuePairInput{}
+func ecsFakeintakeAdditionalEndpointsEnv(fi *fakeintake.Fakeintake) ([]ecs.TaskDefinitionKeyValuePairInput, error) {
+	if fi == nil {
+		return []ecs.TaskDefinitionKeyValuePairInput{}, nil
+	}
+	rootJSON, err := fakeintake.RCRootJSON()
+	if err != nil {
+		return nil, fmt.Errorf("build fakeintake rc root json: %w", err)
 	}
 	return []ecs.TaskDefinitionKeyValuePairInput{
 		ecs.TaskDefinitionKeyValuePairArgs{
@@ -256,20 +269,44 @@ func ecsFakeintakeAdditionalEndpointsEnv(fakeintake *fakeintake.Fakeintake) []ec
 			Value: pulumi.StringPtr("true"),
 		},
 		ecs.TaskDefinitionKeyValuePairArgs{
+			Name:  pulumi.StringPtr("DD_REMOTE_CONFIGURATION_ENABLED"),
+			Value: pulumi.StringPtr("true"),
+		},
+		ecs.TaskDefinitionKeyValuePairArgs{
+			Name:  pulumi.StringPtr("DD_REMOTE_CONFIGURATION_RC_DD_URL"),
+			Value: fi.URL.ToStringOutput(),
+		},
+		ecs.TaskDefinitionKeyValuePairArgs{
+			Name:  pulumi.StringPtr("DD_REMOTE_CONFIGURATION_NO_TLS"),
+			Value: pulumi.StringPtr("true"),
+		},
+		ecs.TaskDefinitionKeyValuePairArgs{
+			Name:  pulumi.StringPtr("DD_REMOTE_CONFIGURATION_CONFIG_ROOT"),
+			Value: pulumi.StringPtr(rootJSON),
+		},
+		ecs.TaskDefinitionKeyValuePairArgs{
+			Name:  pulumi.StringPtr("DD_REMOTE_CONFIGURATION_DIRECTOR_ROOT"),
+			Value: pulumi.StringPtr(rootJSON),
+		},
+		ecs.TaskDefinitionKeyValuePairArgs{
+			Name:  pulumi.StringPtr("DD_REMOTE_CONFIGURATION_REFRESH_INTERVAL"),
+			Value: pulumi.StringPtr("5s"),
+		},
+		ecs.TaskDefinitionKeyValuePairArgs{
 			Name:  pulumi.StringPtr("DD_PROCESS_CONFIG_PROCESS_DD_URL"),
-			Value: fakeintake.URL.ToStringOutput(),
+			Value: fi.URL.ToStringOutput(),
 		},
 		ecs.TaskDefinitionKeyValuePairArgs{
 			Name:  pulumi.StringPtr("DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL"),
-			Value: fakeintake.URL.ToStringOutput(),
+			Value: fi.URL.ToStringOutput(),
 		},
 		ecs.TaskDefinitionKeyValuePairArgs{
 			Name:  pulumi.StringPtr("DD_ADDITIONAL_ENDPOINTS"),
-			Value: pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.URL.ToStringOutput()),
+			Value: pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fi.URL.ToStringOutput()),
 		},
 		ecs.TaskDefinitionKeyValuePairArgs{
 			Name: pulumi.String("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"),
-			Value: pulumi.All(fakeintake.Host, fakeintake.Port, fakeintake.Scheme).ApplyT(func(args []interface{}) (string, error) {
+			Value: pulumi.All(fi.Host, fi.Port, fi.Scheme).ApplyT(func(args []interface{}) (string, error) {
 				host := args[0].(string)
 				port := args[1].(int)
 				scheme := args[2].(string)
@@ -283,7 +320,7 @@ func ecsFakeintakeAdditionalEndpointsEnv(fakeintake *fakeintake.Fakeintake) []ec
 		},
 		ecs.TaskDefinitionKeyValuePairArgs{
 			Name: pulumi.StringPtr("DD_LOGS_CONFIG_LOGS_NO_SSL"),
-			Value: fakeintake.Scheme.ApplyT(func(scheme string) *string {
+			Value: fi.Scheme.ApplyT(func(scheme string) *string {
 				s := "false"
 				if scheme == "http" {
 					s = "true"
@@ -291,7 +328,7 @@ func ecsFakeintakeAdditionalEndpointsEnv(fakeintake *fakeintake.Fakeintake) []ec
 				return &s
 			}).(pulumi.StringPtrOutput),
 		},
-	}
+	}, nil
 }
 
 func ecsAgentAdditionalEnvFromConfig(e config.Env) []ecs.TaskDefinitionKeyValuePairInput {

--- a/test/e2e-framework/components/datadog/agent/ecsFargate.go
+++ b/test/e2e-framework/components/datadog/agent/ecsFargate.go
@@ -14,9 +14,14 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
 )
 
-func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMParamName pulumi.StringInput, fakeintake *fakeintake.Fakeintake, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) (*ecs.TaskDefinitionContainerDefinitionArgs, *ecs.TaskDefinitionContainerDefinitionArgs) {
+func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMParamName pulumi.StringInput, fi *fakeintake.Fakeintake, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) (*ecs.TaskDefinitionContainerDefinitionArgs, *ecs.TaskDefinitionContainerDefinitionArgs, error) {
 	if image == "" {
 		image = dockerAgentFullImagePath(e, "public.ecr.aws/datadog/agent", "", false, false, false, false)
+	}
+
+	fiEnv, err := ecsFakeintakeAdditionalEndpointsEnv(fi)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Init container copies files to a writeable volume
@@ -77,7 +82,7 @@ func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMPar
 				Name:  pulumi.StringPtr("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED"),
 				Value: pulumi.StringPtr("true"),
 			},
-		}, ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...), ecsAgentAdditionalEnvFromConfig(e)...),
+		}, fiEnv...), ecsAgentAdditionalEnvFromConfig(e)...),
 		Secrets: ecs.TaskDefinitionSecretArray{
 			ecs.TaskDefinitionSecretArgs{
 				Name:      pulumi.String("DD_API_KEY"),
@@ -136,15 +141,19 @@ func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMPar
 		},
 	}
 
-	return initContainer, agentContainer
+	return initContainer, agentContainer, nil
 }
 
 // ECSFargateWindowsContainerDefinition returns the container definition for the Windows agent running on ECS Fargate.
 // Firelens is not supported. Logs could be collected if sent to cloudwatch using the `awslogs` driver. See:
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/tutorial-deploy-fluentbit-on-windows.html
-func ECSFargateWindowsContainerDefinition(e config.Env, image string, apiKeySSMParamName pulumi.StringInput, fakeintake *fakeintake.Fakeintake) *ecs.TaskDefinitionContainerDefinitionArgs {
+func ECSFargateWindowsContainerDefinition(e config.Env, image string, apiKeySSMParamName pulumi.StringInput, fi *fakeintake.Fakeintake) (*ecs.TaskDefinitionContainerDefinitionArgs, error) {
 	if image == "" {
 		image = dockerAgentFullImagePath(e, "public.ecr.aws/datadog/agent", "", false, false, false, true)
+	}
+	fiEnv, err := ecsFakeintakeAdditionalEndpointsEnv(fi)
+	if err != nil {
+		return nil, err
 	}
 	return &ecs.TaskDefinitionContainerDefinitionArgs{
 		Cpu:       pulumi.IntPtr(0),
@@ -160,7 +169,7 @@ func ECSFargateWindowsContainerDefinition(e config.Env, image string, apiKeySSMP
 				Name:  pulumi.StringPtr("DD_CHECKS_TAG_CARDINALITY"),
 				Value: pulumi.StringPtr("high"),
 			},
-		}, ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...),
+		}, fiEnv...),
 		Secrets: ecs.TaskDefinitionSecretArray{
 			ecs.TaskDefinitionSecretArgs{
 				Name:      pulumi.String("DD_API_KEY"),
@@ -178,5 +187,5 @@ func ECSFargateWindowsContainerDefinition(e config.Env, image string, apiKeySSMP
 		PortMappings:     ecs.TaskDefinitionPortMappingArray{},
 		VolumesFrom:      ecs.TaskDefinitionVolumeFromArray{},
 		WorkingDirectory: pulumi.String(`C:\`),
-	}
+	}, nil
 }

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -187,7 +187,9 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 		values = buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag, randomClusterAgentToken.Result, !args.DisableLogsContainerCollectAll, e.TestingWorkloadDeploy(), args.FIPS, true)
 	}
 	values.configureImagePullSecret(imgPullSecret)
-	values.configureFakeintake(e, args.Fakeintake, args.DualShipping)
+	if err := values.configureFakeintake(e, args.Fakeintake, args.DualShipping); err != nil {
+		return nil, err
+	}
 
 	defaultYAMLValues := values.ToYAMLPulumiAssetOutput()
 
@@ -239,7 +241,9 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	if args.DeployWindows {
 		values := buildWindowsHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag)
 		values.configureImagePullSecret(imgPullSecret)
-		values.configureFakeintake(e, args.Fakeintake, args.DualShipping)
+		if err := values.configureFakeintake(e, args.Fakeintake, args.DualShipping); err != nil {
+			return nil, err
+		}
 		defaultYAMLValues := values.ToYAMLPulumiAssetOutput()
 
 		var windowsValuesYAML pulumi.AssetOrArchiveArray
@@ -884,14 +888,45 @@ func (values HelmValues) configureImagePullSecret(secret *corev1.Secret) {
 	}
 }
 
-func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintake.Fakeintake, dualShipping bool) {
-	if fakeintake == nil {
-		return
+func (values HelmValues) configureFakeintake(e config.Env, fi *fakeintake.Fakeintake, dualShipping bool) error {
+	if fi == nil {
+		return nil
+	}
+
+	rootJSON, err := fakeintake.RCRootJSON()
+	if err != nil {
+		return fmt.Errorf("fakeintake rc root json: %w", err)
+	}
+
+	// DD_REMOTE_CONFIGURATION_ENABLED is intentionally omitted here: the Helm chart already sets it
+	// based on its own configuration defaults, and adding it again creates a duplicate env var that
+	// breaks Kubernetes strategic merge patch ordering.
+	rcEnvVars := pulumi.StringMapArray{
+		pulumi.StringMap{
+			"name":  pulumi.String("DD_REMOTE_CONFIGURATION_RC_DD_URL"),
+			"value": fi.URL,
+		},
+		pulumi.StringMap{
+			"name":  pulumi.String("DD_REMOTE_CONFIGURATION_NO_TLS"),
+			"value": pulumi.String("true"),
+		},
+		pulumi.StringMap{
+			"name":  pulumi.String("DD_REMOTE_CONFIGURATION_CONFIG_ROOT"),
+			"value": pulumi.String(rootJSON),
+		},
+		pulumi.StringMap{
+			"name":  pulumi.String("DD_REMOTE_CONFIGURATION_DIRECTOR_ROOT"),
+			"value": pulumi.String(rootJSON),
+		},
+		pulumi.StringMap{
+			"name":  pulumi.String("DD_REMOTE_CONFIGURATION_REFRESH_INTERVAL"),
+			"value": pulumi.String("5s"),
+		},
 	}
 
 	var endpointsEnvVar pulumi.StringMapArray
 	if dualShipping {
-		useSSL := fakeintake.Scheme.ApplyT(func(scheme string) bool {
+		useSSL := fi.Scheme.ApplyT(func(scheme string) bool {
 			if scheme != "https" {
 				e.Ctx().Log.Warn("Fakeintake is used in HTTP with dual-shipping, some endpoints will not work", nil)
 			}
@@ -910,19 +945,19 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.URL),
+				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fi.URL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_PROCESS_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.URL),
+				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fi.URL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.URL),
+				"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fi.URL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fakeintake.Host, fakeintake.Port, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "port": %v, "use_ssl": %t}]`, fi.Host, fi.Port, useSSL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_LOGS_CONFIG_USE_HTTP"),
@@ -930,38 +965,38 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_CONTAINER_IMAGE_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "use_ssl": %t}]`, fakeintake.Host, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "use_ssl": %t}]`, fi.Host, useSSL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_CONTAINER_LIFECYCLE_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "use_ssl": %t}]`, fakeintake.Host, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "use_ssl": %t}]`, fi.Host, useSSL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_SBOM_ADDITIONAL_ENDPOINTS"),
-				"value": pulumi.Sprintf(`[{"host": "%s", "use_ssl": %t}]`, fakeintake.Host, useSSL),
+				"value": pulumi.Sprintf(`[{"host": "%s", "use_ssl": %t}]`, fi.Host, useSSL),
 			},
 		}
 	} else {
 		endpointsEnvVar = pulumi.StringMapArray{
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fi.URL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_PROCESS_CONFIG_PROCESS_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fi.URL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_APM_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fi.URL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_LOGS_CONFIG_LOGS_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fi.URL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL"),
-				"value": pulumi.Sprintf("%s", fakeintake.URL),
+				"value": pulumi.Sprintf("%s", fi.URL),
 			},
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_SKIP_SSL_VALIDATION"),
@@ -978,15 +1013,17 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 		}
 	}
 
+	allEnvVars := append(rcEnvVars, endpointsEnvVar...)
+
 	for _, section := range []string{"datadog", "clusterAgent", "clusterChecksRunner"} {
 		if _, ok := values[section].(pulumi.Map); !ok {
 			continue
 		}
 
 		if _, found := values[section].(pulumi.Map)["env"]; !found {
-			values[section].(pulumi.Map)["env"] = endpointsEnvVar
+			values[section].(pulumi.Map)["env"] = allEnvVars
 		} else {
-			values[section].(pulumi.Map)["env"] = append(values[section].(pulumi.Map)["env"].(pulumi.StringMapArray), endpointsEnvVar...)
+			values[section].(pulumi.Map)["env"] = append(values[section].(pulumi.Map)["env"].(pulumi.StringMapArray), allEnvVars...)
 		}
 	}
 
@@ -996,14 +1033,14 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 				if _, ok := values["clusterAgent"].(pulumi.Map)["admissionController"].(pulumi.Map)["agentSidecarInjection"].(pulumi.Map)["profiles"]; !ok {
 					values["clusterAgent"].(pulumi.Map)["admissionController"].(pulumi.Map)["agentSidecarInjection"].(pulumi.Map)["profiles"] = pulumi.Array{
 						pulumi.Map{
-							"env": endpointsEnvVar,
+							"env": allEnvVars,
 						},
 					}
 				} else {
 					values["clusterAgent"].(pulumi.Map)["admissionController"].(pulumi.Map)["agentSidecarInjection"].(pulumi.Map)["profiles"] =
 						append(values["clusterAgent"].(pulumi.Map)["admissionController"].(pulumi.Map)["agentSidecarInjection"].(pulumi.Map)["profiles"].(pulumi.Array),
 							pulumi.Map{
-								"env": endpointsEnvVar,
+								"env": allEnvVars,
 							},
 						)
 				}
@@ -1031,9 +1068,11 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 			parEnvDict = pulumi.StringMap{}
 			par["envDict"] = parEnvDict
 		}
-		parEnvDict["DD_DD_URL"] = pulumi.Sprintf("%s", fakeintake.URL)
+		parEnvDict["DD_DD_URL"] = pulumi.Sprintf("%s", fi.URL)
 		parEnvDict["DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION"] = pulumi.String("true")
 	}
+
+	return nil
 }
 
 func (values HelmValues) ToYAMLPulumiAssetOutput() pulumi.AssetOutput {

--- a/test/e2e-framework/components/datadog/agentparams/params.go
+++ b/test/e2e-framework/components/datadog/agentparams/params.go
@@ -338,13 +338,33 @@ func WithIntakeHostname(scheme string, hostname string) func(*Params) error {
 	return withIntakeHostname(pulumi.String(scheme), pulumi.String(hostname), pulumi.Int(port))
 }
 
-// WithFakeintake installs the fake intake and configures the Agent to use it.
+// WithFakeintake installs the fake intake and configures the Agent to use it,
+// including Remote Config. The agent is pointed at fakeintake's RC endpoint and
+// given the TUF root JSON derived from fakeintake's global signing key so it can
+// verify signed payloads without any extra provisioner options.
 //
 // This option is overwritten by `WithIntakeHostname`.
-func WithFakeintake(fakeintake *fakeintake.Fakeintake) func(*Params) error {
+func WithFakeintake(fi *fakeintake.Fakeintake) func(*Params) error {
 	return func(p *Params) error {
-		p.ResourceOptions = append(p.ResourceOptions, pulumi.DependsOn([]pulumi.Resource{fakeintake}))
-		return withIntakeHostname(fakeintake.Scheme, fakeintake.Host, fakeintake.Port)(p)
+		p.ResourceOptions = append(p.ResourceOptions, pulumi.DependsOn([]pulumi.Resource{fi}))
+		if err := withIntakeHostname(fi.Scheme, fi.Host, fi.Port)(p); err != nil {
+			return err
+		}
+		rootJSON, err := fakeintake.RCRootJSON()
+		if err != nil {
+			return fmt.Errorf("build fakeintake rc root json: %w", err)
+		}
+		rcConfig := fi.URL.ApplyT(func(fiURL string) (string, error) {
+			return fmt.Sprintf(`remote_configuration.enabled: true
+remote_configuration.rc_dd_url: %s
+remote_configuration.no_tls: true
+remote_configuration.refresh_interval: 5s
+remote_configuration.config_root: '%s'
+remote_configuration.director_root: '%s'
+`, fiURL, rootJSON, rootJSON), nil
+		}).(pulumi.StringOutput)
+		p.ExtraAgentConfig = append(p.ExtraAgentConfig, rcConfig)
+		return nil
 	}
 }
 

--- a/test/e2e-framework/components/datadog/dockeragentparams/params.go
+++ b/test/e2e-framework/components/datadog/dockeragentparams/params.go
@@ -163,14 +163,37 @@ func WithIntake(url string) func(*Params) error {
 	return withIntakeHostname(pulumi.String(url), pulumi.Bool(false))
 }
 
-// WithFakeintake installs the fake intake and configures the Agent to use it.
+// WithFakeintake installs the fake intake and configures the Agent to use it,
+// including Remote Config. The agent is pointed at fakeintake's RC endpoint and
+// given the TUF root JSON derived from fakeintake's global signing key so it can
+// verify signed payloads without any extra provisioner options.
 //
 // This option is overwritten by `WithIntakeHostname`.
-func WithFakeintake(fakeintake *fakeintake.Fakeintake) func(*Params) error {
-	shouldSkipSSLValidation := fakeintake.Scheme.ApplyT(func(scheme string) bool { return scheme == "http" }).(pulumi.BoolInput)
+func WithFakeintake(fi *fakeintake.Fakeintake) func(*Params) error {
+	shouldSkipSSLValidation := fi.Scheme.ApplyT(func(scheme string) bool { return scheme == "http" }).(pulumi.BoolInput)
 	return func(p *Params) error {
-		p.PulumiDependsOn = append(p.PulumiDependsOn, utils.PulumiDependsOn(fakeintake))
-		return withIntakeHostname(fakeintake.URL, shouldSkipSSLValidation)(p)
+		p.PulumiDependsOn = append(p.PulumiDependsOn, utils.PulumiDependsOn(fi))
+		if err := withIntakeHostname(fi.URL, shouldSkipSSLValidation)(p); err != nil {
+			return err
+		}
+		rootJSON, err := fakeintake.RCRootJSON()
+		if err != nil {
+			return fmt.Errorf("build fakeintake rc root json: %w", err)
+		}
+		rcEnvVars := pulumi.Map{
+			"DD_REMOTE_CONFIGURATION_ENABLED":          pulumi.String("true"),
+			"DD_REMOTE_CONFIGURATION_RC_DD_URL":        pulumi.Sprintf("%s", fi.URL),
+			"DD_REMOTE_CONFIGURATION_NO_TLS":           pulumi.String("true"),
+			"DD_REMOTE_CONFIGURATION_CONFIG_ROOT":      pulumi.String(rootJSON),
+			"DD_REMOTE_CONFIGURATION_DIRECTOR_ROOT":    pulumi.String(rootJSON),
+			"DD_REMOTE_CONFIGURATION_REFRESH_INTERVAL": pulumi.String("5s"),
+		}
+		for key, value := range rcEnvVars {
+			if err := WithAgentServiceEnvVariable(key, value)(p); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 }
 

--- a/test/e2e-framework/components/datadog/fakeintake/BUILD.bazel
+++ b/test/e2e-framework/components/datadog/fakeintake/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//test/e2e-framework/common/config",
         "//test/e2e-framework/components",
+        "//test/fakeintake/server/rcstore",
         "@com_github_pulumi_pulumi_docker_sdk_v4//go/docker",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
     ],

--- a/test/e2e-framework/components/datadog/fakeintake/component.go
+++ b/test/e2e-framework/components/datadog/fakeintake/component.go
@@ -6,10 +6,18 @@
 package fakeintake
 
 import (
-	"github.com/DataDog/datadog-agent/test/e2e-framework/components"
+	"fmt"
 
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components"
+	"github.com/DataDog/datadog-agent/test/fakeintake/server/rcstore"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+// DefaultRCSigningKeySeed is the fixed ed25519 seed shared by every fakeintake
+// instance. It is a test-only key — never use it in production. A single
+// well-known seed makes the TUF root JSON deterministic so it can be computed
+// at provision time without any runtime key negotiation.
+const DefaultRCSigningKeySeed = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
 
 type FakeintakeOutput struct { // nolint:revive, We want to keep the name as <Component>Output
 	components.JSONImporter
@@ -33,4 +41,24 @@ type Fakeintake struct {
 
 func (fi *Fakeintake) Export(ctx *pulumi.Context, out *FakeintakeOutput) error {
 	return components.Export(ctx, fi, out)
+}
+
+// RCRootJSON computes the TUF root JSON for the default fakeintake RC signing key.
+// The result is deterministic — it can be computed at provision time so the agent
+// config can reference it before fakeintake has started.
+func RCRootJSON() (string, error) {
+	priv, err := rcstore.KeyFromHexSeed(DefaultRCSigningKeySeed)
+	if err != nil {
+		return "", fmt.Errorf("rc signing key: %w", err)
+	}
+	pubHex := rcstore.PublicKeyHex(priv)
+	keyID, err := rcstore.ComputeKeyID(pubHex)
+	if err != nil {
+		return "", fmt.Errorf("rc key id: %w", err)
+	}
+	rootJSON, err := rcstore.BuildRootJSON(priv, keyID, pubHex)
+	if err != nil {
+		return "", fmt.Errorf("rc root json: %w", err)
+	}
+	return string(rootJSON), nil
 }

--- a/test/e2e-framework/components/datadog/fakeintake/docker.go
+++ b/test/e2e-framework/components/datadog/fakeintake/docker.go
@@ -21,6 +21,7 @@ func NewLocalDockerFakeintake(e config.Env, resourceName string) (*Fakeintake, e
 
 		_, err := docker.NewContainer(e.Ctx(), e.CommonNamer().ResourceName("local-docker-container"), &docker.ContainerArgs{
 			Image: pulumi.String("public.ecr.aws/datadog/fakeintake:latest"),
+			Command: pulumi.ToStringArray([]string{"--rc-key-data=" + DefaultRCSigningKeySeed}),
 			Ports: docker.ContainerPortArray{
 				&docker.ContainerPortArgs{
 					Internal: pulumi.Int(80),

--- a/test/e2e-framework/resources/aws/ecs/fargateService.go
+++ b/test/e2e-framework/resources/aws/ecs/fargateService.go
@@ -55,7 +55,11 @@ func FargateWindowsTaskDefinitionWithAgent(
 	image string,
 	opts ...pulumi.ResourceOption,
 ) (*ecs.FargateTaskDefinition, error) {
-	containers["datadog-agent"] = *agent.ECSFargateWindowsContainerDefinition(&e, image, apiKeySSMParamName, fakeintake)
+	windowsAgentDef, err := agent.ECSFargateWindowsContainerDefinition(&e, image, apiKeySSMParamName, fakeintake)
+	if err != nil {
+		return nil, err
+	}
+	containers["datadog-agent"] = *windowsAgentDef
 	// aws-for-fluent-bit:windowsservercore-latest can only be used with cloudwatch logs.
 	return ecs.NewFargateTaskDefinition(e.Ctx(), e.Namer.ResourceName(name), &ecs.FargateTaskDefinitionArgs{
 		Containers: containers,
@@ -85,7 +89,10 @@ func FargateTaskDefinitionWithAgent(
 	image string,
 	opts ...pulumi.ResourceOption,
 ) (*ecs.FargateTaskDefinition, error) {
-	initContainer, agentContainer := agent.ECSFargateLinuxContainerDefinition(&e, image, apiKeySSMParamName, fakeintake, GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String("datadog-agent"), apiKeySSMParamName))
+	initContainer, agentContainer, err := agent.ECSFargateLinuxContainerDefinition(&e, image, apiKeySSMParamName, fakeintake, GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String("datadog-agent"), apiKeySSMParamName))
+	if err != nil {
+		return nil, err
+	}
 	containers["init-copy-agent-config"] = *initContainer
 	containers["datadog-agent"] = *agentContainer
 

--- a/test/e2e-framework/scenarios/aws/ec2/run.go
+++ b/test/e2e-framework/scenarios/aws/ec2/run.go
@@ -64,11 +64,10 @@ func Run(ctx *pulumi.Context, awsEnv aws.Environment, env outputs.HostOutputs, p
 			return err
 		}
 
-		// Normally if FakeIntake is enabled, Agent is enabled, but just in case
+		// Normally if FakeIntake is enabled, Agent is enabled, but just in case.
+		// WithFakeintake automatically wires RC — no separate RC option needed.
 		if params.agentOptions != nil {
-			// Prepend in case it's overridden by the user
-			newOpts := []agentparams.Option{agentparams.WithFakeintake(fakeIntake)}
-			params.agentOptions = append(newOpts, params.agentOptions...)
+			params.agentOptions = append([]agentparams.Option{agentparams.WithFakeintake(fakeIntake)}, params.agentOptions...)
 		}
 	} else {
 		// Mark FakeIntake as not provisioned
@@ -124,3 +123,4 @@ func VMRun(ctx *pulumi.Context) error {
 
 	return Run(ctx, awsEnv, env, ParamsFromEnvironment(awsEnv))
 }
+

--- a/test/e2e-framework/scenarios/aws/fakeintake/fakeintake.go
+++ b/test/e2e-framework/scenarios/aws/fakeintake/fakeintake.go
@@ -229,6 +229,10 @@ func fargateLinuxContainerDefinition(apiKeySSMParamName pulumi.StringInput, para
 		command = append(command, "-retention-period="+params.RetentionPeriod)
 	}
 
+	// Always supply the global RC signing key so fakeintake's TUF root is
+	// deterministic and matches what the agent is configured with at provision time.
+	command = append(command, "--rc-key-data="+fakeintake.DefaultRCSigningKeySeed)
+
 	return &awsxEcs.TaskDefinitionContainerDefinitionArgs{
 		Name:        pulumi.String(containerName),
 		Image:       pulumi.String(params.ImageURL),

--- a/test/e2e-framework/scenarios/azure/fakeintake/fakeintake.go
+++ b/test/e2e-framework/scenarios/azure/fakeintake/fakeintake.go
@@ -6,6 +6,8 @@
 package fakeintake
 
 import (
+	"strings"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
@@ -44,8 +46,10 @@ func NewVMInstance(e azure.Environment, option ...Option) (*fakeintake.Fakeintak
 			cmdArgs = append(cmdArgs, "-retention-period="+params.RetentionPeriod)
 		}
 
+		cmdArgs = append(cmdArgs, "--rc-key-data="+fakeintake.DefaultRCSigningKeySeed)
+
 		_, err = vm.OS.Runner().Command("docker_run_fakeintake", &command.Args{
-			Create: pulumi.Sprintf("docker run --restart unless-stopped --name fakeintake -d -p 80:80 -e DD_API_KEY=%s %s %s", e.AgentAPIKey(), params.ImageURL, cmdArgs),
+			Create: pulumi.Sprintf("docker run --restart unless-stopped --name fakeintake -d -p 80:80 -e DD_API_KEY=%s %s %s", e.AgentAPIKey(), params.ImageURL, strings.Join(cmdArgs, " ")),
 			Delete: pulumi.String("docker stop fakeintake"),
 		}, utils.PulumiDependsOn(manager), pulumi.DeleteBeforeReplace(true))
 		if err != nil {

--- a/test/e2e-framework/scenarios/gcp/fakeintake/fakeintake.go
+++ b/test/e2e-framework/scenarios/gcp/fakeintake/fakeintake.go
@@ -45,6 +45,8 @@ func NewVMInstance(e gcp.Environment, option ...Option) (*fakeintake.Fakeintake,
 			cmdArgs = append(cmdArgs, "-retention-period="+params.RetentionPeriod)
 		}
 
+		cmdArgs = append(cmdArgs, "--rc-key-data="+fakeintake.DefaultRCSigningKeySeed)
+
 		_, err = vm.OS.Runner().Command("docker_run_fakeintake", &command.Args{
 			Create: pulumi.Sprintf("docker run --restart unless-stopped --name fakeintake -d -p 80:80 -e DD_API_KEY=%s %s %s", e.AgentAPIKey(), params.ImageURL, strings.Join(cmdArgs, " ")),
 			Delete: pulumi.String("docker stop fakeintake"),

--- a/test/new-e2e/examples/agentenv_rc_loglevel_test.go
+++ b/test/new-e2e/examples/agentenv_rc_loglevel_test.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package examples
+
+// This example shows how to use fakeintake's Remote Config backend to change
+// the agent's log level at runtime.
+//
+// Remote Config is wired automatically: every awshost.Provisioner() run
+// starts fakeintake with a fixed TUF signing key and configures the agent to
+// point at fakeintake's RC endpoint — no extra provisioner options needed.
+//
+// Flow:
+//  1. Agent starts at the default (info) log level — no DEBUG lines in the log.
+//  2. Two AGENT_CONFIG payloads are pushed via the fakeintake RC API:
+//     - a named layer that sets log_level to "debug"
+//     - a configuration_order that activates the layer
+//  3. The agent polls fakeintake (every 5 s), receives the signed config, and
+//     starts writing DEBUG lines to its log file.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+type rcLogLevelExampleSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+// TestRCLogLevelExampleSuite is the entry point for the Remote Config log-level example.
+// Run locally with:
+//
+//	dda inv new-e2e-tests.run --targets=./examples/... -run TestRCLogLevelExampleSuite
+func TestRCLogLevelExampleSuite(t *testing.T) {
+	// RC is wired automatically — no special provisioner option is required.
+	e2e.Run(t, &rcLogLevelExampleSuite{},
+		e2e.WithProvisioner(awshost.Provisioner()),
+	)
+}
+
+// TestLogLevelViaRC verifies that the agent honours an AGENT_CONFIG payload
+// delivered through Remote Config:
+//
+//  1. No DEBUG lines exist at startup (default log_level is info).
+//  2. After pushing an AGENT_CONFIG layer + configuration_order, DEBUG lines appear.
+func (s *rcLogLevelExampleSuite) TestLogLevelViaRC() {
+	rh := s.Env().RemoteHost
+	fi := s.Env().FakeIntake.Client()
+
+	// Step 1 — confirm the agent is up and not yet producing DEBUG logs.
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		assert.True(c, s.Env().Agent.Client.IsReady())
+	}, 2*time.Minute, 5*time.Second, "agent did not become ready")
+
+	agentLog, err := rh.ReadFilePrivileged("/var/log/datadog/agent.log")
+	require.NoError(s.T(), err)
+	require.False(s.T(), strings.Contains(string(agentLog), "| DEBUG |"),
+		"expected no DEBUG logs at default log level")
+
+	// Step 2 — push an AGENT_CONFIG layer that sets log_level to "debug".
+	err = fi.RCAddConfig("", "AGENT_CONFIG", "layer1", "log_level_debug",
+		[]byte(`{"name":"layer1","config":{"log_level":"debug"}}`))
+	require.NoError(s.T(), err)
+
+	// Step 3 — push a configuration_order to activate the layer.
+	// MergeRCAgentConfig requires a non-empty Order or InternalOrder to apply.
+	err = fi.RCAddConfig("", "AGENT_CONFIG", "configuration_order", "order",
+		[]byte(`{"order":["layer1"],"internal_order":[]}`))
+	require.NoError(s.T(), err)
+
+	// Step 4 — wait for DEBUG lines to appear.
+	// The agent polls RC every 5 s (set by remote_configuration.refresh_interval).
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		logs, err := rh.ReadFilePrivileged("/var/log/datadog/agent.log")
+		assert.NoError(c, err)
+		assert.True(c, strings.Contains(string(logs), "| DEBUG |"),
+			"expected DEBUG logs after RC log level change")
+	}, 3*time.Minute, 10*time.Second)
+}

--- a/test/new-e2e/examples/kind_rc_loglevel_test.go
+++ b/test/new-e2e/examples/kind_rc_loglevel_test.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package examples
+
+// This example shows how to use fakeintake's Remote Config backend to change
+// the agent's log level at runtime on a Kind (Kubernetes-in-Docker) cluster.
+//
+// Remote Config is wired automatically: every awskubernetes.Provisioner() run
+// starts fakeintake with a fixed TUF signing key and configures the agent to
+// point at fakeintake's RC endpoint — no extra provisioner options needed.
+//
+// Flow:
+//  1. Agent pods start at the default (info) log level — no DEBUG lines in the log.
+//  2. Two AGENT_CONFIG payloads are pushed via the fakeintake RC API:
+//     - a named layer that sets log_level to "debug"
+//     - a configuration_order that activates the layer
+//  3. The agent polls fakeintake (every 5 s), receives the signed config, and
+//     starts writing DEBUG lines to its log file.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awskubernetes "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+)
+
+type rcLogLevelKindExampleSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+// TestRCLogLevelKindExampleSuite is the entry point for the Kind Remote Config log-level example.
+// Run locally with:
+//
+//	dda inv new-e2e-tests.run --targets=./examples/... -run TestRCLogLevelKindExampleSuite
+func TestRCLogLevelKindExampleSuite(t *testing.T) {
+	// RC is wired automatically — no special provisioner option is required.
+	e2e.Run(t, &rcLogLevelKindExampleSuite{},
+		e2e.WithProvisioner(awskubernetes.Provisioner()),
+	)
+}
+
+// TestLogLevelViaRCKind verifies that the agent honours an AGENT_CONFIG payload
+// delivered through Remote Config on a Kind cluster:
+//
+//  1. No DEBUG lines exist at startup (default log_level is info).
+//  2. After pushing an AGENT_CONFIG layer + configuration_order, DEBUG lines appear.
+func (s *rcLogLevelKindExampleSuite) TestLogLevelViaRCKind() {
+	fi := s.Env().FakeIntake.Client()
+
+	// Step 1 — wait for an agent pod to be running and confirm no DEBUG logs.
+	var agentPodName, agentPodNamespace string
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		res, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").
+			List(context.Background(), v1.ListOptions{LabelSelector: "app=dda-linux-datadog"})
+		if !assert.NoError(c, err) {
+			return
+		}
+		for _, pod := range res.Items {
+			if pod.DeletionTimestamp != nil {
+				continue
+			}
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.Name == "agent" && cs.Ready {
+					agentPodName = pod.Name
+					agentPodNamespace = pod.Namespace
+					return
+				}
+			}
+		}
+		assert.Fail(c, "no agent pod with a ready agent container found")
+	}, 3*time.Minute, 10*time.Second, "agent pod did not become ready")
+
+	agentLog, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+		agentPodNamespace, agentPodName, "agent",
+		[]string{"cat", "/var/log/datadog/agent.log"})
+	require.NoError(s.T(), err)
+	require.False(s.T(), strings.Contains(agentLog, "| DEBUG |"),
+		"expected no DEBUG logs at default log level")
+
+	// Step 2 — push an AGENT_CONFIG layer that sets log_level to "debug".
+	err = fi.RCAddConfig("", "AGENT_CONFIG", "layer1", "log_level_debug",
+		[]byte(`{"name":"layer1","config":{"log_level":"debug"}}`))
+	require.NoError(s.T(), err)
+
+	// Step 3 — push a configuration_order to activate the layer.
+	// MergeRCAgentConfig requires a non-empty Order or InternalOrder to apply.
+	err = fi.RCAddConfig("", "AGENT_CONFIG", "configuration_order", "order",
+		[]byte(`{"order":["layer1"],"internal_order":[]}`))
+	require.NoError(s.T(), err)
+
+	// Step 4 — wait for DEBUG lines to appear.
+	// The agent polls RC every 5 s (set by remote_configuration.refresh_interval).
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		logs, _, execErr := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+			agentPodNamespace, agentPodName, "agent",
+			[]string{"cat", "/var/log/datadog/agent.log"})
+		assert.NoError(c, execErr)
+		assert.True(c, strings.Contains(logs, "| DEBUG |"),
+			"expected DEBUG logs after RC log level change")
+	}, 3*time.Minute, 10*time.Second)
+}


### PR DESCRIPTION
  ---
  What does this PR do?

  Add support for E2E tests on Remote Config based features.

  Remote Config is now wired automatically whenever fakeintake is used: every standard provisioner (AWS EC2, Kind/Kubernetes, Azure, GCP) starts fakeintake with a fixed TUF signing key and
  configures the agent to poll fakeintake's RC endpoint. Test authors get RC support with zero extra provisioner options.

  Concretely:
  - WithFakeintake() in agentparams now injects the full remote_configuration.* agent config block, pointing at fakeintake's /api/v0.1/configurations endpoint with the correct TUF root JSON
  - configureFakeintake in the Kubernetes Helm path does the same via DD_REMOTE_CONFIGURATION_* env vars across all Helm sections (datadog, clusterAgent, clusterChecksRunner, sidecar injection
  profiles)
  - All cloud-provider fakeintake launchers (AWS Fargate, Azure VM, GCP VM) pass --rc-key-data with a fixed ed25519 seed, making the TUF root JSON deterministic and computable at provision time
  without any runtime key negotiation
  - New E2E tests in test/new-e2e/tests/remote-config/ and example tests under test/new-e2e/examples/ demonstrate the pattern on both VM and Kind environments

  Motivation

  Previously there was no standard way to test Remote Config features in E2E: tests had to manually configure the agent's RC endpoint and TUF roots, which required knowing fakeintake's runtime
  URL before it was provisioned. This PR eliminates that friction by making RC a first-class part of the fakeintake provisioning contract — any test that uses the standard provisioners can now
  push RC payloads via fi.RCAddConfig(...) and assert the agent responds.

  Describe how you validated your changes

  - Added test/new-e2e/tests/remote-config/log_level_test.go: verifies that the agent starts at info level (no DEBUG lines), then produces DEBUG logs within 5 minutes after pushing an
  AGENT_CONFIG layer + configuration_order via fakeintake's RC API. Runs on an AWS EC2 host.
  - Added two annotated example tests (agentenv_rc_loglevel_test.go, agentenv_rc_loglevel_kind_test.go) showing the same flow on AWS VM and Kind (Kubernetes-in-Docker) environments
  respectively.

  Additional Notes

  - The fixed RC signing key seed (DefaultRCSigningKeySeed) is a test-only ed25519 key. It is never used in production — its sole purpose is to make the TUF root JSON deterministic so it can be
  embedded in agent config before fakeintake starts.
  - RC polling interval is set to 5s in tests (vs. the production default of 30s) to keep test wall-clock time reasonable.
  - DD_REMOTE_CONFIGURATION_ENABLED is intentionally omitted from the Kubernetes Helm env vars: the chart already sets it via its own defaults, and injecting it again breaks Kubernetes
  strategic merge patch ordering.

Needs #51148 