### PR TITLE
[host-profiler] Enable context sharing by default and add context-latest dev image

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2833,6 +2833,7 @@ core,go.opentelemetry.io/ebpf-profiler/interpreter/perl,Apache-2.0,Copyright The
 core,go.opentelemetry.io/ebpf-profiler/interpreter/php,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/ebpf-profiler/interpreter/python,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/ebpf-profiler/interpreter/ruby,Apache-2.0,Copyright The OpenTelemetry Authors
+core,go.opentelemetry.io/ebpf-profiler/interpreter/threadcontext,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/ebpf-profiler/kallsyms,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/ebpf-profiler/libc,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/ebpf-profiler/libpf,Apache-2.0,Copyright The OpenTelemetry Authors
@@ -2989,6 +2990,7 @@ core,go.opentelemetry.io/otel/semconv/v1.22.0,Apache-2.0,Copyright The OpenTelem
 core,go.opentelemetry.io/otel/semconv/v1.25.0,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/otel/semconv/v1.26.0,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/otel/semconv/v1.27.0,Apache-2.0,Copyright The OpenTelemetry Authors
+core,go.opentelemetry.io/otel/semconv/v1.34.0,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/otel/semconv/v1.37.0,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/otel/semconv/v1.37.0/goconv,Apache-2.0,Copyright The OpenTelemetry Authors
 core,go.opentelemetry.io/otel/semconv/v1.38.0,Apache-2.0,Copyright The OpenTelemetry Authors

--- a/cmd/host-profiler/deploy/bundled/configuration.md
+++ b/cmd/host-profiler/deploy/bundled/configuration.md
@@ -49,3 +49,4 @@ These options are for Datadog Support diagnostics only. Leave self-profiling dis
 |:-----------------------------------|:-------|:--------------------------|:-------------------------------------------------------------------------------------------------------------------|
 | `hostprofiler.ddprofiling.enabled` | bool   | `false`                   | Enables Datadog profiling for the Host Profiler process itself. This does not control profiling of your workloads. |
 | `hostprofiler.ddprofiling.period`  | int    | `60` seconds when enabled | Self-profiling collection interval. Used only when `hostprofiler.ddprofiling.enabled` is `true`.                   |
+| `hostprofiler.ddprofiling.port`    | int    | `7501`                    | Local port used by the self-profiling HTTP server. Used only when `hostprofiler.ddprofiling.enabled` is `true`. Change this only if the default port conflicts with another service. |

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -197,6 +197,10 @@ func buildConfig(agent configManager, p params.CollectorParams) confMap {
 		if agent.hostProfilerConfig.DDProfiling.Period > 0 {
 			_ = confmaputils.Set(ddprofilingConf, "profiler_options::period", agent.hostProfilerConfig.DDProfiling.Period)
 		}
+		if agent.hostProfilerConfig.DDProfiling.Port > 0 {
+			// The ddprofiling extension expects a bare port for its "endpoint" field.
+			_ = confmaputils.Set(ddprofilingConf, "endpoint", strconv.Itoa(agent.hostProfilerConfig.DDProfiling.Port))
+		}
 		_ = confmaputils.Set(config, "extensions::"+ddprofilingName, ddprofilingConf)
 		serviceExtensions = append(serviceExtensions, ddprofilingName)
 	}

--- a/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder_test.go
@@ -120,6 +120,47 @@ func TestBuildConfigDDProfilingEnabledWithPeriod(t *testing.T) {
 	assert.Contains(t, svcExtensions, ddprofilingName)
 }
 
+func TestBuildConfigDDProfilingEnabledWithPort(t *testing.T) {
+	agent := configManager{
+		endpoints: []endpoint{{
+			site:    "datadoghq.com",
+			apiKeys: []string{"test_key"},
+		}},
+		endpointsTotalLength: 1,
+		hostProfilerConfig: hostProfilerConfig{
+			DDProfiling: ddProfilingConfig{Enabled: true, Port: 1234},
+		},
+	}
+	conf := buildConfig(agent, testCollectorParams{})
+
+	extensions, ok := conf["extensions"].(confMap)
+	require.True(t, ok)
+	ddprofiling, ok := extensions[ddprofilingName].(confMap)
+	require.True(t, ok)
+	assert.Equal(t, "1234", ddprofiling["endpoint"])
+}
+
+func TestBuildConfigDDProfilingEnabledDefaultPort(t *testing.T) {
+	agent := configManager{
+		endpoints: []endpoint{{
+			site:    "datadoghq.com",
+			apiKeys: []string{"test_key"},
+		}},
+		endpointsTotalLength: 1,
+		hostProfilerConfig: hostProfilerConfig{
+			DDProfiling: ddProfilingConfig{Enabled: true},
+		},
+	}
+	conf := buildConfig(agent, testCollectorParams{})
+
+	extensions, ok := conf["extensions"].(confMap)
+	require.True(t, ok)
+	ddprofiling, ok := extensions[ddprofilingName].(confMap)
+	require.True(t, ok)
+	_, ok = ddprofiling["endpoint"]
+	assert.False(t, ok, "endpoint should not be set when port is unset; extension applies its own default")
+}
+
 func TestBuildConfigDDProfilingDisabled(t *testing.T) {
 	agent := configManager{
 		endpoints: []endpoint{{

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager.go
@@ -21,6 +21,9 @@ type healthMetricsConfig struct {
 type ddProfilingConfig struct {
 	Enabled bool
 	Period  int
+	// Port is the local port the ddprofiling HTTP server listens on. 0 means the
+	// extension applies its own default.
+	Port int
 }
 
 // hpFlareConfig holds configuration for the hpflare diagnostics extension.
@@ -99,6 +102,7 @@ func newConfigManager(config config.Component) configManager {
 		DDProfiling: ddProfilingConfig{
 			Enabled: config.GetBool("hostprofiler.ddprofiling.enabled"),
 			Period:  config.GetInt("hostprofiler.ddprofiling.period"),
+			Port:    config.GetInt("hostprofiler.ddprofiling.port"),
 		},
 		HealthMetrics: healthMetricsConfig{
 			Enabled: config.GetBool("hostprofiler.health_metrics.enabled"),

--- a/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_manager_test.go
@@ -150,6 +150,41 @@ site: datadoghq.com
 	assert.Equal(t, 0, mgr.hostProfilerConfig.DDProfiling.Period)
 }
 
+func TestNewConfigManagerDDProfilingPortFromYAML(t *testing.T) {
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+hostprofiler:
+  ddprofiling:
+    port: 1234
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, 1234, mgr.hostProfilerConfig.DDProfiling.Port)
+}
+
+func TestNewConfigManagerDDProfilingPortFromEnvVar(t *testing.T) {
+	t.Setenv("DD_HOSTPROFILER_DDPROFILING_PORT", "1234")
+
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, 1234, mgr.hostProfilerConfig.DDProfiling.Port)
+}
+
+func TestNewConfigManagerDDProfilingPortDefault(t *testing.T) {
+	cfg := config.NewMockFromYAML(t, `
+api_key: test-key
+site: datadoghq.com
+`)
+	mgr := newConfigManager(cfg)
+
+	assert.Equal(t, 0, mgr.hostProfilerConfig.DDProfiling.Port)
+}
+
 func TestNewConfigManagerHPFlarePortFromYAML(t *testing.T) {
 	cfg := config.NewMockFromYAML(t, `
 api_key: test-key

--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -96,7 +96,7 @@ func defaultConfig(profilerName string) component.Config {
 	return Config{
 		EbpfCollectorConfig: cfg,
 		SymbolUploader:      symbolUploaderConfig,
-		CollectContext:      false,
+		CollectContext:      true,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ replace (
 	// To update the Datadog/opentelemetry-ebpf-profiler dependency on latest commit on datadog branch, change the following line to:
 	// replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog
 	// and run `go mod tidy` then `dda inv tidy`
-	go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260615120033-4edb1d33d277
+	go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260630153253-a8fe26bca2bf
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2579,8 +2579,8 @@ github.com/DataDog/netlink v1.0.1-0.20240223195320-c7a4f832a3d1 h1:HnvrdC79xJ+RP
 github.com/DataDog/netlink v1.0.1-0.20240223195320-c7a4f832a3d1/go.mod h1:whJevzBpTrid75eZy99s3DqCmy05NfibNaF2Ol5Ox5A=
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816 h1:8diKw2aLYE6LsjWfYxDEqx0ZmcyMMmqB+qapRJrGtys=
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816/go.mod h1:7cPuErOAt7k/oVWAVJnxqAC6mwArrAazkvk0RXiih2A=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260615120033-4edb1d33d277 h1:iWjjDyM+IVIK2b8ib7x4+6ovZl8q/Q6Qb5qqCveyhHc=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260615120033-4edb1d33d277/go.mod h1:DqHEtu1S8fTmyvvrSSum1lssLKwYM7aExPNZ/+vWZ6U=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260630153253-a8fe26bca2bf h1:nZcaigSxQCQ+EfctkLL/SVY8YHgMOW7A/8BRaCKAQ6M=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20260630153253-a8fe26bca2bf/go.mod h1:DqHEtu1S8fTmyvvrSSum1lssLKwYM7aExPNZ/+vWZ6U=
 github.com/DataDog/rshell v0.0.22 h1:SO+CbjmL7iL2kHS0RJODcInaerZNEdQq6QeISqjRIO0=
 github.com/DataDog/rshell v0.0.22/go.mod h1:jZm0YIxCKYEyHJeSSH5rxqmlI1oUi+mXQF6Zf102q+k=
 github.com/DataDog/sketches-go v1.4.8 h1:pFk9BNn+Rzv8IMIoPUttoOpOr3bJOqU3P6EP5wK+Lv8=

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -8824,6 +8824,10 @@ properties:
             node_type: setting
             type: integer
             default: 0
+          port:
+            node_type: setting
+            type: integer
+            default: 0
       debug:
         node_type: section
         type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1140,6 +1140,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("hostprofiler.additional_http_headers", map[string]string{})
 	config.BindEnvAndSetDefault("hostprofiler.ddprofiling.enabled", false)
 	config.BindEnvAndSetDefault("hostprofiler.ddprofiling.period", 0)
+	config.BindEnvAndSetDefault("hostprofiler.ddprofiling.port", 0)
 	config.BindEnvAndSetDefault("hostprofiler.health_metrics.enabled", true)
 	config.BindEnvAndSetDefault("hostprofiler.health_metrics.target", "127.0.0.1:8889")
 	config.BindEnvAndSetDefault("hostprofiler.hpflare.port", 7778)


### PR DESCRIPTION
> [!WARNING]
> This PR is **not intended to be merged**. It exists solely to test context sharing in the host-profiler.

### What does this PR do?

Enables context sharing in the host-profiler by default.

- Bumps `opentelemetry-ebpf-profiler` to `v0.0.0-20260519132841-ac9d69edae97` to pull in context-sharing support.
- Flips `CollectContext` default from `false` to `true` in the host-profiler receiver config.
- Adds `OTEL_RESOURCE_ATTRIBUTES` to the list of env vars read from profiled processes for unified service tag resolution.
- Implements `OpenELFMapping` on the symbol-uploader test's `dummyProcess` to satisfy the updated profiler interface.

### Motivation

We want to validate context sharing in the host-profiler before broader rollout.
