### PR TITLE
[FA] fix(rc): run agent task timeout monitor in background to unblock RC update loop

### DIFF
--- a/comp/remote-config/rcclient/impl/rcclient.go
+++ b/comp/remote-config/rcclient/impl/rcclient.go
@@ -491,19 +491,20 @@ func (rc *rcClient) agentTaskUpdateCallback(updates map[string]state.RawConfig, 
 		}(originalConfigPath, originalConfig)
 	}
 
-	// Check if one of the task reaches timeout
-	c := make(chan struct{})
+	// Check if one of the task reaches timeout in the background so we don't
+	// block the RC update loop. Other product callbacks (e.g. AGENT_CONFIG log
+	// level changes) must be able to fire while tasks are running.
 	go func() {
-		defer close(c)
-		wg.Wait()
+		c := make(chan struct{})
+		go func() {
+			defer close(c)
+			wg.Wait()
+		}()
+		select {
+		case <-c:
+			pkglog.Debugf("All %d agent tasks were applied successfully", len(updates))
+		case <-time.After(agentTaskTimeout):
+			pkglog.Warnf("Timeout of at least one agent task configuration")
+		}
 	}()
-	select {
-	case <-c:
-		// completed normally
-		pkglog.Debugf("All %d agent tasks were applied successfully", len(updates))
-		return
-	case <-time.After(agentTaskTimeout):
-		// timed out
-		pkglog.Warnf("Timeout of at least one agent task configuration")
-	}
 }


### PR DESCRIPTION
## Problem

When Fleet Automation sends both an `AGENT_CONFIG` update (e.g. `log_level: debug`) and an `AGENT_TASK` (e.g. flare) in the same RC polling cycle, the RC client's `update()` function iterates `c.listeners` — a `map[string][]Listener` — in non-deterministic order while holding `c.m`.

If Go's map iteration happened to put `AGENT_TASK` before `AGENT_CONFIG`, `agentTaskUpdateCallback` would **block the entire update loop** for the full duration of the flare (up to 5 minutes). `agentConfigUpdateCallback` — which changes the log level — was only called *after* the flare completed, so the debug log level was never applied during flare collection.

## Fix

Move the timeout-monitoring `select` into its own goroutine so `agentTaskUpdateCallback` returns immediately after spawning the task goroutines. The RC update loop can then proceed to call all other product callbacks (including `AGENT_CONFIG`) without waiting for tasks to finish.

All `applyStateCallback` calls already live inside the task goroutines, so no functional behaviour is lost.

## Test plan

- [ ] Verify existing RC client unit tests still pass: `dda inv test --targets=./comp/remote-config/...`
- [ ] Manual: trigger a fleet flare with `log_level: debug` and confirm the debug log level is applied before the flare begins collecting