### PR TITLE
host-profiler: switch to jq for JSON parsing in deploy script

### DIFF
--- a/.gitlab/distribute/deploy_containers_a7.yml
+++ b/.gitlab/distribute/deploy_containers_a7.yml
@@ -174,7 +174,7 @@ deploy_containers-a7-fips_internal:
   stage: deploy_containers
   dependencies: []
   before_script:
-    - if [[ "$VERSION" == "" ]]; then VERSION=$(yq -r '.current_milestone' release.json); fi
+    - if [[ "$VERSION" == "" ]]; then VERSION=$(jq -r '.current_milestone' release.json); fi
     - export IMG_SOURCES="${SRC_DDOT_EBPF}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64"
     - export IMG_DESTINATIONS="ddot-ebpf:${VERSION}-preview-host-profiler-${PREVIEW_NUMBER}"
 


### PR DESCRIPTION
### What does this PR do?

Switch from yq to jq for parsing current milestone for host profiler preview

### Motivation

Fix failing release job (incorrect syntax for yq)

Both seem to be present in the image, but yq is explicitly installed in https://github.com/DataDog/datadog-agent-buildimages/blob/main/docker-x64/Dockerfile#L51 and jq is an implicit dependency from the images repo

Since this is a json, and seeing other usage in CI to parse it with `jq` https://github.com/search?q=repo%3ADataDog%2Fdatadog-agent+%22jq+%22+release.json&type=code, switching to using `jq`.

### Describe how you validated your changes

N/A

### Additional Notes

N/A
