### PR TITLE
dyninst: fix the upload json field names

### DIFF
--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -398,10 +398,10 @@ func (b *BatchEncoder) Flush(ctx context.Context, final bool) error {
 		Language       string    `json:"language"`
 		RuntimeID      string    `json:"runtimeId"`
 		Type           string    `json:"type"`
-		UploadID       uuid.UUID `json:"upload_id"`
-		BatchNum       int       `json:"batch_num"`
+		UploadID       uuid.UUID `json:"uploadId"`
+		BatchNum       int       `json:"batchNum"`
 		Final          bool      `json:"final"`
-		AttachmentSize int64     `json:"attachment_size"`
+		AttachmentSize int64     `json:"attachmentSize"`
 	}{
 		DDSource:       "dd_debugger",
 		Service:        b.up.service,

--- a/pkg/dyninst/symdb/uploader/uploader_test.go
+++ b/pkg/dyninst/symdb/uploader/uploader_test.go
@@ -49,10 +49,10 @@ type EventMetadata struct {
 	Language       string `json:"language"`
 	RuntimeID      string `json:"runtimeId"`
 	Type           string `json:"type"`
-	UploadID       string `json:"upload_id"`
-	BatchNum       int    `json:"batch_num"`
+	UploadID       string `json:"uploadId"`
+	BatchNum       int    `json:"batchNum"`
 	Final          bool   `json:"final"`
-	AttachmentSize int    `json:"attachment_size"`
+	AttachmentSize int    `json:"attachmentSize"`
 }
 
 type testServer struct {


### PR DESCRIPTION
For the symdb upload events we were producing snake_case fields when the backend wants camelCase.

