### PR TITLE
[oracle] document tablespaces.collection_interval in conf.yaml.example

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -231,8 +231,6 @@ instances:
 
       ## @param collection_interval - int - optional - default: 600
       ## The interval in seconds between tablespace usage collections.
-      ## Tablespace queries can be expensive on large databases; the default of 600s (10 minutes)
-      ## reduces overhead while keeping metrics reasonably fresh.
       #
       # collection_interval: 600
 

--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -229,6 +229,13 @@ instances:
       #
       # enabled: true
 
+      ## @param collection_interval - int - optional - default: 600
+      ## The interval in seconds between tablespace usage collections.
+      ## Tablespace queries can be expensive on large databases; the default of 600s (10 minutes)
+      ## reduces overhead while keeping metrics reasonably fresh.
+      #
+      # collection_interval: 600
+
     ## Configure collection of process memory usage
     #
     # processes:


### PR DESCRIPTION
## What does this PR do?

Documents the `tablespaces.collection_interval` configuration parameter (default: 600s) in the Oracle check's `conf.yaml.example`. The parameter existed in the Go config struct (`TablespacesConfig`) with a hardcoded default applied in the initializer, but was absent from the example config file.

## Motivation

Customer tuning monitor setup needed a documented collection interval.

## Changes

- `cmd/agent/dist/conf.d/oracle.d/conf.yaml.example`: adds `collection_interval` option under `tablespaces` with default 600.

## Validation

Diff-only change. Parameter is wired up in `pkg/collector/corechecks/oracle/config/config.go:280`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)