### PR TITLE
[snmpscan] configurable + adaptive GetBulk max-repetitions

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"strconv"
@@ -279,6 +280,9 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, flags scanFlags
 	deviceAddr := args[0]
 	if len(args) > 1 {
 		return confErrf("unexpected extra arguments; only one argument expected.")
+	}
+	if flags.bulkMaxRep < 0 || uint64(flags.bulkMaxRep) > math.MaxUint32 {
+		return confErrf("--bulk-max-rep must be between 1 and %d (0 = default)", uint32(math.MaxUint32))
 	}
 	// Parse port from IP address
 	connParams.IPAddress, connParams.Port, _ = maybeSplitIP(deviceAddr)

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -47,6 +47,11 @@ const (
 // argsType is an alias so we can inject the args via fx.
 type argsType []string
 
+// scanFlags carries scan-specific CLI flag values into fx-resolved functions.
+type scanFlags struct {
+	bulkMaxRep int
+}
+
 // configErr wraps any error caused by invalid configuration.
 // If the main script returns a configErr it will print the usage string along
 // with the error message.
@@ -143,6 +148,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 	logLevelDefaultOff := command.LogLevelDefaultOff{}
 
+	var bulkMaxRep int
+
 	// This command does nothing until the backend supports it, so it isn't visible yet.
 	snmpScanCmd := &cobra.Command{
 		Hidden: true,
@@ -153,7 +160,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			err := fxutil.OneShot(scanDevice,
-				fx.Supply(connParams, globalParams, cmd),
+				fx.Supply(connParams, globalParams, cmd, scanFlags{bulkMaxRep: bulkMaxRep}),
 				fx.Provide(func() argsType { return args }),
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
@@ -204,6 +211,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	// general communication options
 	snmpScanCmd.Flags().IntVarP(&connParams.Retries, "retries", "r", defaultRetries, "Set the number of retries")
 	snmpScanCmd.Flags().IntVarP(&connParams.Timeout, "timeout", "t", defaultTimeout, "Set the request timeout (in seconds)")
+	snmpScanCmd.Flags().IntVar(&bulkMaxRep, "bulk-max-rep", 0, "Starting max-repetitions for GetBulk during scan (0 = default 10, matching snmpbulkwalk -Cr). Halves on timeout, recovers on success.")
 
 	// This command does nothing until the backend supports it, so it isn't enabled yet.
 	snmpCmd.AddCommand(snmpScanCmd)
@@ -263,7 +271,7 @@ func setDefaultsFromAgent(connParams *snmpparse.SNMPConfig, agentParams *snmppar
 	}
 }
 
-func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snmpscan.Component, conf config.Component, client ipc.HTTPClient) error {
+func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, flags scanFlags, snmpScanner snmpscan.Component, conf config.Component, client ipc.HTTPClient) error {
 	// Parse args
 	if len(args) == 0 {
 		return confErrf("missing argument: IP address")
@@ -287,7 +295,8 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 	fmt.Printf("Launching scan for device: %s\n", deviceID)
 	err := snmpScanner.ScanDeviceAndSendData(context.Background(), connParams, namespace,
 		snmpscan.ScanParams{
-			ScanType: metadata.ManualScan,
+			ScanType:           metadata.ManualScan,
+			BulkMaxRepetitions: flags.bulkMaxRep,
 		})
 	if err != nil {
 		fmt.Printf("Unable to perform device scan for device %s: %v\n", deviceID, err)

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -35,4 +35,10 @@ type ScanParams struct {
 	// MaxCallCount limits the total number of SNMP calls in a scan.
 	// A value of 0 means there is no limit.
 	MaxCallCount int
+
+	// BulkMaxRepetitions is the starting max-repetitions value for GetBulk
+	// during a device scan. 0 means use the default (10, matching snmpbulkwalk).
+	// The scan halves this value on timeout/failure and recovers toward this
+	// ceiling on success.
+	BulkMaxRepetitions int
 }

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -14,6 +14,7 @@ import (
 
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
+	"github.com/DataDog/datadog-agent/pkg/snmp/batchsize"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 
@@ -62,8 +63,12 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(ctx context.Context, connParams *
 				snmp.LocalAddr, snmp.Port, errors.Join(errs...)),
 		)
 	}
+	bulkMaxRep := scanParams.BulkMaxRepetitions
+	if bulkMaxRep <= 0 {
+		bulkMaxRep = defaultBulkMaxRepetitions
+	}
 	err = s.runDeviceScan(ctx, snmp, namespace, deviceID,
-		scanParams.CallInterval, scanParams.MaxCallCount)
+		scanParams.CallInterval, scanParams.MaxCallCount, bulkMaxRep)
 	if err != nil {
 		errs := []error{err}
 
@@ -109,16 +114,17 @@ func (s snmpScannerImpl) runDeviceScan(
 	deviceID string,
 	callInterval time.Duration,
 	maxCallCount int,
+	bulkMaxRep int,
 ) error {
 	if comparisonModeEnabled {
-		return s.runDeviceScanComparison(ctx, snmpConnection, callInterval, maxCallCount)
+		return s.runDeviceScanComparison(ctx, snmpConnection, callInterval, maxCallCount, bulkMaxRep)
 	}
 
 	// Execute the scan using GetBulk-based walk.
 	// This approach never sends fabricated OIDs to devices, which:
 	// - Prevents infinite loops on devices that respond incorrectly to non-existent OIDs
 	// - Prevents crashes on devices that can't handle malformed table indices
-	pdus, err := gatherPDUsWithBulk(ctx, snmpConnection, callInterval, maxCallCount)
+	pdus, err := gatherPDUsWithBulk(ctx, snmpConnection, callInterval, maxCallCount, bulkMaxRep)
 	if err != nil {
 		return err
 	}
@@ -159,6 +165,7 @@ func (s snmpScannerImpl) runDeviceScanComparison(
 	snmpConnection *gosnmp.GoSNMP,
 	callInterval time.Duration,
 	maxCallCount int,
+	bulkMaxRep int,
 ) error {
 	fmt.Println("\n" + strings.Repeat("=", 60))
 	fmt.Println("SCAN COMPARISON MODE (testing only - no data sent)")
@@ -169,7 +176,7 @@ func (s snmpScannerImpl) runDeviceScanComparison(
 	// Run GetBulk-based scan FIRST (safer - won't crash devices)
 	fmt.Println("\n[1/2] Running GetBulk-based scan (new, safe approach)...")
 	bulkStart := time.Now()
-	bulkPDUs, bulkErr := gatherPDUsWithBulk(ctx, snmpConnection, callInterval, maxCallCount)
+	bulkPDUs, bulkErr := gatherPDUsWithBulk(ctx, snmpConnection, callInterval, maxCallCount, bulkMaxRep)
 	bulkDuration := time.Since(bulkStart)
 
 	bulkResult := scanResult{
@@ -263,7 +270,15 @@ func gatherPDUs(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Dura
 	return pdus, nil
 }
 
-const defaultBulkBatchSize = 50
+// defaultBulkMaxRepetitions is the starting max-repetitions value for GetBulk
+// during a device scan. Matches net-snmp's `snmpbulkwalk -Cr` default.
+const defaultBulkMaxRepetitions = 10
+
+// bulkGetter is the GetBulk surface gatherPDUsWithBulk needs. Wrapping it in an
+// interface lets tests substitute a fake without depending on a live gosnmp.
+type bulkGetter interface {
+	GetBulk(oids []string, nonRepeaters uint8, maxRepetitions uint32) (*gosnmp.SnmpPacket, error)
+}
 
 // gatherPDUsWithBulk returns PDUs from the given SNMP device using GetBulk operations.
 // It walks the entire MIB tree but filters results to keep only one row per column.
@@ -273,9 +288,13 @@ const defaultBulkBatchSize = 50
 //   - Cannot cause infinite loops - tracks visited OIDs
 //   - Cannot crash devices - never sends malformed table indices
 //
+// Adaptive max-repetitions: on GetBulk error the value is halved and the same
+// OID is retried, so a device that times out at a high value can still be
+// walked. On success the value grows back toward bulkMaxRep.
+//
 // Trade-off: May be slower than gatherPDUs for devices with large tables (1000+ rows)
 // because it retrieves all rows before filtering.
-func gatherPDUsWithBulk(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval time.Duration, maxCallCount int) ([]*gosnmp.SnmpPDU, error) {
+func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, callInterval time.Duration, maxCallCount int, bulkMaxRep int) ([]*gosnmp.SnmpPDU, error) {
 	var result []*gosnmp.SnmpPDU
 	seenColumns := make(map[string]bool)
 	visitedOIDs := make(map[string]bool)
@@ -283,7 +302,7 @@ func gatherPDUsWithBulk(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval t
 	// Start from the beginning of the MIB tree
 	oid := ".0.0"
 	requests := 0
-	batchSize := uint32(defaultBulkBatchSize)
+	maxRepOpt := batchsize.NewOptimizer(bulkMaxRep)
 
 	for {
 		select {
@@ -302,10 +321,16 @@ func gatherPDUsWithBulk(ctx context.Context, snmp *gosnmp.GoSNMP, callInterval t
 		}
 
 		// Use GetBulk with REAL OIDs only (never fabricated)
-		response, err := snmp.GetBulk([]string{oid}, 0, batchSize)
+		maxRep := uint32(maxRepOpt.BatchSize())
+		response, err := snmp.GetBulk([]string{oid}, 0, maxRep)
 		if err != nil {
-			return result, fmt.Errorf("GetBulk error at OID %s: %w", oid, err)
+			if maxRepOpt.OnFailure() {
+				// Retry against the same OID at a smaller max-repetitions.
+				continue
+			}
+			return result, fmt.Errorf("GetBulk error at OID %s (max-rep=%d): %w", oid, maxRep, err)
 		}
+		maxRepOpt.OnSuccess()
 
 		if len(response.Variables) == 0 {
 			// No more data

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/snmp/batchsize"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/gosnmp/gosnmp"
 )
@@ -324,13 +325,21 @@ func gatherPDUsWithBulk(ctx context.Context, snmp bulkGetter, callInterval time.
 		maxRep := uint32(maxRepOpt.BatchSize())
 		response, err := snmp.GetBulk([]string{oid}, 0, maxRep)
 		if err != nil {
-			if maxRepOpt.OnFailure() {
+			shouldRetry := maxRepOpt.OnFailure()
+			log.Debugf("SNMP scan GetBulk at OID %s with max-rep %d failed, new max-rep is %d",
+				oid, maxRep, maxRepOpt.BatchSize())
+			if shouldRetry {
 				// Retry against the same OID at a smaller max-repetitions.
 				continue
 			}
 			return result, fmt.Errorf("GetBulk error at OID %s (max-rep=%d): %w", oid, maxRep, err)
 		}
+		oldMaxRep := maxRepOpt.BatchSize()
 		maxRepOpt.OnSuccess()
+		if newMaxRep := maxRepOpt.BatchSize(); newMaxRep != oldMaxRep {
+			log.Debugf("SNMP scan GetBulk at OID %s with max-rep %d success, new max-rep is %d",
+				oid, oldMaxRep, newMaxRep)
+		}
 
 		if len(response.Variables) == 0 {
 			// No more data

--- a/comp/snmpscan/impl/devicescan_test.go
+++ b/comp/snmpscan/impl/devicescan_test.go
@@ -9,12 +9,14 @@ package snmpscanimpl
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractColumnSignatureIntegration(t *testing.T) {
@@ -80,7 +82,7 @@ func TestGatherPDUsWithBulk_ContextCancellation(t *testing.T) {
 		Version:   gosnmp.Version2c,
 	}
 
-	_, err := gatherPDUsWithBulk(ctx, snmp, 0, 0)
+	_, err := gatherPDUsWithBulk(ctx, snmp, 0, 0, defaultBulkMaxRepetitions)
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -102,8 +104,85 @@ func TestGatherPDUsWithBulk_MaxCallCount(t *testing.T) {
 
 	// With maxCallCount=1, it should try one GetBulk, fail to connect,
 	// and return an error (either connection error or max count error)
-	_, err := gatherPDUsWithBulk(ctx, snmp, 0, 1)
+	_, err := gatherPDUsWithBulk(ctx, snmp, 0, 1, defaultBulkMaxRepetitions)
 	assert.Error(t, err)
+}
+
+// fakeBulkGetter is a scripted GetBulk for testing adaptive behavior.
+type fakeBulkGetter struct {
+	responses []bulkResponse
+	calls     []bulkCall
+}
+
+type bulkCall struct {
+	oid    string
+	maxRep uint32
+}
+
+type bulkResponse struct {
+	packet *gosnmp.SnmpPacket
+	err    error
+}
+
+func (f *fakeBulkGetter) GetBulk(oids []string, _ uint8, maxRep uint32) (*gosnmp.SnmpPacket, error) {
+	f.calls = append(f.calls, bulkCall{oid: oids[0], maxRep: maxRep})
+	if len(f.calls) > len(f.responses) {
+		return nil, errors.New("fakeBulkGetter: no more canned responses")
+	}
+	resp := f.responses[len(f.calls)-1]
+	return resp.packet, resp.err
+}
+
+// endOfMibPacket returns a packet that immediately ends the walk.
+func endOfMibPacket() *gosnmp.SnmpPacket {
+	return &gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{Name: ".0.0", Type: gosnmp.EndOfMibView},
+		},
+	}
+}
+
+func TestGatherPDUsWithBulk_AdaptsMaxRepOnFailure(t *testing.T) {
+	// First call at max-rep=10 times out; optimizer halves to 5; second call
+	// succeeds. Verify the OID didn't advance and the second call used a
+	// smaller max-rep.
+	fake := &fakeBulkGetter{
+		responses: []bulkResponse{
+			{err: errors.New("request timeout")},
+			{packet: endOfMibPacket()},
+		},
+	}
+
+	_, err := gatherPDUsWithBulk(context.Background(), fake, 0, 0, 10)
+	require.NoError(t, err)
+
+	require.Len(t, fake.calls, 2)
+	assert.Equal(t, ".0.0", fake.calls[0].oid)
+	assert.Equal(t, ".0.0", fake.calls[1].oid, "OID should not advance on retry")
+	assert.Equal(t, uint32(10), fake.calls[0].maxRep)
+	assert.Equal(t, uint32(5), fake.calls[1].maxRep, "max-rep should halve on failure")
+}
+
+func TestGatherPDUsWithBulk_GivesUpWhenMaxRepCannotShrink(t *testing.T) {
+	// Every call fails. The optimizer halves down to 1 and then has nowhere
+	// further to go, so OnFailure returns false and gatherPDUsWithBulk
+	// surfaces the error.
+	timeoutErr := errors.New("request timeout")
+	fake := &fakeBulkGetter{
+		responses: []bulkResponse{
+			{err: timeoutErr},
+			{err: timeoutErr},
+			{err: timeoutErr},
+			{err: timeoutErr},
+			{err: timeoutErr}, // floor at 1
+		},
+	}
+
+	_, err := gatherPDUsWithBulk(context.Background(), fake, 0, 0, 4)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request timeout")
+	// 4 → 2 → 1 → still 1 (OnFailure returns false): 3 calls.
+	assert.GreaterOrEqual(t, len(fake.calls), 2)
 }
 
 func TestColumnFilteringLogic(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/fetch/batch_size_optimizers.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/batch_size_optimizers.go
@@ -8,115 +8,42 @@ package fetch
 import (
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/snmp/batchsize"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	onSuccessIncreaseValue  = 1
-	onFailureDecreaseFactor = 2
+const failuresWindowDuration = 60 * time.Minute
 
-	failuresWindowDuration = 60 * time.Minute
-	maxFailuresPerWindow   = 2
-)
-
-// OidBatchSizeOptimizers holds oidBatchSizeOptimizer for each SNMP request operation
+// OidBatchSizeOptimizers holds a batch size Optimizer for each SNMP request operation.
 type OidBatchSizeOptimizers struct {
-	snmpGetOptimizer     *oidBatchSizeOptimizer
-	snmpGetBulkOptimizer *oidBatchSizeOptimizer
-	snmpGetNextOptimizer *oidBatchSizeOptimizer
+	snmpGetOptimizer     *batchsize.Optimizer
+	snmpGetBulkOptimizer *batchsize.Optimizer
+	snmpGetNextOptimizer *batchsize.Optimizer
 	lastRefreshTs        time.Time
 }
 
-// oidBatchSizeOptimizer holds data between check runs to be able to find an optimized batch size for SNMP requests
-type oidBatchSizeOptimizer struct {
-	snmpOperation           snmpOperation
-	configBatchSize         int
-	batchSize               int
-	failuresByBatchSize     map[int]int
-	lastSuccessfulBatchSize int
-}
-
-// NewOidBatchSizeOptimizers creates a OidBatchSizeOptimizers
+// NewOidBatchSizeOptimizers creates a OidBatchSizeOptimizers.
 func NewOidBatchSizeOptimizers(configBatchSize int) *OidBatchSizeOptimizers {
-	now := time.Now()
-
 	return &OidBatchSizeOptimizers{
-		snmpGetOptimizer:     newOidBatchSizeOptimizer(snmpGet, configBatchSize),
-		snmpGetBulkOptimizer: newOidBatchSizeOptimizer(snmpGetBulk, configBatchSize),
-		snmpGetNextOptimizer: newOidBatchSizeOptimizer(snmpGetNext, configBatchSize),
-		lastRefreshTs:        now,
+		snmpGetOptimizer:     batchsize.NewOptimizer(configBatchSize),
+		snmpGetBulkOptimizer: batchsize.NewOptimizer(configBatchSize),
+		snmpGetNextOptimizer: batchsize.NewOptimizer(configBatchSize),
+		lastRefreshTs:        time.Now(),
 	}
 }
 
-// Refresh refreshes each oidBatchSizeOptimizer in OidBatchSizeOptimizers when outdated
+// refreshIfOutdated clears each per-operation failure window when the
+// configured window has elapsed since the last refresh.
 func (o *OidBatchSizeOptimizers) refreshIfOutdated(now time.Time) {
 	if now.Sub(o.lastRefreshTs) < failuresWindowDuration {
 		return
 	}
 
-	o.snmpGetOptimizer.refreshFailures()
-	o.snmpGetBulkOptimizer.refreshFailures()
-	o.snmpGetNextOptimizer.refreshFailures()
+	o.snmpGetOptimizer.RefreshFailures()
+	o.snmpGetBulkOptimizer.RefreshFailures()
+	o.snmpGetNextOptimizer.RefreshFailures()
 
 	o.lastRefreshTs = now
 
 	log.Debug("SNMP batch size optimizers have been refreshed")
-}
-
-// newOidBatchSizeOptimizer creates a oidBatchSizeOptimizer
-func newOidBatchSizeOptimizer(snmpOperation snmpOperation, configBatchSize int) *oidBatchSizeOptimizer {
-	return &oidBatchSizeOptimizer{
-		snmpOperation:       snmpOperation,
-		configBatchSize:     configBatchSize,
-		batchSize:           configBatchSize,
-		failuresByBatchSize: make(map[int]int),
-	}
-}
-
-// refreshFailures refreshes the failures count for each batch size in oidBatchSizeOptimizer
-func (o *oidBatchSizeOptimizer) refreshFailures() {
-	o.failuresByBatchSize = make(map[int]int)
-}
-
-// onBatchSizeFailure decreases the batch size and returns whether the batch size changed
-func (o *oidBatchSizeOptimizer) onBatchSizeFailure() bool {
-	o.failuresByBatchSize[o.batchSize]++
-
-	oldBatchSize := o.batchSize
-
-	newBatchSize := max(o.batchSize/onFailureDecreaseFactor, 1)
-	if oldBatchSize > o.lastSuccessfulBatchSize && newBatchSize < o.lastSuccessfulBatchSize {
-		newBatchSize = o.lastSuccessfulBatchSize
-	}
-
-	o.batchSize = newBatchSize
-
-	log.Debugf("SNMP fetch using %s with batch size %d failed, new batch size is %d",
-		o.snmpOperation, oldBatchSize, newBatchSize)
-
-	return oldBatchSize != newBatchSize
-}
-
-// onBatchSizeSuccess increases the batch size
-func (o *oidBatchSizeOptimizer) onBatchSizeSuccess() {
-	o.lastSuccessfulBatchSize = o.batchSize
-
-	if o.batchSize >= o.maxBatchSize() {
-		return
-	}
-
-	newBatchSize := min(o.batchSize+onSuccessIncreaseValue, o.maxBatchSize())
-	if o.failuresByBatchSize[newBatchSize] >= maxFailuresPerWindow {
-		return
-	}
-
-	log.Debugf("SNMP fetch using %s with batch size %d success, new batch size is %d",
-		o.snmpOperation, o.lastSuccessfulBatchSize, newBatchSize)
-
-	o.batchSize = newBatchSize
-}
-
-// maxBatchSize returns the max batch size
-func (o *oidBatchSizeOptimizer) maxBatchSize() int {
-	return o.configBatchSize
 }

--- a/pkg/collector/corechecks/snmp/internal/fetch/batch_size_optimizers_test.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/batch_size_optimizers_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
+//go:build test
+
 package fetch
 
 import (
@@ -10,306 +12,63 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/batchsize"
 )
 
 func Test_batchSizeOptimizers_refreshIfOutdated(t *testing.T) {
 	now := time.Now()
 
+	makeOptimizers := func(refreshTs time.Time, getFailures, getBulkFailures, getNextFailures map[int]int) *OidBatchSizeOptimizers {
+		return &OidBatchSizeOptimizers{
+			snmpGetOptimizer:     batchsize.NewOptimizerForTest(10, 6, getFailures, 0),
+			snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(2, 1, getBulkFailures, 0),
+			snmpGetNextOptimizer: batchsize.NewOptimizerForTest(12, 2, getNextFailures, 0),
+			lastRefreshTs:        refreshTs,
+		}
+	}
+
 	tests := []struct {
-		name                        string
-		batchSizeOptimizers         *OidBatchSizeOptimizers
-		expectedBatchSizeOptimizers *OidBatchSizeOptimizers
+		name     string
+		input    *OidBatchSizeOptimizers
+		expected *OidBatchSizeOptimizers
 	}{
 		{
 			name: "batch size is not outdated",
-			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     10,
-					batchSize:           6,
-					failuresByBatchSize: map[int]int{1: 2, 6: 10},
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     2,
-					batchSize:           1,
-					failuresByBatchSize: map[int]int{},
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     12,
-					batchSize:           2,
-					failuresByBatchSize: map[int]int{10: 6, 12: 10},
-				},
-				lastRefreshTs: now.Add(-failuresWindowDuration / 2),
-			},
-			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     10,
-					batchSize:           6,
-					failuresByBatchSize: map[int]int{1: 2, 6: 10},
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     2,
-					batchSize:           1,
-					failuresByBatchSize: map[int]int{},
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     12,
-					batchSize:           2,
-					failuresByBatchSize: map[int]int{10: 6, 12: 10},
-				},
-				lastRefreshTs: now.Add(-failuresWindowDuration / 2),
-			},
+			input: makeOptimizers(
+				now.Add(-failuresWindowDuration/2),
+				map[int]int{1: 2, 6: 10},
+				map[int]int{},
+				map[int]int{10: 6, 12: 10},
+			),
+			expected: makeOptimizers(
+				now.Add(-failuresWindowDuration/2),
+				map[int]int{1: 2, 6: 10},
+				map[int]int{},
+				map[int]int{10: 6, 12: 10},
+			),
 		},
 		{
 			name: "batch size is outdated",
-			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     10,
-					batchSize:           6,
-					failuresByBatchSize: map[int]int{1: 2, 6: 10},
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     2,
-					batchSize:           1,
-					failuresByBatchSize: map[int]int{},
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     12,
-					batchSize:           2,
-					failuresByBatchSize: map[int]int{10: 6, 12: 10},
-				},
-				lastRefreshTs: now.Add(-failuresWindowDuration * 2),
-			},
-			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     10,
-					batchSize:           6,
-					failuresByBatchSize: map[int]int{},
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     2,
-					batchSize:           1,
-					failuresByBatchSize: map[int]int{},
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					configBatchSize:     12,
-					batchSize:           2,
-					failuresByBatchSize: map[int]int{},
-				},
-				lastRefreshTs: now,
-			},
+			input: makeOptimizers(
+				now.Add(-failuresWindowDuration*2),
+				map[int]int{1: 2, 6: 10},
+				map[int]int{},
+				map[int]int{10: 6, 12: 10},
+			),
+			expected: makeOptimizers(
+				now,
+				map[int]int{},
+				map[int]int{},
+				map[int]int{},
+			),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.batchSizeOptimizers.refreshIfOutdated(now)
-			assert.Equal(t, tt.expectedBatchSizeOptimizers, tt.batchSizeOptimizers)
-		})
-	}
-}
-
-func Test_batchSizeOptimizer_onBatchSizeFailure(t *testing.T) {
-	tests := []struct {
-		name                       string
-		batchSizeOptimizer         *oidBatchSizeOptimizer
-		expectedBatchSizeOptimizer *oidBatchSizeOptimizer
-		expectedBatchSizeChanged   bool
-	}{
-		{
-			name: "batch size is 1",
-			batchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 4,
-				batchSize:       1,
-				failuresByBatchSize: map[int]int{
-					4: 1,
-					2: 1,
-				},
-				lastSuccessfulBatchSize: 1,
-			},
-			expectedBatchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 4,
-				batchSize:       1,
-				failuresByBatchSize: map[int]int{
-					4: 1,
-					2: 1,
-					1: 1,
-				},
-				lastSuccessfulBatchSize: 1,
-			},
-			expectedBatchSizeChanged: false,
-		},
-		{
-			name: "new batch size is lesser than the last successful batch size",
-			batchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize:         4,
-				batchSize:               4,
-				failuresByBatchSize:     map[int]int{},
-				lastSuccessfulBatchSize: 3,
-			},
-			expectedBatchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 4,
-				batchSize:       3,
-				failuresByBatchSize: map[int]int{
-					4: 1,
-				},
-				lastSuccessfulBatchSize: 3,
-			},
-			expectedBatchSizeChanged: true,
-		},
-		{
-			name: "batch size is equal to the last successful batch size",
-			batchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize:         4,
-				batchSize:               3,
-				failuresByBatchSize:     map[int]int{},
-				lastSuccessfulBatchSize: 3,
-			},
-			expectedBatchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 4,
-				batchSize:       3 / onFailureDecreaseFactor,
-				failuresByBatchSize: map[int]int{
-					3: 1,
-				},
-				lastSuccessfulBatchSize: 3,
-			},
-			expectedBatchSizeChanged: true,
-		},
-		{
-			name: "batch size is lesser to the last successful batch size",
-			batchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize:         4,
-				batchSize:               2,
-				failuresByBatchSize:     map[int]int{},
-				lastSuccessfulBatchSize: 3,
-			},
-			expectedBatchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 4,
-				batchSize:       2 / onFailureDecreaseFactor,
-				failuresByBatchSize: map[int]int{
-					2: 1,
-				},
-				lastSuccessfulBatchSize: 3,
-			},
-			expectedBatchSizeChanged: true,
-		},
-		{
-			name: "batch size is greater than the last successful batch size",
-			batchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize:         10,
-				batchSize:               10,
-				failuresByBatchSize:     map[int]int{},
-				lastSuccessfulBatchSize: 3,
-			},
-			expectedBatchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 10,
-				batchSize:       10 / onFailureDecreaseFactor,
-				failuresByBatchSize: map[int]int{
-					10: 1,
-				},
-				lastSuccessfulBatchSize: 3,
-			},
-			expectedBatchSizeChanged: true,
-		},
-		{
-			name: "batch size should be decreased",
-			batchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 4,
-				batchSize:       4,
-				failuresByBatchSize: map[int]int{
-					4: 1,
-				},
-				lastSuccessfulBatchSize: 0,
-			},
-			expectedBatchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 4,
-				batchSize:       4 / onFailureDecreaseFactor,
-				failuresByBatchSize: map[int]int{
-					4: 2,
-				},
-				lastSuccessfulBatchSize: 0,
-			},
-			expectedBatchSizeChanged: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			batchSizeChanged := tt.batchSizeOptimizer.onBatchSizeFailure()
-			assert.Equal(t, tt.expectedBatchSizeOptimizer, tt.batchSizeOptimizer)
-			assert.Equal(t, tt.expectedBatchSizeChanged, batchSizeChanged)
-		})
-	}
-}
-
-func Test_batchSizeOptimizer_onBatchSizeSuccess(t *testing.T) {
-	tests := []struct {
-		name                       string
-		batchSizeOptimizer         *oidBatchSizeOptimizer
-		expectedBatchSizeOptimizer *oidBatchSizeOptimizer
-	}{
-		{
-			name: "new batch size has too much failures",
-			batchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 10,
-				batchSize:       6,
-				failuresByBatchSize: map[int]int{
-					7: maxFailuresPerWindow + 1,
-				},
-				lastSuccessfulBatchSize: 5,
-			},
-			expectedBatchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 10,
-				batchSize:       6,
-				failuresByBatchSize: map[int]int{
-					7: maxFailuresPerWindow + 1,
-				},
-				lastSuccessfulBatchSize: 6,
-			},
-		},
-		{
-			name: "batch size is config batch size",
-			batchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 10,
-				batchSize:       10,
-				failuresByBatchSize: map[int]int{
-					6: 1,
-				},
-				lastSuccessfulBatchSize: 9,
-			},
-			expectedBatchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 10,
-				batchSize:       10,
-				failuresByBatchSize: map[int]int{
-					6: 1,
-				},
-				lastSuccessfulBatchSize: 10,
-			},
-		},
-		{
-			name: "batch size should be increased",
-			batchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 10,
-				batchSize:       6,
-				failuresByBatchSize: map[int]int{
-					6: 1,
-				},
-				lastSuccessfulBatchSize: 9,
-			},
-			expectedBatchSizeOptimizer: &oidBatchSizeOptimizer{
-				configBatchSize: 10,
-				batchSize:       6 + onSuccessIncreaseValue,
-				failuresByBatchSize: map[int]int{
-					6: 1,
-				},
-				lastSuccessfulBatchSize: 6,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.batchSizeOptimizer.onBatchSizeSuccess()
-			assert.Equal(t, tt.expectedBatchSizeOptimizer, tt.batchSizeOptimizer)
+			tt.input.refreshIfOutdated(now)
+			assert.Equal(t, tt.expected, tt.input)
 		})
 	}
 }

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
@@ -32,12 +32,20 @@ func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeO
 		return nil, fmt.Errorf("failed to create column oid batches: %s", err)
 	}
 
+	op := snmpGetBulk
+	if fetchStrategy == useGetNext {
+		op = snmpGetNext
+	}
+
 	for _, batchColumnOids := range batches {
 		results, err := fetchColumnOids(sess, batchColumnOids, bulkMaxRepetitions, fetchStrategy)
 		if err != nil {
 			var fetchErr *fetchError
 			if errors.As(err, &fetchErr) {
+				oldBatchSize := batchSizeOptimizer.BatchSize()
 				shouldRetry := batchSizeOptimizer.OnFailure()
+				log.Debugf("SNMP fetch using %s with batch size %d failed, new batch size is %d",
+					op, oldBatchSize, batchSizeOptimizer.BatchSize())
 				if shouldRetry {
 					return fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, bulkMaxRepetitions, fetchStrategy)
 				}
@@ -55,7 +63,12 @@ func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeO
 		}
 	}
 
+	oldBatchSize := batchSizeOptimizer.BatchSize()
 	batchSizeOptimizer.OnSuccess()
+	if newBatchSize := batchSizeOptimizer.BatchSize(); newBatchSize != oldBatchSize {
+		log.Debugf("SNMP fetch using %s with batch size %d success, new batch size is %d",
+			op, oldBatchSize, newBatchSize)
+	}
 
 	return retValues, nil
 }

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
@@ -16,17 +16,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/common"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/session"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
+	"github.com/DataDog/datadog-agent/pkg/snmp/batchsize"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeOptimizer *oidBatchSizeOptimizer, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
+func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeOptimizer *batchsize.Optimizer, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
 	retValues := make(valuestore.ColumnResultValuesType, len(oids))
 	if len(oids) == 0 {
 		return retValues, nil
 	}
 
-	batches, err := common.CreateStringBatches(oids, batchSizeOptimizer.batchSize)
+	batches, err := common.CreateStringBatches(oids, batchSizeOptimizer.BatchSize())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create column oid batches: %s", err)
 	}
@@ -36,7 +37,7 @@ func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeO
 		if err != nil {
 			var fetchErr *fetchError
 			if errors.As(err, &fetchErr) {
-				shouldRetry := batchSizeOptimizer.onBatchSizeFailure()
+				shouldRetry := batchSizeOptimizer.OnFailure()
 				if shouldRetry {
 					return fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, bulkMaxRepetitions, fetchStrategy)
 				}
@@ -54,7 +55,7 @@ func fetchColumnOidsWithBatching(sess session.Session, oids []string, batchSizeO
 		}
 	}
 
-	batchSizeOptimizer.onBatchSizeSuccess()
+	batchSizeOptimizer.OnSuccess()
 
 	return retValues, nil
 }

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_scalar.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_scalar.go
@@ -18,17 +18,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/common"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/session"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
+	"github.com/DataDog/datadog-agent/pkg/snmp/batchsize"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func fetchScalarOidsWithBatching(sess session.Session, oids []string, batchSizeOptimizer *oidBatchSizeOptimizer) (valuestore.ScalarResultValuesType, error) {
+func fetchScalarOidsWithBatching(sess session.Session, oids []string, batchSizeOptimizer *batchsize.Optimizer) (valuestore.ScalarResultValuesType, error) {
 	retValues := make(valuestore.ScalarResultValuesType, len(oids))
 	if len(oids) == 0 {
 		return retValues, nil
 	}
 
-	batches, err := common.CreateStringBatches(oids, batchSizeOptimizer.batchSize)
+	batches, err := common.CreateStringBatches(oids, batchSizeOptimizer.BatchSize())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create oid batches: %s", err)
 	}
@@ -38,7 +39,7 @@ func fetchScalarOidsWithBatching(sess session.Session, oids []string, batchSizeO
 		if err != nil {
 			var fetchErr *fetchError
 			if errors.As(err, &fetchErr) {
-				shouldRetry := batchSizeOptimizer.onBatchSizeFailure()
+				shouldRetry := batchSizeOptimizer.OnFailure()
 				if shouldRetry {
 					return fetchScalarOidsWithBatching(sess, oids, batchSizeOptimizer)
 				}
@@ -49,7 +50,7 @@ func fetchScalarOidsWithBatching(sess session.Session, oids []string, batchSizeO
 		maps.Copy(retValues, results)
 	}
 
-	batchSizeOptimizer.onBatchSizeSuccess()
+	batchSizeOptimizer.OnSuccess()
 
 	return retValues, nil
 }

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_scalar.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_scalar.go
@@ -39,7 +39,10 @@ func fetchScalarOidsWithBatching(sess session.Session, oids []string, batchSizeO
 		if err != nil {
 			var fetchErr *fetchError
 			if errors.As(err, &fetchErr) {
+				oldBatchSize := batchSizeOptimizer.BatchSize()
 				shouldRetry := batchSizeOptimizer.OnFailure()
+				log.Debugf("SNMP fetch using %s with batch size %d failed, new batch size is %d",
+					snmpGet, oldBatchSize, batchSizeOptimizer.BatchSize())
 				if shouldRetry {
 					return fetchScalarOidsWithBatching(sess, oids, batchSizeOptimizer)
 				}
@@ -50,7 +53,12 @@ func fetchScalarOidsWithBatching(sess session.Session, oids []string, batchSizeO
 		maps.Copy(retValues, results)
 	}
 
+	oldBatchSize := batchSizeOptimizer.BatchSize()
 	batchSizeOptimizer.OnSuccess()
+	if newBatchSize := batchSizeOptimizer.BatchSize(); newBatchSize != oldBatchSize {
+		log.Debugf("SNMP fetch using %s with batch size %d success, new batch size is %d",
+			snmpGet, oldBatchSize, newBatchSize)
+	}
 
 	return retValues, nil
 }

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
@@ -1132,7 +1132,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			columnOids: []string{},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
 				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 3, map[int]int{4: maxFailuresPerWindow}, 2),
-				lastRefreshTs: now,
+				lastRefreshTs:    now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{
@@ -1146,7 +1146,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
 				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 3, map[int]int{4: maxFailuresPerWindow}, 3),
-				lastRefreshTs: now,
+				lastRefreshTs:    now,
 			},
 		},
 		{
@@ -1186,10 +1186,10 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			scalarOids: []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0"},
 			columnOids: []string{"1.1.1", "1.1.2", "1.1.3", "1.1.4"},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
+				snmpGetOptimizer:     batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
 				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
 				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
-				lastRefreshTs: now,
+				lastRefreshTs:        now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{
@@ -1215,10 +1215,10 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4/onFailureDecreaseFactor + onSuccessIncreaseValue, map[int]int{4: 1}, 2),
-				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 4/onFailureDecreaseFactor + onSuccessIncreaseValue, map[int]int{4: 1}, 2),
+				snmpGetOptimizer:     batchsize.NewOptimizerForTest(4, 4/onFailureDecreaseFactor+onSuccessIncreaseValue, map[int]int{4: 1}, 2),
+				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 4/onFailureDecreaseFactor+onSuccessIncreaseValue, map[int]int{4: 1}, 2),
 				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
-				lastRefreshTs: now,
+				lastRefreshTs:        now,
 			},
 		},
 		{
@@ -1243,7 +1243,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			columnOids: []string{},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
 				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 3),
-				lastRefreshTs: now,
+				lastRefreshTs:    now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{
@@ -1257,7 +1257,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
 				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{4: 1}, 3),
-				lastRefreshTs: now,
+				lastRefreshTs:    now,
 			},
 		},
 		{
@@ -1290,7 +1290,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			columnOids: []string{},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
 				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 2, map[int]int{}, 3),
-				lastRefreshTs: now,
+				lastRefreshTs:    now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{
@@ -1304,7 +1304,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
 				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 2, map[int]int{2: 1}, 1),
-				lastRefreshTs: now,
+				lastRefreshTs:    now,
 			},
 		},
 		{
@@ -1330,10 +1330,10 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			scalarOids: []string{},
 			columnOids: []string{"1.1.1", "1.1.2", "1.1.3", "1.1.4"},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
+				snmpGetOptimizer:     batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
 				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 3, map[int]int{4: 1}, 2),
 				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
-				lastRefreshTs: now,
+				lastRefreshTs:        now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{},
@@ -1354,10 +1354,10 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
+				snmpGetOptimizer:     batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
 				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 1, map[int]int{4: 1, 3: 1, 2: 1, 1: 1}, 2),
 				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
-				lastRefreshTs: now,
+				lastRefreshTs:        now,
 			},
 		},
 		{
@@ -1384,18 +1384,18 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			scalarOids: []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0"},
 			columnOids: []string{"1.1.1", "1.1.2", "1.1.3", "1.1.4"},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
+				snmpGetOptimizer:     batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
 				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
 				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
-				lastRefreshTs: now,
+				lastRefreshTs:        now,
 			},
 			expectedValues: nil,
 			expectedError:  errors.New("failed to fetch oids with GetNext batching: failed to fetch column oids: fetch column: failed getting oids `[1.1.1]` using GetNext: next error"),
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
+				snmpGetOptimizer:     batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
 				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 1, map[int]int{4: 1, 2: 1, 1: 1}, 0),
 				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 1, map[int]int{4: 1, 2: 1, 1: 1}, 0),
-				lastRefreshTs: now,
+				lastRefreshTs:        now,
 			},
 		},
 	}
@@ -1433,10 +1433,10 @@ func Test_batchSizeOptimizers_notFetchErrors(t *testing.T) {
 	assert.EqualError(t, err, "failed to fetch scalar oids: invalid ErrorIndex `200` when fetching oids `[1.1.1.1.0]`")
 	assert.Nil(t, scalarValues)
 	assert.Equal(t, &OidBatchSizeOptimizers{
-		snmpGetOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
+		snmpGetOptimizer:     batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
 		snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
 		snmpGetNextOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
-		lastRefreshTs: lastRefreshTs,
+		lastRefreshTs:        lastRefreshTs,
 	}, batchSizeOptimizers)
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, []string{"1.1.1"}, batchSizeOptimizers.snmpGetBulkOptimizer,
@@ -1444,10 +1444,10 @@ func Test_batchSizeOptimizers_notFetchErrors(t *testing.T) {
 	assert.EqualError(t, err, "failed to fetch column oids: GetBulk not supported in SNMP v1")
 	assert.Nil(t, columnValues)
 	assert.Equal(t, &OidBatchSizeOptimizers{
-		snmpGetOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
+		snmpGetOptimizer:     batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
 		snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
 		snmpGetNextOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
-		lastRefreshTs: lastRefreshTs,
+		lastRefreshTs:        lastRefreshTs,
 	}, batchSizeOptimizers)
 }
 

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/session"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
+	"github.com/DataDog/datadog-agent/pkg/snmp/batchsize"
 )
 
 func Test_fetchColumnOids(t *testing.T) {
@@ -91,7 +92,7 @@ func Test_fetchColumnOids(t *testing.T) {
 
 	oids := []string{"1.1.1", "1.1.2"}
 
-	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 100)
+	batchSizeOptimizer := batchsize.NewOptimizer(100)
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
 	assert.Nil(t, err)
@@ -184,7 +185,7 @@ func Test_fetchColumnOidsBatch_usingGetBulk(t *testing.T) {
 
 	oids := []string{"1.1.1", "1.1.2"}
 
-	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 2)
+	batchSizeOptimizer := batchsize.NewOptimizer(2)
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, 10, useGetBulk)
 	assert.Nil(t, err)
@@ -343,7 +344,7 @@ func Test_fetchColumnOidsBatch_truncatedResponse_reducesBatchSize(t *testing.T) 
 	sess.On("GetBulk", []string{"1.1.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&singlePacket2, nil)
 
 	oids := []string{"1.1.1", "1.1.2"}
-	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 2)
+	batchSizeOptimizer := batchsize.NewOptimizer(2)
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
 	require.NoError(t, err)
@@ -357,7 +358,7 @@ func Test_fetchColumnOidsBatch_truncatedResponse_reducesBatchSize(t *testing.T) 
 		},
 	}
 	assert.Equal(t, expectedColumnValues, columnValues)
-	assert.Equal(t, 1, batchSizeOptimizer.lastSuccessfulBatchSize)
+	assert.Equal(t, 1, batchSizeOptimizer.LastSuccessfulBatchSize())
 }
 
 func Test_fetchColumnOidsBatch_truncatedResponseAtBatchSizeOne_returnsError(t *testing.T) {
@@ -372,13 +373,13 @@ func Test_fetchColumnOidsBatch_truncatedResponseAtBatchSizeOne_returnsError(t *t
 	sess.On("GetBulk", []string{"1.1.1"}, checkconfig.DefaultBulkMaxRepetitions).Return(&truncatedPacket, nil)
 
 	oids := []string{"1.1.1"}
-	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 1)
+	batchSizeOptimizer := batchsize.NewOptimizer(1)
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "response truncated")
 	assert.Nil(t, columnValues)
-	assert.Equal(t, 1, batchSizeOptimizer.batchSize)
+	assert.Equal(t, 1, batchSizeOptimizer.BatchSize())
 	sess.AssertNumberOfCalls(t, "GetBulk", 1)
 }
 
@@ -537,7 +538,7 @@ func Test_fetchOidBatchSize(t *testing.T) {
 
 	oids := []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0", "1.1.1.5.0", "1.1.1.6.0"}
 
-	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGet, 2)
+	batchSizeOptimizer := batchsize.NewOptimizer(2)
 
 	columnValues, err := fetchScalarOidsWithBatching(sess, oids, batchSizeOptimizer)
 	assert.Nil(t, err)
@@ -622,7 +623,7 @@ func Test_fetchOidBatchSize_v1NoSuchName(t *testing.T) {
 	oids := []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0", "1.1.1.5.0", "1.1.1.6.0"}
 	origOids := slices.Clone(oids)
 
-	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGet, 2)
+	batchSizeOptimizer := batchsize.NewOptimizer(2)
 
 	columnValues, err := fetchScalarOidsWithBatching(sess, oids, batchSizeOptimizer)
 	assert.Nil(t, err)
@@ -642,7 +643,7 @@ func Test_fetchOidBatchSize_zeroSizeError(t *testing.T) {
 	sess := session.CreateMockSession()
 
 	oids := []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0", "1.1.1.5.0", "1.1.1.6.0"}
-	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGet, 0)
+	batchSizeOptimizer := batchsize.NewOptimizer(0)
 	columnValues, err := fetchScalarOidsWithBatching(sess, oids, batchSizeOptimizer)
 
 	assert.EqualError(t, err, "failed to create oid batches: batch size must be positive. invalid size: 0")
@@ -656,7 +657,7 @@ func Test_fetchOidBatchSize_fetchError(t *testing.T) {
 	sess.On("Get", []string{"1.1.1.1.0"}).Return(&gosnmp.SnmpPacket{}, errors.New("my error"))
 
 	oids := []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0", "1.1.1.5.0", "1.1.1.6.0"}
-	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGet, 2)
+	batchSizeOptimizer := batchsize.NewOptimizer(2)
 	columnValues, err := fetchScalarOidsWithBatching(sess, oids, batchSizeOptimizer)
 
 	assert.EqualError(t, err, "failed to fetch scalar oids: fetch scalar: failed getting oids `[1.1.1.1.0]` using Get: my error")
@@ -1045,7 +1046,7 @@ func Test_fetchColumnOids_alreadyProcessed(t *testing.T) {
 
 	oids := []string{"1.1.1", "1.1.2"}
 
-	batchSizeOptimizer := newOidBatchSizeOptimizer(snmpGetBulk, 100)
+	batchSizeOptimizer := batchsize.NewOptimizer(100)
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, oids, batchSizeOptimizer, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
 	assert.Nil(t, err)
@@ -1079,6 +1080,16 @@ func Test_fetchColumnOids_alreadyProcessed(t *testing.T) {
 
 func Test_batchSizeOptimizers(t *testing.T) {
 	now := time.Now()
+
+	// Mirror of the batchsize package's internal tuning constants. Kept here
+	// so the table-driven cases below read symbolically rather than as bare
+	// numerics. If batchsize changes its policy, these tests will fail and
+	// need updating in lockstep.
+	const (
+		maxFailuresPerWindow    = 2
+		onFailureDecreaseFactor = 2
+		onSuccessIncreaseValue  = 1
+	)
 
 	scalarVariable1 := gosnmp.SnmpPDU{Name: "1.1.1.1.0", Type: gosnmp.Gauge32, Value: 10}
 	scalarVariable2 := gosnmp.SnmpPDU{Name: "1.1.1.2.0", Type: gosnmp.Gauge32, Value: 20}
@@ -1120,13 +1131,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			scalarOids: []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0"},
 			columnOids: []string{},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               3,
-					failuresByBatchSize:     map[int]int{4: maxFailuresPerWindow},
-					lastSuccessfulBatchSize: 2,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 3, map[int]int{4: maxFailuresPerWindow}, 2),
 				lastRefreshTs: now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
@@ -1140,13 +1145,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               3,
-					failuresByBatchSize:     map[int]int{4: maxFailuresPerWindow},
-					lastSuccessfulBatchSize: 3,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 3, map[int]int{4: maxFailuresPerWindow}, 3),
 				lastRefreshTs: now,
 			},
 		},
@@ -1187,27 +1186,9 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			scalarOids: []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0"},
 			columnOids: []string{"1.1.1", "1.1.2", "1.1.3", "1.1.4"},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 0,
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetBulk,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 0,
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetNext,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 0,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
+				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
+				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
 				lastRefreshTs: now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
@@ -1234,27 +1215,9 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               4/onFailureDecreaseFactor + onSuccessIncreaseValue,
-					failuresByBatchSize:     map[int]int{4: 1},
-					lastSuccessfulBatchSize: 2,
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetBulk,
-					configBatchSize:         4,
-					batchSize:               4/onFailureDecreaseFactor + onSuccessIncreaseValue,
-					failuresByBatchSize:     map[int]int{4: 1},
-					lastSuccessfulBatchSize: 2,
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetNext,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 0,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4/onFailureDecreaseFactor + onSuccessIncreaseValue, map[int]int{4: 1}, 2),
+				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 4/onFailureDecreaseFactor + onSuccessIncreaseValue, map[int]int{4: 1}, 2),
+				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
 				lastRefreshTs: now,
 			},
 		},
@@ -1279,13 +1242,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			scalarOids: []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0"},
 			columnOids: []string{},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 3,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 3),
 				lastRefreshTs: now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
@@ -1299,13 +1256,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{4: 1},
-					lastSuccessfulBatchSize: 3,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{4: 1}, 3),
 				lastRefreshTs: now,
 			},
 		},
@@ -1338,13 +1289,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			scalarOids: []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0"},
 			columnOids: []string{},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               2,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 3,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 2, map[int]int{}, 3),
 				lastRefreshTs: now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
@@ -1358,13 +1303,7 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               2,
-					failuresByBatchSize:     map[int]int{2: 1},
-					lastSuccessfulBatchSize: 1,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 2, map[int]int{2: 1}, 1),
 				lastRefreshTs: now,
 			},
 		},
@@ -1391,27 +1330,9 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			scalarOids: []string{},
 			columnOids: []string{"1.1.1", "1.1.2", "1.1.3", "1.1.4"},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 4,
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetBulk,
-					configBatchSize:         4,
-					batchSize:               3,
-					failuresByBatchSize:     map[int]int{4: 1},
-					lastSuccessfulBatchSize: 2,
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetNext,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 0,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
+				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 3, map[int]int{4: 1}, 2),
+				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
 				lastRefreshTs: now,
 			},
 			expectedValues: &valuestore.ResultValueStore{
@@ -1433,27 +1354,9 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 4,
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetBulk,
-					configBatchSize:         4,
-					batchSize:               1,
-					failuresByBatchSize:     map[int]int{4: 1, 3: 1, 2: 1, 1: 1},
-					lastSuccessfulBatchSize: 2,
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetNext,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 4,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
+				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 1, map[int]int{4: 1, 3: 1, 2: 1, 1: 1}, 2),
+				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
 				lastRefreshTs: now,
 			},
 		},
@@ -1481,53 +1384,17 @@ func Test_batchSizeOptimizers(t *testing.T) {
 			scalarOids: []string{"1.1.1.1.0", "1.1.1.2.0", "1.1.1.3.0", "1.1.1.4.0"},
 			columnOids: []string{"1.1.1", "1.1.2", "1.1.3", "1.1.4"},
 			batchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 4,
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetBulk,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 0,
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetNext,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 0,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
+				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
+				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 0),
 				lastRefreshTs: now,
 			},
 			expectedValues: nil,
 			expectedError:  errors.New("failed to fetch oids with GetNext batching: failed to fetch column oids: fetch column: failed getting oids `[1.1.1]` using GetNext: next error"),
 			expectedBatchSizeOptimizers: &OidBatchSizeOptimizers{
-				snmpGetOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGet,
-					configBatchSize:         4,
-					batchSize:               4,
-					failuresByBatchSize:     map[int]int{},
-					lastSuccessfulBatchSize: 4,
-				},
-				snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetBulk,
-					configBatchSize:         4,
-					batchSize:               1,
-					failuresByBatchSize:     map[int]int{4: 1, 2: 1, 1: 1},
-					lastSuccessfulBatchSize: 0,
-				},
-				snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-					snmpOperation:           snmpGetNext,
-					configBatchSize:         4,
-					batchSize:               1,
-					failuresByBatchSize:     map[int]int{4: 1, 2: 1, 1: 1},
-					lastSuccessfulBatchSize: 0,
-				},
+				snmpGetOptimizer: batchsize.NewOptimizerForTest(4, 4, map[int]int{}, 4),
+				snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(4, 1, map[int]int{4: 1, 2: 1, 1: 1}, 0),
+				snmpGetNextOptimizer: batchsize.NewOptimizerForTest(4, 1, map[int]int{4: 1, 2: 1, 1: 1}, 0),
 				lastRefreshTs: now,
 			},
 		},
@@ -1566,24 +1433,9 @@ func Test_batchSizeOptimizers_notFetchErrors(t *testing.T) {
 	assert.EqualError(t, err, "failed to fetch scalar oids: invalid ErrorIndex `200` when fetching oids `[1.1.1.1.0]`")
 	assert.Nil(t, scalarValues)
 	assert.Equal(t, &OidBatchSizeOptimizers{
-		snmpGetOptimizer: &oidBatchSizeOptimizer{
-			snmpOperation:       snmpGet,
-			configBatchSize:     2,
-			batchSize:           2,
-			failuresByBatchSize: map[int]int{},
-		},
-		snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-			snmpOperation:       snmpGetBulk,
-			configBatchSize:     2,
-			batchSize:           2,
-			failuresByBatchSize: map[int]int{},
-		},
-		snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-			snmpOperation:       snmpGetNext,
-			configBatchSize:     2,
-			batchSize:           2,
-			failuresByBatchSize: map[int]int{},
-		},
+		snmpGetOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
+		snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
+		snmpGetNextOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
 		lastRefreshTs: lastRefreshTs,
 	}, batchSizeOptimizers)
 
@@ -1592,24 +1444,9 @@ func Test_batchSizeOptimizers_notFetchErrors(t *testing.T) {
 	assert.EqualError(t, err, "failed to fetch column oids: GetBulk not supported in SNMP v1")
 	assert.Nil(t, columnValues)
 	assert.Equal(t, &OidBatchSizeOptimizers{
-		snmpGetOptimizer: &oidBatchSizeOptimizer{
-			snmpOperation:       snmpGet,
-			configBatchSize:     2,
-			batchSize:           2,
-			failuresByBatchSize: map[int]int{},
-		},
-		snmpGetBulkOptimizer: &oidBatchSizeOptimizer{
-			snmpOperation:       snmpGetBulk,
-			configBatchSize:     2,
-			batchSize:           2,
-			failuresByBatchSize: map[int]int{},
-		},
-		snmpGetNextOptimizer: &oidBatchSizeOptimizer{
-			snmpOperation:       snmpGetNext,
-			configBatchSize:     2,
-			batchSize:           2,
-			failuresByBatchSize: map[int]int{},
-		},
+		snmpGetOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
+		snmpGetBulkOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
+		snmpGetNextOptimizer: batchsize.NewOptimizerForTest(2, 2, map[int]int{}, 0),
 		lastRefreshTs: lastRefreshTs,
 	}, batchSizeOptimizers)
 }
@@ -1618,9 +1455,9 @@ func Test_batchSizeOptimizers_areRefreshed(t *testing.T) {
 	sess := session.CreateMockSession()
 
 	batchSizeOptimizers := NewOidBatchSizeOptimizers(2)
-	batchSizeOptimizers.snmpGetOptimizer.failuresByBatchSize = map[int]int{4: 2, 3: 1}
-	batchSizeOptimizers.snmpGetBulkOptimizer.failuresByBatchSize = map[int]int{4: 2, 3: 1}
-	batchSizeOptimizers.snmpGetNextOptimizer.failuresByBatchSize = map[int]int{4: 2, 3: 1}
+	batchSizeOptimizers.snmpGetOptimizer.SetFailuresByBatchSize(map[int]int{4: 2, 3: 1})
+	batchSizeOptimizers.snmpGetBulkOptimizer.SetFailuresByBatchSize(map[int]int{4: 2, 3: 1})
+	batchSizeOptimizers.snmpGetNextOptimizer.SetFailuresByBatchSize(map[int]int{4: 2, 3: 1})
 	batchSizeOptimizers.lastRefreshTs = batchSizeOptimizers.lastRefreshTs.Add(-failuresWindowDuration * 2)
 
 	oldLastRefreshTs := batchSizeOptimizers.lastRefreshTs
@@ -1632,8 +1469,8 @@ func Test_batchSizeOptimizers_areRefreshed(t *testing.T) {
 		ColumnValues: valuestore.ColumnResultValuesType{},
 	}, values)
 
-	assert.Empty(t, batchSizeOptimizers.snmpGetOptimizer.failuresByBatchSize)
-	assert.Empty(t, batchSizeOptimizers.snmpGetBulkOptimizer.failuresByBatchSize)
-	assert.Empty(t, batchSizeOptimizers.snmpGetNextOptimizer.failuresByBatchSize)
+	assert.Empty(t, batchSizeOptimizers.snmpGetOptimizer.FailuresByBatchSize())
+	assert.Empty(t, batchSizeOptimizers.snmpGetBulkOptimizer.FailuresByBatchSize())
+	assert.Empty(t, batchSizeOptimizers.snmpGetNextOptimizer.FailuresByBatchSize())
 	assert.True(t, batchSizeOptimizers.lastRefreshTs.After(oldLastRefreshTs))
 }

--- a/pkg/snmp/batchsize/BUILD.bazel
+++ b/pkg/snmp/batchsize/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "batchsize",
+    srcs = [
+        "optimizer.go",
+        "testhelpers.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/snmp/batchsize",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "batchsize_test",
+    srcs = ["optimizer_test.go"],
+    embed = [":batchsize"],
+    gotags = ["test"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/pkg/snmp/batchsize/optimizer.go
+++ b/pkg/snmp/batchsize/optimizer.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package batchsize provides an adaptive feedback controller for an integer
+// "batch size" parameter. Callers report success or failure of each operation
+// and the controller halves on failure (with a floor at the last successful
+// value) and increments back toward the configured ceiling on success.
+//
+// The primitive is generic: callers decide what the integer represents
+// (number of OIDs per request, max-repetitions, etc.) and what counts as a
+// success or failure.
+package batchsize
+
+const (
+	onSuccessIncreaseValue  = 1
+	onFailureDecreaseFactor = 2
+
+	maxFailuresPerWindow = 2
+)
+
+// Optimizer is a feedback controller on a positive integer batch size.
+type Optimizer struct {
+	configBatchSize         int
+	batchSize               int
+	failuresByBatchSize     map[int]int
+	lastSuccessfulBatchSize int
+}
+
+// NewOptimizer returns an Optimizer starting at configBatchSize.
+func NewOptimizer(configBatchSize int) *Optimizer {
+	return &Optimizer{
+		configBatchSize:     configBatchSize,
+		batchSize:           configBatchSize,
+		failuresByBatchSize: make(map[int]int),
+	}
+}
+
+// BatchSize returns the current batch size.
+func (o *Optimizer) BatchSize() int {
+	return o.batchSize
+}
+
+// OnFailure halves the batch size (with a floor at 1, never crossing below
+// the last successful value) and returns whether the batch size changed.
+// A true return means a retry at the new size is worth attempting.
+func (o *Optimizer) OnFailure() bool {
+	o.failuresByBatchSize[o.batchSize]++
+
+	oldBatchSize := o.batchSize
+
+	newBatchSize := max(o.batchSize/onFailureDecreaseFactor, 1)
+	if oldBatchSize > o.lastSuccessfulBatchSize && newBatchSize < o.lastSuccessfulBatchSize {
+		newBatchSize = o.lastSuccessfulBatchSize
+	}
+
+	o.batchSize = newBatchSize
+
+	return oldBatchSize != newBatchSize
+}
+
+// OnSuccess increments the batch size toward the configured ceiling, skipping
+// sizes that have already failed too many times in the current failure window.
+func (o *Optimizer) OnSuccess() {
+	o.lastSuccessfulBatchSize = o.batchSize
+
+	if o.batchSize >= o.configBatchSize {
+		return
+	}
+
+	newBatchSize := min(o.batchSize+onSuccessIncreaseValue, o.configBatchSize)
+	if o.failuresByBatchSize[newBatchSize] >= maxFailuresPerWindow {
+		return
+	}
+
+	o.batchSize = newBatchSize
+}
+
+// RefreshFailures clears the failure-count map. Callers managing a failure
+// window should call this when the window expires.
+func (o *Optimizer) RefreshFailures() {
+	o.failuresByBatchSize = make(map[int]int)
+}

--- a/pkg/snmp/batchsize/optimizer_test.go
+++ b/pkg/snmp/batchsize/optimizer_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package batchsize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Optimizer_OnFailure(t *testing.T) {
+	tests := []struct {
+		name             string
+		optimizer        *Optimizer
+		expectedOptimizer *Optimizer
+		expectedChanged  bool
+	}{
+		{
+			name: "batch size is 1",
+			optimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       1,
+				failuresByBatchSize: map[int]int{
+					4: 1,
+					2: 1,
+				},
+				lastSuccessfulBatchSize: 1,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       1,
+				failuresByBatchSize: map[int]int{
+					4: 1,
+					2: 1,
+					1: 1,
+				},
+				lastSuccessfulBatchSize: 1,
+			},
+			expectedChanged: false,
+		},
+		{
+			name: "new batch size is lesser than the last successful batch size",
+			optimizer: &Optimizer{
+				configBatchSize:         4,
+				batchSize:               4,
+				failuresByBatchSize:     map[int]int{},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       3,
+				failuresByBatchSize: map[int]int{
+					4: 1,
+				},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "batch size is equal to the last successful batch size",
+			optimizer: &Optimizer{
+				configBatchSize:         4,
+				batchSize:               3,
+				failuresByBatchSize:     map[int]int{},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       3 / onFailureDecreaseFactor,
+				failuresByBatchSize: map[int]int{
+					3: 1,
+				},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "batch size is lesser to the last successful batch size",
+			optimizer: &Optimizer{
+				configBatchSize:         4,
+				batchSize:               2,
+				failuresByBatchSize:     map[int]int{},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       2 / onFailureDecreaseFactor,
+				failuresByBatchSize: map[int]int{
+					2: 1,
+				},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "batch size is greater than the last successful batch size",
+			optimizer: &Optimizer{
+				configBatchSize:         10,
+				batchSize:               10,
+				failuresByBatchSize:     map[int]int{},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       10 / onFailureDecreaseFactor,
+				failuresByBatchSize: map[int]int{
+					10: 1,
+				},
+				lastSuccessfulBatchSize: 3,
+			},
+			expectedChanged: true,
+		},
+		{
+			name: "batch size should be decreased",
+			optimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       4,
+				failuresByBatchSize: map[int]int{
+					4: 1,
+				},
+				lastSuccessfulBatchSize: 0,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 4,
+				batchSize:       4 / onFailureDecreaseFactor,
+				failuresByBatchSize: map[int]int{
+					4: 2,
+				},
+				lastSuccessfulBatchSize: 0,
+			},
+			expectedChanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := tt.optimizer.OnFailure()
+			assert.Equal(t, tt.expectedOptimizer, tt.optimizer)
+			assert.Equal(t, tt.expectedChanged, changed)
+		})
+	}
+}
+
+func Test_Optimizer_OnSuccess(t *testing.T) {
+	tests := []struct {
+		name              string
+		optimizer         *Optimizer
+		expectedOptimizer *Optimizer
+	}{
+		{
+			name: "new batch size has too much failures",
+			optimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       6,
+				failuresByBatchSize: map[int]int{
+					7: maxFailuresPerWindow + 1,
+				},
+				lastSuccessfulBatchSize: 5,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       6,
+				failuresByBatchSize: map[int]int{
+					7: maxFailuresPerWindow + 1,
+				},
+				lastSuccessfulBatchSize: 6,
+			},
+		},
+		{
+			name: "batch size is config batch size",
+			optimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       10,
+				failuresByBatchSize: map[int]int{
+					6: 1,
+				},
+				lastSuccessfulBatchSize: 9,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       10,
+				failuresByBatchSize: map[int]int{
+					6: 1,
+				},
+				lastSuccessfulBatchSize: 10,
+			},
+		},
+		{
+			name: "batch size should be increased",
+			optimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       6,
+				failuresByBatchSize: map[int]int{
+					6: 1,
+				},
+				lastSuccessfulBatchSize: 9,
+			},
+			expectedOptimizer: &Optimizer{
+				configBatchSize: 10,
+				batchSize:       6 + onSuccessIncreaseValue,
+				failuresByBatchSize: map[int]int{
+					6: 1,
+				},
+				lastSuccessfulBatchSize: 6,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.optimizer.OnSuccess()
+			assert.Equal(t, tt.expectedOptimizer, tt.optimizer)
+		})
+	}
+}
+
+func Test_Optimizer_BatchSize(t *testing.T) {
+	o := NewOptimizer(5)
+	assert.Equal(t, 5, o.BatchSize())
+	o.OnFailure()
+	assert.Equal(t, 2, o.BatchSize())
+}
+
+func Test_Optimizer_RefreshFailures(t *testing.T) {
+	o := &Optimizer{
+		configBatchSize:     4,
+		batchSize:           2,
+		failuresByBatchSize: map[int]int{4: 3, 2: 1},
+	}
+	o.RefreshFailures()
+	assert.Equal(t, map[int]int{}, o.failuresByBatchSize)
+}

--- a/pkg/snmp/batchsize/optimizer_test.go
+++ b/pkg/snmp/batchsize/optimizer_test.go
@@ -13,10 +13,10 @@ import (
 
 func Test_Optimizer_OnFailure(t *testing.T) {
 	tests := []struct {
-		name             string
-		optimizer        *Optimizer
+		name              string
+		optimizer         *Optimizer
 		expectedOptimizer *Optimizer
-		expectedChanged  bool
+		expectedChanged   bool
 	}{
 		{
 			name: "batch size is 1",

--- a/pkg/snmp/batchsize/testhelpers.go
+++ b/pkg/snmp/batchsize/testhelpers.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package batchsize
+
+// NewOptimizerForTest constructs an Optimizer with explicit internal state for
+// use in tests in other packages. Not for production use.
+func NewOptimizerForTest(configBatchSize, batchSize int, failures map[int]int, lastSuccessfulBatchSize int) *Optimizer {
+	if failures == nil {
+		failures = make(map[int]int)
+	}
+	return &Optimizer{
+		configBatchSize:         configBatchSize,
+		batchSize:               batchSize,
+		failuresByBatchSize:     failures,
+		lastSuccessfulBatchSize: lastSuccessfulBatchSize,
+	}
+}
+
+// FailuresByBatchSize exposes the internal failure map for assertions in tests.
+func (o *Optimizer) FailuresByBatchSize() map[int]int {
+	return o.failuresByBatchSize
+}
+
+// LastSuccessfulBatchSize exposes the internal last-successful tracker for assertions in tests.
+func (o *Optimizer) LastSuccessfulBatchSize() int {
+	return o.lastSuccessfulBatchSize
+}
+
+// SetFailuresByBatchSize replaces the internal failure map. For tests only.
+func (o *Optimizer) SetFailuresByBatchSize(failures map[int]int) {
+	o.failuresByBatchSize = failures
+}


### PR DESCRIPTION
### What does this PR do?

Follow-up to #49734. Makes the GetBulk max-repetitions value used by `agent snmp scan`:

1. **Configurable** via a new `--bulk-max-rep` CLI flag (mirrors `snmpbulkwalk -Cr`).
2. **Adaptive** — halves on timeout/failure and retries the same OID; recovers toward the configured ceiling on success; gives up cleanly when it can't shrink any further.
3. **Lower default**: 50 → 10, matching net-snmp's `snmpbulkwalk -Cr` default.
4. **Extracts** the feedback-controller primitive that already lives in the SNMP integration into a neutral package (`pkg/snmp/batchsize/`) so both the scan and the integration share it.

The 3-way `OidBatchSizeOptimizers` holder stays in the `fetch` package — it bundles Get/GetBulk/GetNext + a 60-min refresh window that is integration-specific. Only the single-knob feedback controller moves out.

### Motivation

Customer escalation AGENT-16184 (banco BV): `agent snmp scan` against a Ciena 6500 times out because the device cannot return a 50-PDU `GetBulk` response packet. The aggressive 50 was the primary culprit (net-snmp uses 10 by default), and the scan has no fallback if the chosen value is still too high for some other device.

This PR:
- Lowers the default to 10, which by itself likely fixes the reported device.
- Adds an adaptive escape hatch so the next device where even 10 is too aggressive still completes.
- Adds the flag so the customer can pick a smaller starting value without waiting for the adaptive logic to kick in.

The new `pkg/snmp/batchsize/` package keeps the abstraction honest — the shared type is "adaptive positive integer with halve-on-failure / +1-on-success semantics," not "the integration's GetBulk batch size." Each caller names it for what it controls in its context (`maxRepOpt` in scan; `Get`/`GetBulk`/`GetNext` in integration).

### Describe how you validated your changes

**Unit tests** (all green):
- `dda inv test --targets=./pkg/snmp/batchsize` — 11 tests (new package).
- `dda inv test --targets=./pkg/collector/corechecks/snmp/internal/fetch` — 29 tests (existing tests retained after refactor).
- `dda inv test --targets=./pkg/collector/corechecks/snmp/internal/devicecheck` — 31 tests (no breakage in the integration that depends on the holder).
- `dda inv test --targets=./comp/snmpscan/...` — 11 tests, including two new ones for the adaptive path (`TestGatherPDUsWithBulk_AdaptsMaxRepOnFailure`, `TestGatherPDUsWithBulk_GivesUpWhenMaxRepCannotShrink`) that drive `gatherPDUsWithBulk` through a scripted `bulkGetter` fake.
- `dda inv test --targets=./cmd/agent/subcommands/snmp` — 4 tests (subcommand still compiles & wires).
- `dda inv linter.go --module=. --targets=./pkg/snmp/batchsize` — clean.

**End-to-end smoke against a fake SNMP server** — built a small hand-rolled SNMPv2c responder (~200 lines, off-repo) that logs every incoming `GetBulk` with its max-repetitions, and ran the freshly-built `agent snmp scan` against it under five scenarios. Server log + agent log captured for each.

| # | Scenario | Server config | Agent invocation | Observed server requests | Pass? |
|---|---|---|---|---|---|
| 1 | Default (no flag) | always-ok | `agent snmp scan 127.0.0.1:1161 -v 2c -C public` | 4 calls, all `maxRep=10` | ✓ default lowered |
| 2 | Custom ceiling, healthy device | always-ok | `… --bulk-max-rep 20` | 2 calls, all `maxRep=20` | ✓ flag honored |
| 3 | Adaptive halving | drop reply when `maxRep > 10` | `… --bulk-max-rep 50` | `50 → 25 → 12 → 6` against the same OID `.0.0`, then climbs `7 → 8 → 9 → 10` as the walk progresses | ✓ same-OID retry, halve-on-fail, +1-on-success |
| 4 | Recovery + 2-failure cap | drop reply when `maxRep > 10`, longer MIB | `… --bulk-max-rep 50` | Same descent as #3, then probes `11` → fails → drops to `10`; probes `11` once more → fails → optimizer stops trying `11` (2-failure-in-window cap) and stays at `10` for the rest of the walk | ✓ ceiling probing + failure-count cap |
| 5 | Floor reached | always-fail | `… --bulk-max-rep 4` | `4 → 2 → 1`, then agent reports `GetBulk error at OID .0.0 (max-rep=1): request timeout` | ✓ clean error surface |

Cases 3 and 4 are the most interesting: the server traces in case 4 show the optimizer probing the ceiling, retreating after a failure, retrying once, and then stabilising — exactly the steady-state behaviour we want a device with a hard `maxRep` ceiling to settle into.

### Additional Notes

- Based on #49734 (Nouha's GetBulk-based scan). Will retarget to `main` after that PR merges.
- No comparison-mode change here. The `comparisonModeEnabled = true` constant stays as-is — flipping it off is a separate PR.
- No change to the SNMP integration's `bulkMaxRepetitions` config knob — that's a different code path; this PR only shares the underlying controller primitive.
- The customer fix path: try `agent snmp scan <device>` with no flag first (default 10 likely sufficient); if a future device still struggles, the adaptive logic will halve into a range that works without needing operator intervention.