### PR TITLE
ci(codeowners): enforce explicit ownership for AI artefacts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,24 +18,27 @@
 /.claude/agents/tend.md               @DataDog/single-machine-performance
 /.claude/agents/weed.md               @DataDog/single-machine-performance
 /.claude/rules/allium.md              @DataDog/single-machine-performance
+/.claude/rules/bazel.md               @DataDog/agent-build
 /.claude/skills/allium/               @DataDog/single-machine-performance
 /.claude/skills/agent-supply-chain-newsletter/ @DataDog/agent-devx
 /.claude/skills/auto-jira/            @DataDog/agent-devx
 /.claude/skills/create-component/     @DataDog/agent-metric-pipelines
-/.claude/skills/create-config-field/  @DataDog/agent-metric-pipelines
+/.claude/skills/create-config-field/  @DataDog/agent-configuration
 /.claude/skills/create-core-check/    @DataDog/agent-metric-pipelines
-/.claude/skills/create-go-module/     @DataDog/agent-metric-pipelines
+/.claude/skills/create-go-module/     @DataDog/agent-runtimes
 /.claude/skills/create-invoke-task/   @DataDog/agent-devx
 /.claude/skills/create-pr/            @DataDog/agent-devx
-/.claude/skills/create-release-note/  @DataDog/agent-metric-pipelines
+/.claude/skills/create-release-note/  @DataDog/agent-devx
 /.claude/skills/create-runtime-setting/ @DataDog/agent-metric-pipelines
 /.claude/skills/create-status-provider/ @DataDog/agent-metric-pipelines
 /.claude/skills/create-subcommand/    @DataDog/agent-metric-pipelines
+/.claude/skills/explain-lading-config @DataDog/single-machine-performance
 /.claude/skills/omnibus-to-bazel/     @DataDog/agent-build
 /.claude/skills/quality-gate-size-analysis/ @DataDog/agent-build
 /.claude/skills/review-pr-comments/   @DataDog/agent-devx
 /.claude/skills/run-e2e/              @DataDog/agent-devx
 /.claude/skills/run-jira/             @DataDog/agent-devx
+/.claude/skills/update-3rd-party-libs @DataDog/agent-build
 /.claude/skills/write-e2e/            @DataDog/agent-devx
 # changing the config of mockery will regenerate the mocks, so owners will have to review anyway
 /.mockery.yaml                          # do not notify anyone
@@ -984,11 +987,6 @@
 # Add here modules that need explicit review from the team owning them
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
-
-# AI-related files
-/.claude/rules/bazel.md               @DataDog/agent-build
-/.claude/skills/explain-lading-config @DataDog/single-machine-performance
-/.claude/skills/update-3rd-party-libs @DataDog/agent-build
 
 # Temporary during Bazel migration
 # This needs to go after all other rules that may include BUILD.bazel files, it otherwise gets overridden

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /.claude/agents/weed.md                          @DataDog/single-machine-performance
 /.claude/rules/allium.md                         @DataDog/single-machine-performance
 /.claude/rules/bazel.md                          @DataDog/agent-build
-/.claude/skills/codereview_guidelines.md         @DataDog/agent-devx
+/.claude/skills/codereview_guideline.md          @DataDog/agent-devx
 /.claude/skills/allium/                          @DataDog/single-machine-performance
 /.claude/skills/agent-supply-chain-newsletter/   @DataDog/agent-devx
 /.claude/skills/auto-jira/                       @DataDog/agent-devx
@@ -39,6 +39,7 @@
 /.claude/skills/run-e2e/                         @DataDog/agent-devx
 /.claude/skills/run-jira/                        @DataDog/agent-devx
 /.claude/skills/update-3rd-party-libs            @DataDog/agent-build
+/.claude/skills/update-otel-deps/                @DataDog/opentelemetry-agent
 /.claude/skills/write-e2e/                       @DataDog/agent-devx
 # changing the config of mockery will regenerate the mocks, so owners will have to review anyway
 /.mockery.yaml                          # do not notify anyone

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,6 @@
 # Config files for various CI systems / tasks
 /.*                                     @DataDog/agent-devx
 /.claude/settings.json                 @DataDog/agent-devx
-/.claude/settings.local.json          @DataDog/agent-devx
 /.claude/agents/tend.md               @DataDog/single-machine-performance
 /.claude/agents/weed.md               @DataDog/single-machine-performance
 /.claude/rules/allium.md              @DataDog/single-machine-performance

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,30 @@
 
 # Config files for various CI systems / tasks
 /.*                                     @DataDog/agent-devx
+/.claude/settings.json                 @DataDog/agent-devx
+/.claude/settings.local.json          @DataDog/agent-devx
+/.claude/agents/tend.md               @DataDog/single-machine-performance
+/.claude/agents/weed.md               @DataDog/single-machine-performance
+/.claude/rules/allium.md              @DataDog/single-machine-performance
+/.claude/skills/allium/               @DataDog/single-machine-performance
+/.claude/skills/agent-supply-chain-newsletter/ @DataDog/agent-devx
+/.claude/skills/auto-jira/            @DataDog/agent-devx
+/.claude/skills/create-component/     @DataDog/agent-metric-pipelines
+/.claude/skills/create-config-field/  @DataDog/agent-metric-pipelines
+/.claude/skills/create-core-check/    @DataDog/agent-metric-pipelines
+/.claude/skills/create-go-module/     @DataDog/agent-metric-pipelines
+/.claude/skills/create-invoke-task/   @DataDog/agent-devx
+/.claude/skills/create-pr/            @DataDog/agent-devx
+/.claude/skills/create-release-note/  @DataDog/agent-metric-pipelines
+/.claude/skills/create-runtime-setting/ @DataDog/agent-metric-pipelines
+/.claude/skills/create-status-provider/ @DataDog/agent-metric-pipelines
+/.claude/skills/create-subcommand/    @DataDog/agent-metric-pipelines
+/.claude/skills/omnibus-to-bazel/     @DataDog/agent-build
+/.claude/skills/quality-gate-size-analysis/ @DataDog/agent-build
+/.claude/skills/review-pr-comments/   @DataDog/agent-devx
+/.claude/skills/run-e2e/              @DataDog/agent-devx
+/.claude/skills/run-jira/             @DataDog/agent-devx
+/.claude/skills/write-e2e/            @DataDog/agent-devx
 # changing the config of mockery will regenerate the mocks, so owners will have to review anyway
 /.mockery.yaml                          # do not notify anyone
 /.go-version                            @DataDog/agent-runtimes @DataDog/agent-build
@@ -43,6 +67,7 @@
 
 /*.md                                   @DataDog/agent-devx
 /CHANGELOG-AIX.md                       @DataDog/agent-runtimes
+/AGENTS.md                              @DataDog/agent-devx
 /NOTICE                                 @DataDog/agent-delivery
 
 /LICENSE*                               # do not notify anyone
@@ -830,6 +855,7 @@
 /test/benchmarks/kubernetes_state/      @DataDog/container-integrations
 /test/integration/                      @DataDog/serverless-azure-gcp
 /test/integration/docker/               @DataDog/opentelemetry-agent
+/test/e2e-framework/AGENTS.md                           @DataDog/agent-devx
 /test/e2e-framework/testing/testcommon/check            @DataDog/agent-runtimes
 /test/e2e-framework/testing/utils/e2e/client/ecs/       @DataDog/ecs-experiences
 /test/e2e-framework/testing/provisioners/aws/ecs/       @DataDog/ecs-experiences

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,8 @@
 /*.md                                   @DataDog/agent-devx
 /CHANGELOG-AIX.md                       @DataDog/agent-runtimes
 /AGENTS.md                              @DataDog/agent-devx
+/CLAUDE.md                              @DataDog/agent-devx
+/GEMINI.md                              @DataDog/agent-devx
 /NOTICE                                 @DataDog/agent-delivery
 
 /LICENSE*                               # do not notify anyone
@@ -855,6 +857,7 @@
 /test/integration/                      @DataDog/serverless-azure-gcp
 /test/integration/docker/               @DataDog/opentelemetry-agent
 /test/e2e-framework/AGENTS.md                           @DataDog/agent-devx
+/test/e2e-framework/CLAUDE.md                          @DataDog/agent-devx
 /test/e2e-framework/testing/testcommon/check            @DataDog/agent-runtimes
 /test/e2e-framework/testing/utils/e2e/client/ecs/       @DataDog/ecs-experiences
 /test/e2e-framework/testing/provisioners/aws/ecs/       @DataDog/ecs-experiences

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,7 +68,6 @@
 /CHANGELOG-AIX.md                       @DataDog/agent-runtimes
 /AGENTS.md                              @DataDog/agent-devx
 /CLAUDE.md                              @DataDog/agent-devx
-/GEMINI.md                              @DataDog/agent-devx
 /NOTICE                                 @DataDog/agent-delivery
 
 /LICENSE*                               # do not notify anyone

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 /.claude/agents/weed.md               @DataDog/single-machine-performance
 /.claude/rules/allium.md              @DataDog/single-machine-performance
 /.claude/rules/bazel.md               @DataDog/agent-build
+/.claude/skills/codereview_guidelines @DataDog/agent-devx
 /.claude/skills/allium/               @DataDog/single-machine-performance
 /.claude/skills/agent-supply-chain-newsletter/ @DataDog/agent-devx
 /.claude/skills/auto-jira/            @DataDog/agent-devx
@@ -33,7 +34,6 @@
 /.claude/skills/create-status-provider/ @DataDog/agent-metric-pipelines
 /.claude/skills/create-subcommand/    @DataDog/agent-metric-pipelines
 /.claude/skills/explain-lading-config @DataDog/single-machine-performance
-/.claude/skills/omnibus-to-bazel/     @DataDog/agent-build
 /.claude/skills/quality-gate-size-analysis/ @DataDog/agent-build
 /.claude/skills/review-pr-comments/   @DataDog/agent-devx
 /.claude/skills/run-e2e/              @DataDog/agent-devx

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,33 +13,33 @@
 # a slack channel in tasks/libs/pipeline_notifications.py
 
 # Config files for various CI systems / tasks
-/.*                                     @DataDog/agent-devx
-/.claude/settings.json                 @DataDog/agent-devx
-/.claude/agents/tend.md               @DataDog/single-machine-performance
-/.claude/agents/weed.md               @DataDog/single-machine-performance
-/.claude/rules/allium.md              @DataDog/single-machine-performance
-/.claude/rules/bazel.md               @DataDog/agent-build
-/.claude/skills/codereview_guidelines.md @DataDog/agent-devx
-/.claude/skills/allium/               @DataDog/single-machine-performance
-/.claude/skills/agent-supply-chain-newsletter/ @DataDog/agent-devx
-/.claude/skills/auto-jira/            @DataDog/agent-devx
-/.claude/skills/create-component/     @DataDog/agent-metric-pipelines
-/.claude/skills/create-config-field/  @DataDog/agent-configuration
-/.claude/skills/create-core-check/    @DataDog/agent-metric-pipelines
-/.claude/skills/create-go-module/     @DataDog/agent-runtimes
-/.claude/skills/create-invoke-task/   @DataDog/agent-devx
-/.claude/skills/create-pr/            @DataDog/agent-devx
-/.claude/skills/create-release-note/  @DataDog/agent-devx
-/.claude/skills/create-runtime-setting/ @DataDog/agent-metric-pipelines
-/.claude/skills/create-status-provider/ @DataDog/agent-metric-pipelines
-/.claude/skills/create-subcommand/    @DataDog/agent-metric-pipelines
-/.claude/skills/explain-lading-config @DataDog/single-machine-performance
-/.claude/skills/quality-gate-size-analysis/ @DataDog/agent-build
-/.claude/skills/review-pr-comments/   @DataDog/agent-devx
-/.claude/skills/run-e2e/              @DataDog/agent-devx
-/.claude/skills/run-jira/             @DataDog/agent-devx
-/.claude/skills/update-3rd-party-libs @DataDog/agent-build
-/.claude/skills/write-e2e/            @DataDog/agent-devx
+/.*                                              @DataDog/agent-devx
+/.claude/settings.json                           @DataDog/agent-devx
+/.claude/agents/tend.md                          @DataDog/single-machine-performance
+/.claude/agents/weed.md                          @DataDog/single-machine-performance
+/.claude/rules/allium.md                         @DataDog/single-machine-performance
+/.claude/rules/bazel.md                          @DataDog/agent-build
+/.claude/skills/codereview_guidelines.md         @DataDog/agent-devx
+/.claude/skills/allium/                          @DataDog/single-machine-performance
+/.claude/skills/agent-supply-chain-newsletter/   @DataDog/agent-devx
+/.claude/skills/auto-jira/                       @DataDog/agent-devx
+/.claude/skills/create-component/                @DataDog/agent-runtimes
+/.claude/skills/create-config-field/             @DataDog/agent-configuration
+/.claude/skills/create-core-check/               @DataDog/agent-runtimes
+/.claude/skills/create-go-module/                @DataDog/agent-runtimes
+/.claude/skills/create-invoke-task/              @DataDog/agent-devx
+/.claude/skills/create-pr/                       @DataDog/agent-devx
+/.claude/skills/create-release-note/             @DataDog/agent-devx
+/.claude/skills/create-runtime-setting/          @DataDog/agent-runtimes
+/.claude/skills/create-status-provider/          @DataDog/agent-runtimes
+/.claude/skills/create-subcommand/               @DataDog/agent-runtimes
+/.claude/skills/explain-lading-config            @DataDog/single-machine-performance
+/.claude/skills/quality-gate-size-analysis/      @DataDog/agent-build
+/.claude/skills/review-pr-comments/              @DataDog/agent-devx
+/.claude/skills/run-e2e/                         @DataDog/agent-devx
+/.claude/skills/run-jira/                        @DataDog/agent-devx
+/.claude/skills/update-3rd-party-libs            @DataDog/agent-build
+/.claude/skills/write-e2e/                       @DataDog/agent-devx
 # changing the config of mockery will regenerate the mocks, so owners will have to review anyway
 /.mockery.yaml                          # do not notify anyone
 /.go-version                            @DataDog/agent-runtimes @DataDog/agent-build

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,9 +30,9 @@
 /.claude/skills/create-invoke-task/              @DataDog/agent-devx
 /.claude/skills/create-pr/                       @DataDog/agent-devx
 /.claude/skills/create-release-note/             @DataDog/agent-devx
-/.claude/skills/create-runtime-setting/          @DataDog/agent-runtimes
-/.claude/skills/create-status-provider/          @DataDog/agent-runtimes
-/.claude/skills/create-subcommand/               @DataDog/agent-runtimes
+/.claude/skills/create-runtime-setting/          @DataDog/agent-runtimes @DataDog/agent-configuration
+/.claude/skills/create-status-provider/          @DataDog/agent-configuration
+/.claude/skills/create-subcommand/               @DataDog/agent-configuration
 /.claude/skills/explain-lading-config            @DataDog/single-machine-performance
 /.claude/skills/quality-gate-size-analysis/      @DataDog/agent-build
 /.claude/skills/review-pr-comments/              @DataDog/agent-devx

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /.claude/agents/weed.md               @DataDog/single-machine-performance
 /.claude/rules/allium.md              @DataDog/single-machine-performance
 /.claude/rules/bazel.md               @DataDog/agent-build
-/.claude/skills/codereview_guidelines @DataDog/agent-devx
+/.claude/skills/codereview_guidelines.md @DataDog/agent-devx
 /.claude/skills/allium/               @DataDog/single-machine-performance
 /.claude/skills/agent-supply-chain-newsletter/ @DataDog/agent-devx
 /.claude/skills/auto-jira/            @DataDog/agent-devx

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -133,7 +133,7 @@ def lint_codeowner(ctx, owners_file=".github/CODEOWNERS"):
     linters = [
         directory_has_packages_without_owner,
         codeowner_has_orphans,
-        functools.partial(ai_artefacts_have_owner, ctx=ctx),
+        functools.partial(ai_artefacts_have_owner, ctx),
     ]
 
     # Execute linters

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import json
 import os
 from collections import Counter
@@ -114,7 +115,7 @@ def update_windows_runner_version(
 
 
 @task
-def lint_codeowner(_, owners_file=".github/CODEOWNERS"):
+def lint_codeowner(ctx, owners_file=".github/CODEOWNERS"):
     """
     Run multiple checks on the provided CODEOWNERS file
     """
@@ -129,7 +130,11 @@ def lint_codeowner(_, owners_file=".github/CODEOWNERS"):
     owners = read_owners(owners_file)
 
     # Define linters
-    linters = [directory_has_packages_without_owner, codeowner_has_orphans, ai_artefacts_have_owner]
+    linters = [
+        directory_has_packages_without_owner,
+        codeowner_has_orphans,
+        functools.partial(ai_artefacts_have_owner, ctx=ctx),
+    ]
 
     # Execute linters
     for linter in linters:

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -18,7 +18,11 @@ from tasks.libs.ciproviders.github_actions_tools import (
 )
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.datadog_api import send_event
-from tasks.libs.owners.linter import codeowner_has_orphans, directory_has_packages_without_owner
+from tasks.libs.owners.linter import (
+    ai_artefacts_have_owner,
+    codeowner_has_orphans,
+    directory_has_packages_without_owner,
+)
 from tasks.libs.owners.parsing import read_owners
 from tasks.libs.pipeline.notifications import DEFAULT_SLACK_CHANNEL, GITHUB_SLACK_MAP
 from tasks.libs.releasing.version import current_version
@@ -125,7 +129,7 @@ def lint_codeowner(_, owners_file=".github/CODEOWNERS"):
     owners = read_owners(owners_file)
 
     # Define linters
-    linters = [directory_has_packages_without_owner, codeowner_has_orphans]
+    linters = [directory_has_packages_without_owner, codeowner_has_orphans, ai_artefacts_have_owner]
 
     # Execute linters
     for linter in linters:

--- a/tasks/libs/owners/linter.py
+++ b/tasks/libs/owners/linter.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 from tasks.libs.common.color import color_message
@@ -64,34 +65,35 @@ def codeowner_has_orphans(owners):
 _CATCH_ALL_PATTERNS = frozenset(["/.*", "/*.md"])
 
 
+_AI_ARTEFACT_NAMES = frozenset(["AGENTS.md", "CLAUDE.md", "GEMINI.md"])
+
+
 def ai_artefacts_have_owner(owners):
-    """Check that every AGENTS.md file and every file under .claude/ has an explicit owner in
-    CODEOWNERS — i.e. is not solely covered by a broad catch-all rule like /.*  or /*.md."""
+    """Check that every AI artefact file has an explicit owner in CODEOWNERS — i.e. is not
+    solely covered by a broad catch-all rule like /.*  or /*.md, and has a non-empty owner list.
+
+    AI artefacts are: AGENTS.md, CLAUDE.md, GEMINI.md (any depth), and everything under .claude/.
+    """
 
     error = False
 
-    # Collect all AI artefact paths: **/AGENTS.md and .claude/**
-    ai_files = []
-    for root, dirs, files in os.walk("."):
-        # Normalize path separator for CODEOWNERS comparison
-        norm_root = root[2:].replace('\\', '/')  # strip leading "./"
-
-        # Skip .git directory
-        dirs[:] = [d for d in dirs if d != '.git']
-
-        for name in files:
-            rel = (norm_root + "/" + name).lstrip("/")
-            if name == "AGENTS.md" or rel.startswith(".claude/"):
-                ai_files.append(rel)
+    # Collect all AI artefact paths from tracked files only (respects .gitignore).
+    # Symlinks point to external targets and are excluded — only regular files are checked.
+    tracked = subprocess.check_output(["git", "ls-files"], text=True).splitlines()
+    ai_files = [
+        p
+        for p in tracked
+        if (os.path.basename(p) in _AI_ARTEFACT_NAMES or p.startswith(".claude/")) and not os.path.islink(p)
+    ]
 
     for path in ai_files:
         matched_rule = next((rule for rule in owners.paths if rule[0].match(path)), None)
-        if matched_rule is None or matched_rule[1] in _CATCH_ALL_PATTERNS:
+        if matched_rule is None or matched_rule[1] in _CATCH_ALL_PATTERNS or not matched_rule[2]:
             if not error:
                 print(
                     color_message(
                         "The following AI artefacts don't have an explicit owner in the CODEOWNERS file"
-                        " (catch-all rules like /.*  or /*.md don't count)",
+                        " (catch-all rules like /.*  or /*.md don't count, and rules with no owners don't count)",
                         "red",
                     ),
                     file=sys.stderr,

--- a/tasks/libs/owners/linter.py
+++ b/tasks/libs/owners/linter.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import sys
 
 from tasks.libs.common.color import color_message
@@ -68,7 +67,7 @@ _CATCH_ALL_PATTERNS = frozenset(["/.*", "/*.md"])
 _AI_ARTEFACT_NAMES = frozenset(["AGENTS.md", "CLAUDE.md", "GEMINI.md"])
 
 
-def ai_artefacts_have_owner(owners):
+def ai_artefacts_have_owner(owners, ctx=None):
     """Check that every AI artefact file has an explicit owner in CODEOWNERS — i.e. is not
     solely covered by a broad catch-all rule like /.*  or /*.md, and has a non-empty owner list.
 
@@ -79,7 +78,7 @@ def ai_artefacts_have_owner(owners):
 
     # Collect all AI artefact paths from tracked files only (respects .gitignore).
     # Symlinks point to external targets and are excluded — only regular files are checked.
-    tracked = subprocess.check_output(["git", "ls-files"], text=True).splitlines()
+    tracked = ctx.run("git ls-files", hide=True).stdout.splitlines()
     ai_files = [
         p
         for p in tracked

--- a/tasks/libs/owners/linter.py
+++ b/tasks/libs/owners/linter.py
@@ -67,14 +67,12 @@ _CATCH_ALL_PATTERNS = frozenset(["/.*", "/*.md"])
 _AI_ARTEFACT_NAMES = frozenset(["AGENTS.md", "CLAUDE.md", "GEMINI.md"])
 
 
-def ai_artefacts_have_owner(owners, ctx=None):
+def ai_artefacts_have_owner(ctx, owners):
     """Check that every AI artefact file has an explicit owner in CODEOWNERS — i.e. is not
     solely covered by a broad catch-all rule like /.*  or /*.md, and has a non-empty owner list.
 
     AI artefacts are: AGENTS.md, CLAUDE.md, GEMINI.md (any depth), and everything under .claude/.
     """
-
-    error = False
 
     # Collect all AI artefact paths from tracked files only (respects .gitignore).
     # Symlinks point to external targets and are excluded — only regular files are checked.
@@ -85,22 +83,25 @@ def ai_artefacts_have_owner(owners, ctx=None):
         if (os.path.basename(p) in _AI_ARTEFACT_NAMES or p.startswith(".claude/")) and not os.path.islink(p)
     ]
 
+    unowned = []
     for path in ai_files:
         matched_rule = next((rule for rule in owners.paths if rule[0].match(path)), None)
         if matched_rule is None or matched_rule[1] in _CATCH_ALL_PATTERNS or not matched_rule[2]:
-            if not error:
-                print(
-                    color_message(
-                        "The following AI artefacts don't have an explicit owner in the CODEOWNERS file"
-                        " (catch-all rules like /.*  or /*.md don't count, and rules with no owners don't count)",
-                        "red",
-                    ),
-                    file=sys.stderr,
-                )
-                error = True
+            unowned.append(path)
+
+    if unowned:
+        print(
+            color_message(
+                "The following AI artefacts don't have an explicit owner in the CODEOWNERS file"
+                " (catch-all rules like /.*  or /*.md don't count, and rules with no owners don't count)",
+                "red",
+            ),
+            file=sys.stderr,
+        )
+        for path in unowned:
             print(color_message(f"\t- /{path}", "orange"), file=sys.stderr)
 
-    return error
+    return bool(unowned)
 
 
 def _get_static_root(pattern):

--- a/tasks/libs/owners/linter.py
+++ b/tasks/libs/owners/linter.py
@@ -61,6 +61,47 @@ def codeowner_has_orphans(owners):
     return err_invalid_rule_path or err_orphans_path
 
 
+_CATCH_ALL_PATTERNS = frozenset(["/.*", "/*.md"])
+
+
+def ai_artefacts_have_owner(owners):
+    """Check that every AGENTS.md file and every file under .claude/ has an explicit owner in
+    CODEOWNERS — i.e. is not solely covered by a broad catch-all rule like /.*  or /*.md."""
+
+    error = False
+
+    # Collect all AI artefact paths: **/AGENTS.md and .claude/**
+    ai_files = []
+    for root, dirs, files in os.walk("."):
+        # Normalize path separator for CODEOWNERS comparison
+        norm_root = root[2:].replace('\\', '/')  # strip leading "./"
+
+        # Skip .git directory
+        dirs[:] = [d for d in dirs if d != '.git']
+
+        for name in files:
+            rel = (norm_root + "/" + name).lstrip("/")
+            if name == "AGENTS.md" or rel.startswith(".claude/"):
+                ai_files.append(rel)
+
+    for path in ai_files:
+        matched_rule = next((rule for rule in owners.paths if rule[0].match(path)), None)
+        if matched_rule is None or matched_rule[1] in _CATCH_ALL_PATTERNS:
+            if not error:
+                print(
+                    color_message(
+                        "The following AI artefacts don't have an explicit owner in the CODEOWNERS file"
+                        " (catch-all rules like /.*  or /*.md don't count)",
+                        "red",
+                    ),
+                    file=sys.stderr,
+                )
+                error = True
+            print(color_message(f"\t- /{path}", "orange"), file=sys.stderr)
+
+    return error
+
+
 def _get_static_root(pattern):
     """_get_static_root returns the longest prefix path from the pattern without any wildcards."""
     result = "."

--- a/tasks/unit_tests/codeowner_linter_tests.py
+++ b/tasks/unit_tests/codeowner_linter_tests.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import MagicMock
 
 from codeowners import CodeOwners
 
@@ -50,6 +51,7 @@ class TestAIArtefactsHaveOwner(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
         self.backup_cwd = os.getcwd()
+        self._tracked_files = []
         os.chdir(self.test_dir)
 
     def tearDown(self):
@@ -61,58 +63,65 @@ class TestAIArtefactsHaveOwner(unittest.TestCase):
             full = os.path.join(self.test_dir, path)
             os.makedirs(os.path.dirname(full), exist_ok=True)
             open(full, 'w').close()
+            self._tracked_files.append(path)
+
+    def _ctx(self):
+        """Return a mock ctx whose run('git ls-files') returns the tracked files."""
+        ctx = MagicMock()
+        ctx.run.return_value.stdout = "\n".join(self._tracked_files)
+        return ctx
 
     def test_no_ai_artefacts(self):
         # No AGENTS.md or .claude/ — nothing to check
         codeowner = CodeOwners("")
-        self.assertFalse(ai_artefacts_have_owner(codeowner))
+        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
 
     def test_agents_md_has_owner(self):
         self._create("pkg/foo/AGENTS.md")
         codeowner = CodeOwners("/pkg/foo/AGENTS.md @DataDog/team-a\n")
-        self.assertFalse(ai_artefacts_have_owner(codeowner))
+        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
 
     def test_agents_md_missing_owner(self):
         self._create("pkg/foo/AGENTS.md")
         # A rule for a different path does not cover pkg/foo/AGENTS.md
         codeowner = CodeOwners("/pkg/bar/ @DataDog/team-a\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner))
+        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
 
     def test_claude_file_has_owner(self):
         self._create(".claude/skills/my-skill.md")
         codeowner = CodeOwners("/.claude/ @DataDog/devx\n")
-        self.assertFalse(ai_artefacts_have_owner(codeowner))
+        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
 
     def test_claude_file_missing_owner(self):
         self._create(".claude/skills/my-skill.md")
         codeowner = CodeOwners("/pkg/foo/ @DataDog/team-a\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner))
+        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
 
     def test_wildcard_covers_agents_md(self):
         self._create("pkg/foo/AGENTS.md", "comp/bar/AGENTS.md")
         codeowner = CodeOwners("**/AGENTS.md @DataDog/devx\n")
-        self.assertFalse(ai_artefacts_have_owner(codeowner))
+        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
 
     def test_mixed_some_missing(self):
         self._create("pkg/foo/AGENTS.md", "pkg/bar/AGENTS.md")
         # Only pkg/foo/AGENTS.md is covered
         codeowner = CodeOwners("/pkg/foo/AGENTS.md @DataDog/team-a\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner))
+        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
 
     def test_catch_all_dot_files_is_not_explicit(self):
         # /.*  matches .claude/ files but is not considered explicit ownership
         self._create(".claude/skills/my-skill.md")
         codeowner = CodeOwners("/.*  @DataDog/agent-devx\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner))
+        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
 
     def test_catch_all_md_is_not_explicit(self):
         # /*.md matches root AGENTS.md but is not considered explicit ownership
         self._create("AGENTS.md")
         codeowner = CodeOwners("/*.md @DataDog/agent-devx\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner))
+        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
 
     def test_explicit_rule_takes_precedence_over_catch_all(self):
         # Explicit rule listed after the catch-all overrides it (last-match-wins, like GitHub)
         self._create("AGENTS.md")
         codeowner = CodeOwners("/*.md @DataDog/agent-devx\n/AGENTS.md @DataDog/agent-devx\n")
-        self.assertFalse(ai_artefacts_have_owner(codeowner))
+        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))

--- a/tasks/unit_tests/codeowner_linter_tests.py
+++ b/tasks/unit_tests/codeowner_linter_tests.py
@@ -5,7 +5,11 @@ import unittest
 
 from codeowners import CodeOwners
 
-from tasks.libs.owners.linter import codeowner_has_orphans, directory_has_packages_without_owner
+from tasks.libs.owners.linter import (
+    ai_artefacts_have_owner,
+    codeowner_has_orphans,
+    directory_has_packages_without_owner,
+)
 
 
 class TestCodeownerLinter(unittest.TestCase):
@@ -40,3 +44,75 @@ class TestCodeownerLinter(unittest.TestCase):
         codeowner = CodeOwners("\n".join(os.path.join("/pkg/", pkg) for pkg in [*self.fake_pkgs, "old_deleted_pkg"]))
         self.assertFalse(directory_has_packages_without_owner(codeowner))
         self.assertTrue(codeowner_has_orphans(codeowner))
+
+
+class TestAIArtefactsHaveOwner(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.backup_cwd = os.getcwd()
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+        os.chdir(self.backup_cwd)
+
+    def _create(self, *paths):
+        for path in paths:
+            full = os.path.join(self.test_dir, path)
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+            open(full, 'w').close()
+
+    def test_no_ai_artefacts(self):
+        # No AGENTS.md or .claude/ — nothing to check
+        codeowner = CodeOwners("")
+        self.assertFalse(ai_artefacts_have_owner(codeowner))
+
+    def test_agents_md_has_owner(self):
+        self._create("pkg/foo/AGENTS.md")
+        codeowner = CodeOwners("/pkg/foo/AGENTS.md @DataDog/team-a\n")
+        self.assertFalse(ai_artefacts_have_owner(codeowner))
+
+    def test_agents_md_missing_owner(self):
+        self._create("pkg/foo/AGENTS.md")
+        # A rule for a different path does not cover pkg/foo/AGENTS.md
+        codeowner = CodeOwners("/pkg/bar/ @DataDog/team-a\n")
+        self.assertTrue(ai_artefacts_have_owner(codeowner))
+
+    def test_claude_file_has_owner(self):
+        self._create(".claude/skills/my-skill.md")
+        codeowner = CodeOwners("/.claude/ @DataDog/devx\n")
+        self.assertFalse(ai_artefacts_have_owner(codeowner))
+
+    def test_claude_file_missing_owner(self):
+        self._create(".claude/skills/my-skill.md")
+        codeowner = CodeOwners("/pkg/foo/ @DataDog/team-a\n")
+        self.assertTrue(ai_artefacts_have_owner(codeowner))
+
+    def test_wildcard_covers_agents_md(self):
+        self._create("pkg/foo/AGENTS.md", "comp/bar/AGENTS.md")
+        codeowner = CodeOwners("**/AGENTS.md @DataDog/devx\n")
+        self.assertFalse(ai_artefacts_have_owner(codeowner))
+
+    def test_mixed_some_missing(self):
+        self._create("pkg/foo/AGENTS.md", "pkg/bar/AGENTS.md")
+        # Only pkg/foo/AGENTS.md is covered
+        codeowner = CodeOwners("/pkg/foo/AGENTS.md @DataDog/team-a\n")
+        self.assertTrue(ai_artefacts_have_owner(codeowner))
+
+    def test_catch_all_dot_files_is_not_explicit(self):
+        # /.*  matches .claude/ files but is not considered explicit ownership
+        self._create(".claude/skills/my-skill.md")
+        codeowner = CodeOwners("/.*  @DataDog/agent-devx\n")
+        self.assertTrue(ai_artefacts_have_owner(codeowner))
+
+    def test_catch_all_md_is_not_explicit(self):
+        # /*.md matches root AGENTS.md but is not considered explicit ownership
+        self._create("AGENTS.md")
+        codeowner = CodeOwners("/*.md @DataDog/agent-devx\n")
+        self.assertTrue(ai_artefacts_have_owner(codeowner))
+
+    def test_explicit_rule_takes_precedence_over_catch_all(self):
+        # Explicit rule listed after the catch-all overrides it (last-match-wins, like GitHub)
+        self._create("AGENTS.md")
+        codeowner = CodeOwners("/*.md @DataDog/agent-devx\n/AGENTS.md @DataDog/agent-devx\n")
+        self.assertFalse(ai_artefacts_have_owner(codeowner))

--- a/tasks/unit_tests/codeowner_linter_tests.py
+++ b/tasks/unit_tests/codeowner_linter_tests.py
@@ -74,54 +74,54 @@ class TestAIArtefactsHaveOwner(unittest.TestCase):
     def test_no_ai_artefacts(self):
         # No AGENTS.md or .claude/ — nothing to check
         codeowner = CodeOwners("")
-        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertFalse(ai_artefacts_have_owner(self._ctx(), codeowner))
 
     def test_agents_md_has_owner(self):
         self._create("pkg/foo/AGENTS.md")
         codeowner = CodeOwners("/pkg/foo/AGENTS.md @DataDog/team-a\n")
-        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertFalse(ai_artefacts_have_owner(self._ctx(), codeowner))
 
     def test_agents_md_missing_owner(self):
         self._create("pkg/foo/AGENTS.md")
         # A rule for a different path does not cover pkg/foo/AGENTS.md
         codeowner = CodeOwners("/pkg/bar/ @DataDog/team-a\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertTrue(ai_artefacts_have_owner(self._ctx(), codeowner))
 
     def test_claude_file_has_owner(self):
         self._create(".claude/skills/my-skill.md")
         codeowner = CodeOwners("/.claude/ @DataDog/devx\n")
-        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertFalse(ai_artefacts_have_owner(self._ctx(), codeowner))
 
     def test_claude_file_missing_owner(self):
         self._create(".claude/skills/my-skill.md")
         codeowner = CodeOwners("/pkg/foo/ @DataDog/team-a\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertTrue(ai_artefacts_have_owner(self._ctx(), codeowner))
 
     def test_wildcard_covers_agents_md(self):
         self._create("pkg/foo/AGENTS.md", "comp/bar/AGENTS.md")
         codeowner = CodeOwners("**/AGENTS.md @DataDog/devx\n")
-        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertFalse(ai_artefacts_have_owner(self._ctx(), codeowner))
 
     def test_mixed_some_missing(self):
         self._create("pkg/foo/AGENTS.md", "pkg/bar/AGENTS.md")
         # Only pkg/foo/AGENTS.md is covered
         codeowner = CodeOwners("/pkg/foo/AGENTS.md @DataDog/team-a\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertTrue(ai_artefacts_have_owner(self._ctx(), codeowner))
 
     def test_catch_all_dot_files_is_not_explicit(self):
         # /.*  matches .claude/ files but is not considered explicit ownership
         self._create(".claude/skills/my-skill.md")
         codeowner = CodeOwners("/.*  @DataDog/agent-devx\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertTrue(ai_artefacts_have_owner(self._ctx(), codeowner))
 
     def test_catch_all_md_is_not_explicit(self):
         # /*.md matches root AGENTS.md but is not considered explicit ownership
         self._create("AGENTS.md")
         codeowner = CodeOwners("/*.md @DataDog/agent-devx\n")
-        self.assertTrue(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertTrue(ai_artefacts_have_owner(self._ctx(), codeowner))
 
     def test_explicit_rule_takes_precedence_over_catch_all(self):
         # Explicit rule listed after the catch-all overrides it (last-match-wins, like GitHub)
         self._create("AGENTS.md")
         codeowner = CodeOwners("/*.md @DataDog/agent-devx\n/AGENTS.md @DataDog/agent-devx\n")
-        self.assertFalse(ai_artefacts_have_owner(codeowner, ctx=self._ctx()))
+        self.assertFalse(ai_artefacts_have_owner(self._ctx(), codeowner))


### PR DESCRIPTION
### What does this PR do?

Adds a new `lint_codeowners` check that validates every `AGENTS.md` file and every file under `.claude/` has an **explicit** entry in `.github/CODEOWNERS`. Catch-all rules like `/.*` or `/*.md` do not count.

Also adds the missing explicit CODEOWNERS entries for all existing AI artefacts in the repo.

### Motivation

AI artefacts (`AGENTS.md` files and `.claude/` skills/agents/rules) carry per-team context that drives AI coding assistant behaviour. Letting them silently fall through to broad catch-alls means ownership is ambiguous and teams won't get review requests when those files change. This change makes ownership intentional and auditable.

### Changes

**`tasks/libs/owners/linter.py`**
- New `ai_artefacts_have_owner(owners)` function: walks the repo, collects all `AGENTS.md` files and `.claude/**` files, and fails if any are only covered by `/.*` or `/*.md` catch-alls.

**`tasks/github_tasks.py`**
- Adds `ai_artefacts_have_owner` to the `lint_codeowner` task's linter list.

**`tasks/unit_tests/codeowner_linter_tests.py`**
- 10 new test cases covering: no artefacts, explicit ownership, missing ownership, catch-all dot-files rejection, catch-all `*.md` rejection, and last-match-wins precedence.

**`.github/CODEOWNERS`**
- Explicit entries added for `/AGENTS.md`, `/test/e2e-framework/AGENTS.md`, `/.claude/settings.json`, `/.claude/settings.local.json`.
- Explicit per-team entries for all `.claude/agents/`, `.claude/rules/`, and `.claude/skills/` artefacts (owners derived from git history).

### Describe how you validated your changes

- All 13 `codeowner_linter_tests.py` tests pass.
- Ran the new linter against the real `.github/CODEOWNERS` — no errors.

### Additional Notes

Ownership assignments were derived from `git log` author history and cross-referenced against existing CODEOWNERS team mappings. The one pre-existing explicit `.claude/` entry (`explain-lading-config` → `@DataDog/single-machine-performance`) was left unchanged.