### PR TITLE
fix(e2e): wait for installer service in TestInstallAgentPackageWithProxy

### DIFF
--- a/test/new-e2e/tests/installer/windows/install_exe_test.go
+++ b/test/new-e2e/tests/installer/windows/install_exe_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"go.yaml.in/yaml/v2"
 
@@ -271,6 +272,11 @@ func (s *testInstallExeProxySuite) TestInstallAgentPackageWithProxy() {
 	s.Require().NoError(err)
 
 	// Assert
+	s.Require().Eventually(func() bool {
+		status, _ := wincommon.GetServiceStatus(windowsHost, consts.ServiceName)
+		return status == "Running"
+	}, 15*time.Minute, 30*time.Second, "Datadog Installer service did not reach Running")
+
 	s.Require().Host(windowsHost).
 		HasARunningDatadogInstallerService().
 		HasARunningDatadogAgentService().RuntimeConfig().


### PR DESCRIPTION
### What does this PR do?

Add an `Eventually` poll for the Datadog Installer service status before the existing one-shot assertion in `TestInstallAgentPackageWithProxy`.

### Motivation

`install.exe` returns before the service has finished starting, so the assertion races.