### PR TITLE
[AGNTLOG-154] feat(logs): add observability_pipelines_worker.logs.dual_ship config

### DIFF
--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -372,7 +372,13 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 		log.Warn("observability_pipelines_worker.logs.dual_ship_reliable=true has no effect because observability_pipelines_worker.logs.dual_ship is false")
 	}
 
-	if vectorURL, vectorURLDefined := logsConfig.getObsPipelineURL(); logsConfig.obsPipelineWorkerEnabled() && vectorURLDefined {
+	vectorURL, vectorURLDefined := logsConfig.getObsPipelineURL()
+	opwEnabled := logsConfig.obsPipelineWorkerEnabled() && vectorURLDefined
+	if logsConfig.obsPipelineWorkerDualShip() && !opwEnabled {
+		log.Warn("observability_pipelines_worker.logs.dual_ship=true has no effect because OPW is not enabled or its url is empty")
+	}
+
+	if opwEnabled {
 		host, port, _, useSSL, err := parseAddressWithScheme(vectorURL, defaultNoSSL, parseAddress)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse %s: %v", vectorURL, err)

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -382,12 +382,21 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 			// cannot apply backpressure to the main pipeline and stall delivery to
 			// Datadog. Operators who want OPW to participate in flow control can opt
 			// in via observability_pipelines_worker.logs.dual_ship_reliable.
+			//
+			// Inherit the v2-API metadata (Version, TrackType, Protocol, Origin) from
+			// the main endpoint so OPW receives the same URL path (/api/v2/logs) and
+			// DD-PROTOCOL/DD-EVP-ORIGIN headers as the primary Datadog destination —
+			// matching how user-supplied additional_endpoints inherit these fields.
 			opwEndpoint := newHTTPEndpoint(logsConfig, registerCallback)
 			opwEndpoint.Host = host
 			opwEndpoint.Port = port
 			opwEndpoint.useSSL = useSSL
 			opwEndpoint.isAdditionalEndpoint = true
 			opwEndpoint.isReliable = logsConfig.obsPipelineWorkerDualShipReliable()
+			opwEndpoint.Version = main.Version
+			opwEndpoint.TrackType = main.TrackType
+			opwEndpoint.Protocol = main.Protocol
+			opwEndpoint.Origin = main.Origin
 			opwAdditionals = append(opwAdditionals, opwEndpoint)
 		} else {
 			// Default behaviour: OPW replaces the primary Datadog endpoint and is the only

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -364,36 +364,61 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 		main.CompressionLevel = compressionOptions.CompressionLevel
 	}
 
+	// opwAdditionals collects any OPW dual-ship endpoint before the user-configured
+	// additional_endpoints so they are included in the final endpoint list.
+	var opwAdditionals []Endpoint
+
 	if vectorURL, vectorURLDefined := logsConfig.getObsPipelineURL(); logsConfig.obsPipelineWorkerEnabled() && vectorURLDefined {
 		host, port, _, useSSL, err := parseAddressWithScheme(vectorURL, defaultNoSSL, parseAddress)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse %s: %v", vectorURL, err)
 		}
-		main.Host = host
-		main.Port = port
-		main.useSSL = useSSL
-	} else if logsDDURL, logsDDURLDefined := logsConfig.logsDDURL(); logsDDURLDefined {
-		host, port, pathPrefix, useSSL, err := parseAddressWithScheme(logsDDURL, defaultNoSSL, parseAddress)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse %s: %v", logsDDURL, err)
+		if logsConfig.obsPipelineWorkerDualShip() {
+			// dual_ship=true: Datadog remains the primary endpoint; OPW is appended as
+			// an additional reliable endpoint. The primary DD host is resolved below via
+			// the normal logsDDURL / GetMainEndpoint path.
+			opwEndpoint := newHTTPEndpoint(logsConfig, registerCallback)
+			opwEndpoint.Host = host
+			opwEndpoint.Port = port
+			opwEndpoint.useSSL = useSSL
+			opwEndpoint.isAdditionalEndpoint = true
+			opwAdditionals = append(opwAdditionals, opwEndpoint)
+		} else {
+			// Default (legacy) behaviour: OPW replaces the primary Datadog endpoint.
+			main.Host = host
+			main.Port = port
+			main.useSSL = useSSL
 		}
-		main.Host = host
-		main.Port = port
-		main.PathPrefix = pathPrefix
-		main.useSSL = useSSL
-	} else {
-		addr := pkgconfigutils.GetMainEndpoint(coreConfig, endpointPrefix, logsConfig.getConfigKey("dd_url"))
-		host, port, _, useSSL, err := parseAddressWithScheme(addr, logsConfig.devModeNoSSL(), parseAddressAsHost)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse %s: %v", logsDDURL, err)
-		}
+	}
 
-		main.Host = host
-		main.Port = port
-		main.useSSL = useSSL
+	// Resolve the primary Datadog endpoint when it has not been replaced by OPW.
+	if main.Host == "" {
+		if logsDDURL, logsDDURLDefined := logsConfig.logsDDURL(); logsDDURLDefined {
+			host, port, pathPrefix, useSSL, err := parseAddressWithScheme(logsDDURL, defaultNoSSL, parseAddress)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse %s: %v", logsDDURL, err)
+			}
+			main.Host = host
+			main.Port = port
+			main.PathPrefix = pathPrefix
+			main.useSSL = useSSL
+		} else {
+			addr := pkgconfigutils.GetMainEndpoint(coreConfig, endpointPrefix, logsConfig.getConfigKey("dd_url"))
+			host, port, _, useSSL, err := parseAddressWithScheme(addr, logsConfig.devModeNoSSL(), parseAddressAsHost)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse %s: %v", addr, err)
+			}
+
+			main.Host = host
+			main.Port = port
+			main.useSSL = useSSL
+		}
 	}
 
 	additionals := loadHTTPAdditionalEndpoints(main, logsConfig, intakeTrackType, intakeProtocol, intakeOrigin, registerCallback)
+
+	// Prepend OPW dual-ship endpoints so they appear before user-configured additional_endpoints.
+	additionals = append(opwAdditionals, additionals...)
 
 	// Add in the MRF endpoint if MRF is enabled.
 	if coreConfig.GetBool("multi_region_failover.enabled") {

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -375,13 +375,19 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 		}
 		if logsConfig.obsPipelineWorkerDualShip() {
 			// dual_ship=true: Datadog remains the primary endpoint; OPW is appended as
-			// an additional reliable endpoint. The primary DD host is resolved below via
-			// the normal logsDDURL / GetMainEndpoint path.
+			// an additional endpoint. The primary DD host is resolved below via the
+			// normal logsDDURL / GetMainEndpoint path.
+			//
+			// OPW is best-effort (unreliable) by default so that an unhealthy OPW
+			// cannot apply backpressure to the main pipeline and stall delivery to
+			// Datadog. Operators who want OPW to participate in flow control can opt
+			// in via observability_pipelines_worker.logs.dual_ship_reliable.
 			opwEndpoint := newHTTPEndpoint(logsConfig, registerCallback)
 			opwEndpoint.Host = host
 			opwEndpoint.Port = port
 			opwEndpoint.useSSL = useSSL
 			opwEndpoint.isAdditionalEndpoint = true
+			opwEndpoint.isReliable = logsConfig.obsPipelineWorkerDualShipReliable()
 			opwAdditionals = append(opwAdditionals, opwEndpoint)
 		} else {
 			// Default (legacy) behaviour: OPW replaces the primary Datadog endpoint.

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -368,6 +368,10 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 	// additional_endpoints so they are included in the final endpoint list.
 	var opwAdditionals []Endpoint
 
+	if logsConfig.obsPipelineWorkerDualShipReliable() && !logsConfig.obsPipelineWorkerDualShip() {
+		log.Warn("observability_pipelines_worker.logs.dual_ship_reliable=true has no effect because observability_pipelines_worker.logs.dual_ship is false")
+	}
+
 	if vectorURL, vectorURLDefined := logsConfig.getObsPipelineURL(); logsConfig.obsPipelineWorkerEnabled() && vectorURLDefined {
 		host, port, _, useSSL, err := parseAddressWithScheme(vectorURL, defaultNoSSL, parseAddress)
 		if err != nil {
@@ -397,6 +401,18 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 			opwEndpoint.TrackType = main.TrackType
 			opwEndpoint.Protocol = main.Protocol
 			opwEndpoint.Origin = main.Origin
+			// Mirror the fields that loadHTTPAdditionalEndpoints copies from main so that
+			// any compression override applied to main (e.g. via BuildHTTPEndpointsWithCompressionOverride)
+			// and all backoff/recovery settings are consistent between the two endpoints.
+			opwEndpoint.UseCompression = main.UseCompression
+			opwEndpoint.CompressionKind = main.CompressionKind
+			opwEndpoint.CompressionLevel = main.CompressionLevel
+			opwEndpoint.BackoffFactor = main.BackoffFactor
+			opwEndpoint.BackoffBase = main.BackoffBase
+			opwEndpoint.BackoffMax = main.BackoffMax
+			opwEndpoint.RecoveryInterval = main.RecoveryInterval
+			opwEndpoint.RecoveryReset = main.RecoveryReset
+			opwEndpoint.ConnectionResetInterval = main.ConnectionResetInterval
 			opwAdditionals = append(opwAdditionals, opwEndpoint)
 		} else {
 			// Default behaviour: OPW replaces the primary Datadog endpoint and is the only

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -390,7 +390,9 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 			opwEndpoint.isReliable = logsConfig.obsPipelineWorkerDualShipReliable()
 			opwAdditionals = append(opwAdditionals, opwEndpoint)
 		} else {
-			// Default (legacy) behaviour: OPW replaces the primary Datadog endpoint.
+			// Default behaviour: OPW replaces the primary Datadog endpoint and is the only
+			// destination logs are shipped to. dual_ship is the opt-in for users who want
+			// to evaluate OPW alongside an unchanged flow of telemetry to Datadog.
 			main.Host = host
 			main.Port = port
 			main.useSSL = useSSL

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -330,11 +330,17 @@ func (l *LogsConfigKeys) obsPipelineWorkerEnabled() bool {
 // sent to both the primary Datadog intake and the Observability Pipelines Worker simultaneously.
 // This method always returns false when the vectorPrefix is empty (i.e. the config keys instance
 // was not constructed with OPW support).
+// It mirrors the fallback pattern of obsPipelineWorkerEnabled / getObsPipelineURL: if the modern
+// observability_pipelines_worker key is not set it falls back to the legacy vector.* key so that
+// users still on the legacy config are not silently broken.
 func (l *LogsConfigKeys) obsPipelineWorkerDualShip() bool {
 	if l.vectorPrefix == "" {
 		return false
 	}
-	return l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dual_ship"))
+	if l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dual_ship")) {
+		return true
+	}
+	return l.getConfig().GetBool(l.getObsPipelineConfigKey("vector", "dual_ship"))
 }
 
 // obsPipelineWorkerDualShipReliable reports whether the OPW dual-ship endpoint should be treated
@@ -342,11 +348,15 @@ func (l *LogsConfigKeys) obsPipelineWorkerDualShip() bool {
 // which can stall delivery to Datadog when OPW is degraded. The default is false (best-effort) so
 // that an unhealthy OPW cannot block the primary Datadog destination; operators who want OPW to
 // participate in flow control can opt in by setting this key to true.
+// Like obsPipelineWorkerDualShip it falls back to the legacy vector.* prefix.
 func (l *LogsConfigKeys) obsPipelineWorkerDualShipReliable() bool {
 	if l.vectorPrefix == "" {
 		return false
 	}
-	return l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dual_ship_reliable"))
+	if l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dual_ship_reliable")) {
+		return true
+	}
+	return l.getConfig().GetBool(l.getObsPipelineConfigKey("vector", "dual_ship_reliable"))
 }
 
 func (l *LogsConfigKeys) getObsPipelineURL() (string, bool) {

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -326,6 +326,17 @@ func (l *LogsConfigKeys) obsPipelineWorkerEnabled() bool {
 	return l.getConfig().GetBool(l.getObsPipelineConfigKey("vector", "enabled"))
 }
 
+// obsPipelineWorkerDualShip returns true when dual-ship mode is enabled, i.e. logs should be
+// sent to both the primary Datadog intake and the Observability Pipelines Worker simultaneously.
+// This method always returns false when the vectorPrefix is empty (i.e. the config keys instance
+// was not constructed with OPW support).
+func (l *LogsConfigKeys) obsPipelineWorkerDualShip() bool {
+	if l.vectorPrefix == "" {
+		return false
+	}
+	return l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dual_ship"))
+}
+
 func (l *LogsConfigKeys) getObsPipelineURL() (string, bool) {
 	if l.vectorPrefix != "" {
 		configKey := l.getObsPipelineConfigKey("observability_pipelines_worker", "url")

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -337,6 +337,18 @@ func (l *LogsConfigKeys) obsPipelineWorkerDualShip() bool {
 	return l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dual_ship"))
 }
 
+// obsPipelineWorkerDualShipReliable reports whether the OPW dual-ship endpoint should be treated
+// as reliable. Reliable additional endpoints apply backpressure to the main pipeline if they fail,
+// which can stall delivery to Datadog when OPW is degraded. The default is false (best-effort) so
+// that an unhealthy OPW cannot block the primary Datadog destination; operators who want OPW to
+// participate in flow control can opt in by setting this key to true.
+func (l *LogsConfigKeys) obsPipelineWorkerDualShipReliable() bool {
+	if l.vectorPrefix == "" {
+		return false
+	}
+	return l.getConfig().GetBool(l.getObsPipelineConfigKey("observability_pipelines_worker", "dual_ship_reliable"))
+}
+
 func (l *LogsConfigKeys) getObsPipelineURL() (string, bool) {
 	if l.vectorPrefix != "" {
 		configKey := l.getObsPipelineConfigKey("observability_pipelines_worker", "url")

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -901,7 +901,7 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShipAndAdditionalEndp
 }
 
 // TestBuildEndpointsWithOPWNoDualShipPreservesLegacyBehaviour verifies that when dual_ship is
-// absent (default false) the legacy "OPW replaces primary" behaviour is unchanged.
+// absent (default false) the existing "OPW replaces primary" behaviour is unchanged.
 func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWNoDualShipPreservesLegacyBehaviour() {
 	suite.config.SetWithoutSource("api_key", "123")
 	suite.config.SetWithoutSource("observability_pipelines_worker.logs.enabled", true)
@@ -911,12 +911,12 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWNoDualShipPreservesLegacy
 	endpoints, err := BuildHTTPEndpointsWithVectorOverride(suite.config, "test-track", "test-proto", "test-source")
 	suite.Require().Nil(err)
 
-	// Primary endpoint must be OPW (legacy override behaviour).
+	// Primary endpoint must be OPW (the default OPW-replaces-primary behaviour).
 	suite.Equal("opw.example.com", endpoints.Main.Host)
 	suite.Equal(8443, endpoints.Main.Port)
 
 	// Only one endpoint in total (no additional endpoints).
-	suite.Require().Len(endpoints.Endpoints, 1, "expected 1 endpoint (OPW as primary, legacy mode)")
+	suite.Require().Len(endpoints.Endpoints, 1, "expected 1 endpoint (OPW as primary, default mode)")
 }
 
 func (suite *ConfigTestSuite) TestEndpointsSetNonDefaultCustomConfigs() {

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -852,6 +852,16 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShip() {
 	suite.True(opwEndpoint.UseSSL())
 	suite.False(opwEndpoint.IsReliable(), "OPW dual-ship endpoint must default to unreliable so an unhealthy OPW cannot stall delivery to Datadog")
 	suite.True(opwEndpoint.isAdditionalEndpoint)
+
+	// OPW must inherit v2-API metadata from the main endpoint so traffic uses
+	// /api/v2/logs and the DD-PROTOCOL / DD-EVP-ORIGIN headers — same semantics as
+	// the primary Datadog destination and as user-supplied additional_endpoints.
+	suite.Equal(endpoints.Main.Version, opwEndpoint.Version)
+	suite.Equal(endpoints.Main.TrackType, opwEndpoint.TrackType)
+	suite.Equal(endpoints.Main.Protocol, opwEndpoint.Protocol)
+	suite.Equal(endpoints.Main.Origin, opwEndpoint.Origin)
+	suite.Equal(EPIntakeVersion2, opwEndpoint.Version)
+	suite.Equal(IntakeTrackType("test-track"), opwEndpoint.TrackType)
 }
 
 // TestBuildEndpointsWithOPWDualShipReliable verifies that the dual_ship_reliable opt-in flips the

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -900,9 +900,9 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShipAndAdditionalEndp
 	suite.Equal("extra.logs.example.com", userEndpoint.Host)
 }
 
-// TestBuildEndpointsWithOPWNoDualShipPreservesLegacyBehaviour verifies that when dual_ship is
-// absent (default false) the existing "OPW replaces primary" behaviour is unchanged.
-func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWNoDualShipPreservesLegacyBehaviour() {
+// TestBuildEndpointsWithOPWNoDualShipReplacesPrimary verifies that when dual_ship is absent
+// (default false) OPW continues to replace the primary Datadog endpoint — the default OPW mode.
+func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWNoDualShipReplacesPrimary() {
 	suite.config.SetWithoutSource("api_key", "123")
 	suite.config.SetWithoutSource("observability_pipelines_worker.logs.enabled", true)
 	suite.config.SetWithoutSource("observability_pipelines_worker.logs.url", "https://opw.example.com:8443/")

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -929,6 +929,63 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWNoDualShipReplacesPrimary
 	suite.Require().Len(endpoints.Endpoints, 1, "expected 1 endpoint (OPW as primary, default mode)")
 }
 
+// TestBuildEndpointsWithOPWDualShipInheritsCompressionOverride verifies that a compression override
+// passed via BuildHTTPEndpointsWithCompressionOverride is propagated to the OPW dual-ship endpoint.
+// Without the copy block the OPW endpoint would use the pre-override compression settings while the
+// primary DD endpoint uses the overridden ones — causing the two endpoints to compress differently.
+func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShipInheritsCompressionOverride() {
+	suite.config.SetWithoutSource("api_key", "123")
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.enabled", true)
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.url", "https://opw.example.com:8443/")
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.dual_ship", true)
+
+	logsConfig := NewLogsConfigKeysWithVector("logs_config.", "logs.", suite.config)
+	compressionOverride := EndpointCompressionOptions{
+		CompressionKind:  "zstd",
+		CompressionLevel: 9,
+	}
+
+	endpoints, err := BuildHTTPEndpointsWithCompressionOverride(suite.config, logsConfig, httpEndpointPrefix, "test-track", "test-proto", "test-source", compressionOverride)
+	suite.Require().Nil(err)
+
+	suite.Require().Len(endpoints.Endpoints, 2)
+	opwEndpoint := endpoints.Endpoints[1]
+	suite.Equal("opw.example.com", opwEndpoint.Host)
+
+	// OPW must use the same compression as the primary DD endpoint.
+	suite.Equal(endpoints.Main.UseCompression, opwEndpoint.UseCompression, "OPW must inherit UseCompression from main")
+	suite.Equal("zstd", opwEndpoint.CompressionKind, "OPW must inherit CompressionKind override from main")
+	suite.Equal(9, opwEndpoint.CompressionLevel, "OPW must inherit CompressionLevel override from main")
+	suite.Equal(endpoints.Main.BackoffFactor, opwEndpoint.BackoffFactor, "OPW must inherit BackoffFactor from main")
+	suite.Equal(endpoints.Main.BackoffBase, opwEndpoint.BackoffBase, "OPW must inherit BackoffBase from main")
+	suite.Equal(endpoints.Main.BackoffMax, opwEndpoint.BackoffMax, "OPW must inherit BackoffMax from main")
+	suite.Equal(endpoints.Main.RecoveryInterval, opwEndpoint.RecoveryInterval, "OPW must inherit RecoveryInterval from main")
+	suite.Equal(endpoints.Main.RecoveryReset, opwEndpoint.RecoveryReset, "OPW must inherit RecoveryReset from main")
+	suite.Equal(endpoints.Main.ConnectionResetInterval, opwEndpoint.ConnectionResetInterval, "OPW must inherit ConnectionResetInterval from main")
+}
+
+// TestBuildEndpointsWithOPWDualShipReliableWithoutDualShipWarns verifies that setting
+// dual_ship_reliable=true without dual_ship=true emits a startup warning, because the
+// reliability setting is silently ignored in that configuration.
+func TestBuildEndpointsWithOPWDualShipReliableWithoutDualShipWarns(t *testing.T) {
+	cfg := config.NewMock(t)
+	cfg.SetWithoutSource("api_key", "123")
+	cfg.SetWithoutSource("observability_pipelines_worker.logs.enabled", true)
+	cfg.SetWithoutSource("observability_pipelines_worker.logs.url", "https://opw.example.com:8443/")
+	// dual_ship_reliable=true but dual_ship is false (default) — should warn.
+	cfg.SetWithoutSource("observability_pipelines_worker.logs.dual_ship_reliable", true)
+
+	var buf bytes.Buffer
+	logger, err := pkglog.LoggerFromWriterWithMinLevelAndLvlMsgFormat(&buf, pkglog.WarnLvl)
+	assert.NoError(t, err)
+	pkglog.SetupLogger(logger, "warn")
+
+	_, buildErr := BuildHTTPEndpointsWithVectorOverride(cfg, "test-track", "test-proto", "test-source")
+	assert.NoError(t, buildErr)
+
+	assert.True(t, strings.Contains(buf.String(), "dual_ship_reliable=true has no effect"), "expected startup warning when dual_ship_reliable=true and dual_ship=false; got: %s", buf.String())
+}
+
 func (suite *ConfigTestSuite) TestEndpointsSetNonDefaultCustomConfigs() {
 	suite.config.SetWithoutSource("api_key", "123")
 

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -830,7 +830,7 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithoutVector() {
 }
 
 // TestBuildEndpointsWithOPWDualShip verifies that when dual_ship=true the primary DD endpoint
-// is kept and OPW is added as an additional reliable endpoint.
+// is kept and OPW is added as an additional best-effort (unreliable) endpoint by default.
 func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShip() {
 	suite.config.SetWithoutSource("api_key", "123")
 	suite.config.SetWithoutSource("observability_pipelines_worker.logs.enabled", true)
@@ -850,8 +850,26 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShip() {
 	suite.Equal("opw.example.com", opwEndpoint.Host)
 	suite.Equal(8443, opwEndpoint.Port)
 	suite.True(opwEndpoint.UseSSL())
-	suite.True(opwEndpoint.IsReliable())
+	suite.False(opwEndpoint.IsReliable(), "OPW dual-ship endpoint must default to unreliable so an unhealthy OPW cannot stall delivery to Datadog")
 	suite.True(opwEndpoint.isAdditionalEndpoint)
+}
+
+// TestBuildEndpointsWithOPWDualShipReliable verifies that the dual_ship_reliable opt-in flips the
+// OPW additional endpoint to reliable mode (so OPW failures apply backpressure to the main pipeline).
+func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShipReliable() {
+	suite.config.SetWithoutSource("api_key", "123")
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.enabled", true)
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.url", "https://opw.example.com:8443/")
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.dual_ship", true)
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.dual_ship_reliable", true)
+
+	endpoints, err := BuildHTTPEndpointsWithVectorOverride(suite.config, "test-track", "test-proto", "test-source")
+	suite.Require().Nil(err)
+
+	suite.Require().Len(endpoints.Endpoints, 2)
+	opwEndpoint := endpoints.Endpoints[1]
+	suite.Equal("opw.example.com", opwEndpoint.Host)
+	suite.True(opwEndpoint.IsReliable(), "dual_ship_reliable=true must make OPW a reliable additional endpoint")
 }
 
 // TestBuildEndpointsWithOPWDualShipAndAdditionalEndpoints verifies that when dual_ship=true is

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -829,6 +829,78 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithoutVector() {
 	suite.compareEndpoints(expectedEndpoints, endpoints)
 }
 
+// TestBuildEndpointsWithOPWDualShip verifies that when dual_ship=true the primary DD endpoint
+// is kept and OPW is added as an additional reliable endpoint.
+func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShip() {
+	suite.config.SetWithoutSource("api_key", "123")
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.enabled", true)
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.url", "https://opw.example.com:8443/")
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.dual_ship", true)
+
+	endpoints, err := BuildHTTPEndpointsWithVectorOverride(suite.config, "test-track", "test-proto", "test-source")
+	suite.Require().Nil(err)
+
+	// Primary endpoint must be the Datadog intake, not OPW.
+	suite.Equal("agent-http-intake.logs.datadoghq.com.", endpoints.Main.Host)
+
+	// There must be exactly two endpoints: [main (DD), OPW additional].
+	suite.Require().Len(endpoints.Endpoints, 2, "expected 2 endpoints (DD primary + OPW additional)")
+
+	opwEndpoint := endpoints.Endpoints[1]
+	suite.Equal("opw.example.com", opwEndpoint.Host)
+	suite.Equal(8443, opwEndpoint.Port)
+	suite.True(opwEndpoint.UseSSL())
+	suite.True(opwEndpoint.IsReliable())
+	suite.True(opwEndpoint.isAdditionalEndpoint)
+}
+
+// TestBuildEndpointsWithOPWDualShipAndAdditionalEndpoints verifies that when dual_ship=true is
+// combined with explicit additional_endpoints the user-configured endpoints are preserved and
+// the final list is: [DD primary, OPW additional, ...user additional_endpoints].
+func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShipAndAdditionalEndpoints() {
+	suite.config.SetWithoutSource("api_key", "123")
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.enabled", true)
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.url", "https://opw.example.com:8443/")
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.dual_ship", true)
+	suite.config.SetWithoutSource("logs_config.additional_endpoints", []map[string]interface{}{
+		{"api_key": "456", "host": "extra.logs.example.com", "port": 443, "use_ssl": true},
+	})
+
+	endpoints, err := BuildHTTPEndpointsWithVectorOverride(suite.config, "test-track", "test-proto", "test-source")
+	suite.Require().Nil(err)
+
+	// Primary endpoint must be Datadog.
+	suite.Equal("agent-http-intake.logs.datadoghq.com.", endpoints.Main.Host)
+
+	// [DD primary, OPW additional, user-configured additional] = 3 total.
+	suite.Require().Len(endpoints.Endpoints, 3, "expected 3 endpoints (DD + OPW + user additional)")
+
+	opwEndpoint := endpoints.Endpoints[1]
+	suite.Equal("opw.example.com", opwEndpoint.Host)
+
+	userEndpoint := endpoints.Endpoints[2]
+	suite.Equal("extra.logs.example.com", userEndpoint.Host)
+}
+
+// TestBuildEndpointsWithOPWNoDualShipPreservesLegacyBehaviour verifies that when dual_ship is
+// absent (default false) the legacy "OPW replaces primary" behaviour is unchanged.
+func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWNoDualShipPreservesLegacyBehaviour() {
+	suite.config.SetWithoutSource("api_key", "123")
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.enabled", true)
+	suite.config.SetWithoutSource("observability_pipelines_worker.logs.url", "https://opw.example.com:8443/")
+	// dual_ship is intentionally NOT set — should default to false.
+
+	endpoints, err := BuildHTTPEndpointsWithVectorOverride(suite.config, "test-track", "test-proto", "test-source")
+	suite.Require().Nil(err)
+
+	// Primary endpoint must be OPW (legacy override behaviour).
+	suite.Equal("opw.example.com", endpoints.Main.Host)
+	suite.Equal(8443, endpoints.Main.Port)
+
+	// Only one endpoint in total (no additional endpoints).
+	suite.Require().Len(endpoints.Endpoints, 1, "expected 1 endpoint (OPW as primary, legacy mode)")
+}
+
 func (suite *ConfigTestSuite) TestEndpointsSetNonDefaultCustomConfigs() {
 	suite.config.SetWithoutSource("api_key", "123")
 

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -964,6 +964,72 @@ func (suite *ConfigTestSuite) TestBuildEndpointsWithOPWDualShipInheritsCompressi
 	suite.Equal(endpoints.Main.ConnectionResetInterval, opwEndpoint.ConnectionResetInterval, "OPW must inherit ConnectionResetInterval from main")
 }
 
+// TestBuildEndpointsWithLegacyVectorDualShip verifies that the legacy vector.* prefix is
+// honoured for dual_ship so that users still on the old config are not silently broken.
+// When vector.logs.dual_ship=true the OPW endpoint must appear as an additional endpoint
+// (dual-ship mode) exactly as it would when the modern observability_pipelines_worker key is set.
+func (suite *ConfigTestSuite) TestBuildEndpointsWithLegacyVectorDualShip() {
+	suite.config.SetWithoutSource("api_key", "123")
+	// Use the legacy vector.* prefix for all three OPW settings.
+	suite.config.SetWithoutSource("vector.logs.enabled", true)
+	suite.config.SetWithoutSource("vector.logs.url", "https://opw.example.com:8443/")
+	suite.config.SetWithoutSource("vector.logs.dual_ship", true)
+
+	endpoints, err := BuildHTTPEndpointsWithVectorOverride(suite.config, "test-track", "test-proto", "test-source")
+	suite.Require().Nil(err)
+
+	// Primary endpoint must be the Datadog intake, not OPW.
+	suite.Equal("agent-http-intake.logs.datadoghq.com.", endpoints.Main.Host)
+
+	// There must be exactly two endpoints: [main (DD), OPW additional].
+	suite.Require().Len(endpoints.Endpoints, 2, "expected 2 endpoints (DD primary + OPW additional) when legacy vector.logs.dual_ship=true")
+
+	opwEndpoint := endpoints.Endpoints[1]
+	suite.Equal("opw.example.com", opwEndpoint.Host)
+	suite.Equal(8443, opwEndpoint.Port)
+	suite.True(opwEndpoint.UseSSL())
+	suite.True(opwEndpoint.isAdditionalEndpoint)
+	suite.False(opwEndpoint.IsReliable(), "OPW dual-ship endpoint must default to unreliable even via legacy prefix")
+}
+
+// TestBuildEndpointsWithLegacyVectorDualShipReliable verifies that the legacy
+// vector.logs.dual_ship_reliable key is honoured via the fallback path.
+func (suite *ConfigTestSuite) TestBuildEndpointsWithLegacyVectorDualShipReliable() {
+	suite.config.SetWithoutSource("api_key", "123")
+	suite.config.SetWithoutSource("vector.logs.enabled", true)
+	suite.config.SetWithoutSource("vector.logs.url", "https://opw.example.com:8443/")
+	suite.config.SetWithoutSource("vector.logs.dual_ship", true)
+	suite.config.SetWithoutSource("vector.logs.dual_ship_reliable", true)
+
+	endpoints, err := BuildHTTPEndpointsWithVectorOverride(suite.config, "test-track", "test-proto", "test-source")
+	suite.Require().Nil(err)
+
+	suite.Require().Len(endpoints.Endpoints, 2)
+	opwEndpoint := endpoints.Endpoints[1]
+	suite.Equal("opw.example.com", opwEndpoint.Host)
+	suite.True(opwEndpoint.IsReliable(), "vector.logs.dual_ship_reliable=true must make OPW a reliable additional endpoint via legacy prefix")
+}
+
+// TestBuildEndpointsWithOPWDualShipNoOPWEnabledWarns verifies that setting dual_ship=true when
+// OPW is not enabled (or has no URL) emits a startup warning, because dual_ship has no effect
+// in that configuration — the OPW block is skipped entirely.
+func TestBuildEndpointsWithOPWDualShipNoOPWEnabledWarns(t *testing.T) {
+	cfg := config.NewMock(t)
+	cfg.SetWithoutSource("api_key", "123")
+	// OPW is NOT enabled — dual_ship=true should warn and silently no-op.
+	cfg.SetWithoutSource("observability_pipelines_worker.logs.dual_ship", true)
+
+	var buf bytes.Buffer
+	logger, err := pkglog.LoggerFromWriterWithMinLevelAndLvlMsgFormat(&buf, pkglog.WarnLvl)
+	assert.NoError(t, err)
+	pkglog.SetupLogger(logger, "warn")
+
+	_, buildErr := BuildHTTPEndpointsWithVectorOverride(cfg, "test-track", "test-proto", "test-source")
+	assert.NoError(t, buildErr)
+
+	assert.True(t, strings.Contains(buf.String(), "dual_ship=true has no effect"), "expected startup warning when dual_ship=true and OPW is not enabled; got: %s", buf.String())
+}
+
 // TestBuildEndpointsWithOPWDualShipReliableWithoutDualShipWarns verifies that setting
 // dual_ship_reliable=true without dual_ship=true emits a startup warning, because the
 // reliability setting is silently ignored in that configuration.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -787,6 +787,26 @@ api_key:
 #
 #     url: "http://127.0.0.1:8080"
 
+#     # @param dual_ship - boolean - optional - default: false
+#     # @env DD_OBSERVABILITY_PIPELINES_WORKER_LOGS_DUAL_SHIP - boolean - optional - default: false
+#     # When false (default), the Observability Pipelines Worker replaces the primary
+#     # Datadog logs intake as the sole destination. When true, logs are sent to BOTH
+#     # the primary Datadog intake and the Observability Pipelines Worker, which is
+#     # useful for evaluating OPW without interrupting the existing flow of telemetry
+#     # to Datadog.
+#
+#     dual_ship: false
+
+#     # @param dual_ship_reliable - boolean - optional - default: false
+#     # @env DD_OBSERVABILITY_PIPELINES_WORKER_LOGS_DUAL_SHIP_RELIABLE - boolean - optional - default: false
+#     # Only meaningful when `dual_ship` is true. When false (default), the OPW
+#     # destination is treated as best-effort: failures to OPW do not apply
+#     # backpressure to the main pipeline, so an unhealthy OPW cannot stall delivery
+#     # to Datadog. Set to true to make the OPW destination reliable, meaning its
+#     # failures participate in flow control just like the primary Datadog endpoint.
+#
+#     dual_ship_reliable: false
+
 #   # @param traces - custom object - optional
 #   # Specific configurations for traces
 #

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1940,8 +1940,10 @@ func vector(config pkgconfigmodel.Setup) {
 	// dual_ship is logs-only: there is no equivalent dual-shipping code path for metrics, so
 	// these keys live outside bindVectorOptions to avoid registering an unused metrics variant.
 	//
-	// dual_ship: when false (default), OPW replaces the primary Datadog endpoint (legacy behaviour).
-	// When true, Datadog remains the primary endpoint and OPW is added as an additional endpoint.
+	// dual_ship: when false (default), OPW replaces the primary Datadog endpoint and is the only
+	// destination logs are shipped to. When true, Datadog remains the primary endpoint and OPW is
+	// added as an additional endpoint — intended for operators evaluating OPW without interrupting
+	// the existing flow of telemetry to Datadog.
 	//
 	// dual_ship_reliable: when dual_ship=true, controls whether the OPW additional endpoint applies
 	// backpressure to the main pipeline on failure (true) or is best-effort (false, the default).

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1936,17 +1936,23 @@ func logsagent(config pkgconfigmodel.Setup) {
 func vector(config pkgconfigmodel.Setup) {
 	bindVectorOptions(config, Metrics)
 	bindVectorOptions(config, Logs)
+
+	// dual_ship is logs-only: there is no equivalent dual-shipping code path for metrics, so
+	// these keys live outside bindVectorOptions to avoid registering an unused metrics variant.
+	//
+	// dual_ship: when false (default), OPW replaces the primary Datadog endpoint (legacy behaviour).
+	// When true, Datadog remains the primary endpoint and OPW is added as an additional endpoint.
+	//
+	// dual_ship_reliable: when dual_ship=true, controls whether the OPW additional endpoint applies
+	// backpressure to the main pipeline on failure (true) or is best-effort (false, the default).
+	// Best-effort is the safer default: an unreachable OPW must not block delivery to Datadog.
+	config.BindEnvAndSetDefault("observability_pipelines_worker.logs.dual_ship", false)
+	config.BindEnvAndSetDefault("observability_pipelines_worker.logs.dual_ship_reliable", false)
 }
 
 func bindVectorOptions(config pkgconfigmodel.Setup, datatype string) {
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.enabled", datatype), false)
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.url", datatype), "")
-	// dual_ship controls whether logs are sent to BOTH Datadog and OPW simultaneously.
-	// When false (default), OPW replaces the primary Datadog endpoint (legacy behaviour).
-	// When true, Datadog remains the primary endpoint and OPW is added as an additional
-	// reliable endpoint — equivalent to the user manually composing additional_endpoints
-	// with the OPW URL.
-	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.dual_ship", datatype), false)
 
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.enabled", datatype), false)
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.url", datatype), "")

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -7,6 +7,7 @@
 package setup
 
 import (
+	"fmt"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -1933,14 +1934,22 @@ func logsagent(config pkgconfigmodel.Setup) {
 
 // vector integration
 func vector(config pkgconfigmodel.Setup) {
-	config.BindEnvAndSetDefault("observability_pipelines_worker.metrics.enabled", false)
-	config.BindEnvAndSetDefault("observability_pipelines_worker.metrics.url", "")
-	config.BindEnvAndSetDefault("vector.metrics.enabled", false)
-	config.BindEnvAndSetDefault("vector.metrics.url", "")
-	config.BindEnvAndSetDefault("observability_pipelines_worker.logs.enabled", false)
-	config.BindEnvAndSetDefault("observability_pipelines_worker.logs.url", "")
-	config.BindEnvAndSetDefault("vector.logs.enabled", false)
-	config.BindEnvAndSetDefault("vector.logs.url", "")
+	bindVectorOptions(config, Metrics)
+	bindVectorOptions(config, Logs)
+}
+
+func bindVectorOptions(config pkgconfigmodel.Setup, datatype string) {
+	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.enabled", datatype), false)
+	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.url", datatype), "")
+	// dual_ship controls whether logs are sent to BOTH Datadog and OPW simultaneously.
+	// When false (default), OPW replaces the primary Datadog endpoint (legacy behaviour).
+	// When true, Datadog remains the primary endpoint and OPW is added as an additional
+	// reliable endpoint — equivalent to the user manually composing additional_endpoints
+	// with the OPW URL.
+	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.dual_ship", datatype), false)
+
+	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.enabled", datatype), false)
+	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.url", datatype), "")
 }
 
 func cloudfoundry(config pkgconfigmodel.Setup) {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1950,6 +1950,11 @@ func vector(config pkgconfigmodel.Setup) {
 	// Best-effort is the safer default: an unreachable OPW must not block delivery to Datadog.
 	config.BindEnvAndSetDefault("observability_pipelines_worker.logs.dual_ship", false)
 	config.BindEnvAndSetDefault("observability_pipelines_worker.logs.dual_ship_reliable", false)
+
+	// Legacy vector.* aliases for dual_ship keys — users still on the legacy prefix must not have
+	// dual_ship=true silently dropped when the fallback in obsPipelineWorkerDualShip reads these keys.
+	config.BindEnvAndSetDefault("vector.logs.dual_ship", false)
+	config.BindEnvAndSetDefault("vector.logs.dual_ship_reliable", false)
 }
 
 func bindVectorOptions(config pkgconfigmodel.Setup, datatype string) {

--- a/releasenotes/notes/opw-dual-ship-config-AGNTLOG154-a1b2c3d4e5f6a7b8.yaml
+++ b/releasenotes/notes/opw-dual-ship-config-AGNTLOG154-a1b2c3d4e5f6a7b8.yaml
@@ -14,3 +14,10 @@ features:
     without requiring users to manually compose ``logs_config.additional_endpoints``.
     The default value is ``false``, which preserves the existing behaviour where OPW
     replaces the primary Datadog endpoint.
+
+    By default the OPW destination is treated as a best-effort (unreliable) additional
+    endpoint, so an unhealthy OPW cannot apply backpressure to the main pipeline and
+    stall delivery to Datadog. Set
+    ``observability_pipelines_worker.logs.dual_ship_reliable`` to ``true`` to opt OPW
+    into reliable mode, where failures to OPW participate in flow control just like
+    the primary Datadog endpoint.

--- a/releasenotes/notes/opw-dual-ship-config-AGNTLOG154-a1b2c3d4e5f6a7b8.yaml
+++ b/releasenotes/notes/opw-dual-ship-config-AGNTLOG154-a1b2c3d4e5f6a7b8.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Logs: Add ``observability_pipelines_worker.logs.dual_ship`` configuration option.
+    When set to ``true``, the Agent sends logs simultaneously to both the primary
+    Datadog intake **and** the configured Observability Pipelines Worker (OPW) URL,
+    without requiring users to manually compose ``logs_config.additional_endpoints``.
+    The default value is ``false``, which preserves the existing behaviour where OPW
+    replaces the primary Datadog endpoint.


### PR DESCRIPTION
## Summary

JIRA: [AGNTLOG-154](https://datadoghq.atlassian.net/browse/AGNTLOG-154)

Today, users who want to dual-ship logs to both Datadog and an Observability Pipelines Worker (OPW) must know to manually combine two config sections:
- `observability_pipelines_worker.logs.url` (to configure OPW)
- `logs_config.additional_endpoints` (to retain the DD intake)

This PR adds a single dedicated config key that does the same composition under the hood, with no manual wiring required.

### Design

A new key is registered in `observability_pipelines_worker.logs`:

```yaml
observability_pipelines_worker:
  logs:
    enabled: true
    url: "https://opw.example.com:8443"
    dual_ship: true   # NEW — default: false
```

**When `dual_ship: false` (default):** Existing behaviour unchanged. OPW replaces the primary Datadog endpoint.

**When `dual_ship: true`:** The Datadog intake remains the primary endpoint. OPW is added as an additional reliable endpoint, equivalent to the user manually adding the OPW URL to `logs_config.additional_endpoints`. The same API key is used for both.

User-configured `additional_endpoints` are preserved and appear after the OPW entry, so `dual_ship: true` + manual `additional_endpoints` yields 3 total endpoints (DD primary, OPW additional, user additional).

### Changed files

| File | Change |
|------|--------|
| `pkg/config/setup/common_settings.go` | Register `observability_pipelines_worker.logs.dual_ship` (default `false`) |
| `comp/logs/agent/config/config_keys.go` | Add `obsPipelineWorkerDualShip()` accessor |
| `comp/logs/agent/config/config.go` | Wire dual-ship logic in `buildHTTPEndpoints` |
| `comp/logs/agent/config/config_test.go` | 3 new test cases (see below) |
| `releasenotes/notes/opw-dual-ship-config-AGNTLOG154-*.yaml` | Release note |

## Manual QA

The agent was built cleanly on macOS arm64:

```
dda inv agent.build --build-exclude=systemd
# Build completed successfully
```

### Unit test output

All 3 new scenarios pass:

```
=== RUN   TestConfigTestSuite/TestBuildEndpointsWithOPWDualShip
--- PASS: TestConfigTestSuite/TestBuildEndpointsWithOPWDualShip (0.01s)

=== RUN   TestConfigTestSuite/TestBuildEndpointsWithOPWDualShipAndAdditionalEndpoints
--- PASS: TestConfigTestSuite/TestBuildEndpointsWithOPWDualShipAndAdditionalEndpoints (0.01s)

=== RUN   TestConfigTestSuite/TestBuildEndpointsWithOPWNoDualShipPreservesLegacyBehaviour
--- PASS: TestConfigTestSuite/TestBuildEndpointsWithOPWNoDualShipPreservesLegacyBehaviour (0.01s)
```

Full suite (207 tests):

```
✓  comp/logs/agent/config (1.698s)
DONE 207 tests in 1.699s — All tests passed
```

### Scenario descriptions

**Scenario A — Legacy (dual_ship absent/false): OPW replaces primary**
Config: `opw.enabled=true, opw.url=https://opw.example.com:8443/` — `dual_ship` not set.
Result: `main.Host=opw.example.com`, 1 total endpoint. Existing behaviour unchanged. ✓

**Scenario B — dual_ship=true: 2 endpoints (DD primary + OPW additional)**
Config: `opw.enabled=true, opw.url=https://opw.example.com:8443/, dual_ship=true`.
Result: `main.Host=agent-http-intake.logs.datadoghq.com.`, `endpoints[1].Host=opw.example.com`, 2 total endpoints. ✓

**Scenario C — dual_ship=true + user additional_endpoints: 3 endpoints**
Config: same as B, plus `logs_config.additional_endpoints=[{host: extra.logs.example.com}]`.
Result: 3 total endpoints: [DD primary, OPW additional, user additional]. User-configured endpoints are NOT clobbered. ✓

## Backward compatibility

- `dual_ship` defaults to `false` — existing OPW configurations are 100% unaffected.
- No new required config keys; no changes to the wire format.
- Existing `additional_endpoints` users are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGNTLOG-154]: https://datadoghq.atlassian.net/browse/AGNTLOG-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

## End-to-end binary QA (live agent run)

`dda inv agent.build --build-exclude=systemd` → built. Two real `./bin/agent/agent run` runs, comparing the logs data path:

```yaml
# Scenario A — opw.enabled, no dual_ship: OPW replaces primary (legacy)
observability_pipelines_worker:
  logs:
    enabled: true
    url: "https://opw-a.example.com:8443"
```

Result (filtered to logs library data-path log lines):
```
CheckConnectivity → opw-a.example.com:8443/api/v2/logs
sendAndRetry      → opw-a.example.com:8443/api/v2/logs  (single endpoint)
```
No log payload was sent to `agent-http-intake.logs.datadoghq.com`. The DD intake hit visible in the diagnose-connectivity sweep is the unrelated startup probe, not the logs data path.

```yaml
# Scenario B — same + dual_ship: true
observability_pipelines_worker:
  logs:
    enabled: true
    url: "https://opw-b.example.com:8443"
    dual_ship: true
```

Result:
```
CheckConnectivity → agent-http-intake.logs.datadoghq.com/api/v2/logs  (DD primary)
sendAndRetry      → opw-b.example.com:8443/v1/input                    (OPW additional)
unconditionalSend → agent-http-intake.logs.datadoghq.com/api/v2/logs   (DD primary)
```
Both endpoints active.

Confirms the unit-test scenarios (A, B, C) reflect real binary behavior; legacy path unchanged.