### PR TITLE
Add per-replicate network egress bounds to Quality Gate experiments

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -46,6 +46,12 @@ checks:
       series: "connection.current"
       upper_bound: 4
 
+  - name: total_bytes_received
+    description: "Bytes received quality gate. This bounds total network egress."
+    bounds:
+      series: total_bytes_received
+      upper_bound: "0.8 MiB"
+
 report_links:
   - text: "bounds checks dashboard"
     link: "https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id }}&view=spans&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -72,6 +72,12 @@ checks:
       series: "connection.current"
       upper_bound: 4
 
+  - name: total_bytes_received
+    description: "Bytes received quality gate. This bounds total network egress."
+    bounds:
+      series: total_bytes_received
+      upper_bound: "1.25 MiB"
+
 report_links:
   - text: "bounds checks dashboard"
     link: "https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id }}&view=spans&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -45,6 +45,12 @@ checks:
       series: "connection.current"
       upper_bound: 6
 
+  - name: total_bytes_received
+    description: "Bytes received quality gate. This bounds total network egress."
+    bounds:
+      series: total_bytes_received
+      upper_bound: "292 MiB"
+
 report_links:
   - text: "bounds checks dashboard"
     link: "https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id }}&view=spans&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"

--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -53,6 +53,12 @@ checks:
       series: missed_bytes
       upper_bound: 0KiB
 
+  - name: total_bytes_received
+    description: "Bytes received quality gate. This bounds total network egress."
+    bounds:
+      series: total_bytes_received
+      upper_bound: "1065 MiB"
+
 report_links:
   - text: "bounds checks dashboard"
     link: "https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id }}&view=spans&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"


### PR DESCRIPTION
### What does this PR do?

Bounds total egress per replicate for the four Performance Quality Gate experiments, sized at ~10% over the max observed across nightly runs over the prior 14 days. 

### Motivation

Catch regressions that increase per-replicate egress.
