### PR TITLE
kmt_os: defer user_group resolution to call time

### DIFF
--- a/tasks/kernel_matrix_testing/kmt_os.py
+++ b/tasks/kernel_matrix_testing/kmt_os.py
@@ -35,7 +35,6 @@ def get_kmt_os():
 class Linux:
     kmt_dir = get_home_linux()
     name = "linux"
-    user_group = getpass.getuser()
     libvirt_group = "libvirt"
     rootfs_dir = kmt_dir / "rootfs"
     stacks_dir = kmt_dir / "stacks"
@@ -47,6 +46,13 @@ class Linux:
     config_path = kmt_dir / "config.json"
 
     qemu_conf = Path("/etc/libvirt/qemu.conf")
+
+    # Deferred so importing this module doesn't fail on Windows, where
+    # getpass.getuser() can fall back to `import pwd` if no user env var
+    # (USER/USERNAME/...) is set in the subprocess.
+    @classmethod
+    def user_group(cls):
+        return getpass.getuser()
 
     @staticmethod
     def flare(ctx: Context, flare_folder: Path):
@@ -60,7 +66,6 @@ class Linux:
 class MacOS:
     kmt_dir = get_home_macos()
     name = "macos"
-    user_group = "staff"
     libvirt_group = "staff"
     rootfs_dir = kmt_dir / "rootfs"
     stacks_dir = kmt_dir / "stacks"
@@ -73,6 +78,10 @@ class MacOS:
     virtlogd_conf = get_homebrew_prefix() / "etc/libvirt/virtlogd.conf"
     ddvm_rsa = kmt_dir / "ddvm_rsa"
     config_path = kmt_dir / "config.json"
+
+    @classmethod
+    def user_group(cls):
+        return "staff"
 
     @staticmethod
     def flare(ctx: Context, flare_folder: Path):

--- a/tasks/kernel_matrix_testing/setup/common.py
+++ b/tasks/kernel_matrix_testing/setup/common.py
@@ -225,7 +225,7 @@ class KMTDirectoriesRequirement(Requirement):
         ]
 
         user = getpass.getuser()
-        group = kmt_os.user_group
+        group = kmt_os.user_group()
 
         return check_directories(ctx, dirs, fix, user, group, 0o755)
 


### PR DESCRIPTION
### What does this PR do?

Converts `Linux.user_group` and `MacOS.user_group` from class-body attributes
to `@classmethod`s. Updates the single consumer at
`tasks/kernel_matrix_testing/setup/common.py:228` accordingly.

### Motivation

`Linux.user_group = getpass.getuser()` evaluates at import time. On Windows,
when no `USER` / `USERNAME` / `LOGNAME` / `LNAME` env var is set in the
subprocess (e.g. when a parent process doesn't propagate them), Python's
`getpass.getuser()` falls back to `import pwd` — which doesn't exist on
Windows — and raises `ModuleNotFoundError`.

This can occur when using `dda` from Bazel inside the Windows build container: the cascade `tasks/__init__.py` →
`tasks.ebpf` → `tasks.kmt` → `tasks.kernel_matrix_testing.kmt_os` hit the
class-body `getpass.getuser()` and crashed before any task could run.

See https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1697476875

Deferring the call to the first access makes `tasks/kernel_matrix_testing.kmt_os`
import-safe on Windows without changing the observed behavior on other platforms

### Describe how you validated your changes

- `dda inv print-default-build-tags --build=agent` still resolves and prints
  the same tag set (smoke test that the broader `tasks/__init__.py` chain
  imports cleanly). (tested in https://github.com/DataDog/datadog-agent/pull/51063)

### Additional Notes

