### PR TITLE
[PROF-14698] Enable ddprofiling on relenv standalone deployments

### DIFF
--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -330,6 +330,11 @@ func TestConverterWithoutAgentErrors(t *testing.T) {
 			provided:      "no_agent/reserved-proc-empty/in.yaml",
 			expectedError: "reserved resource processor name",
 		},
+		{
+			name:          "multiple-ddprofiling-extensions",
+			provided:      "no_agent/multi-ddprofiling-ext/in.yaml",
+			expectedError: "only one ddprofiling extension can be enabled in standalone mode",
+		},
 	}
 
 	runErrorTests(t, newConverterWithoutAgent(confmap.ConverterSettings{Logger: zap.NewNop()}), tests)

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -46,7 +46,7 @@ var resourceDetectionDefaultConfig = confMap{
 //   - Check if used otlphttpexporter has dd-api-key as string, if not string convert it, if not at all notify user
 //   - If profiling::symbol_uploader::enabled == true, convert api_key/app_key to strings in each endpoint
 //   - If no profiling is used & configured, add minimal one with symbol_uploader: false
-//   - remove ddprofiling & hpflare extensions
+//   - remove hpflare extensions
 type converterWithoutAgent struct{}
 
 func newConverterWithoutAgent(convSettings confmap.ConverterSettings) confmap.Converter {
@@ -402,8 +402,8 @@ func (c *converterWithoutAgent) removeAgentOnlyExtensions(conf confMap) error {
 			return errors.New("extension names in service should be strings")
 		}
 
-		// Skip ddprofiling and hpflare extensions
-		if isComponentType(ext, componentTypeDDProfiling) || isComponentType(ext, componentTypeHPFlare) {
+		// Skip hpflare extensions
+		if isComponentType(ext, componentTypeHPFlare) {
 			continue
 		}
 
@@ -416,7 +416,7 @@ func (c *converterWithoutAgent) removeAgentOnlyExtensions(conf confMap) error {
 	extensionsConf, ok := Get[confMap](conf, "extensions")
 	if ok {
 		for name := range extensionsConf {
-			if isComponentType(name, componentTypeDDProfiling) || isComponentType(name, componentTypeHPFlare) {
+			if isComponentType(name, componentTypeHPFlare) {
 				delete(extensionsConf, name)
 			}
 		}

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -396,10 +396,15 @@ func (c *converterWithoutAgent) removeAgentOnlyExtensions(conf confMap) error {
 
 	// Filter out agent-only extensions
 	filteredExtensions := make([]any, 0, len(extensions))
+	ddProfilingExtensions := 0
 	for _, extAny := range extensions {
 		ext, ok := extAny.(string)
 		if !ok {
 			return errors.New("extension names in service should be strings")
+		}
+
+		if isComponentType(ext, componentTypeDDProfiling) {
+			ddProfilingExtensions++
 		}
 
 		// Skip hpflare extensions
@@ -411,6 +416,10 @@ func (c *converterWithoutAgent) removeAgentOnlyExtensions(conf confMap) error {
 	}
 
 	service["extensions"] = filteredExtensions
+
+	if ddProfilingExtensions > 1 {
+		return errors.New("only one ddprofiling extension can be enabled in standalone mode")
+	}
 
 	// Also remove the extension definitions from global config
 	extensionsConf, ok := Get[confMap](conf, "extensions")

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-ddprofiling-ext/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/multi-ddprofiling-ext/in.yaml
@@ -1,0 +1,23 @@
+service:
+  pipelines:
+    profiles:
+      receivers: [profiling]
+      processors: []
+      exporters: [otlphttp]
+  extensions:
+    - ddprofiling
+    - ddprofiling/custom
+
+extensions:
+  ddprofiling: {}
+  ddprofiling/custom: {}
+
+receivers:
+  profiling:
+    symbol_uploader:
+      enabled: false
+
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/in.yaml
@@ -6,7 +6,6 @@ service:
       exporters: [otlphttp]
   extensions:
     - ddprofiling
-    - ddprofiling/custom
     - hpflare
     - hpflare/prod
     - custom
@@ -15,8 +14,6 @@ service:
 extensions:
   ddprofiling:
     config: value
-  ddprofiling/custom:
-    config: custom
   hpflare:
     config: value
   hpflare/prod:

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/rm-agent-ext/out.yaml
@@ -9,6 +9,8 @@ exporters:
 extensions:
     custom:
         config: value
+    ddprofiling:
+        config: value
     other:
         config: value
 processors:
@@ -40,6 +42,7 @@ receivers:
             enabled: false
 service:
     extensions:
+        - ddprofiling
         - custom
         - other
     pipelines:

--- a/comp/host-profiler/collector/impl/otel_col_factories.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories.go
@@ -170,6 +170,7 @@ func (e extraFactoriesWithoutAgentCore) GetAgentConfig() config.Component {
 // GetExtensions returns the extensions for the collector.
 func (e extraFactoriesWithoutAgentCore) GetExtensions() []extension.Factory {
 	return []extension.Factory{
+		ddprofilingextensionimpl.NewFactory(),
 		healthcheckextension.NewFactory(),
 	}
 }

--- a/comp/otelcol/ddprofilingextension/impl/config.go
+++ b/comp/otelcol/ddprofilingextension/impl/config.go
@@ -9,6 +9,7 @@ package ddprofilingextensionimpl
 // Config contains the config of the profiler.
 type Config struct {
 	ProfilerOptions ProfilerOptions `mapstructure:"profiler_options"`
+	AgentAddr       string          `mapstructure:"agent_addr"`
 	// Endpoint is the local port the profiling HTTP server listens on; used as "localhost:<endpoint>".
 	// Default: "7501"
 	Endpoint string `mapstructure:"endpoint"`

--- a/comp/otelcol/ddprofilingextension/impl/extension.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension.go
@@ -129,6 +129,8 @@ func (e *ddExtension) buildProfilerOptions() []profiler.Option {
 func (e *ddExtension) Shutdown(ctx context.Context) error {
 	profiler.Stop()
 	if e.server == nil {
+		// Standalone mode sends directly to an external trace-agent and does not
+		// start the local forwarding server used in bundled mode.
 		return nil
 	}
 	return e.server.Shutdown(ctx)

--- a/comp/otelcol/ddprofilingextension/impl/extension.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension.go
@@ -35,6 +35,7 @@ type ddExtension struct {
 	traceAgent traceagent.Component
 	server     *http.Server
 	log        corelog.Component
+	agentMode  bool
 }
 
 // NewExtension creates a new instance of the extension.
@@ -44,14 +45,18 @@ func NewExtension(cfg *Config, info component.BuildInfo, traceAgent traceagent.C
 		info:       info,
 		traceAgent: traceAgent,
 		log:        log,
+		agentMode:  traceAgent != nil,
 	}, nil
 }
 
 func (e *ddExtension) Start(_ context.Context, host component.Host) error {
-	return e.startForOTelAgent(host)
+	if e.agentMode {
+		return e.startForAgent(host)
+	}
+	return e.startForStandalone()
 }
 
-func (e *ddExtension) startForOTelAgent(host component.Host) error {
+func (e *ddExtension) startForAgent(host component.Host) error {
 	// start server that handles profiles
 	err := e.newServer()
 	if err != nil {
@@ -67,6 +72,14 @@ func (e *ddExtension) startForOTelAgent(host component.Host) error {
 	return profiler.Start(
 		profilerOptions...,
 	)
+}
+
+func (e *ddExtension) startForStandalone() error {
+	profilerOptions := e.buildProfilerOptions()
+	if e.cfg.AgentAddr != "" {
+		profilerOptions = append(profilerOptions, profiler.WithAgentAddr(e.cfg.AgentAddr))
+	}
+	return profiler.Start(profilerOptions...)
 }
 
 func (e *ddExtension) buildProfilerOptions() []profiler.Option {
@@ -115,5 +128,8 @@ func (e *ddExtension) buildProfilerOptions() []profiler.Option {
 
 func (e *ddExtension) Shutdown(ctx context.Context) error {
 	profiler.Stop()
+	if e.server == nil {
+		return nil
+	}
 	return e.server.Shutdown(ctx)
 }

--- a/comp/otelcol/ddprofilingextension/impl/extension_test.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension_test.go
@@ -134,3 +134,35 @@ func TestAgentExtension(t *testing.T) {
 	err = ext.Shutdown(ctx)
 	assert.NoError(t, err)
 }
+
+func TestStandaloneExtension(t *testing.T) {
+	got := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/profiling/v1/input", req.URL.Path)
+		got <- req.Header.Get("User-Agent")
+		rw.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	ext, err := NewExtension(&Config{
+		AgentAddr: server.Listener.Addr().String(),
+		ProfilerOptions: ProfilerOptions{
+			Period: 1,
+		},
+	}, component.BuildInfo{}, nil, nil)
+	require.NoError(t, err)
+
+	err = ext.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	timeout := time.After(15 * time.Second)
+	select {
+	case out := <-got:
+		assert.Equal(t, "Go-http-client/1.1", out)
+	case <-timeout:
+		t.Fatal("Timed out")
+	}
+
+	err = ext.Shutdown(context.Background())
+	require.NoError(t, err)
+}

--- a/comp/otelcol/ddprofilingextension/impl/factory.go
+++ b/comp/otelcol/ddprofilingextension/impl/factory.go
@@ -34,6 +34,11 @@ func NewFactoryForAgent(traceAgent traceagent.Component, log corelog.Component) 
 	}
 }
 
+// NewFactory creates a factory for Datadog Profiling Extension for standalone use with local agent running.
+func NewFactory() extension.Factory {
+	return &ddExtensionFactory{}
+}
+
 // Create creates a new instance of the Datadog Profiling Extension
 func (f *ddExtensionFactory) Create(_ context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {
 	config, ok := cfg.(*Config)


### PR DESCRIPTION
### What does this PR do?

Enables the `ddprofiling` extension in standalone mode. When running with a local agent, we can simply send data to `localhost:8126` (by default if no AgentAddr). This option is not documented, as it will likely not work for clients using standalone mode.

### Motivation

We want to enable memory profiling on `relenv`.

### Describe how you validated your changes

Deployed and verified [here](https://ddstaging.datadoghq.com/profiling/explorer?query=perf.lang.native.deployment%3Arp-native-fullhost-standalone&agg_m=%40prof_go_cpu_cores&agg_m_source=base&agg_t=sum&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&fromUser=true&my_code=enabled&viz=flame_graph&start=1779177860705&end=1779264260705&paused=true).

### Additional Notes