### PR TITLE
Add GitHub Actions workflow to post @codex review on draft PRs

### DIFF
--- a/.github/workflows/codex-review-draft.yml
+++ b/.github/workflows/codex-review-draft.yml
@@ -3,7 +3,7 @@ name: "Codex review on draft PR"
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
     branches:
       - main
       - "[0-9]+.[0-9]+.x"

--- a/.github/workflows/codex-review-draft.yml
+++ b/.github/workflows/codex-review-draft.yml
@@ -1,0 +1,28 @@
+---
+name: "Codex review on draft PR"
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - main
+      - "[0-9]+.[0-9]+.x"
+
+permissions: {}
+
+jobs:
+  codex-review:
+    if: github.event.pull_request.draft == true && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '@codex review'
+            })


### PR DESCRIPTION
## Summary
- Adds a new workflow that automatically posts `@codex review` as a comment when a PR is opened as a draft
- Scoped to `main` and release branches, internal (non-fork) PRs only

## Test plan
- [x] Open a draft PR targeting `main` and verify the `@codex review` comment is posted automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)