### PR TITLE
[FA] fix(rc): skip empty log_level when merging AGENT_CONFIG layers

### DIFF
--- a/pkg/remoteconfig/state/agent_config.go
+++ b/pkg/remoteconfig/state/agent_config.go
@@ -139,9 +139,15 @@ func MergeRCAgentConfig(applyStatus func(cfgPath string, status ApplyStatus), up
 		return ConfigContent{}, fullErr
 	}
 
-	// Go through all the layers that were sent, and apply them one by one to the merged structure.
+	// Go through all the layers that were sent and apply them one by one to the merged structure.
+	// Priority: Order[0] > Order[1] > … (the loop is reversed so Order[0] is written last and wins).
+	// InternalOrder runs after Order, so InternalOrder[0] has the highest overall priority.
 	// Only overwrite a field when the layer provides a non-empty value; an absent or empty field
-	// means "this layer has no opinion" and must not clear a value set by a lower-priority layer.
+	// means "this layer has no opinion" and must not clear a value already set by a lower-priority
+	// layer. To reset a field entirely, the backend removes the config file rather than sending an
+	// explicit empty value.
+	// NOTE: every field in ConfigContent must follow the same non-empty guard pattern used for
+	// LogLevel below — omitting it for a new field reintroduces the same silent-overwrite bug.
 	mergedConfig := ConfigContent{}
 	for i := len(orderFile.Config.Order) - 1; i >= 0; i-- {
 		if layer, found := parsedLayers[orderFile.Config.Order[i]]; found {

--- a/pkg/remoteconfig/state/agent_config.go
+++ b/pkg/remoteconfig/state/agent_config.go
@@ -139,17 +139,23 @@ func MergeRCAgentConfig(applyStatus func(cfgPath string, status ApplyStatus), up
 		return ConfigContent{}, fullErr
 	}
 
-	// Go through all the layers that were sent, and apply them one by one to the merged structure
+	// Go through all the layers that were sent, and apply them one by one to the merged structure.
+	// Only overwrite a field when the layer provides a non-empty value; an absent or empty field
+	// means "this layer has no opinion" and must not clear a value set by a lower-priority layer.
 	mergedConfig := ConfigContent{}
 	for i := len(orderFile.Config.Order) - 1; i >= 0; i-- {
 		if layer, found := parsedLayers[orderFile.Config.Order[i]]; found {
-			mergedConfig.LogLevel = layer.Config.Config.LogLevel
+			if layer.Config.Config.LogLevel != "" {
+				mergedConfig.LogLevel = layer.Config.Config.LogLevel
+			}
 		}
 	}
 	// Same for internal config
 	for i := len(orderFile.Config.InternalOrder) - 1; i >= 0; i-- {
 		if layer, found := parsedLayers[orderFile.Config.InternalOrder[i]]; found {
-			mergedConfig.LogLevel = layer.Config.Config.LogLevel
+			if layer.Config.Config.LogLevel != "" {
+				mergedConfig.LogLevel = layer.Config.Config.LogLevel
+			}
 		}
 	}
 

--- a/pkg/remoteconfig/state/agent_config_test.go
+++ b/pkg/remoteconfig/state/agent_config_test.go
@@ -6,8 +6,10 @@
 package state
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeRCConfigWithEmptyData(t *testing.T) {
@@ -16,4 +18,83 @@ func TestMergeRCConfigWithEmptyData(t *testing.T) {
 	content, err := MergeRCAgentConfig(emptyUpdateStatus, make(map[string]RawConfig))
 	assert.NoError(t, err)
 	assert.Equal(t, ConfigContent{}, content)
+}
+
+// rawConfig builds a RawConfig with the given JSON body for use in merge tests.
+// pathName is the config ID segment (e.g. "configuration_order", "fleet_debug").
+func rawConfig(pathName, body string) (string, RawConfig) {
+	path := "datadog/1/AGENT_CONFIG/" + pathName + "/abc"
+	return path, RawConfig{Config: []byte(body)}
+}
+
+func TestMergeRCAgentConfig_LogLevelSet(t *testing.T) {
+	noopStatus := func(_ string, _ ApplyStatus) {}
+
+	orderPath, orderRaw := rawConfig("configuration_order", `{"order":["fleet_debug"],"internal_order":[]}`)
+	cfgPath, cfgRaw := rawConfig("fleet_debug", `{"name":"fleet_debug","config":{"log_level":"debug"}}`)
+
+	content, err := MergeRCAgentConfig(noopStatus, map[string]RawConfig{
+		orderPath: orderRaw,
+		cfgPath:   cfgRaw,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "debug", content.LogLevel)
+}
+
+// TestMergeRCAgentConfig_EmptyLayerDoesNotClearLogLevel is the regression test for
+// the fleet-flare log_level bug: when an Order or InternalOrder layer has no
+// log_level field, it must not overwrite a valid value supplied by another layer.
+func TestMergeRCAgentConfig_EmptyLayerDoesNotClearLogLevel(t *testing.T) {
+	noopStatus := func(_ string, _ ApplyStatus) {}
+
+	// Order: [base (no log_level), fleet_debug (log_level=debug)]
+	// With reverse iteration, Order[0]="base" is processed last and previously
+	// overwrote "debug" with "".
+	orderPath, orderRaw := rawConfig("configuration_order", `{"order":["base","fleet_debug"],"internal_order":[]}`)
+	basePath, baseRaw := rawConfig("base", `{"name":"base","config":{}}`)
+	cfgPath, cfgRaw := rawConfig("fleet_debug", `{"name":"fleet_debug","config":{"log_level":"debug"}}`)
+
+	content, err := MergeRCAgentConfig(noopStatus, map[string]RawConfig{
+		orderPath: orderRaw,
+		basePath:  baseRaw,
+		cfgPath:   cfgRaw,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "debug", content.LogLevel)
+}
+
+// TestMergeRCAgentConfig_InternalOrderDoesNotClearLogLevel is the regression test
+// for the second variant of the bug: an InternalOrder layer without log_level must
+// not clear a value set by the Order loop.
+func TestMergeRCAgentConfig_InternalOrderDoesNotClearLogLevel(t *testing.T) {
+	noopStatus := func(_ string, _ ApplyStatus) {}
+
+	orderPath, orderRaw := rawConfig("configuration_order", `{"order":["fleet_debug"],"internal_order":["internal_base"]}`)
+	cfgPath, cfgRaw := rawConfig("fleet_debug", `{"name":"fleet_debug","config":{"log_level":"debug"}}`)
+	internalPath, internalRaw := rawConfig("internal_base", `{"name":"internal_base","config":{}}`)
+
+	content, err := MergeRCAgentConfig(noopStatus, map[string]RawConfig{
+		orderPath:    orderRaw,
+		cfgPath:      cfgRaw,
+		internalPath: internalRaw,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "debug", content.LogLevel)
+}
+
+// TestMergeRCAgentConfig_ResetWhenNoLayerSetsLogLevel verifies that when all active
+// configs omit log_level, the merged result is empty — which triggers the "fall back
+// to previous source" path in agentConfigUpdateCallback.
+func TestMergeRCAgentConfig_ResetWhenNoLayerSetsLogLevel(t *testing.T) {
+	noopStatus := func(_ string, _ ApplyStatus) {}
+
+	orderPath, orderRaw := rawConfig("configuration_order", `{"order":["base"],"internal_order":[]}`)
+	basePath, baseRaw := rawConfig("base", `{"name":"base","config":{}}`)
+
+	content, err := MergeRCAgentConfig(noopStatus, map[string]RawConfig{
+		orderPath: orderRaw,
+		basePath:  baseRaw,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "", content.LogLevel)
 }

--- a/pkg/remoteconfig/state/agent_config_test.go
+++ b/pkg/remoteconfig/state/agent_config_test.go
@@ -98,3 +98,44 @@ func TestMergeRCAgentConfig_ResetWhenNoLayerSetsLogLevel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", content.LogLevel)
 }
+
+// TestMergeRCAgentConfig_OrderPriority verifies the priority semantics of the Order
+// array: Order[0] is highest priority (the loop is reversed, so index 0 is written
+// last and wins over all higher indices).
+func TestMergeRCAgentConfig_OrderPriority(t *testing.T) {
+	noopStatus := func(_ string, _ ApplyStatus) {}
+
+	// Order[0]="override" (highest priority, log_level=warn) should beat Order[1]="fleet_debug" (debug).
+	orderPath, orderRaw := rawConfig("configuration_order", `{"order":["override","fleet_debug"],"internal_order":[]}`)
+	overridePath, overrideRaw := rawConfig("override", `{"name":"override","config":{"log_level":"warn"}}`)
+	cfgPath, cfgRaw := rawConfig("fleet_debug", `{"name":"fleet_debug","config":{"log_level":"debug"}}`)
+
+	content, err := MergeRCAgentConfig(noopStatus, map[string]RawConfig{
+		orderPath:    orderRaw,
+		overridePath: overrideRaw,
+		cfgPath:      cfgRaw,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "warn", content.LogLevel)
+}
+
+// TestMergeRCAgentConfig_InternalOrderOverridesOrder verifies that a non-empty
+// InternalOrder layer wins over a non-empty Order layer, since the InternalOrder
+// loop runs after the Order loop and Order[0] is the last write.
+func TestMergeRCAgentConfig_InternalOrderOverridesOrder(t *testing.T) {
+	noopStatus := func(_ string, _ ApplyStatus) {}
+
+	orderPath, orderRaw := rawConfig("configuration_order",
+		`{"order":["fleet_debug"],"internal_order":["internal_override"]}`)
+	cfgPath, cfgRaw := rawConfig("fleet_debug", `{"name":"fleet_debug","config":{"log_level":"debug"}}`)
+	internalPath, internalRaw := rawConfig("internal_override",
+		`{"name":"internal_override","config":{"log_level":"trace"}}`)
+
+	content, err := MergeRCAgentConfig(noopStatus, map[string]RawConfig{
+		orderPath:    orderRaw,
+		cfgPath:      cfgRaw,
+		internalPath: internalRaw,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "trace", content.LogLevel)
+}


### PR DESCRIPTION
## Problem

`MergeRCAgentConfig` iterates config layers in reverse order and unconditionally assigns:
```go
mergedConfig.LogLevel = layer.Config.Config.LogLevel
```

A layer whose JSON config omits `log_level` unmarshals to an empty string `""`, which **silently overwrites a valid value** set by a higher-priority layer. This was observed in the fleet-flare investigation: the agent log showed `log_level: ''` even though the backend sent `log_level: debug`.

Two broken cases:

1. **Within `Order`**: `Order[0]` is highest priority (processed last in the reverse loop). If it's a base config with no `log_level`, it clears "debug" set by `Order[1]`.
2. **Across loops**: the `InternalOrder` loop runs unconditionally after `Order`. Any InternalOrder layer without `log_level` wipes the result from the Order loop.

In both cases `mergedConfig.LogLevel` comes back as `""`, triggering the early `return` in `agentConfigUpdateCallback` (`"nothing to do"`) and leaving the agent at its previous log level.

## Fix

Only update `mergedConfig.LogLevel` when the layer provides a non-empty value. A layer that omits `log_level` has no opinion and must not override one that does.

The reset path is preserved: when all active configs are removed, no layer contributes a non-empty value, so the merge returns `""`, which correctly triggers `UnsetForSource("log_level", SourceRC)` in `agentConfigUpdateCallback`.

## Test plan

- [ ] `go test ./pkg/remoteconfig/state/ -run TestMergeRC -v` — four new cases added
- [ ] Manual: fleet flare with `log_level: debug` + a base config active simultaneously