### PR TITLE
bazel: drive Gazelle build_tags from a shared tasks/build_tags.bzl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -755,7 +755,8 @@
 /tasks/macos.py                         @DataDog/windows-products
 /tasks/msi.py                           @DataDog/windows-products
 /tasks/agent.py                         @DataDog/agent-runtimes
-/tasks/build_tags.py                    @DataDog/agent-devx @DataDog/agent-build
+/tasks/build_tags.py                    @DataDog/agent-build
+/tasks/build_tags.bzl                   @DataDog/agent-build
 /tasks/anomalydetection.py              @DataDog/q-branch
 /tasks/loader.py                        @DataDog/agent-runtimes
 /tasks/go_deps.py                       @DataDog/agent-runtimes
@@ -808,6 +809,7 @@
 /tasks/libs/releasing/                  @DataDog/agent-delivery
 /tasks/schema/                          @DataDog/agent-configuration
 /tasks/unit_tests/components_tests.py   @DataDog/agent-runtimes
+/tasks/unit_tests/build_tags_tests.py   @DataDog/agent-build
 /tasks/unit_tests/libs/build/           @DataDog/agent-build
 /tasks/unit_tests/omnibus_tests.py      @DataDog/agent-build
 /tasks/unit_tests/testdata/components_src/ @DataDog/agent-runtimes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,9 @@ Go build tags control feature inclusion, some examples are:
 - `docker` - Docker support
 - `ebpf` - eBPF support
 - `python` - Python check support
-- and MANY more, refer to ./tasks/build_tags.py for a full reference.
+- and MANY more, refer to `tasks/build_tags.bzl` (the source of truth) for a full reference.
+
+Bazel/Gazelle build-tag handling is documented in `bazel/AGENTS.md` ("Go build tags and flavors").
 
 ## Important Files
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@ load("@bazel_lib//lib:write_source_files.bzl", "write_source_file", "write_sourc
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
+load("//tasks:build_tags.bzl", "GAZELLE_BUILD_TAGS")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -677,72 +678,15 @@ exports_files(glob(
 # gazelle:exclude **/testdata/**/*.go
 # ======= END TESTDATA EXCLUDES =======
 
-# All custom build tags from tasks/build_tags.py ALL_TAGS, plus "test".
-# "test" is included so Gazelle analyzes test-only sources and generates their
-# deps. The go_build_tags Gazelle extension removes those files from go_library
-# and moves them into go_test targets; their deps remain in go_library (harmless
-# extra) and are accessible to go_test via embedding.
-_GAZELLE_BUILD_TAGS = [
-    "bundle_installer",
-    "cel",
-    "clusterchecks",
-    "consul",
-    "containerd",
-    "cri",
-    "crio",
-    "cws_instrumentation_injector_only",
-    "datadog.no_waf",
-    "docker",
-    "e2eunit",
-    "ec2",
-    "etcd",
-    "fargateprocess",
-    "goexperiment.systemcrypto",
-    "grpcnotrace",
-    "jetson",
-    "jmx",
-    "kubeapiserver",
-    "kubelet",
-    "linux_bpf",
-    "ncm",
-    "netcgo",
-    "netgo",
-    "no_dynamic_plugins",
-    "npm",
-    "nvml",
-    "oracle",
-    "orchestrator",
-    "osusergo",
-    "otlp",
-    "podman",
-    "private_runner_experimental",
-    "python",
-    "requirefips",
-    "retrynotrace",
-    "seclmax",
-    "serverless",
-    "sharedlibrarycheck",
-    "systemd",
-    "systemprobechecks",
-    "test",
-    "trivy",
-    "trivy_no_javadb",
-    "wmi",
-    "zk",
-    "zlib",
-    "zstd",
-    "e2ecoverage",
-    "functionaltests",
-    "manualtest",
-]
-
 # gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/actionsclient //pkg/proto/pbgo/privateactionrunner/actionsclient
 # gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/errorcode //pkg/proto/pbgo/privateactionrunner/errorcode
 # gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactions //pkg/proto/pbgo/privateactionrunner/privateactions
 # gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx //pkg/proto/pbgo/trace/idx
+# GAZELLE_BUILD_TAGS is the source-of-truth tag list from
+# tasks/build_tags.bzl, shared with the dda inv build-tag code.
 gazelle(
     name = "gazelle",
-    build_tags = _GAZELLE_BUILD_TAGS,
+    build_tags = GAZELLE_BUILD_TAGS,
     external = "static",  # don't use the network: https://github.com/bazel-contrib/bazel-gazelle/issues/1385
     extra_args = [
         "-build_file_name=BUILD.bazel",  # avoid BUILD/build mess: https://github.com/docker/desktop-feedback/issues/251

--- a/bazel/AGENTS.md
+++ b/bazel/AGENTS.md
@@ -277,6 +277,14 @@ BUILD files are configuration, not code — prioritize readability over deduplic
   directory *node*, not its contents, breaking incremental builds.
 - Use `[]` to express "no targets", not a glob that matches nothing.
 
+## Go build tags and flavors
+
+Tags and per-flavor tag sets are defined in `tasks/build_tags.bzl`, the single source of truth. It
+is written in the Starlark∩Python subset so it is both `load()`ed by `//BUILD.bazel` (for
+`GAZELLE_BUILD_TAGS`, the `//:gazelle` `build_tags`) and exec'd by `tasks/build_tags.py` — no codegen
+step. Edit that file to add or change a tag, using `set([...])` (a `{...}` literal is a dict in
+Starlark). The `AgentFlavor` mapping stays in `build_tags.py`, since Starlark has no enums.
+
 ## Starlark language
 
 Starlark is Python-like but with deliberate restrictions for hermeticity and parallelism. Key divergences:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -90,7 +90,7 @@ from tasks import (
     windows_dev_env,
     worktree,
 )
-from tasks.build_tags import audit_tag_impact, print_default_build_tags
+from tasks.build_tags import audit_tag_impact, codegen_to_json, print_default_build_tags
 from tasks.components import lint_components, lint_fxutil_oneshot_test
 from tasks.custom_task.custom_task import custom__call__
 
@@ -168,6 +168,7 @@ ns.add_task(show_linters_issues)
 ns.add_task(go_version)
 ns.add_task(update_go)
 ns.add_task(audit_tag_impact)
+ns.add_task(codegen_to_json)
 ns.add_task(print_default_build_tags)
 ns.add_task(e2e_tests)
 ns.add_task(install_shellcheck)

--- a/tasks/build_tags.bzl
+++ b/tasks/build_tags.bzl
@@ -246,7 +246,7 @@ SYSTEM_PROBE_TAGS = set([
     "seclmax",
 ])
 
-# TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
+# TRACE_AGENT_TAGS lists the tags necessary to build the trace-agent
 TRACE_AGENT_TAGS = set([
     "docker",
     "containerd",

--- a/tasks/build_tags.bzl
+++ b/tasks/build_tags.bzl
@@ -1,0 +1,333 @@
+"""Canonical build-tag data, shared by Python and Bazel.
+
+This is the single source of truth for the agent's Go build tags. It is
+deliberately written in the common subset of Starlark and Python so that:
+
+  - //BUILD.bazel can `load()` GAZELLE_BUILD_TAGS directly, and
+  - tasks/build_tags.py can exec it to obtain the same data.
+
+Keep it in that subset: build sets with `set([...])` (a `{...}` literal is a
+dict in Starlark, not a set) and use set operators/methods (`|`, `-`,
+`.union()`, `.difference()`). The AgentFlavor-keyed mapping and the codegen
+payload live in build_tags.py, because Starlark has no enums.
+"""
+
+# Common build tags, added on all builds
+COMMON_TAGS = set([
+    # removes the import to golang.org/x/net/trace in google.golang.org/grpc,
+    # which prevents dead code elimination, see https://github.com/golang/go/issues/62024
+    "grpcnotrace",
+    # removes the import to golang.org/x/net/trace in github.com/grpc-ecosystem/go-grpc-middleware
+    # which prevents dead code elimination, see https://github.com/golang/go/issues/62024
+    "retrynotrace",
+    # Disables dynamic plugins in containerd v1, which removes the import to std "plugin" package on Linux amd64,
+    # which makes the agent significantly smaller.
+    # This can be removed when we start using containerd v2.1 or later.
+    "no_dynamic_plugins",
+    # Remove some dependencies from Trivy to reduce binary size.
+    "trivy_no_javadb",
+])
+
+# ALL_TAGS lists all available build tags.
+# Used to remove unknown tags from provided tag lists.
+ALL_TAGS = set([
+    "bundle_installer",
+    "clusterchecks",
+    "consul",
+    "containerd",
+    "cri",
+    "crio",
+    # Opt out of the ASM build requirements of dd-trace-go
+    "datadog.no_waf",
+    "docker",
+    "ec2",
+    "etcd",
+    "fargateprocess",
+    "goexperiment.systemcrypto",  # used for FIPS mode
+    "jetson",
+    "jmx",
+    "kubeapiserver",
+    "kubelet",
+    "linux_bpf",
+    "ncm",
+    "netcgo",  # Force the use of the CGO resolver. This will also have the effect of making the binary non-static
+    "netgo",
+    "npm",
+    "nvml",  # used for the nvidia go-nvml library
+    "oracle",
+    "orchestrator",
+    "osusergo",
+    "otlp",
+    "pcap",  # used by system-probe to compile packet filters using google/gopacket/pcap, which requires cgo to link libpcap
+    "podman",
+    "python",
+    "requirefips",  # used for Linux FIPS mode to avoid having to set GOFIPS
+    "seclmax",  # used for security agent/system-probe to compile the full feature set of secl
+    "serverless",
+    "sharedlibrarycheck",
+    "systemd",
+    "systemprobechecks",  # used to include system-probe based checks in the agent build
+    "test",  # used for unit-tests
+    "trivy",
+    "wmi",
+    "zk",
+    "zlib",
+    "zstd",
+    "cel",
+    "cws_instrumentation_injector_only",  # used for building cws-instrumentation with only the injector code
+    "remove_all_sd",  # remove all discovery provider from prometheusreceiver components
+]).union(COMMON_TAGS)
+
+# Tags Gazelle needs to see in addition to ALL_TAGS so it can analyse test-only
+# files gated by them. Kept separate because they're test-only and don't belong
+# in ALL_TAGS (which is also used to validate user-provided tag lists).
+GAZELLE_EXTRA_TAGS = set([
+    "e2ecoverage",
+    "e2eunit",
+    "functionaltests",
+    "manualtest",
+    "private_runner_experimental",
+])
+
+# Tags in ALL_TAGS that we deliberately keep out of Gazelle's set, typically
+# because they require cgo/native deps that Gazelle's static analysis can't
+# resolve cleanly.
+GAZELLE_OMIT_TAGS = set(["pcap", "remove_all_sd"])
+
+# Build tags Gazelle considers when analysing tag-gated .go files. Loaded by the
+# root BUILD.bazel as the `build_tags` attribute of //:gazelle, so it must be a
+# sorted list of strings (deterministic, and the gazelle rule wants a list).
+GAZELLE_BUILD_TAGS = sorted((ALL_TAGS - GAZELLE_OMIT_TAGS) | GAZELLE_EXTRA_TAGS)
+
+### Tag inclusion lists
+
+# AGENT_TAGS lists the tags needed when building the agent.
+AGENT_TAGS = set([
+    "consul",
+    "containerd",
+    "cri",
+    "datadog.no_waf",
+    "crio",
+    "docker",
+    "ec2",
+    "etcd",
+    "fargateprocess",
+    "jetson",
+    "jmx",
+    "kubeapiserver",
+    "kubelet",
+    "ncm",
+    "netcgo",
+    "nvml",
+    "oracle",
+    "orchestrator",
+    "otlp",
+    "podman",
+    "python",
+    "sharedlibrarycheck",
+    "systemd",
+    "systemprobechecks",
+    "trivy",
+    "zk",
+    "zlib",
+    "zstd",
+    "cel",
+])
+
+# AGENT_HEROKU_TAGS lists the tags for Heroku agent build
+AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
+    set([
+        "containerd",
+        "cri",
+        "crio",
+        "docker",
+        "ec2",
+        "fargateprocess",
+        "jetson",
+        "kubeapiserver",
+        "kubelet",
+        "nvml",
+        "oracle",
+        "orchestrator",
+        "podman",
+        "systemd",
+        "trivy",
+        "cel",
+    ]),
+).union(
+    set([
+        "bundle_installer",
+    ]),
+)
+
+FIPS_TAGS = set(["goexperiment.systemcrypto", "requirefips"])
+
+# CLUSTER_AGENT_TAGS lists the tags needed when building the cluster-agent
+CLUSTER_AGENT_TAGS = set([
+    "clusterchecks",
+    "datadog.no_waf",
+    "kubeapiserver",
+    "orchestrator",
+    "zlib",
+    "zstd",
+    "ec2",
+    "cel",
+])
+
+# CLUSTER_AGENT_CLOUDFOUNDRY_TAGS lists the tags needed when building the cloudfoundry cluster-agent
+CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = set(["clusterchecks", "cel"])
+
+# DOGSTATSD_TAGS lists the tags needed when building dogstatsd
+DOGSTATSD_TAGS = set(["containerd", "docker", "kubelet", "podman", "zlib", "zstd"])
+
+# IOT_AGENT_TAGS lists the tags needed when building the IoT agent
+IOT_AGENT_TAGS = set(["jetson", "systemd", "zlib", "zstd"])
+
+# INSTALLER_TAGS lists the tags needed when building the installer
+INSTALLER_TAGS = set(["ec2"])
+
+# PROCESS_AGENT_TAGS lists the tags necessary to build the process-agent
+PROCESS_AGENT_TAGS = set([
+    "containerd",
+    "cri",
+    "crio",
+    "datadog.no_waf",
+    "ec2",
+    "docker",
+    "fargateprocess",
+    "kubelet",
+    "netcgo",
+    "podman",
+    "zlib",
+    "zstd",
+])
+
+# PROCESS_AGENT_HEROKU_TAGS lists the tags necessary to build the process-agent for Heroku
+PROCESS_AGENT_HEROKU_TAGS = set([
+    "datadog.no_waf",
+    "fargateprocess",
+    "netcgo",
+    "zlib",
+    "zstd",
+])
+
+# SECURITY_AGENT_TAGS lists the tags necessary to build the security agent
+SECURITY_AGENT_TAGS = set([
+    "netcgo",
+    "datadog.no_waf",
+    "docker",
+    "zlib",
+    "zstd",
+    "ec2",
+])
+
+# SBOMGEN_TAGS lists the tags necessary to build sbomgen
+SBOMGEN_TAGS = set([
+    "trivy",
+    "containerd",
+    "docker",
+    "crio",
+])
+
+# SERVERLESS_TAGS lists the tags necessary to build serverless
+SERVERLESS_TAGS = set(["serverless", "otlp"])
+
+# SYSTEM_PROBE_TAGS lists the tags necessary to build system-probe
+SYSTEM_PROBE_TAGS = set([
+    "datadog.no_waf",
+    "ec2",
+    "linux_bpf",
+    "netcgo",
+    "npm",
+    "nvml",
+    "pcap",
+    "zlib",
+    "zstd",
+    "seclmax",
+])
+
+# TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
+TRACE_AGENT_TAGS = set([
+    "docker",
+    "containerd",
+    "datadog.no_waf",
+    "kubelet",
+    "otlp",
+    "netcgo",
+    "podman",
+])
+
+# TRACE_AGENT_HEROKU_TAGS lists the tags necessary to build the trace-agent for Heroku
+TRACE_AGENT_HEROKU_TAGS = TRACE_AGENT_TAGS.difference(
+    set([
+        "containerd",
+        "docker",
+        "kubeapiserver",
+        "kubelet",
+        "podman",
+    ]),
+)
+
+CWS_INSTRUMENTATION_TAGS = set(["netgo", "osusergo"])
+
+OTEL_AGENT_TAGS = set(["otlp", "zlib", "zstd", "kubelet"])
+
+LOADER_TAGS = set()
+
+# We need to remove all discovery provider from prometheusreceiver components to avoid loading too many dependencies in the host-profiler binary.
+# imported by https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/f963ab53ee55aeb56d58617ed12c840e8b07cc53/receiver/prometheusreceiver/factory.go#L10
+HOST_PROFILER_TAGS = set(["remove_all_sd", "docker", "kubelet"])
+
+PRIVATEACTIONRUNNER_TAGS = set()
+
+SECRET_GENERIC_CONNECTOR_TAGS = set()
+
+# AGENT_TEST_TAGS lists the tags that have to be added to run tests
+AGENT_TEST_TAGS = AGENT_TAGS.union(set(["clusterchecks"]))
+
+### Tag exclusion lists
+
+# List of tags to always remove when not building on Linux
+LINUX_ONLY_TAGS = set(["netcgo", "systemd", "jetson", "linux_bpf", "nvml", "pcap", "podman", "trivy", "crio"])
+
+# List of tags to always remove when building on AIX
+AIX_EXCLUDED_TAGS = set([
+    "cel",
+    "clusterchecks",
+    "containerd",
+    "cri",
+    "crio",
+    "docker",
+    "fargateprocess",
+    "jetson",
+    "jmx",
+    "kubeapiserver",
+    "kubelet",
+    "linux_bpf",
+    "netcgo",
+    "npm",
+    "nvml",
+    "orchestrator",
+    "pcap",
+    "podman",
+    "systemd",
+    "systemprobechecks",
+    "trivy",
+])
+
+# List of tags to always add when building on Windows
+WINDOWS_INCLUDED_TAGS = set(["wmi"])
+
+# List of tags to always remove when building on Windows
+WINDOWS_EXCLUDED_TAGS = set([
+    "requirefips",
+])
+
+# List of tags to always remove when building on Darwin/macOS
+DARWIN_EXCLUDED_TAGS = set(["docker", "containerd", "cri"])
+
+# Unit test build tags
+UNIT_TEST_TAGS = set(["test"])
+
+# List of tags to always remove when running unit tests
+UNIT_TEST_EXCLUDED_TAGS = set(["datadog.no_waf", "pcap"])

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -273,7 +273,7 @@ AGENT_TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
 LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "nvml", "pcap", "podman", "trivy", "crio"}
 
 # List of tags to always remove when building on AIX
-AIX_EXCLUDE_TAGS = {
+AIX_EXCLUDED_TAGS = {
     "cel",
     "clusterchecks",
     "containerd",
@@ -298,7 +298,7 @@ AIX_EXCLUDE_TAGS = {
 }
 
 # List of tags to always remove when building on Windows
-WINDOWS_EXCLUDE_TAGS = {
+WINDOWS_EXCLUDED_TAGS = {
     "requirefips",
 }
 
@@ -309,7 +309,7 @@ DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "cri"}
 UNIT_TEST_TAGS = {"test"}
 
 # List of tags to always remove when running unit tests
-UNIT_TEST_EXCLUDE_TAGS = {"datadog.no_waf", "pcap"}
+UNIT_TEST_EXCLUDED_TAGS = {"datadog.no_waf", "pcap"}
 
 # Build type: maps flavor to build tags map
 build_tags = {
@@ -324,7 +324,7 @@ build_tags = {
         "security-agent": SECURITY_AGENT_TAGS,
         "serverless": SERVERLESS_TAGS,
         "system-probe": SYSTEM_PROBE_TAGS,
-        "system-probe-unit-tests": SYSTEM_PROBE_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
+        "system-probe-unit-tests": SYSTEM_PROBE_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
         "trace-agent": TRACE_AGENT_TAGS,
         "cws-instrumentation": CWS_INSTRUMENTATION_TAGS,
         "sbomgen": SBOMGEN_TAGS,
@@ -337,15 +337,15 @@ build_tags = {
         "test": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS)
         .union(CLUSTER_AGENT_TAGS)
         .union(UNIT_TEST_TAGS)
-        .difference(UNIT_TEST_EXCLUDE_TAGS),
+        .difference(UNIT_TEST_EXCLUDED_TAGS),
         "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS)
         .union(CLUSTER_AGENT_TAGS)
         .union(UNIT_TEST_TAGS)
-        .difference(UNIT_TEST_EXCLUDE_TAGS),
+        .difference(UNIT_TEST_EXCLUDED_TAGS),
         "unit-tests": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS)
         .union(CLUSTER_AGENT_TAGS)
         .union(UNIT_TEST_TAGS)
-        .difference(UNIT_TEST_EXCLUDE_TAGS),
+        .difference(UNIT_TEST_EXCLUDED_TAGS),
     },
     AgentFlavor.fips: {
         "agent": AGENT_TAGS.union(FIPS_TAGS),
@@ -356,7 +356,7 @@ build_tags = {
         "system-probe": SYSTEM_PROBE_TAGS.union(FIPS_TAGS),
         "system-probe-unit-tests": SYSTEM_PROBE_TAGS.union(FIPS_TAGS)
         .union(UNIT_TEST_TAGS)
-        .difference(UNIT_TEST_EXCLUDE_TAGS),
+        .difference(UNIT_TEST_EXCLUDED_TAGS),
         "trace-agent": TRACE_AGENT_TAGS.union(FIPS_TAGS),
         "cws-instrumentation": CWS_INSTRUMENTATION_TAGS.union(FIPS_TAGS),
         "sbomgen": SBOMGEN_TAGS.union(FIPS_TAGS),
@@ -364,26 +364,26 @@ build_tags = {
         "privateactionrunner": PRIVATEACTIONRUNNER_TAGS.union(FIPS_TAGS),
         "secret-generic-connector": SECRET_GENERIC_CONNECTOR_TAGS.union(FIPS_TAGS),
         # Test setups
-        "lint": AGENT_TAGS.union(FIPS_TAGS).union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
-        "unit-tests": AGENT_TAGS.union(FIPS_TAGS).union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
+        "lint": AGENT_TAGS.union(FIPS_TAGS).union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
+        "unit-tests": AGENT_TAGS.union(FIPS_TAGS).union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
         "otel-agent": OTEL_AGENT_TAGS.union(FIPS_TAGS),
     },
     AgentFlavor.heroku: {
         "agent": AGENT_HEROKU_TAGS,
         "process-agent": PROCESS_AGENT_HEROKU_TAGS,
         "trace-agent": TRACE_AGENT_HEROKU_TAGS,
-        "lint": AGENT_HEROKU_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
-        "unit-tests": AGENT_HEROKU_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
+        "lint": AGENT_HEROKU_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
+        "unit-tests": AGENT_HEROKU_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
     },
     AgentFlavor.iot: {
         "agent": IOT_AGENT_TAGS,
-        "lint": IOT_AGENT_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
-        "unit-tests": IOT_AGENT_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
+        "lint": IOT_AGENT_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
+        "unit-tests": IOT_AGENT_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
     },
     AgentFlavor.dogstatsd: {
         "dogstatsd": DOGSTATSD_TAGS,
-        "lint": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
-        "unit-tests": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
+        "lint": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
+        "unit-tests": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
     },
 }
 
@@ -485,13 +485,13 @@ def filter_incompatible_tags(include, platform=None):
 
     if platform == "win32":
         include = include.union(["wmi"])
-        exclude = exclude.union(WINDOWS_EXCLUDE_TAGS)
+        exclude = exclude.union(WINDOWS_EXCLUDED_TAGS)
 
     if platform == "darwin":
         exclude = exclude.union(DARWIN_EXCLUDED_TAGS)
 
     if platform == "aix":
-        exclude = exclude.union(AIX_EXCLUDE_TAGS)
+        exclude = exclude.union(AIX_EXCLUDED_TAGS)
 
     return get_build_tags(include, exclude)
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -1,318 +1,79 @@
 """
-Utilities to manage build tags
+Utilities to manage build tags.
+
+The canonical tag-set data lives in build_tags.bzl, which is written in the
+common subset of Starlark and Python so it can be both `load()`ed by
+//BUILD.bazel (for GAZELLE_BUILD_TAGS) and exec'd here. This module loads that
+data, layers on the AgentFlavor-keyed `build_tags` mapping and the codegen
+payload (which can't live in Starlark — no enums), and provides the @task entry
+points and helpers that operate on the tags.
 """
 
-# TODO: check if we really need the typing import.
-# Recent versions of Python should be able to use dict and list directly in type hints,
-# so we only need to check that we don't run this code with old Python versions.
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
+import json
 import os
 import sys
+from pathlib import Path
+from typing import Any
 
 from invoke import task
 
 from tasks.flavor import AgentFlavor
 
-# Common build tags, added on all builds
-COMMON_TAGS = {
-    # removes the import to golang.org/x/net/trace in google.golang.org/grpc,
-    # which prevents dead code elimination, see https://github.com/golang/go/issues/62024
-    "grpcnotrace",
-    # removes the import to golang.org/x/net/trace in github.com/grpc-ecosystem/go-grpc-middleware
-    # which prevents dead code elimination, see https://github.com/golang/go/issues/62024
-    "retrynotrace",
-    # Disables dynamic plugins in containerd v1, which removes the import to std "plugin" package on Linux amd64,
-    # which makes the agent significantly smaller.
-    # This can be removed when we start using containerd v2.1 or later.
-    "no_dynamic_plugins",
-    # Remove some dependencies from Trivy to reduce binary size.
-    "trivy_no_javadb",
-}
+# Load the shared Starlark/Python data file. It is valid Python (set([...])
+# literals, set operators/methods), so we exec it and rebind the names below.
+# An explicit SourceFileLoader is needed because importlib won't infer one from
+# the .bzl extension. Typed as Any so the dynamic attribute access is mypy-clean.
+_BZL_PATH = Path(__file__).with_name("build_tags.bzl")
+_loader = importlib.machinery.SourceFileLoader("tasks._build_tags_data", str(_BZL_PATH))
+_spec = importlib.util.spec_from_loader(_loader.name, _loader)
+assert _spec is not None
+_data: Any = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_data)
 
-# ALL_TAGS lists all available build tags.
-# Used to remove unknown tags from provided tag lists.
-ALL_TAGS = {
-    "bundle_installer",
-    "clusterchecks",
-    "consul",
-    "containerd",
-    "cri",
-    "crio",
-    # Opt out of the ASM build requirements of dd-trace-go
-    "datadog.no_waf",
-    "docker",
-    "ec2",
-    "etcd",
-    "fargateprocess",
-    "goexperiment.systemcrypto",  # used for FIPS mode
-    "jetson",
-    "jmx",
-    "kubeapiserver",
-    "kubelet",
-    "linux_bpf",
-    "ncm",
-    "netcgo",  # Force the use of the CGO resolver. This will also have the effect of making the binary non-static
-    "netgo",
-    "npm",
-    "nvml",  # used for the nvidia go-nvml library
-    "oracle",
-    "orchestrator",
-    "osusergo",
-    "otlp",
-    "pcap",  # used by system-probe to compile packet filters using google/gopacket/pcap, which requires cgo to link libpcap
-    "podman",
-    "python",
-    "requirefips",  # used for Linux FIPS mode to avoid having to set GOFIPS
-    "seclmax",  # used for security agent/system-probe to compile the full feature set of secl
-    "serverless",
-    "sharedlibrarycheck",
-    "systemd",
-    "systemprobechecks",  # used to include system-probe based checks in the agent build
-    "test",  # used for unit-tests
-    "trivy",
-    "wmi",
-    "zk",
-    "zlib",
-    "zstd",
-    "cel",
-    "cws_instrumentation_injector_only",  # used for building cws-instrumentation with only the injector code
-    "remove_all_sd",  # remove all discovery provider from prometheusreceiver components
-}.union(COMMON_TAGS)
+# Gazelle / "all tags" sets
+COMMON_TAGS = _data.COMMON_TAGS
+ALL_TAGS = _data.ALL_TAGS
+GAZELLE_EXTRA_TAGS = _data.GAZELLE_EXTRA_TAGS
+GAZELLE_OMIT_TAGS = _data.GAZELLE_OMIT_TAGS
+GAZELLE_BUILD_TAGS = _data.GAZELLE_BUILD_TAGS
 
-### Tag inclusion lists
+# Per-binary inclusion lists
+AGENT_TAGS = _data.AGENT_TAGS
+AGENT_HEROKU_TAGS = _data.AGENT_HEROKU_TAGS
+FIPS_TAGS = _data.FIPS_TAGS
+CLUSTER_AGENT_TAGS = _data.CLUSTER_AGENT_TAGS
+CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = _data.CLUSTER_AGENT_CLOUDFOUNDRY_TAGS
+DOGSTATSD_TAGS = _data.DOGSTATSD_TAGS
+IOT_AGENT_TAGS = _data.IOT_AGENT_TAGS
+INSTALLER_TAGS = _data.INSTALLER_TAGS
+PROCESS_AGENT_TAGS = _data.PROCESS_AGENT_TAGS
+PROCESS_AGENT_HEROKU_TAGS = _data.PROCESS_AGENT_HEROKU_TAGS
+SECURITY_AGENT_TAGS = _data.SECURITY_AGENT_TAGS
+SBOMGEN_TAGS = _data.SBOMGEN_TAGS
+SERVERLESS_TAGS = _data.SERVERLESS_TAGS
+SYSTEM_PROBE_TAGS = _data.SYSTEM_PROBE_TAGS
+TRACE_AGENT_TAGS = _data.TRACE_AGENT_TAGS
+TRACE_AGENT_HEROKU_TAGS = _data.TRACE_AGENT_HEROKU_TAGS
+CWS_INSTRUMENTATION_TAGS = _data.CWS_INSTRUMENTATION_TAGS
+OTEL_AGENT_TAGS = _data.OTEL_AGENT_TAGS
+LOADER_TAGS = _data.LOADER_TAGS
+HOST_PROFILER_TAGS = _data.HOST_PROFILER_TAGS
+PRIVATEACTIONRUNNER_TAGS = _data.PRIVATEACTIONRUNNER_TAGS
+SECRET_GENERIC_CONNECTOR_TAGS = _data.SECRET_GENERIC_CONNECTOR_TAGS
+AGENT_TEST_TAGS = _data.AGENT_TEST_TAGS
 
-# AGENT_TAGS lists the tags needed when building the agent.
-AGENT_TAGS = {
-    "consul",
-    "containerd",
-    "cri",
-    "datadog.no_waf",
-    "crio",
-    "docker",
-    "ec2",
-    "etcd",
-    "fargateprocess",
-    "jetson",
-    "jmx",
-    "kubeapiserver",
-    "kubelet",
-    "ncm",
-    "netcgo",
-    "nvml",
-    "oracle",
-    "orchestrator",
-    "otlp",
-    "podman",
-    "python",
-    "sharedlibrarycheck",
-    "systemd",
-    "systemprobechecks",
-    "trivy",
-    "zk",
-    "zlib",
-    "zstd",
-    "cel",
-}
-
-# AGENT_HEROKU_TAGS lists the tags for Heroku agent build
-AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
-    {
-        "containerd",
-        "cri",
-        "crio",
-        "docker",
-        "ec2",
-        "fargateprocess",
-        "jetson",
-        "kubeapiserver",
-        "kubelet",
-        "nvml",
-        "oracle",
-        "orchestrator",
-        "podman",
-        "systemd",
-        "trivy",
-        "cel",
-    }
-).union(
-    {
-        "bundle_installer",
-    }
-)
-
-FIPS_TAGS = {"goexperiment.systemcrypto", "requirefips"}
-
-# CLUSTER_AGENT_TAGS lists the tags needed when building the cluster-agent
-CLUSTER_AGENT_TAGS = {
-    "clusterchecks",
-    "datadog.no_waf",
-    "kubeapiserver",
-    "orchestrator",
-    "zlib",
-    "zstd",
-    "ec2",
-    "cel",
-}
-
-# CLUSTER_AGENT_CLOUDFOUNDRY_TAGS lists the tags needed when building the cloudfoundry cluster-agent
-CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = {"clusterchecks", "cel"}
-
-# DOGSTATSD_TAGS lists the tags needed when building dogstatsd
-DOGSTATSD_TAGS = {"containerd", "docker", "kubelet", "podman", "zlib", "zstd"}
-
-# IOT_AGENT_TAGS lists the tags needed when building the IoT agent
-IOT_AGENT_TAGS = {"jetson", "systemd", "zlib", "zstd"}
-
-# INSTALLER_TAGS lists the tags needed when building the installer
-INSTALLER_TAGS = {"ec2"}
-
-# PROCESS_AGENT_TAGS lists the tags necessary to build the process-agent
-PROCESS_AGENT_TAGS = {
-    "containerd",
-    "cri",
-    "crio",
-    "datadog.no_waf",
-    "ec2",
-    "docker",
-    "fargateprocess",
-    "kubelet",
-    "netcgo",
-    "podman",
-    "zlib",
-    "zstd",
-}
-
-# PROCESS_AGENT_HEROKU_TAGS lists the tags necessary to build the process-agent for Heroku
-PROCESS_AGENT_HEROKU_TAGS = {
-    "datadog.no_waf",
-    "fargateprocess",
-    "netcgo",
-    "zlib",
-    "zstd",
-}
-
-# SECURITY_AGENT_TAGS lists the tags necessary to build the security agent
-SECURITY_AGENT_TAGS = {
-    "netcgo",
-    "datadog.no_waf",
-    "docker",
-    "zlib",
-    "zstd",
-    "ec2",
-}
-
-# SBOMGEN_TAGS lists the tags necessary to build sbomgen
-SBOMGEN_TAGS = {
-    "trivy",
-    "containerd",
-    "docker",
-    "crio",
-}
-
-# SERVERLESS_TAGS lists the tags necessary to build serverless
-SERVERLESS_TAGS = {"serverless", "otlp"}
-
-# SYSTEM_PROBE_TAGS lists the tags necessary to build system-probe
-SYSTEM_PROBE_TAGS = {
-    "datadog.no_waf",
-    "ec2",
-    "linux_bpf",
-    "netcgo",
-    "npm",
-    "nvml",
-    "pcap",
-    "zlib",
-    "zstd",
-    "seclmax",
-}
-
-# TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
-TRACE_AGENT_TAGS = {
-    "docker",
-    "containerd",
-    "datadog.no_waf",
-    "kubelet",
-    "otlp",
-    "netcgo",
-    "podman",
-}
-
-# TRACE_AGENT_HEROKU_TAGS lists the tags necessary to build the trace-agent for Heroku
-TRACE_AGENT_HEROKU_TAGS = TRACE_AGENT_TAGS.difference(
-    {
-        "containerd",
-        "docker",
-        "kubeapiserver",
-        "kubelet",
-        "podman",
-    }
-)
-
-CWS_INSTRUMENTATION_TAGS = {"netgo", "osusergo"}
-
-OTEL_AGENT_TAGS = {"otlp", "zlib", "zstd", "kubelet"}
-
-LOADER_TAGS = set()
-
-# We need to remove all discovery provider from prometheusreceiver components to avoid loading too many dependencies in the host-profiler binary.
-# imported by https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/f963ab53ee55aeb56d58617ed12c840e8b07cc53/receiver/prometheusreceiver/factory.go#L10
-HOST_PROFILER_TAGS = {"remove_all_sd", "docker", "kubelet"}
-
-PRIVATEACTIONRUNNER_TAGS = set()
-
-SECRET_GENERIC_CONNECTOR_TAGS = set()
-
-# AGENT_TEST_TAGS lists the tags that have to be added to run tests
-AGENT_TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
-
-
-### Tag exclusion lists
-
-# List of tags to always remove when not building on Linux
-LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "nvml", "pcap", "podman", "trivy", "crio"}
-
-# List of tags to always remove when building on AIX
-AIX_EXCLUDED_TAGS = {
-    "cel",
-    "clusterchecks",
-    "containerd",
-    "cri",
-    "crio",
-    "docker",
-    "fargateprocess",
-    "jetson",
-    "jmx",
-    "kubeapiserver",
-    "kubelet",
-    "linux_bpf",
-    "netcgo",
-    "npm",
-    "nvml",
-    "orchestrator",
-    "pcap",
-    "podman",
-    "systemd",
-    "systemprobechecks",
-    "trivy",
-}
-
-# List of tags to always add when building on Windows
-WINDOWS_INCLUDED_TAGS = {"wmi"}
-
-# List of tags to always remove when building on Windows
-WINDOWS_EXCLUDED_TAGS = {
-    "requirefips",
-}
-
-# List of tags to always remove when building on Darwin/macOS
-DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "cri"}
-
-# Unit test build tags
-UNIT_TEST_TAGS = {"test"}
-
-# List of tags to always remove when running unit tests
-UNIT_TEST_EXCLUDED_TAGS = {"datadog.no_waf", "pcap"}
+# Exclusion lists
+LINUX_ONLY_TAGS = _data.LINUX_ONLY_TAGS
+AIX_EXCLUDED_TAGS = _data.AIX_EXCLUDED_TAGS
+WINDOWS_INCLUDED_TAGS = _data.WINDOWS_INCLUDED_TAGS
+WINDOWS_EXCLUDED_TAGS = _data.WINDOWS_EXCLUDED_TAGS
+DARWIN_EXCLUDED_TAGS = _data.DARWIN_EXCLUDED_TAGS
+UNIT_TEST_TAGS = _data.UNIT_TEST_TAGS
+UNIT_TEST_EXCLUDED_TAGS = _data.UNIT_TEST_EXCLUDED_TAGS
 
 # Build type: maps flavor to build tags map
 build_tags = {
@@ -389,6 +150,28 @@ build_tags = {
         "unit-tests": DOGSTATSD_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDED_TAGS),
     },
 }
+
+
+def build_tags_codegen_payload() -> dict[str, object]:
+    """Structured view of the tag data consumed by the codegen.
+
+    All list values are sorted and deduplicated so the generated JSON / .go
+    files are byte-stable.
+    """
+    return {
+        "common_tags": sorted(COMMON_TAGS),
+        "unit_test_tags": sorted(UNIT_TEST_TAGS),
+        "linux_only_tags": sorted(LINUX_ONLY_TAGS),
+        "windows_included_tags": sorted(WINDOWS_INCLUDED_TAGS),
+        "windows_excluded_tags": sorted(WINDOWS_EXCLUDED_TAGS),
+        "darwin_excluded_tags": sorted(DARWIN_EXCLUDED_TAGS),
+        "flavor_specific_tags": {
+            flavor.name: sorted(build_tags[flavor]["unit-tests"] - COMMON_TAGS - UNIT_TEST_TAGS)
+            for flavor in AgentFlavor
+            if "unit-tests" in build_tags.get(flavor, {})
+        },
+        "gazelle_build_tags": sorted(GAZELLE_BUILD_TAGS),
+    }
 
 
 _GOOS_TO_SYS_PLATFORM = {
@@ -589,3 +372,18 @@ def compute_config_build_tags(
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     use_tags = get_build_tags(build_include, build_exclude)
     return use_tags
+
+
+@task
+def codegen_to_json(_, output=""):
+    """Emit build-tag data as JSON.
+
+    Writes to --output= path if provided (so callers can sidestep stdout noise
+    from dda/rich's console init on Windows), otherwise prints to stdout.
+    """
+    text = json.dumps(build_tags_codegen_payload(), indent=2, sort_keys=True)
+    if output:
+        with open(output, "w") as f:
+            f.write(text)
+    else:
+        print(text)

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -297,6 +297,9 @@ AIX_EXCLUDED_TAGS = {
     "trivy",
 }
 
+# List of tags to always add when building on Windows
+WINDOWS_INCLUDED_TAGS = {"wmi"}
+
 # List of tags to always remove when building on Windows
 WINDOWS_EXCLUDED_TAGS = {
     "requirefips",
@@ -484,7 +487,7 @@ def filter_incompatible_tags(include, platform=None):
         exclude = exclude.union(LINUX_ONLY_TAGS)
 
     if platform == "win32":
-        include = include.union(["wmi"])
+        include = include.union(WINDOWS_INCLUDED_TAGS)
         exclude = exclude.union(WINDOWS_EXCLUDED_TAGS)
 
     if platform == "darwin":

--- a/tasks/unit_tests/build_tags_tests.py
+++ b/tasks/unit_tests/build_tags_tests.py
@@ -1,0 +1,85 @@
+import unittest
+
+from tasks import build_tags
+from tasks.build_tags import (
+    ALL_TAGS,
+    COMMON_TAGS,
+    GAZELLE_BUILD_TAGS,
+    GAZELLE_EXTRA_TAGS,
+    GAZELLE_OMIT_TAGS,
+    UNIT_TEST_TAGS,
+)
+
+
+def _payload():
+    return build_tags.build_tags_codegen_payload()
+
+
+class TestCodegenPayloadSchema(unittest.TestCase):
+    REQUIRED_KEYS = {
+        "common_tags",
+        "unit_test_tags",
+        "linux_only_tags",
+        "windows_included_tags",
+        "windows_excluded_tags",
+        "darwin_excluded_tags",
+        "flavor_specific_tags",
+        "gazelle_build_tags",
+    }
+
+    def test_required_keys_present(self):
+        self.assertEqual(set(_payload().keys()), self.REQUIRED_KEYS)
+
+    def test_top_level_lists_are_sorted_and_unique(self):
+        payload = _payload()
+        for key in self.REQUIRED_KEYS - {"flavor_specific_tags"}:
+            with self.subTest(key=key):
+                value = payload[key]
+                self.assertIsInstance(value, list)
+                self.assertEqual(value, sorted(value), f"{key} not sorted")
+                self.assertEqual(len(value), len(set(value)), f"{key} has duplicates")
+
+    def test_flavor_specific_tags_are_sorted_and_unique(self):
+        for flavor, tags in _payload()["flavor_specific_tags"].items():
+            with self.subTest(flavor=flavor):
+                self.assertIsInstance(tags, list)
+                self.assertEqual(tags, sorted(tags))
+                self.assertEqual(len(tags), len(set(tags)))
+
+
+class TestCodegenPayloadData(unittest.TestCase):
+    def test_fips_includes_goexperiment_systemcrypto(self):
+        self.assertIn("goexperiment.systemcrypto", _payload()["flavor_specific_tags"]["fips"])
+
+    def test_base_excludes_requirefips(self):
+        self.assertNotIn("requirefips", _payload()["flavor_specific_tags"]["base"])
+
+    def test_wmi_in_windows_included_not_in_linux_only(self):
+        payload = _payload()
+        self.assertIn("wmi", payload["windows_included_tags"])
+        self.assertNotIn("wmi", payload["linux_only_tags"])
+
+    def test_common_tags_disjoint_from_flavor_specific(self):
+        # The .bzl/.go consumers compose flavor tag sets as
+        # flavor_specific + common_tags + unit_test_tags; if common appears in
+        # the flavor-specific list too we'd emit duplicates.
+        payload = _payload()
+        common = set(payload["common_tags"])
+        for flavor, tags in payload["flavor_specific_tags"].items():
+            with self.subTest(flavor=flavor):
+                self.assertFalse(common & set(tags), f"{flavor} overlaps COMMON_TAGS")
+
+    def test_gazelle_build_tags_matches_drift_formula(self):
+        expected = sorted((ALL_TAGS - GAZELLE_OMIT_TAGS) | GAZELLE_EXTRA_TAGS)
+        self.assertEqual(_payload()["gazelle_build_tags"], expected)
+        self.assertEqual(sorted(GAZELLE_BUILD_TAGS), expected)
+
+    def test_unit_test_tags_payload_matches_constant(self):
+        self.assertEqual(_payload()["unit_test_tags"], sorted(UNIT_TEST_TAGS))
+
+    def test_common_tags_payload_matches_constant(self):
+        self.assertEqual(_payload()["common_tags"], sorted(COMMON_TAGS))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What does this PR do?

Wires the `//:gazelle` `build_tags` to the canonical Go build-tag data instead of the hand-curated `_GAZELLE_BUILD_TAGS` list duplicated in the root `BUILD.bazel`.

The tag data moves into `tasks/build_tags.bzl`, written in the common subset of Starlark and Python so one file serves both consumers:
- `//BUILD.bazel` `load()`s `GAZELLE_BUILD_TAGS` from it directly, and
- `tasks/build_tags.py` `exec`s it (via `SourceFileLoader`) and layers on the `AgentFlavor`-keyed `build_tags` mapping and the codegen payload, which can't live in Starlark (no enums).

`GAZELLE_BUILD_TAGS` is computed in the `.bzl` as `(ALL_TAGS - GAZELLE_OMIT_TAGS) | GAZELLE_EXTRA_TAGS`, so the test-only additions and cgo-incompatible removals are explicit constants rather than hand-maintained drift. Both consumers read the same file, so the two lists can't drift.

Folded-in cleanups in the tag data:
- Lifts `WINDOWS_INCLUDED_TAGS = {"wmi"}` out of the inline `include.union(["wmi"])`.
- Renames `*_EXCLUDE_TAGS` → `*_EXCLUDED_TAGS` for consistency with `DARWIN_EXCLUDED_TAGS`.

Also enables `zstd`/`zlib` for the Private Action Runner.

### Motivation

The Gazelle tag list in the root `BUILD.bazel` is a hand-maintained near-duplicate of `tasks/build_tags.py`'s `ALL_TAGS` — the same tags written twice, with deliberate drift (test-only additions, cgo-incompatible removals) and nothing keeping the two in sync. Starlark's `set` type (Bazel 8+) lets one file be the source of truth for both Bazel and Python, removing the duplication. It also lays the ground for a follow-up per-flavor PR that needs the same data in `.bzl` form.

### Describe how you validated your changes

- Build-tag unit tests (`tasks/unit_tests/build_tags_tests.py`) — 10/10 OK.
- `bazel query //:gazelle` — the `load()` resolves and the tag list reaches the gazelle runner.
- `bazel run //bazel/buildifier` — clean.
- `dda inv -- -e linter.python` — ruff/vulture/mypy green on the dynamic `.bzl` loader.
- `dda inv codegen-to-json` — Python-side inspection works.

### Additional Notes

- Preliminary work for https://github.com/DataDog/datadog-agent/pull/50355 v2.
