### PR TITLE
[Host Profiler] Migrate confmap helpers to standalone package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -619,6 +619,7 @@
 /pkg/util/aggregatingqueue              @DataDog/container-integrations @DataDog/container-platform
 /pkg/util/cloudproviders/cloudfoundry/  @DataDog/agent-integrations
 /pkg/util/clusteragent/                 @DataDog/container-platform
+/pkg/util/confmaputils                       @DataDog/opentelemetry-agent @DataDog/profiling-full-host
 /pkg/util/containerd/                   @DataDog/container-integrations
 /pkg/util/containers/                   @DataDog/container-integrations
 /pkg/util/containers/metrics/ecsfargate/          @DataDog/ecs-experiences @DataDog/container-integrations

--- a/comp/anomalydetection/observer/def/go.mod
+++ b/comp/anomalydetection/observer/def/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/anomalydetection/recorder/def/go.mod
+++ b/comp/anomalydetection/recorder/def/go.mod
@@ -146,6 +146,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/api/api/def/go.mod
+++ b/comp/api/api/def/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/agenttelemetry/def/go.mod
+++ b/comp/core/agenttelemetry/def/go.mod
@@ -165,6 +165,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/agenttelemetry/fx/go.mod
+++ b/comp/core/agenttelemetry/fx/go.mod
@@ -252,6 +252,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/agenttelemetry/impl/go.mod
+++ b/comp/core/agenttelemetry/impl/go.mod
@@ -256,6 +256,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/config/go.mod
+++ b/comp/core/config/go.mod
@@ -223,6 +223,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/core/configsync/go.mod
+++ b/comp/core/configsync/go.mod
@@ -234,6 +234,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/core/delegatedauth/api/cloudauth/aws/go.mod
+++ b/comp/core/delegatedauth/api/cloudauth/aws/go.mod
@@ -213,6 +213,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../../../pkg/util/executable

--- a/comp/core/delegatedauth/go.mod
+++ b/comp/core/delegatedauth/go.mod
@@ -229,6 +229,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/core/flare/builder/go.mod
+++ b/comp/core/flare/builder/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/flare/types/go.mod
+++ b/comp/core/flare/types/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/hostname/hostnameinterface/go.mod
+++ b/comp/core/hostname/hostnameinterface/go.mod
@@ -166,6 +166,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/ipc/def/go.mod
+++ b/comp/core/ipc/def/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/ipc/httphelpers/go.mod
+++ b/comp/core/ipc/httphelpers/go.mod
@@ -232,6 +232,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/ipc/impl/go.mod
+++ b/comp/core/ipc/impl/go.mod
@@ -232,6 +232,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/ipc/mock/go.mod
+++ b/comp/core/ipc/mock/go.mod
@@ -230,6 +230,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/log/def/go.mod
+++ b/comp/core/log/def/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/log/fx/go.mod
+++ b/comp/core/log/fx/go.mod
@@ -227,6 +227,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/log/impl-trace/go.mod
+++ b/comp/core/log/impl-trace/go.mod
@@ -230,6 +230,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/log/impl/go.mod
+++ b/comp/core/log/impl/go.mod
@@ -226,6 +226,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/log/mock/go.mod
+++ b/comp/core/log/mock/go.mod
@@ -158,6 +158,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/secrets/def/go.mod
+++ b/comp/core/secrets/def/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/secrets/fx/go.mod
+++ b/comp/core/secrets/fx/go.mod
@@ -243,6 +243,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/secrets/impl/go.mod
+++ b/comp/core/secrets/impl/go.mod
@@ -240,6 +240,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/secrets/mock/go.mod
+++ b/comp/core/secrets/mock/go.mod
@@ -150,6 +150,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/secrets/noop-impl/go.mod
+++ b/comp/core/secrets/noop-impl/go.mod
@@ -167,6 +167,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/secrets/utils/go.mod
+++ b/comp/core/secrets/utils/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/status/go.mod
+++ b/comp/core/status/go.mod
@@ -170,6 +170,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/core/status/statusimpl/go.mod
+++ b/comp/core/status/statusimpl/go.mod
@@ -233,6 +233,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/def/go.mod
+++ b/comp/core/tagger/def/go.mod
@@ -231,6 +231,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/fx-remote/go.mod
+++ b/comp/core/tagger/fx-remote/go.mod
@@ -281,6 +281,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/generic_store/go.mod
+++ b/comp/core/tagger/generic_store/go.mod
@@ -158,6 +158,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/impl-remote/go.mod
+++ b/comp/core/tagger/impl-remote/go.mod
@@ -288,6 +288,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/origindetection/go.mod
+++ b/comp/core/tagger/origindetection/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/subscriber/go.mod
+++ b/comp/core/tagger/subscriber/go.mod
@@ -189,6 +189,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/tags/go.mod
+++ b/comp/core/tagger/tags/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/telemetry/go.mod
+++ b/comp/core/tagger/telemetry/go.mod
@@ -165,6 +165,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/types/go.mod
+++ b/comp/core/tagger/types/go.mod
@@ -158,6 +158,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/tagger/utils/go.mod
+++ b/comp/core/tagger/utils/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/core/telemetry/go.mod
+++ b/comp/core/telemetry/go.mod
@@ -179,6 +179,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/def/go.mod
+++ b/comp/def/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -252,6 +252,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/forwarder/orchestrator/orchestratorinterface/go.mod
+++ b/comp/forwarder/orchestrator/orchestratorinterface/go.mod
@@ -251,6 +251,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/host-profiler/collector/impl/agentprovider/BUILD.bazel
+++ b/comp/host-profiler/collector/impl/agentprovider/BUILD.bazel
@@ -11,11 +11,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/config",
-        "//comp/host-profiler/collector/impl/converters",
         "//comp/host-profiler/collector/impl/extensions/hpflareextension",
         "//comp/host-profiler/collector/impl/params",
         "//comp/host-profiler/version",
         "//pkg/config/utils",
+        "//pkg/util/confmaputils",
         "//pkg/util/log",
         "@io_opentelemetry_go_collector_confmap//:confmap",
     ],

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -11,10 +11,10 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/converters"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/extensions/hpflareextension"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/params"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
+	"github.com/DataDog/datadog-agent/pkg/util/confmaputils"
 )
 
 type confMap = map[string]any
@@ -29,7 +29,7 @@ func buildReceivers(conf confMap, agent configManager) []any {
 	receivers := make(confMap)
 
 	profiling := make(confMap)
-	_ = converters.Set(profiling, "symbol_uploader::enabled", true)
+	_ = confmaputils.Set(profiling, "symbol_uploader::enabled", true)
 
 	symbolEndpoints := make([]any, 0, agent.endpointsTotalLength)
 	for _, endpoint := range agent.endpoints {
@@ -41,7 +41,7 @@ func buildReceivers(conf confMap, agent configManager) []any {
 		}
 	}
 
-	_ = converters.Set(profiling, "symbol_uploader::symbol_endpoints", symbolEndpoints)
+	_ = confmaputils.Set(profiling, "symbol_uploader::symbol_endpoints", symbolEndpoints)
 
 	receivers["profiling"] = profiling
 	conf["receivers"] = receivers
@@ -86,7 +86,7 @@ func buildExporters(conf confMap, agent configManager) []any {
 			index := siteExporterCount[endpoint.site]
 			siteExporterCount[endpoint.site]++
 			exporterName := fmt.Sprintf(otlpHTTPNameFormat, endpoint.site, index)
-			_ = converters.Set(exporters, exporterName, createOtlpHTTPFromEndpoint(endpoint.site, key))
+			_ = confmaputils.Set(exporters, exporterName, createOtlpHTTPFromEndpoint(endpoint.site, key))
 			profilesExporters = append(profilesExporters, exporterName)
 		}
 	}
@@ -109,7 +109,7 @@ func buildProcessors(conf confMap) []any {
 		"allow_hostname_override": true,
 		"cardinality":             2,
 	}
-	_ = converters.Set(processors, infraAttributesName, infraattributes)
+	_ = confmaputils.Set(processors, infraAttributesName, infraattributes)
 
 	metadata := confMap{
 		"attributes": []any{
@@ -125,7 +125,7 @@ func buildProcessors(conf confMap) []any {
 			},
 		},
 	}
-	_ = converters.Set(processors, "resource/dd-profiler-internal-metadata", metadata)
+	_ = confmaputils.Set(processors, "resource/dd-profiler-internal-metadata", metadata)
 
 	conf["processors"] = processors
 	return []any{infraAttributesName, "resource/dd-profiler-internal-metadata"}
@@ -133,12 +133,12 @@ func buildProcessors(conf confMap) []any {
 
 func buildMetricsTelemetry(conf confMap, healthMetrics healthMetricsConfig) {
 	if !healthMetrics.Enabled {
-		_ = converters.Set(conf, "service::telemetry::metrics::level", "none")
+		_ = confmaputils.Set(conf, "service::telemetry::metrics::level", "none")
 		return
 	}
 	host, portStr, _ := net.SplitHostPort(healthMetrics.Target)
 	port, _ := strconv.Atoi(portStr)
-	_ = converters.Set(conf, "service::telemetry::metrics::readers", []any{
+	_ = confmaputils.Set(conf, "service::telemetry::metrics::readers", []any{
 		confMap{"pull": confMap{"exporter": confMap{"prometheus": confMap{"host": host, "port": port}}}},
 	})
 }
@@ -148,16 +148,16 @@ func buildMetricsPipeline(conf confMap, enableGoRuntimeMetrics bool, healthMetri
 		return
 	}
 
-	metricsPipeline, _ := converters.Ensure[confMap](conf, "service::pipelines::metrics")
-	receivers, _ := converters.Ensure[confMap](conf, "receivers")
-	processors, _ := converters.Ensure[confMap](conf, "processors")
+	metricsPipeline, _ := confmaputils.Ensure[confMap](conf, "service::pipelines::metrics")
+	receivers, _ := confmaputils.Ensure[confMap](conf, "receivers")
+	processors, _ := confmaputils.Ensure[confMap](conf, "processors")
 
 	var metricsReceivers []any
 	metricsProcessors := profilesProcessors
 
 	if healthMetrics.Enabled {
-		receivers["prometheus"] = converters.PrometheusReceiverConfigWithTarget(healthMetrics.Target)
-		processors["filter"] = converters.FilterProcessorConfig()
+		receivers["prometheus"] = confmaputils.PrometheusReceiverConfig("host-profiler-internal", healthMetrics.Target)
+		processors["filter"] = confmaputils.FilterProcessorConfig()
 		processors["cumulativetodelta"] = confMap{}
 		metricsProcessors = append([]any{"filter", "cumulativetodelta"}, profilesProcessors...)
 		metricsReceivers = append(metricsReceivers, "prometheus")
@@ -176,7 +176,7 @@ func buildMetricsPipeline(conf confMap, enableGoRuntimeMetrics bool, healthMetri
 func buildConfig(agent configManager, p params.CollectorParams) confMap {
 	config := make(confMap)
 
-	profilesPipeline, _ := converters.Ensure[confMap](config, "service::pipelines::profiles")
+	profilesPipeline, _ := confmaputils.Ensure[confMap](config, "service::pipelines::profiles")
 
 	profilesProcessors := buildProcessors(config)
 	profilesExporters := buildExporters(config, agent)
@@ -190,17 +190,17 @@ func buildConfig(agent configManager, p params.CollectorParams) confMap {
 	buildMetricsPipeline(config, p.GetGoRuntimeMetrics(), agent.hostProfilerConfig.HealthMetrics, profilesProcessors, profilesExporters)
 
 	hpflareConf := confMap{"endpoint": fmt.Sprintf("localhost:%d", hpflareextension.EffectivePort(agent.hostProfilerConfig.HPFlare.Port))}
-	_ = converters.Set(config, "extensions::"+hpflareName, hpflareConf)
+	_ = confmaputils.Set(config, "extensions::"+hpflareName, hpflareConf)
 	serviceExtensions := []any{hpflareName}
 	if agent.hostProfilerConfig.DDProfiling.Enabled {
 		ddprofilingConf := make(confMap)
 		if agent.hostProfilerConfig.DDProfiling.Period > 0 {
-			_ = converters.Set(ddprofilingConf, "profiler_options::period", agent.hostProfilerConfig.DDProfiling.Period)
+			_ = confmaputils.Set(ddprofilingConf, "profiler_options::period", agent.hostProfilerConfig.DDProfiling.Period)
 		}
-		_ = converters.Set(config, "extensions::"+ddprofilingName, ddprofilingConf)
+		_ = confmaputils.Set(config, "extensions::"+ddprofilingName, ddprofilingConf)
 		serviceExtensions = append(serviceExtensions, ddprofilingName)
 	}
-	_ = converters.Set(config, "service::extensions", serviceExtensions)
+	_ = confmaputils.Set(config, "service::extensions", serviceExtensions)
 
 	return config
 }

--- a/comp/host-profiler/collector/impl/converters/BUILD.bazel
+++ b/comp/host-profiler/collector/impl/converters/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//comp/host-profiler/version",
         "//pkg/config/utils",
+        "//pkg/util/confmaputils",
         "@io_opentelemetry_go_collector_confmap//:confmap",
         "@io_opentelemetry_go_collector_confmap_xconfmap//:xconfmap",
         "@org_uber_go_zap_exp//zapslog",
@@ -28,6 +29,7 @@ go_test(
     gotags = ["test"],
     deps = [
         "//comp/host-profiler/version",
+        "//pkg/util/confmaputils",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_yaml_go_yaml_v3//:yaml",

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
+	"github.com/DataDog/datadog-agent/pkg/util/confmaputils"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.uber.org/zap/exp/zapslog"
@@ -58,24 +59,24 @@ func newConverterWithoutAgent(convSettings confmap.ConverterSettings) confmap.Co
 func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) error {
 	confStringMap := xconfmap.ToStringMapRaw(conf)
 
-	profilesPipeline, err := Ensure[confMap](confStringMap, "service::pipelines::profiles")
+	profilesPipeline, err := confmaputils.Ensure[confMap](confStringMap, "service::pipelines::profiles")
 	if err != nil {
 		return err
 	}
 
 	// no need to check for errors here as we directly depend on profilesPipeline that had to be valid for this code
 	// path to be executed
-	processorNames, err := Ensure[[]any](profilesPipeline, "processors")
+	processorNames, err := confmaputils.Ensure[[]any](profilesPipeline, "processors")
 	if err != nil {
 		return err
 	}
 
-	receiverNames, err := Ensure[[]any](profilesPipeline, "receivers")
+	receiverNames, err := confmaputils.Ensure[[]any](profilesPipeline, "receivers")
 	if err != nil {
 		return err
 	}
 
-	exporterNames, err := Ensure[[]any](profilesPipeline, "exporters")
+	exporterNames, err := confmaputils.Ensure[[]any](profilesPipeline, "exporters")
 	if err != nil {
 		return err
 	}
@@ -124,7 +125,7 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 
 	// Add internal health metrics pipeline
 	// Get updated exporter list from profiles pipeline (may have been modified by ensureOtlpHTTPExporterConfig)
-	updatedExporterNames, err := Ensure[[]any](profilesPipeline, "exporters")
+	updatedExporterNames, err := confmaputils.Ensure[[]any](profilesPipeline, "exporters")
 	if err != nil {
 		return err
 	}
@@ -137,12 +138,12 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 }
 
 func (c *converterWithoutAgent) ensureMetricsPipeline(conf confMap) error {
-	metrics, err := Ensure[confMap](conf, "service::pipelines::metrics")
+	metrics, err := confmaputils.Ensure[confMap](conf, "service::pipelines::metrics")
 	if err != nil {
 		return err
 	}
 
-	processors, err := Ensure[[]any](metrics, "processors")
+	processors, err := confmaputils.Ensure[[]any](metrics, "processors")
 	if err != nil {
 		return err
 	}
@@ -154,7 +155,7 @@ func (c *converterWithoutAgent) ensureMetricsPipeline(conf confMap) error {
 			return errors.New("processors in metrics pipeline should be strings")
 		}
 
-		if isComponentType(processor, componentTypeInfraAttributes) {
+		if confmaputils.IsComponentType(processor, componentTypeInfraAttributes) {
 			continue
 		}
 
@@ -168,13 +169,13 @@ func (c *converterWithoutAgent) ensureMetricsPipeline(conf confMap) error {
 }
 
 func (c *converterWithoutAgent) ensureGlobalProcessors(conf confMap) error {
-	processors, err := Ensure[confMap](conf, "processors")
+	processors, err := confmaputils.Ensure[confMap](conf, "processors")
 	if err != nil {
 		return err
 	}
 
 	for name := range processors {
-		if isComponentType(name, componentTypeInfraAttributes) {
+		if confmaputils.IsComponentType(name, componentTypeInfraAttributes) {
 			delete(processors, name)
 		}
 	}
@@ -182,7 +183,7 @@ func (c *converterWithoutAgent) ensureGlobalProcessors(conf confMap) error {
 }
 
 func (c *converterWithoutAgent) fixProcessorsPipeline(conf confMap, processorNames []any) ([]any, error) {
-	processors, err := Ensure[confMap](conf, "processors")
+	processors, err := confmaputils.Ensure[confMap](conf, "processors")
 	if err != nil {
 		return nil, err
 	}
@@ -198,15 +199,15 @@ func (c *converterWithoutAgent) fixProcessorsPipeline(conf confMap, processorNam
 		}
 
 		// Remove infraattributes from pipeline and global config
-		if isComponentType(name, componentTypeInfraAttributes) {
+		if confmaputils.IsComponentType(name, componentTypeInfraAttributes) {
 			delete(processors, name)
 			toDelete[name] = true
 			continue
 		}
 
 		// Track if we have resourcedetection
-		if isComponentType(name, componentTypeResourceDetection) {
-			if resourceDetectionConfig, ok := Get[confMap](conf, pathPrefixProcessors+name); ok {
+		if confmaputils.IsComponentType(name, componentTypeResourceDetection) {
+			if resourceDetectionConfig, ok := confmaputils.Get[confMap](conf, pathPrefixProcessors+name); ok {
 				if err := c.ensureResourceDetectionConfig(resourceDetectionConfig); err != nil {
 					return nil, err
 				}
@@ -214,14 +215,14 @@ func (c *converterWithoutAgent) fixProcessorsPipeline(conf confMap, processorNam
 			foundResourcedetection = true
 		}
 
-		if isComponentType(name, componentTypeDDHostNameProcessor) {
+		if confmaputils.IsComponentType(name, componentTypeDDHostNameProcessor) {
 			foundDDHostNameProcessor = true
 		}
 	}
 
 	// Add resourcedetection/default if none found
 	if !foundResourcedetection {
-		if err := Set(processors, defaultResourceDetectionName, resourceDetectionDefaultConfig); err != nil {
+		if err := confmaputils.Set(processors, defaultResourceDetectionName, resourceDetectionDefaultConfig); err != nil {
 			return nil, err
 		}
 		slog.Warn("Added minimal resourcedetection processor to user configuration")
@@ -230,7 +231,7 @@ func (c *converterWithoutAgent) fixProcessorsPipeline(conf confMap, processorNam
 
 	// Add ddhostname/default if none found
 	if !foundDDHostNameProcessor {
-		if err := Set(processors, defaultDDHostNameProcessorName, confMap{}); err != nil {
+		if err := confmaputils.Set(processors, defaultDDHostNameProcessorName, confMap{}); err != nil {
 			return nil, err
 		}
 		slog.Info("Added minimal ddhostname processor to user configuration")
@@ -248,7 +249,7 @@ func (c *converterWithoutAgent) fixProcessorsPipeline(conf confMap, processorNam
 }
 
 func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection confMap) error {
-	detectors, err := Ensure[[]any](resourceDetection, "detectors")
+	detectors, err := confmaputils.Ensure[[]any](resourceDetection, "detectors")
 	if err != nil {
 		return err
 	}
@@ -263,7 +264,7 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 	}
 
 	// Always ensure host.arch is enabled
-	ddDefaultValue, err := SetDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true)
+	ddDefaultValue, err := confmaputils.SetDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true)
 	if err != nil {
 		return err
 	}
@@ -273,10 +274,10 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 
 	// Only set these defaults if we added the system detector
 	if !hasSystemDetector {
-		if _, err := SetDefault(resourceDetection, "system::resource_attributes::host.name::enabled", false); err != nil {
+		if _, err := confmaputils.SetDefault(resourceDetection, "system::resource_attributes::host.name::enabled", false); err != nil {
 			return err
 		}
-		if _, err := SetDefault(resourceDetection, "system::resource_attributes::os.type::enabled", false); err != nil {
+		if _, err := confmaputils.SetDefault(resourceDetection, "system::resource_attributes::os.type::enabled", false); err != nil {
 			return err
 		}
 	}
@@ -295,13 +296,13 @@ func (c *converterWithoutAgent) fixReceiversPipeline(conf confMap, receiverNames
 			return nil, fmt.Errorf("receiver name must be a string, got %T", nameAny)
 		}
 
-		if !isComponentType(name, componentTypeProfiling) {
+		if !confmaputils.IsComponentType(name, componentTypeProfiling) {
 			continue
 		}
 
 		hasProfiling = true
 
-		if profilingConfig, ok := Get[confMap](conf, pathPrefixReceivers+name); ok {
+		if profilingConfig, ok := confmaputils.Get[confMap](conf, pathPrefixReceivers+name); ok {
 			if err := c.checkProfilingReceiverConfig(profilingConfig); err != nil {
 				return nil, err
 			}
@@ -313,7 +314,7 @@ func (c *converterWithoutAgent) fixReceiversPipeline(conf confMap, receiverNames
 	}
 
 	// Ensure default config exists if profiling receiver is not configured
-	if err := Set(conf, pathPrefixReceivers+defaultProfilingName+"::"+pathSymbolUploaderEnabled, false); err != nil {
+	if err := confmaputils.Set(conf, pathPrefixReceivers+defaultProfilingName+"::"+pathSymbolUploaderEnabled, false); err != nil {
 		return nil, err
 	}
 
@@ -325,11 +326,11 @@ func (c *converterWithoutAgent) fixReceiversPipeline(conf confMap, receiverNames
 // It ensures that if symbol_uploader is enabled, symbol_endpoints is properly configured
 // and all api_key/app_key values are strings.
 func (c *converterWithoutAgent) checkProfilingReceiverConfig(profiling confMap) error {
-	if isEnabled, ok := Get[bool](profiling, pathSymbolUploaderEnabled); !ok || !isEnabled {
+	if isEnabled, ok := confmaputils.Get[bool](profiling, pathSymbolUploaderEnabled); !ok || !isEnabled {
 		return nil
 	}
 
-	endpoints, ok := Get[[]any](profiling, pathSymbolEndpoints)
+	endpoints, ok := confmaputils.Get[[]any](profiling, pathSymbolEndpoints)
 
 	if !ok {
 		return errors.New("symbol_endpoints must be a list")
@@ -355,11 +356,11 @@ func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, expor
 		if name, ok := nameAny.(string); ok && isComponentTypeOtlpHTTP(name) {
 			hasOtlpHTTP = true
 
-			if _, err := SetDefault(conf, pathPrefixExporters+name+"::compression", "zstd"); err != nil {
+			if _, err := confmaputils.SetDefault(conf, pathPrefixExporters+name+"::compression", "zstd"); err != nil {
 				return err
 			}
 
-			headers, err := Ensure[confMap](conf, pathPrefixExporters+name+"::headers")
+			headers, err := confmaputils.Ensure[confMap](conf, pathPrefixExporters+name+"::headers")
 			if err != nil {
 				return err
 			}
@@ -367,10 +368,10 @@ func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, expor
 			if !ensureKeyStringValue(headers, fieldDDAPIKey) {
 				return fmt.Errorf("%s exporter missing required dd-api-key header", name)
 			}
-			if _, err := SetDefault(headers, fieldDDEVPOrigin, version.StandaloneProfilerName); err != nil {
+			if _, err := confmaputils.SetDefault(headers, fieldDDEVPOrigin, version.StandaloneProfilerName); err != nil {
 				return err
 			}
-			if _, err := SetDefault(headers, fieldDDEVPOriginVersion, version.ProfilerVersion); err != nil {
+			if _, err := confmaputils.SetDefault(headers, fieldDDEVPOriginVersion, version.ProfilerVersion); err != nil {
 				return err
 			}
 		}
@@ -384,12 +385,12 @@ func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, expor
 }
 
 func (c *converterWithoutAgent) removeAgentOnlyExtensions(conf confMap) error {
-	service, err := Ensure[confMap](conf, "service")
+	service, err := confmaputils.Ensure[confMap](conf, "service")
 	if err != nil {
 		return err
 	}
 
-	extensions, ok := Get[[]any](service, "extensions")
+	extensions, ok := confmaputils.Get[[]any](service, "extensions")
 	if !ok {
 		return nil
 	}
@@ -403,12 +404,12 @@ func (c *converterWithoutAgent) removeAgentOnlyExtensions(conf confMap) error {
 			return errors.New("extension names in service should be strings")
 		}
 
-		if isComponentType(ext, componentTypeDDProfiling) {
+		if confmaputils.IsComponentType(ext, componentTypeDDProfiling) {
 			ddProfilingExtensions++
 		}
 
 		// Skip hpflare extensions
-		if isComponentType(ext, componentTypeHPFlare) {
+		if confmaputils.IsComponentType(ext, componentTypeHPFlare) {
 			continue
 		}
 
@@ -422,10 +423,10 @@ func (c *converterWithoutAgent) removeAgentOnlyExtensions(conf confMap) error {
 	}
 
 	// Also remove the extension definitions from global config
-	extensionsConf, ok := Get[confMap](conf, "extensions")
+	extensionsConf, ok := confmaputils.Get[confMap](conf, "extensions")
 	if ok {
 		for name := range extensionsConf {
-			if isComponentType(name, componentTypeHPFlare) {
+			if confmaputils.IsComponentType(name, componentTypeHPFlare) {
 				delete(extensionsConf, name)
 			}
 		}
@@ -437,27 +438,27 @@ func (c *converterWithoutAgent) removeAgentOnlyExtensions(conf confMap) error {
 // addInternalHealthMetricsPipeline scrapes OTel collector internal telemetry and exports it
 // to the same orgs as profiles. Separate from ensureMetricsPipeline which handles user-defined pipelines.
 func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, profilesExporterNames []any, profilesProcessors []any) error {
-	if existing, ok := Get[confMap](conf, "service::pipelines::"+internalHealthMetricsPipelineName); ok {
+	if existing, ok := confmaputils.Get[confMap](conf, "service::pipelines::"+internalHealthMetricsPipelineName); ok {
 		slog.Warn("metrics/profiler-internal-health pipeline already configured, skipping auto-configuration",
 			slog.Any("existing_config", existing))
 		return nil
 	}
 
-	if level, ok := Get[string](conf, "service::telemetry::metrics::level"); ok {
+	if level, ok := confmaputils.Get[string](conf, "service::telemetry::metrics::level"); ok {
 		if strings.ToLower(level) == "none" {
 			slog.Info("metrics telemetry disabled (level=none), skipping metrics pipeline")
 			return nil
 		}
 	}
 
-	if receivers, ok := Get[confMap](conf, "receivers"); ok {
+	if receivers, ok := confmaputils.Get[confMap](conf, "receivers"); ok {
 		if _, exists := receivers[reservedPrometheusReceiver]; exists {
 			slog.Warn("receiver name conflicts with reserved name, skipping pipeline",
 				slog.String("receiver", reservedPrometheusReceiver))
 			return nil
 		}
 	}
-	if processors, ok := Get[confMap](conf, "processors"); ok {
+	if processors, ok := confmaputils.Get[confMap](conf, "processors"); ok {
 		for _, reserved := range []string{reservedFilterProcessor, reservedCumulativeToDeltaProcessor} {
 			if _, exists := processors[reserved]; exists {
 				slog.Warn("processor name conflicts with reserved name, skipping pipeline",
@@ -478,13 +479,13 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 			continue
 		}
 
-		exporterConf, ok := Get[confMap](conf, pathPrefixExporters+exporterName)
+		exporterConf, ok := confmaputils.Get[confMap](conf, pathPrefixExporters+exporterName)
 		if !ok {
 			slog.Warn("exporter not found in config", slog.String("exporter", exporterName))
 			continue
 		}
 
-		if _, hasMetrics := Get[string](exporterConf, "metrics_endpoint"); hasMetrics {
+		if _, hasMetrics := confmaputils.Get[string](exporterConf, "metrics_endpoint"); hasMetrics {
 			slog.Debug("metrics_endpoint already set, preserving user config", slog.String("exporter", exporterName))
 			metricsExporterNames = append(metricsExporterNames, exporterName)
 			continue
@@ -493,13 +494,13 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 		// If a top-level endpoint is set, otlphttp derives the metrics URL by appending
 		// /v1/metrics. We check this before profiles_endpoint so a bare endpoint takes
 		// precedence over a profiles_endpoint override.
-		if _, hasEndpoint := Get[string](exporterConf, "endpoint"); hasEndpoint {
+		if _, hasEndpoint := confmaputils.Get[string](exporterConf, "endpoint"); hasEndpoint {
 			slog.Debug("endpoint set, reusing exporter for metrics", slog.String("exporter", exporterName))
 			metricsExporterNames = append(metricsExporterNames, exporterName)
 			continue
 		}
 
-		profilesEndpoint, ok := Get[string](exporterConf, "profiles_endpoint")
+		profilesEndpoint, ok := confmaputils.Get[string](exporterConf, "profiles_endpoint")
 		if !ok {
 			slog.Warn("otlp_http exporter missing endpoint and profiles_endpoint, cannot infer metrics endpoint",
 				slog.String("exporter", exporterName))
@@ -515,7 +516,7 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 			continue
 		}
 
-		if err := Set(exporterConf, "metrics_endpoint", metricsEndpoint); err != nil {
+		if err := confmaputils.Set(exporterConf, "metrics_endpoint", metricsEndpoint); err != nil {
 			return fmt.Errorf("failed to set metrics_endpoint for %s: %w", exporterName, err)
 		}
 
@@ -532,14 +533,14 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 		return nil
 	}
 
-	if err := Set(conf, pathPrefixReceivers+reservedPrometheusReceiver, PrometheusReceiverConfig()); err != nil {
+	if err := confmaputils.Set(conf, pathPrefixReceivers+reservedPrometheusReceiver, confmaputils.PrometheusReceiverConfig("host-profiler-internal", "127.0.0.1:8889")); err != nil {
 		return fmt.Errorf("failed to add prometheus receiver: %w", err)
 	}
 
-	if err := Set(conf, pathPrefixProcessors+reservedFilterProcessor, FilterProcessorConfig()); err != nil {
+	if err := confmaputils.Set(conf, pathPrefixProcessors+reservedFilterProcessor, confmaputils.FilterProcessorConfig()); err != nil {
 		return fmt.Errorf("failed to add filter processor: %w", err)
 	}
-	if err := Set(conf, pathPrefixProcessors+reservedCumulativeToDeltaProcessor, confMap{}); err != nil {
+	if err := confmaputils.Set(conf, pathPrefixProcessors+reservedCumulativeToDeltaProcessor, confMap{}); err != nil {
 		return fmt.Errorf("failed to add cumulativetodelta processor: %w", err)
 	}
 
@@ -552,7 +553,7 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 		"exporters":  metricsExporterNames,
 	}
 
-	if err := Set(conf, "service::pipelines::"+internalHealthMetricsPipelineName, metricsPipeline); err != nil {
+	if err := confmaputils.Set(conf, "service::pipelines::"+internalHealthMetricsPipelineName, metricsPipeline); err != nil {
 		return fmt.Errorf("failed to create pipeline: %w", err)
 	}
 

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -12,11 +12,10 @@ package converters
 import (
 	"fmt"
 	"log/slog"
-	"reflect"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/confmaputils"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 )
@@ -27,11 +26,6 @@ func NewFactoryWithoutAgent() confmap.ConverterFactory {
 }
 
 type confMap = map[string]any
-
-// AutoConfiguredID is the OTEL component name suffix used for all components
-// that are automatically injected by the host profiler (as opposed to components
-// explicitly declared by the user).
-const AutoConfiguredID = "dd-autoconfigured"
 
 // Component type names for OTEL configuration
 const (
@@ -51,9 +45,9 @@ const (
 
 // Default component names
 const (
-	defaultInfraAttributesName     = componentTypeInfraAttributes + "/" + AutoConfiguredID
-	defaultResourceDetectionName   = componentTypeResourceDetection + "/" + AutoConfiguredID
-	defaultDDHostNameProcessorName = componentTypeDDHostNameProcessor + "/" + AutoConfiguredID
+	defaultInfraAttributesName     = componentTypeInfraAttributes + "/" + confmaputils.AutoConfiguredSuffix
+	defaultResourceDetectionName   = componentTypeResourceDetection + "/" + confmaputils.AutoConfiguredSuffix
+	defaultDDHostNameProcessorName = componentTypeDDHostNameProcessor + "/" + confmaputils.AutoConfiguredSuffix
 	defaultProfilingName           = "profiling"
 )
 
@@ -87,136 +81,9 @@ const (
 	pathPrefixProcessors = "processors::"
 )
 
-// isComponentType checks if a component name matches a specific type.
-// OTEL components follow the naming convention: "type" or "type/id"
-// Examples: "otlp_http", "otlp_http/prod", "profiling/custom"
-func isComponentType(name, componentType string) bool {
-	return name == componentType || strings.HasPrefix(name, componentType+"/")
-}
-
 // isComponentTypeOtlpHTTP checks for both the current ("otlp_http") and deprecated ("otlphttp") component names.
 func isComponentTypeOtlpHTTP(name string) bool {
-	return isComponentType(name, componentTypeOtlpHTTP) || isComponentType(name, componentTypeOtlpHTTPDeprecated)
-}
-
-// Get retrieves a value of type T from the confMap at the given path.
-// Path segments are separated by "::".
-// Returns the value and true if found and of correct type, zero value and false otherwise.
-// Does not modify the map.
-// Get only logs errors because they are recoverable (ie. Ensure)
-func Get[T any](c confMap, path string) (T, bool) {
-	var zero T
-	currentMap := c
-	pathSlice := strings.Split(path, "::")
-
-	target := pathSlice[len(pathSlice)-1]
-	for _, key := range pathSlice[:len(pathSlice)-1] {
-		childConfMap, exists := currentMap[key]
-		if !exists {
-			slog.Debug("non-existent intermediate map", slog.String("key", key), slog.String("path", path))
-			return zero, false
-		}
-
-		childMap, isMap := childConfMap.(confMap)
-		if !isMap {
-			slog.Debug("intermediate node is not a map", slog.String("key", key), slog.String("path", path))
-			return zero, false
-		}
-
-		currentMap = childMap
-	}
-
-	obj, exists := currentMap[target]
-	if !exists {
-		slog.Debug("leaf element doesn't exist", slog.String("path", path))
-		return zero, false
-	}
-
-	val, ok := obj.(T)
-	return val, ok
-}
-
-// Ensure retrieves a value of type T from the confMap at the given path.
-// If the path doesn't exist, it creates the path with a zero value of type T.
-// Path segments are separated by "::".
-// Returns an error if an intermediate path element exists but is not a map.
-func Ensure[T any](c confMap, path string) (T, error) {
-	if val, ok := Get[T](c, path); ok {
-		return val, nil
-	}
-	var zero T
-	// Special handling for map types
-	// create an empty map instead of nil
-	switch any(zero).(type) {
-	case map[string]any:
-		zero = any(make(map[string]any)).(T)
-	}
-	if err := Set(c, path, zero); err != nil {
-		return zero, fmt.Errorf("failed to ensure path %q: %w", path, err)
-	}
-	return zero, nil
-}
-
-// ensurePath walks the confMap along the given "::" separated path, creating intermediate maps as needed.
-// Returns the final map and the target key name.
-// Returns an error if an intermediate path element exists but is not a map.
-func ensurePath(c confMap, path string) (confMap, string, error) {
-	currentMap := c
-	pathSlice := strings.Split(path, "::")
-
-	target := pathSlice[len(pathSlice)-1]
-	for _, key := range pathSlice[:len(pathSlice)-1] {
-		childConfMap, exists := currentMap[key]
-		if !exists {
-			currentMap[key] = make(confMap)
-			childConfMap = currentMap[key]
-		}
-
-		childMap, isMap := childConfMap.(map[string]any)
-		if !isMap {
-			return nil, "", fmt.Errorf("path element %q is not a map", key)
-		}
-
-		currentMap = childMap
-	}
-
-	return currentMap, target, nil
-}
-
-// Set sets a value of type T in the confMap at the given path.
-// Path segments are separated by "::".
-// Creates intermediate maps as needed.
-// Returns an error if an intermediate path element exists but is not a map.
-func Set[T any](c confMap, path string, value T) error {
-	currentMap, target, err := ensurePath(c, path)
-	if err != nil {
-		return err
-	}
-
-	if existingValue, exists := currentMap[target]; exists {
-		slog.Debug("overwriting config", slog.String("path", path), slog.Any("old", existingValue), slog.Any("new", value))
-	}
-	currentMap[target] = value
-	return nil
-}
-
-// SetDefault sets a default value if the key does not exist or already holds the same value.
-// If the key exists with a different value, the existing value is preserved (user override wins).
-// Path segments are separated by "::".
-// Creates intermediate maps as needed.
-// Returns true if the default is active (set or already matching), false if a user override was preserved.
-// Returns an error only if path traversal fails (intermediate element is not a map).
-func SetDefault[T any](c confMap, path string, value T) (bool, error) {
-	currentMap, target, err := ensurePath(c, path)
-	if err != nil {
-		return false, err
-	}
-
-	if existingValue, exists := currentMap[target]; exists {
-		return reflect.DeepEqual(existingValue, value), nil
-	}
-	currentMap[target] = value
-	return true, nil
+	return confmaputils.IsComponentType(name, componentTypeOtlpHTTP) || confmaputils.IsComponentType(name, componentTypeOtlpHTTPDeprecated)
 }
 
 // ensureKeyStringValue checks if a key exists in the config and converts it to a string if needed.
@@ -235,14 +102,13 @@ func ensureKeyStringValue(config confMap, key string) bool {
 	// Only convert primitive numeric types
 	switch v := val.(type) {
 	case int, int32, int64, float32, float64, uint, uint32, uint64:
-		slog.Debug("converting value to string", slog.String("key", key), slog.String("type", fmt.Sprintf("%T", val)))
 		config[key] = fmt.Sprintf("%v", v)
 		return true
 	case xconfmap.ExpandedValue:
 		// ExpandedValues should not be altered at conversion stage
 		return true
 	default:
-		slog.Warn("API key has unexpected type, cannot convert", slog.String("key", key), slog.String("type", fmt.Sprintf("%T", val)))
+		slog.Warn("API key has unexpected type, cannot convert", slog.String("key", key), slog.String("type", fmt.Sprintf("%T", v)))
 		return false
 	}
 }
@@ -254,7 +120,7 @@ func addProfilerMetadataTags(conf confMap, profilesProcessors []any) ([]any, err
 	const resourceProcessorName = "resource/dd-profiler-internal-metadata"
 
 	// Check if the processor is already defined in root processors
-	globalProcessors, _ := Get[confMap](conf, "processors")
+	globalProcessors, _ := confmaputils.Get[confMap](conf, "processors")
 	if _, exists := globalProcessors[resourceProcessorName]; exists {
 		return nil, fmt.Errorf("%s is a reserved resource processor name. Please change it in your configuration file", resourceProcessorName)
 	}
@@ -265,12 +131,12 @@ func addProfilerMetadataTags(conf confMap, profilesProcessors []any) ([]any, err
 		}
 	}
 
-	resourceProcessor, err := Ensure[confMap](conf, "processors::"+resourceProcessorName)
+	resourceProcessor, err := confmaputils.Ensure[confMap](conf, "processors::"+resourceProcessorName)
 	if err != nil {
 		return nil, err
 	}
 
-	attributes, err := Ensure[[]any](resourceProcessor, "attributes")
+	attributes, err := confmaputils.Ensure[[]any](resourceProcessor, "attributes")
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +154,7 @@ func addProfilerMetadataTags(conf confMap, profilesProcessors []any) ([]any, err
 
 	attributes = append(attributes, profilerNameElement)
 	attributes = append(attributes, profilerVersionElement)
-	if err := Set(resourceProcessor, "attributes", attributes); err != nil {
+	if err := confmaputils.Set(resourceProcessor, "attributes", attributes); err != nil {
 		return nil, err
 	}
 
@@ -310,50 +176,4 @@ func inferMetricsEndpoint(profilesEndpoint string) (string, error) {
 	}
 
 	return fmt.Sprintf("https://otlp.%s/v1/metrics", site), nil
-}
-
-// PrometheusReceiverConfig returns the default configuration for the internal prometheus receiver
-// that scrapes OTel collector's internal telemetry metrics from 127.0.0.1:8889.
-func PrometheusReceiverConfig() map[string]any {
-	return PrometheusReceiverConfigWithTarget("127.0.0.1:8889")
-}
-
-// PrometheusReceiverConfigWithTarget returns a prometheus receiver config that scrapes the given target.
-func PrometheusReceiverConfigWithTarget(target string) map[string]any {
-	return confMap{
-		"config": confMap{
-			"scrape_configs": []any{
-				confMap{
-					"job_name":                      "host-profiler-internal",
-					"metric_name_validation_scheme": "legacy",
-					"metric_name_escaping_scheme":   "underscores",
-					"scrape_interval":               "60s",
-					"scrape_protocols":              []any{"PrometheusText0.0.4"},
-					"fallback_scrape_protocol":      "PrometheusText0.0.4",
-					"static_configs": []any{
-						confMap{
-							"targets": []any{target},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// FilterProcessorConfig returns the default configuration for the filter processor
-// that drops internal prometheus scrape metrics from being exported.
-func FilterProcessorConfig() map[string]any {
-	return confMap{
-		"metrics": confMap{
-			"exclude": confMap{
-				"match_type": "regexp",
-				"metric_names": []any{
-					"^scrape_.*$",                            // Prometheus scraper timing metrics
-					"^up$",                                   // Scraper up/down status
-					"^promhttp_metric_handler_errors_total$", // Prometheus HTTP handler errors
-				},
-			},
-		},
-	}
 }

--- a/comp/host-profiler/collector/impl/converters/converters_test.go
+++ b/comp/host-profiler/collector/impl/converters/converters_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util/confmaputils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
@@ -46,22 +47,22 @@ func TestGetBasicTypes(t *testing.T) {
 	cm := loadTestData(t, "helper_functions/get_simple_values.yaml")
 
 	// String
-	strVal, ok := Get[string](cm, "string_value")
+	strVal, ok := confmaputils.Get[string](cm, "string_value")
 	require.True(t, ok)
 	require.Equal(t, "test-string", strVal)
 
 	// Int
-	intVal, ok := Get[int](cm, "int_value")
+	intVal, ok := confmaputils.Get[int](cm, "int_value")
 	require.True(t, ok)
 	require.Equal(t, 42, intVal)
 
 	// Bool
-	boolVal, ok := Get[bool](cm, "bool_value")
+	boolVal, ok := confmaputils.Get[bool](cm, "bool_value")
 	require.True(t, ok)
 	require.Equal(t, true, boolVal)
 
 	// Float
-	floatVal, ok := Get[float64](cm, "float_value")
+	floatVal, ok := confmaputils.Get[float64](cm, "float_value")
 	require.True(t, ok)
 	require.Equal(t, 3.14, floatVal)
 }
@@ -69,11 +70,11 @@ func TestGetBasicTypes(t *testing.T) {
 func TestGetNestedValues(t *testing.T) {
 	cm := loadTestData(t, "helper_functions/get_nested_values.yaml")
 
-	val, ok := Get[string](cm, "level1::level2::level3::deep_string")
+	val, ok := confmaputils.Get[string](cm, "level1::level2::level3::deep_string")
 	require.True(t, ok)
 	require.Equal(t, "deep-value", val)
 
-	numVal, ok := Get[int](cm, "level1::level2::level3::deep_number")
+	numVal, ok := confmaputils.Get[int](cm, "level1::level2::level3::deep_number")
 	require.True(t, ok)
 	require.Equal(t, 999, numVal)
 }
@@ -82,12 +83,12 @@ func TestGetMapAndArray(t *testing.T) {
 	cm := loadTestData(t, "helper_functions/get_maps_and_arrays.yaml")
 
 	// Get map
-	mapVal, ok := Get[confMap](cm, "processors::batch")
+	mapVal, ok := confmaputils.Get[confMap](cm, "processors::batch")
 	require.True(t, ok)
 	require.Equal(t, "10s", mapVal["timeout"])
 
 	// Get array
-	arrVal, ok := Get[[]any](cm, "list_values")
+	arrVal, ok := confmaputils.Get[[]any](cm, "list_values")
 	require.True(t, ok)
 	require.Len(t, arrVal, 3)
 	require.Equal(t, "item1", arrVal[0])
@@ -96,12 +97,12 @@ func TestGetMapAndArray(t *testing.T) {
 func TestGetNonExistentPath(t *testing.T) {
 	cm := loadTestData(t, "helper_functions/get_simple_values.yaml")
 
-	val, ok := Get[string](cm, "non_existent_field")
+	val, ok := confmaputils.Get[string](cm, "non_existent_field")
 	require.False(t, ok)
 	require.Equal(t, "", val) // Zero value
 
 	// Nested non-existent
-	_, ok = Get[string](cm, "level1::level2::missing")
+	_, ok = confmaputils.Get[string](cm, "level1::level2::missing")
 	require.False(t, ok)
 }
 
@@ -109,15 +110,15 @@ func TestGetWrongType(t *testing.T) {
 	cm := loadTestData(t, "helper_functions/get_wrong_types.yaml")
 
 	// Try to get string as int
-	_, ok := Get[int](cm, "string_field")
+	_, ok := confmaputils.Get[int](cm, "string_field")
 	require.False(t, ok)
 
 	// Try to get number as string
-	_, ok = Get[string](cm, "number_field")
+	_, ok = confmaputils.Get[string](cm, "number_field")
 	require.False(t, ok)
 
 	// Try to get map as string
-	_, ok = Get[string](cm, "map_field")
+	_, ok = confmaputils.Get[string](cm, "map_field")
 	require.False(t, ok)
 }
 
@@ -125,15 +126,15 @@ func TestGetIntermediateNodeNotMap(t *testing.T) {
 	cm := loadTestData(t, "helper_functions/get_inter_nonmap.yaml")
 
 	// Intermediate node is string
-	_, ok := Get[string](cm, "processors::batch::timeout")
+	_, ok := confmaputils.Get[string](cm, "processors::batch::timeout")
 	require.False(t, ok)
 
 	// Intermediate node is number
-	_, ok = Get[string](cm, "receivers::otlp::protocols")
+	_, ok = confmaputils.Get[string](cm, "receivers::otlp::protocols")
 	require.False(t, ok)
 
 	// Intermediate node is array
-	_, ok = Get[string](cm, "exporters::otlp_http::headers")
+	_, ok = confmaputils.Get[string](cm, "exporters::otlp_http::headers")
 	require.False(t, ok)
 }
 
@@ -141,23 +142,23 @@ func TestSetBasicTypes(t *testing.T) {
 	cm := confMap{}
 
 	// Set string
-	err := Set(cm, "string_value", "test")
+	err := confmaputils.Set(cm, "string_value", "test")
 	require.NoError(t, err)
-	val, ok := Get[string](cm, "string_value")
+	val, ok := confmaputils.Get[string](cm, "string_value")
 	require.True(t, ok)
 	require.Equal(t, "test", val)
 
 	// Set int
-	err = Set(cm, "int_value", 42)
+	err = confmaputils.Set(cm, "int_value", 42)
 	require.NoError(t, err)
-	intVal, ok := Get[int](cm, "int_value")
+	intVal, ok := confmaputils.Get[int](cm, "int_value")
 	require.True(t, ok)
 	require.Equal(t, 42, intVal)
 
 	// Set bool
-	err = Set(cm, "bool_value", true)
+	err = confmaputils.Set(cm, "bool_value", true)
 	require.NoError(t, err)
-	boolVal, ok := Get[bool](cm, "bool_value")
+	boolVal, ok := confmaputils.Get[bool](cm, "bool_value")
 	require.True(t, ok)
 	require.Equal(t, true, boolVal)
 }
@@ -165,17 +166,17 @@ func TestSetBasicTypes(t *testing.T) {
 func TestSetNestedPathCreatesIntermediates(t *testing.T) {
 	cm := confMap{}
 
-	err := Set(cm, "level1::level2::level3::value", "deep-value")
+	err := confmaputils.Set(cm, "level1::level2::level3::value", "deep-value")
 	require.NoError(t, err)
 
 	// Verify intermediate maps were created
-	_, ok := Get[confMap](cm, "level1")
+	_, ok := confmaputils.Get[confMap](cm, "level1")
 	require.True(t, ok)
-	_, ok = Get[confMap](cm, "level1::level2")
+	_, ok = confmaputils.Get[confMap](cm, "level1::level2")
 	require.True(t, ok)
 
 	// Verify the value
-	val, ok := Get[string](cm, "level1::level2::level3::value")
+	val, ok := confmaputils.Get[string](cm, "level1::level2::level3::value")
 	require.True(t, ok)
 	require.Equal(t, "deep-value", val)
 }
@@ -184,16 +185,16 @@ func TestSetOverwritesExistingValue(t *testing.T) {
 	cm := loadTestData(t, "helper_functions/set_overwrites.yaml")
 
 	// Get original value
-	origVal, ok := Get[string](cm, "processors::batch::timeout")
+	origVal, ok := confmaputils.Get[string](cm, "processors::batch::timeout")
 	require.True(t, ok)
 	require.Equal(t, "10s", origVal)
 
 	// Overwrite
-	err := Set(cm, "processors::batch::timeout", "20s")
+	err := confmaputils.Set(cm, "processors::batch::timeout", "20s")
 	require.NoError(t, err)
 
 	// Verify new value
-	newVal, ok := Get[string](cm, "processors::batch::timeout")
+	newVal, ok := confmaputils.Get[string](cm, "processors::batch::timeout")
 	require.True(t, ok)
 	require.Equal(t, "20s", newVal)
 }
@@ -203,19 +204,19 @@ func TestSetMapAndArray(t *testing.T) {
 
 	// Set map
 	newMap := confMap{"key1": "value1", "key2": 42}
-	err := Set(cm, "nested::map", newMap)
+	err := confmaputils.Set(cm, "nested::map", newMap)
 	require.NoError(t, err)
 
-	val, ok := Get[confMap](cm, "nested::map")
+	val, ok := confmaputils.Get[confMap](cm, "nested::map")
 	require.True(t, ok)
 	require.Equal(t, "value1", val["key1"])
 
 	// Set array
 	arr := []any{"item1", "item2"}
-	err = Set(cm, "list::items", arr)
+	err = confmaputils.Set(cm, "list::items", arr)
 	require.NoError(t, err)
 
-	arrVal, ok := Get[[]any](cm, "list::items")
+	arrVal, ok := confmaputils.Get[[]any](cm, "list::items")
 	require.True(t, ok)
 	require.Len(t, arrVal, 2)
 }
@@ -224,12 +225,12 @@ func TestSetIntermediateNodeNotMap(t *testing.T) {
 	cm := loadTestData(t, "helper_functions/set_inter_nonmap.yaml")
 
 	// Intermediate node is string - should error
-	err := Set(cm, "processors::batch::timeout", "10s")
+	err := confmaputils.Set(cm, "processors::batch::timeout", "10s")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "processors")
 
 	// Intermediate node is number - should error
-	err = Set(cm, "receivers::otlp::protocols", confMap{})
+	err = confmaputils.Set(cm, "receivers::otlp::protocols", confMap{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "otlp")
 }
@@ -238,17 +239,17 @@ func TestEnsureCreatesZeroValues(t *testing.T) {
 	cm := confMap{}
 
 	// String zero value
-	strVal, err := Ensure[string](cm, "string_field")
+	strVal, err := confmaputils.Ensure[string](cm, "string_field")
 	require.NoError(t, err)
 	require.Equal(t, "", strVal)
 
 	// Int zero value
-	intVal, err := Ensure[int](cm, "int_field")
+	intVal, err := confmaputils.Ensure[int](cm, "int_field")
 	require.NoError(t, err)
 	require.Equal(t, 0, intVal)
 
 	// Bool zero value
-	boolVal, err := Ensure[bool](cm, "bool_field")
+	boolVal, err := confmaputils.Ensure[bool](cm, "bool_field")
 	require.NoError(t, err)
 	require.Equal(t, false, boolVal)
 }
@@ -256,13 +257,13 @@ func TestEnsureCreatesZeroValues(t *testing.T) {
 func TestEnsureCreatesEmptyMapForMapTypes(t *testing.T) {
 	cm := confMap{}
 
-	mapVal, err := Ensure[confMap](cm, "processors")
+	mapVal, err := confmaputils.Ensure[confMap](cm, "processors")
 	require.NoError(t, err)
 	require.NotNil(t, mapVal)
 	require.Empty(t, mapVal)
 
 	// Verify it was set in the config
-	retrieved, ok := Get[confMap](cm, "processors")
+	retrieved, ok := confmaputils.Get[confMap](cm, "processors")
 	require.True(t, ok)
 	require.NotNil(t, retrieved)
 }
@@ -272,7 +273,7 @@ func TestEnsureReturnsExistingValue(t *testing.T) {
 		"field": "existing-value",
 	}
 
-	val, err := Ensure[string](cm, "field")
+	val, err := confmaputils.Ensure[string](cm, "field")
 	require.NoError(t, err)
 	require.Equal(t, "existing-value", val)
 }
@@ -280,12 +281,12 @@ func TestEnsureReturnsExistingValue(t *testing.T) {
 func TestEnsureCreatesNestedPath(t *testing.T) {
 	cm := confMap{}
 
-	val, err := Ensure[int](cm, "a::b::c::d")
+	val, err := confmaputils.Ensure[int](cm, "a::b::c::d")
 	require.NoError(t, err)
 	require.Equal(t, 0, val)
 
 	// Verify intermediate maps were created
-	_, ok := Get[confMap](cm, "a::b::c")
+	_, ok := confmaputils.Get[confMap](cm, "a::b::c")
 	require.True(t, ok)
 }
 
@@ -294,7 +295,7 @@ func TestEnsureErrorWhenIntermediateNotMap(t *testing.T) {
 		"processors": "not-a-map",
 	}
 
-	_, err := Ensure[bool](cm, "processors::batch::enabled")
+	_, err := confmaputils.Ensure[bool](cm, "processors::batch::enabled")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "processors")
 }
@@ -373,7 +374,7 @@ func TestConverterWithoutAgentPreservesExpandedValues(t *testing.T) {
 	require.NoError(t, err)
 
 	convertedMap := xconfmap.ToStringMapRaw(conf)
-	headers, _ := Get[confMap](convertedMap, "exporters::otlp_http::headers")
+	headers, _ := confmaputils.Get[confMap](convertedMap, "exporters::otlp_http::headers")
 	expandedVal, ok := headers["dd-api-key"].(xconfmap.ExpandedValue)
 	require.True(t, ok, "dd-api-key should still be an ExpandedValue, got type: %T", headers["dd-api-key"])
 	require.Equal(t, 6.7, expandedVal.Value)

--- a/comp/logs-library/go.mod
+++ b/comp/logs-library/go.mod
@@ -262,6 +262,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -228,6 +228,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/netflow/payload/go.mod
+++ b/comp/netflow/payload/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/otelcol/collector-contrib/def/go.mod
+++ b/comp/otelcol/collector-contrib/def/go.mod
@@ -273,6 +273,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/collector-contrib/impl/go.mod
+++ b/comp/otelcol/collector-contrib/impl/go.mod
@@ -696,6 +696,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/converter/def/go.mod
+++ b/comp/otelcol/converter/def/go.mod
@@ -165,6 +165,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/converter/impl/go.mod
+++ b/comp/otelcol/converter/impl/go.mod
@@ -244,6 +244,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/ddflareextension/def/go.mod
+++ b/comp/otelcol/ddflareextension/def/go.mod
@@ -168,6 +168,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -677,6 +677,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/ddflareextension/types/go.mod
+++ b/comp/otelcol/ddflareextension/types/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/ddprofilingextension/def/go.mod
+++ b/comp/otelcol/ddprofilingextension/def/go.mod
@@ -168,6 +168,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/ddprofilingextension/impl/go.mod
+++ b/comp/otelcol/ddprofilingextension/impl/go.mod
@@ -298,6 +298,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -267,6 +267,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -261,6 +261,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -399,6 +399,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../../../pkg/util/executable

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -342,6 +342,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../../../pkg/util/executable

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -363,6 +363,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../../../pkg/util/executable

--- a/comp/otelcol/otlp/components/metricsclient/go.mod
+++ b/comp/otelcol/otlp/components/metricsclient/go.mod
@@ -171,6 +171,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../../pkg/util/executable

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.mod
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/go.mod
@@ -325,6 +325,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../../../pkg/util/executable

--- a/comp/otelcol/otlp/testutil/go.mod
+++ b/comp/otelcol/otlp/testutil/go.mod
@@ -228,6 +228,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/status/def/go.mod
+++ b/comp/otelcol/status/def/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/otelcol/status/impl/go.mod
+++ b/comp/otelcol/status/impl/go.mod
@@ -260,6 +260,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/serializer/logscompression/go.mod
+++ b/comp/serializer/logscompression/go.mod
@@ -226,6 +226,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/serializer/metricscompression/go.mod
+++ b/comp/serializer/metricscompression/go.mod
@@ -226,6 +226,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/comp/trace/agent/def/go.mod
+++ b/comp/trace/agent/def/go.mod
@@ -176,6 +176,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/trace/compression/def/go.mod
+++ b/comp/trace/compression/def/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/trace/compression/impl-gzip/go.mod
+++ b/comp/trace/compression/impl-gzip/go.mod
@@ -146,6 +146,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/comp/trace/compression/impl-zstd/go.mod
+++ b/comp/trace/compression/impl-zstd/go.mod
@@ -149,6 +149,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -136,6 +136,7 @@ use_repo(
     "com_github_data_dog_go_sqlmock",
     "com_github_datadog_agent_payload_v5",
     "com_github_datadog_datadog_agent_comp_otelcol_collector_contrib_impl",
+    "com_github_datadog_datadog_agent_pkg_util_confmaputils",
     "com_github_datadog_datadog_api_client_go",
     "com_github_datadog_datadog_api_client_go_v2",
     "com_github_datadog_datadog_go_v5",

--- a/go.mod
+++ b/go.mod
@@ -946,6 +946,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/trace/stats v0.77.0
 	github.com/DataDog/datadog-agent/pkg/trace/traceutil v0.77.0
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/util/hostport v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
@@ -1419,6 +1420,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ./pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ./pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ./pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ./pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ./pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ./pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ./pkg/util/executable

--- a/go.work
+++ b/go.work
@@ -154,6 +154,7 @@ use (
 	pkg/util/cgroups
 	pkg/util/common
 	pkg/util/compression
+	pkg/util/confmaputils
 	pkg/util/containers/image
 	pkg/util/defaultpaths
 	pkg/util/executable

--- a/modules.yml
+++ b/modules.yml
@@ -105,6 +105,8 @@ modules:
   comp/netflow/payload: default
   comp/otelcol/collector-contrib/def: default
   comp/otelcol/collector-contrib/impl: default
+  pkg/util/confmaputils:
+    used_by_otel: true
   comp/otelcol/converter/def: default
   comp/otelcol/converter/impl: default
   comp/otelcol/ddflareextension/def: default

--- a/pkg/aggregator/ckey/go.mod
+++ b/pkg/aggregator/ckey/go.mod
@@ -158,6 +158,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -213,6 +213,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/collector/check/defaults/go.mod
+++ b/pkg/collector/check/defaults/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/config/basic/go.mod
+++ b/pkg/config/basic/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/buildschema/go.mod
+++ b/pkg/config/buildschema/go.mod
@@ -146,6 +146,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/create/go.mod
+++ b/pkg/config/create/go.mod
@@ -179,6 +179,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/env/go.mod
+++ b/pkg/config/env/go.mod
@@ -183,6 +183,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/helper/go.mod
+++ b/pkg/config/helper/go.mod
@@ -177,6 +177,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/mock/go.mod
+++ b/pkg/config/mock/go.mod
@@ -208,6 +208,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/model/go.mod
+++ b/pkg/config/model/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/nodetreemodel/go.mod
+++ b/pkg/config/nodetreemodel/go.mod
@@ -180,6 +180,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/remote/go.mod
+++ b/pkg/config/remote/go.mod
@@ -270,6 +270,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/render_config/go.mod
+++ b/pkg/config/render_config/go.mod
@@ -155,6 +155,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/schema/go.mod
+++ b/pkg/config/schema/go.mod
@@ -162,6 +162,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/setup/go.mod
+++ b/pkg/config/setup/go.mod
@@ -212,6 +212,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/structure/go.mod
+++ b/pkg/config/structure/go.mod
@@ -184,6 +184,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/teeconfig/go.mod
+++ b/pkg/config/teeconfig/go.mod
@@ -162,6 +162,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/utils/go.mod
+++ b/pkg/config/utils/go.mod
@@ -210,6 +210,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/config/viperconfig/go.mod
+++ b/pkg/config/viperconfig/go.mod
@@ -175,6 +175,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/discovery/tracermetadata/model/go.mod
+++ b/pkg/discovery/tracermetadata/model/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/errors/go.mod
+++ b/pkg/errors/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/fips/go.mod
+++ b/pkg/fips/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/gohai/go.mod
+++ b/pkg/gohai/go.mod
@@ -174,6 +174,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/logs/diagnostic/go.mod
+++ b/pkg/logs/diagnostic/go.mod
@@ -228,6 +228,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/logs/message/go.mod
+++ b/pkg/logs/message/go.mod
@@ -216,6 +216,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/logs/sources/go.mod
+++ b/pkg/logs/sources/go.mod
@@ -215,6 +215,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/logs/status/statusinterface/go.mod
+++ b/pkg/logs/status/statusinterface/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/logs/status/utils/go.mod
+++ b/pkg/logs/status/utils/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/logs/types/go.mod
+++ b/pkg/logs/types/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/logs/util/testutils/go.mod
+++ b/pkg/logs/util/testutils/go.mod
@@ -209,6 +209,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -246,6 +246,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/network/driver/go.mod
+++ b/pkg/network/driver/go.mod
@@ -181,6 +181,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/network/payload/go.mod
+++ b/pkg/network/payload/go.mod
@@ -144,6 +144,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/networkdevice/profile/go.mod
+++ b/pkg/networkdevice/profile/go.mod
@@ -168,6 +168,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/networkpath/payload/go.mod
+++ b/pkg/networkpath/payload/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/obfuscate/go.mod
+++ b/pkg/obfuscate/go.mod
@@ -170,6 +170,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/opentelemetry-mapping-go/inframetadata/go.mod
+++ b/pkg/opentelemetry-mapping-go/inframetadata/go.mod
@@ -175,6 +175,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/opentelemetry-mapping-go/inframetadata/gohai/internal/gohaitest/go.mod
+++ b/pkg/opentelemetry-mapping-go/inframetadata/gohai/internal/gohaitest/go.mod
@@ -162,6 +162,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../../../pkg/util/executable

--- a/pkg/opentelemetry-mapping-go/otlp/attributes/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/go.mod
@@ -183,6 +183,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/go.mod
@@ -205,6 +205,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/go.mod
@@ -199,6 +199,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/opentelemetry-mapping-go/otlp/rum/go.mod
+++ b/pkg/opentelemetry-mapping-go/otlp/rum/go.mod
@@ -169,6 +169,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/orchestrator/model/go.mod
+++ b/pkg/orchestrator/model/go.mod
@@ -158,6 +158,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/orchestrator/util/go.mod
+++ b/pkg/orchestrator/util/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/process/util/api/go.mod
+++ b/pkg/process/util/api/go.mod
@@ -232,6 +232,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/proto/go.mod
+++ b/pkg/proto/go.mod
@@ -173,6 +173,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/remoteconfig/state/go.mod
+++ b/pkg/remoteconfig/state/go.mod
@@ -160,6 +160,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -181,6 +181,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/security/seclwin/go.mod
+++ b/pkg/security/seclwin/go.mod
@@ -162,6 +162,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -282,6 +282,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/status/health/go.mod
+++ b/pkg/status/health/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/tagger/types/go.mod
+++ b/pkg/tagger/types/go.mod
@@ -146,6 +146,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/tagset/go.mod
+++ b/pkg/tagset/go.mod
@@ -158,6 +158,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -273,6 +273,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/pkg/trace/log/go.mod
+++ b/pkg/trace/log/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/trace/otel/go.mod
+++ b/pkg/trace/otel/go.mod
@@ -332,6 +332,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/trace/stats/go.mod
+++ b/pkg/trace/stats/go.mod
@@ -202,6 +202,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/trace/traceutil/go.mod
+++ b/pkg/trace/traceutil/go.mod
@@ -163,6 +163,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/aws/creds/go.mod
+++ b/pkg/util/aws/creds/go.mod
@@ -210,6 +210,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/util/backoff/go.mod
+++ b/pkg/util/backoff/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/buf/go.mod
+++ b/pkg/util/buf/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/cache/go.mod
+++ b/pkg/util/cache/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -172,6 +172,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cache => ../../../pkg/util/cache
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/common/go.mod
+++ b/pkg/util/common/go.mod
@@ -156,6 +156,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cache => ../../../pkg/util/cache
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/compression/go.mod
+++ b/pkg/util/compression/go.mod
@@ -226,6 +226,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cache => ../../../pkg/util/cache
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/confmaputils/BUILD.bazel
+++ b/pkg/util/confmaputils/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "confmaputils",
+    srcs = ["confmaputils.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/util/confmaputils",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/confmaputils/confmaputils.go
+++ b/pkg/util/confmaputils/confmaputils.go
@@ -1,0 +1,198 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package confmaputils provides shared utilities for manipulating OpenTelemetry
+// collector confmaps (map[string]any) and building standard Datadog component configs.
+package confmaputils
+
+import (
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strings"
+)
+
+// AutoConfiguredSuffix is the OTEL component name suffix used for all components
+// that are automatically injected by Datadog tooling (as opposed to components
+// explicitly declared by the user).
+const AutoConfiguredSuffix = "dd-autoconfigured"
+
+// ConfMap is an alias for the map type used throughout OTel confmap manipulation.
+type ConfMap = map[string]any
+
+// ComponentName returns the type portion of a full OTEL component name.
+// OTEL components follow the convention "type" or "type/id".
+// Examples: "otlp_http/prod" → "otlp_http", "prometheus" → "prometheus".
+func ComponentName(fullName string) string {
+	parts := strings.SplitN(fullName, "/", 2)
+	return parts[0]
+}
+
+// IsComponentType reports whether name belongs to the given componentType.
+// It matches both the bare type ("prometheus") and any named instance ("prometheus/foo").
+func IsComponentType(name, componentType string) bool {
+	return name == componentType || strings.HasPrefix(name, componentType+"/")
+}
+
+// Get retrieves a value of type T from the ConfMap at the given "::" separated path.
+// Returns the value and true if found and of the correct type, zero value and false otherwise.
+// Does not modify the map.
+func Get[T any](c ConfMap, path string) (T, bool) {
+	var zero T
+	currentMap := c
+	pathSlice := strings.Split(path, "::")
+
+	target := pathSlice[len(pathSlice)-1]
+	for _, key := range pathSlice[:len(pathSlice)-1] {
+		childConfMap, exists := currentMap[key]
+		if !exists {
+			slog.Debug("non-existent intermediate map", slog.String("key", key), slog.String("path", path))
+			return zero, false
+		}
+
+		childMap, isMap := childConfMap.(ConfMap)
+		if !isMap {
+			slog.Debug("intermediate node is not a map", slog.String("key", key), slog.String("path", path))
+			return zero, false
+		}
+
+		currentMap = childMap
+	}
+
+	obj, exists := currentMap[target]
+	if !exists {
+		slog.Debug("leaf element doesn't exist", slog.String("path", path))
+		return zero, false
+	}
+
+	val, ok := obj.(T)
+	return val, ok
+}
+
+// ensurePath walks the ConfMap along the given "::" separated path, creating
+// intermediate maps as needed. Returns the final map and the target key name.
+// Returns an error if an intermediate path element exists but is not a map.
+func ensurePath(c ConfMap, path string) (ConfMap, string, error) {
+	currentMap := c
+	pathSlice := strings.Split(path, "::")
+
+	target := pathSlice[len(pathSlice)-1]
+	for _, key := range pathSlice[:len(pathSlice)-1] {
+		childConfMap, exists := currentMap[key]
+		if !exists {
+			currentMap[key] = make(ConfMap)
+			childConfMap = currentMap[key]
+		}
+
+		childMap, isMap := childConfMap.(ConfMap)
+		if !isMap {
+			if childConfMap != nil {
+				return nil, "", fmt.Errorf("path element %q is not a map", key)
+			}
+			// nil means the YAML section was declared but left empty — treat as an empty map.
+			childMap = make(ConfMap)
+			currentMap[key] = childMap
+		}
+
+		currentMap = childMap
+	}
+
+	return currentMap, target, nil
+}
+
+// Set sets a value of type T in the ConfMap at the given "::" separated path.
+// Creates intermediate maps as needed.
+// Returns an error if an intermediate path element exists but is not a map.
+func Set[T any](c ConfMap, path string, value T) error {
+	currentMap, target, err := ensurePath(c, path)
+	if err != nil {
+		return err
+	}
+
+	if existingValue, exists := currentMap[target]; exists {
+		slog.Debug("overwriting config", slog.String("path", path), slog.Any("old", existingValue), slog.Any("new", value))
+	}
+	currentMap[target] = value
+	return nil
+}
+
+// Ensure retrieves a value of type T from the ConfMap at the given path.
+// If the path does not exist, it creates it with the zero value of T.
+// For map types, creates an empty map rather than nil.
+// Returns an error if an intermediate path element exists but is not a map.
+func Ensure[T any](c ConfMap, path string) (T, error) {
+	if val, ok := Get[T](c, path); ok {
+		return val, nil
+	}
+	var zero T
+	switch any(zero).(type) {
+	case ConfMap:
+		zero = any(make(ConfMap)).(T)
+	}
+	if err := Set(c, path, zero); err != nil {
+		return zero, fmt.Errorf("failed to ensure path %q: %w", path, err)
+	}
+	return zero, nil
+}
+
+// SetDefault sets a default value if the key does not exist at the given path.
+// If the key exists with a different value, the existing value is preserved (user override wins).
+// Returns (true, nil) if the default is active (newly set or already matching), (false, nil) if a
+// user override was preserved, or an error if path traversal fails.
+func SetDefault[T any](c ConfMap, path string, value T) (bool, error) {
+	currentMap, target, err := ensurePath(c, path)
+	if err != nil {
+		return false, err
+	}
+
+	if existingValue, exists := currentMap[target]; exists {
+		return reflect.DeepEqual(existingValue, value), nil
+	}
+	currentMap[target] = value
+	return true, nil
+}
+
+// FilterProcessorConfig returns the configuration for a filter processor that
+// drops internal Prometheus scrape metrics from being exported.
+func FilterProcessorConfig() map[string]any {
+	return ConfMap{
+		"metrics": ConfMap{
+			"exclude": ConfMap{
+				"match_type": "regexp",
+				"metric_names": []any{
+					"^scrape_.*$",
+					"^up$",
+					"^promhttp_metric_handler_errors_total$",
+				},
+			},
+		},
+	}
+}
+
+// PrometheusReceiverConfig returns a Prometheus receiver configuration that
+// scrapes the given target with the given job name.
+// Both the otelcol converter ("datadog-agent", "0.0.0.0:8888") and the host
+// profiler ("host-profiler-internal", "127.0.0.1:8889") use this same structure.
+func PrometheusReceiverConfig(jobName, target string) map[string]any {
+	return ConfMap{
+		"config": ConfMap{
+			"scrape_configs": []any{
+				ConfMap{
+					"job_name":                      jobName,
+					"metric_name_validation_scheme": "legacy",
+					"metric_name_escaping_scheme":   "underscores",
+					"scrape_interval":               "60s",
+					"scrape_protocols":              []any{"PrometheusText0.0.4"},
+					"fallback_scrape_protocol":      "PrometheusText0.0.4",
+					"static_configs": []any{
+						ConfMap{
+							"targets": []any{target},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/util/confmaputils/go.mod
+++ b/pkg/util/confmaputils/go.mod
@@ -1,37 +1,6 @@
-module github.com/DataDog/datadog-agent/pkg/ssi/testutils
+module github.com/DataDog/datadog-agent/pkg/util/confmaputils
 
 go 1.25.0
-
-require (
-	github.com/stretchr/testify v1.11.1
-	k8s.io/api v0.35.5
-	k8s.io/apimachinery v0.35.5
-)
-
-require gopkg.in/yaml.v3 v3.0.1 // indirect
-
-require (
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kr/text v0.2.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/x448/float16 v0.8.4 // indirect
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20260330154417-16be699c7b31 // indirect
-	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
-	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-)
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually
 
@@ -159,6 +128,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/security/secl => ../../../pkg/security/secl
 	github.com/DataDog/datadog-agent/pkg/security/seclwin => ../../../pkg/security/seclwin
 	github.com/DataDog/datadog-agent/pkg/serializer => ../../../pkg/serializer
+	github.com/DataDog/datadog-agent/pkg/ssi/testutils => ../../../pkg/ssi/testutils
 	github.com/DataDog/datadog-agent/pkg/status/health => ../../../pkg/status/health
 	github.com/DataDog/datadog-agent/pkg/tagger/types => ../../../pkg/tagger/types
 	github.com/DataDog/datadog-agent/pkg/tagset => ../../../pkg/tagset
@@ -175,7 +145,6 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
-	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/containers/image/go.mod
+++ b/pkg/util/containers/image/go.mod
@@ -157,6 +157,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable
 	github.com/DataDog/datadog-agent/pkg/util/filesystem => ../../../../pkg/util/filesystem

--- a/pkg/util/defaultpaths/go.mod
+++ b/pkg/util/defaultpaths/go.mod
@@ -205,6 +205,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable
 	github.com/DataDog/datadog-agent/pkg/util/filesystem => ../../../pkg/util/filesystem

--- a/pkg/util/executable/go.mod
+++ b/pkg/util/executable/go.mod
@@ -157,6 +157,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/filesystem => ../../../pkg/util/filesystem

--- a/pkg/util/filesystem/go.mod
+++ b/pkg/util/filesystem/go.mod
@@ -173,6 +173,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/flavor/go.mod
+++ b/pkg/util/flavor/go.mod
@@ -210,6 +210,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/fxutil/go.mod
+++ b/pkg/util/fxutil/go.mod
@@ -166,6 +166,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/grpc/go.mod
+++ b/pkg/util/grpc/go.mod
@@ -253,6 +253,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/hostinfo/go.mod
+++ b/pkg/util/hostinfo/go.mod
@@ -178,6 +178,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/hostname/validate/go.mod
+++ b/pkg/util/hostname/validate/go.mod
@@ -163,6 +163,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/util/hostport/go.mod
+++ b/pkg/util/hostport/go.mod
@@ -145,6 +145,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/http/go.mod
+++ b/pkg/util/http/go.mod
@@ -211,6 +211,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/json/go.mod
+++ b/pkg/util/json/go.mod
@@ -162,6 +162,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/jsonquery/go.mod
+++ b/pkg/util/jsonquery/go.mod
@@ -166,6 +166,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/kubernetes/apiserver/common/namespace/go.mod
+++ b/pkg/util/kubernetes/apiserver/common/namespace/go.mod
@@ -204,6 +204,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../../../pkg/util/executable

--- a/pkg/util/log/go.mod
+++ b/pkg/util/log/go.mod
@@ -164,6 +164,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/log/setup/go.mod
+++ b/pkg/util/log/setup/go.mod
@@ -210,6 +210,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/util/option/go.mod
+++ b/pkg/util/option/go.mod
@@ -157,6 +157,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/otel/go.mod
+++ b/pkg/util/otel/go.mod
@@ -178,6 +178,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/pointer/go.mod
+++ b/pkg/util/pointer/go.mod
@@ -145,6 +145,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/prometheus/go.mod
+++ b/pkg/util/prometheus/go.mod
@@ -185,6 +185,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/quantile/go.mod
+++ b/pkg/util/quantile/go.mod
@@ -163,6 +163,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/quantile/sketchtest/go.mod
+++ b/pkg/util/quantile/sketchtest/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../../pkg/util/executable

--- a/pkg/util/scrubber/go.mod
+++ b/pkg/util/scrubber/go.mod
@@ -158,6 +158,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/sort/go.mod
+++ b/pkg/util/sort/go.mod
@@ -157,6 +157,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/startstop/go.mod
+++ b/pkg/util/startstop/go.mod
@@ -157,6 +157,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/statstracker/go.mod
+++ b/pkg/util/statstracker/go.mod
@@ -157,6 +157,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/system/go.mod
+++ b/pkg/util/system/go.mod
@@ -183,6 +183,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/testutil/go.mod
+++ b/pkg/util/testutil/go.mod
@@ -159,6 +159,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/utilizationtracker/go.mod
+++ b/pkg/util/utilizationtracker/go.mod
@@ -160,6 +160,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/uuid/go.mod
+++ b/pkg/util/uuid/go.mod
@@ -169,6 +169,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/util/winutil/go.mod
+++ b/pkg/util/winutil/go.mod
@@ -166,6 +166,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../../pkg/util/executable

--- a/pkg/version/go.mod
+++ b/pkg/version/go.mod
@@ -157,6 +157,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/test/e2e-framework/go.mod
+++ b/test/e2e-framework/go.mod
@@ -430,6 +430,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/test/fakeintake/go.mod
+++ b/test/fakeintake/go.mod
@@ -198,6 +198,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -533,6 +533,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -383,6 +383,7 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/cgroups => ../../pkg/util/cgroups
 	github.com/DataDog/datadog-agent/pkg/util/common => ../../pkg/util/common
 	github.com/DataDog/datadog-agent/pkg/util/compression => ../../pkg/util/compression
+	github.com/DataDog/datadog-agent/pkg/util/confmaputils => ../../pkg/util/confmaputils
 	github.com/DataDog/datadog-agent/pkg/util/containers/image => ../../pkg/util/containers/image
 	github.com/DataDog/datadog-agent/pkg/util/defaultpaths => ../../pkg/util/defaultpaths
 	github.com/DataDog/datadog-agent/pkg/util/executable => ../../pkg/util/executable


### PR DESCRIPTION
### What does this PR do?

Consolidates confmap helpers into its own package decoupled from the Host Profiler

### Motivation

These helpers were already used outside of the Host Profiler's converter (mainly its `agentprovider`) and could also be used to refactor otelcol's converter pipeline.

### Describe how you validated your changes

Ran Host Profiler's configuration test suite

### Additional Notes
