### PR TITLE
chore(renovate): split linux-images updates into separate PRs for gitlab-ci and devcontainer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,12 @@
         "schedule": ["* 2-6 * * 1-5"]
       },
       {
+        "matchDepNames": ["linux-images-devcontainer"],
+        "maxMajorIncrement": 0,
+        "changelogUrl": "https://github.com/DataDog/datadog-agent-buildimages/commits/main",
+        "schedule": ["* 2-6 * * 1-5"]
+      },
+      {
         "matchDepNames": ["windows-images"],
         "maxMajorIncrement": 0,
         "changelogUrl": "https://github.com/DataDog/datadog-agent-buildimages/commits/main",
@@ -189,7 +195,7 @@
         "matchStrings": [
           "\"image\":\\s*\"registry.ddbuild.io/ci/datadog-agent-buildimages/dev-env-workspace:(?<currentValue>v[^\"]+)\""
         ],
-        "depNameTemplate": "linux-images",
+        "depNameTemplate": "linux-images-devcontainer",
         "versioningTemplate": "loose",
         "datasourceTemplate": "custom.linux-images"
       },


### PR DESCRIPTION
## What does this PR do?

Splits the Renovate `linux-images` dependency into two distinct dep names so that `.gitlab-ci.yml` and `.devcontainer/datadog/default/prebuild-devcontainer.json` updates land in **separate PRs**.

**Root cause of the split:** Both files previously matched `depNameTemplate: "linux-images"`, causing Renovate to bundle them into one PR. This triggered the `prebuild-workspace-image-check` CI job to fail: when `prebuild-devcontainer.json` changes, the workspaces bot must push a new pre-built SHA into `devcontainer.json` — but it can't do that atomically in the same Renovate PR.

## Changes

- Renamed the devcontainer custom manager's `depNameTemplate` from `linux-images` to `linux-images-devcontainer`.
- Added a matching `packageRule` for `linux-images-devcontainer` with the same `maxMajorIncrement`, `changelogUrl`, and `schedule` as `linux-images`.

## Result

| PR | Files updated |
|----|---------------|
| `renovate/linux-images-*.x` | `.gitlab-ci.yml` CI image variables |
| `renovate/linux-images-devcontainer-*.x` | `.devcontainer/.../prebuild-devcontainer.json` |

The workspaces bot can then process the devcontainer PR independently without blocking the GitLab CI image bump.

## Motivation

Fixes the `prebuild-workspace-image-check` failure observed on `renovate/linux-images-113861782.x`.

## Test plan

- [ ] Verify next Renovate run creates two separate PRs for `linux-images` and `linux-images-devcontainer`
- [ ] Verify `prebuild-workspace-image-check` passes on the devcontainer PR once the workspaces bot commits the updated SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)