### PR TITLE
fix(otlp/logs): preserve array attributes as JSON arrays instead of strings

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/logs/transform.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/transform.go
@@ -132,12 +132,16 @@ func transform(lr plog.LogRecord, host, service string, res pcommon.Resource, sc
 		if k == "hostname" || k == "service" {
 			l.AdditionalProperties["otel."+k] = v.AsString()
 		} else {
-			l.AdditionalProperties[k] = v.AsString()
+			for mk, mv := range flattenAttribute(k, v, 1) {
+				l.AdditionalProperties[mk] = mv
+			}
 		}
 		return true
 	})
 	for k, v := range scope.Attributes().Range {
-		l.AdditionalProperties[k] = v.AsString()
+		for mk, mv := range flattenAttribute(k, v, 1) {
+			l.AdditionalProperties[mk] = mv
+		}
 	}
 	if traceID := lr.TraceID(); !traceID.IsEmpty() {
 		l.AdditionalProperties[ddTraceID] = strconv.FormatUint(traceIDToUint64(traceID), 10)
@@ -190,7 +194,8 @@ func flattenAttribute(key string, val pcommon.Value, depth int) map[string]any {
 		if val.Type() == pcommon.ValueTypeStr ||
 			val.Type() == pcommon.ValueTypeInt ||
 			val.Type() == pcommon.ValueTypeBool ||
-			val.Type() == pcommon.ValueTypeDouble {
+			val.Type() == pcommon.ValueTypeDouble ||
+			val.Type() == pcommon.ValueTypeSlice {
 			result[key] = val.AsRaw()
 		} else {
 			result[key] = val.AsString()

--- a/pkg/opentelemetry-mapping-go/otlp/logs/transform_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/transform_test.go
@@ -624,6 +624,60 @@ func generateTranslatorTestCases(traceID [16]byte, spanID [8]byte, ddTr uint64, 
 				},
 			},
 		},
+		{
+			// Array log record attributes must be preserved as JSON arrays, not stringified.
+			// Regression test for https://github.com/DataDog/datadog-agent/issues/28598
+			name: "array attribute preserved as array",
+			args: args{
+				lr: func() plog.LogRecord {
+					l := plog.NewLogRecord()
+					l.SetSeverityNumber(5)
+					arr := l.Attributes().PutEmptySlice("arr")
+					arr.AppendEmpty().SetStr("ab")
+					arr.AppendEmpty().SetStr("cd")
+					return l
+				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
+			},
+			want: datadogV2.HTTPLogItem{
+				Ddtags:  datadog.PtrString("otel_source:test"),
+				Message: *datadog.PtrString(""),
+				AdditionalProperties: map[string]interface{}{
+					"arr":              []interface{}{"ab", "cd"},
+					"status":           "debug",
+					otelSeverityNumber: "5",
+				},
+			},
+		},
+		{
+			// Array values in resource attributes must also be preserved as JSON arrays.
+			name: "array resource attribute preserved as array",
+			args: args{
+				lr: func() plog.LogRecord {
+					l := plog.NewLogRecord()
+					l.SetSeverityNumber(5)
+					return l
+				}(),
+				res: func() pcommon.Resource {
+					r := pcommon.NewResource()
+					arr := r.Attributes().PutEmptySlice("tags")
+					arr.AppendEmpty().SetStr("env:prod")
+					arr.AppendEmpty().SetStr("region:us-east-1")
+					return r
+				}(),
+				scope: pcommon.NewInstrumentationScope(),
+			},
+			want: datadogV2.HTTPLogItem{
+				Ddtags:  datadog.PtrString("otel_source:test"),
+				Message: *datadog.PtrString(""),
+				AdditionalProperties: map[string]interface{}{
+					"tags":             []interface{}{"env:prod", "region:us-east-1"},
+					"status":           "debug",
+					otelSeverityNumber: "5",
+				},
+			},
+		},
 	}
 }
 func TestTranslator(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #28598

OTLP log record attributes of type `ArrayValue` (`pcommon.ValueTypeSlice`) were being serialized via `.AsString()`, producing escaped strings like `"[\"ab\",\"cd\"]"` instead of proper JSON arrays. This broke attribute filtering (e.g. `@arr:ab`) and was blocking users from migrating from JSON-over-TCP to OTLP/gRPC.

### Root cause

`flattenAttribute()` in `transform.go` handled `str`, `int`, `bool`, and `double` via `.AsRaw()` (correct), but fell through to `.AsString()` for all other types including `ValueTypeSlice`. Additionally, resource and scope attribute processing called `.AsString()` directly, bypassing `flattenAttribute()` entirely.

### Changes

- **`flattenAttribute()`**: Add `pcommon.ValueTypeSlice` to the branch that uses `.AsRaw()`, which returns `[]interface{}` and marshals correctly to a JSON array.
- **Resource attributes**: Route non-reserved keys through `flattenAttribute()` instead of calling `.AsString()` directly.
- **Scope attributes**: Same fix — route through `flattenAttribute()`.

### Tests

Added two regression test cases to `transform_test.go`:
- `array attribute preserved as array` — log record attribute with `["ab", "cd"]`
- `array resource attribute preserved as array` — resource attribute with `["env:prod", "region:us-east-1"]`

Both new tests run under `TestTranslator` and `TestTranslatorWithRUMRouting` and pass.

## Test plan

- [x] `go test ./otlp/logs/... -run TestTranslator` — all existing + new tests pass
- [x] Diff verified: only `transform.go` and `transform_test.go` touched, no unrelated changes