### PR TITLE
Use reliable Ubuntu mirrors in CI

### DIFF
--- a/Dockerfiles/ddot-ebpf/Dockerfile
+++ b/Dockerfiles/ddot-ebpf/Dockerfile
@@ -34,6 +34,7 @@ RUN \
 # ------------------------------
 
 FROM $AGENT_BASE_IMAGE_TAG AS release
+ARG CI
 
 LABEL org.opencontainers.image.title="DDOT Ebpf"
 # Copy the built full host profiler from the builder stage
@@ -41,6 +42,18 @@ COPY --from=builder /workspace/datadog-agent/bin/host-profiler/host-profiler /op
 COPY --from=builder /workspace/datadog-agent/bin/host-profiler/dist/host-profiler-config.yaml /etc/datadog-agent/host-profiler-config.yaml
 # Find all directories and files in /etc with world-writable permissions and remove write permissions for group and others
 RUN find /etc -type d,f -perm -o+w -print0 | xargs -r -0 chmod g-w,o-w
+# Prefer reliable Ubuntu mirrors in CI to reduce transient network failures
+RUN if [ "$CI" = "true" ]; then \
+  echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
+  echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
+  for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+    if [ -f "$f" ]; then \
+      sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+             -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+             -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; \
+    fi; \
+  done; \
+  fi
 # Host profiler requires objcopy
 RUN apt-get update && \
     apt-get install -y --no-install-recommends binutils && \


### PR DESCRIPTION
<!-- dd-meta {"pullId":"36496086-fb5a-409b-a885-7990436747b1","source":"chat","resourceId":"41ad5bc9-237e-46a7-b73f-404ee2944d0d","workflowId":"3afef2f0-14e6-4810-b370-c36c325a863c","codeChangeId":"3afef2f0-14e6-4810-b370-c36c325a863c","sourceType":"slack"} -->
### What does this PR do?

Configures reliable Ubuntu mirrors in CI environments to reduce transient network failures during package installation in the ddot-ebpf Docker image build.

### Motivation

High level of [failures](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A%22docker_build_host_profiler_standalone_arm64%22&agg_m=%40ci.job.name&agg_m_source=base&agg_t=cardinality&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cipipeline_explorer_sort=time%2Cdesc&colorByAttr=meta%5B%27ci.stage.name%27%5D&cols=%40git.branch%2C%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40ci.stage.name%2C%40ci.job.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name&currentTab=trace&fromUser=true&graphType=flamegraph&index=cipipeline&mode=sliding&refresh_mode=paused&sort=time&spanViewType=metadata&viz=stream&start=1779204640770&end=1779208584000&paused=true)

The `docker_build_host_profiler_standalone_arm64` job was failing with network connectivity errors when attempting to install the `binutils` package from Ubuntu repositories. The errors indicated timeouts and inability to reach `ports.ubuntu.com` and `archive.ubuntu.com`. By preferring more reliable regional mirrors in CI, we can reduce the impact of transient network issues.

### Describe how you validated your changes

[This](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1695585849) should pass.

This change adds conditional mirror configuration that only applies when the `CI` build argument is set to `true`. The configuration:
- Creates mirror list files pointing to reliable US East Coast Ubuntu mirrors
- Updates APT sources to use `mirror+file:` protocol to reference these mirror lists
- Handles both `/etc/apt/sources.list` and `/etc/apt/sources.list.d/ubuntu.sources` configurations
- Only executes in CI environments, leaving local builds unaffected

### Additional Notes

The fix is non-invasive and only activates in CI pipelines through the `CI` build argument. Regional mirrors (`us-east-1.ec2.archive.ubuntu.com` and `us-east-1.ec2.ports.ubuntu.com`) are preferred as they typically provide better reliability than the default global mirrors.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/41ad5bc9-237e-46a7-b73f-404ee2944d0d)

Comment @datadog to request changes