### PR TITLE
[ABLD-387] Bring `mockgen` under `bazel`

### DIFF
--- a/bazel/rules/go_mockgen/defs.bzl
+++ b/bazel/rules/go_mockgen/defs.bzl
@@ -1,0 +1,52 @@
+"""`gomock` source mode with a stable `// Source:` header.
+
+`@rules_go//extras:gomock` stages the source into a sandbox path that ends up in the generated `// Source:` header and
+therefore varies by CPU/compilation_mode, breaking reproducibility: this wrapper rewrites it to a repo-relative path.
+"""
+
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
+load("@rules_go//extras:gomock.bzl", "gomock")
+
+def _strip_sandbox_path_impl(ctx):
+    ctx.actions.expand_template(
+        output = ctx.outputs.out,
+        substitutions = {"{}/gopath/src/{}/".format(ctx.file.raw.dirname, ctx.attr.prefix): ""},
+        template = ctx.file.raw,
+    )
+
+_strip_sandbox_path = rule(
+    implementation = _strip_sandbox_path_impl,
+    attrs = {
+        "out": attr.output(),
+        "prefix": attr.string(),
+        "raw": attr.label(allow_single_file = True),
+    },
+)
+
+def _impl(name, importpath, out, prefix, src, visibility):
+    raw = "{}_raw".format(name)
+    gomock(
+        name = raw,
+        out = "{}.raw".format(out),
+        source = src,
+        source_importpath = importpath,
+    )
+    stripped = "{}_stripped".format(name)
+    _strip_sandbox_path(
+        name = stripped,
+        out = "{}.stripped".format(out),
+        prefix = prefix,
+        raw = ":{}".format(raw),
+    )
+    native.exports_files([out], visibility)
+    write_source_file(name = name, in_file = ":{}".format(stripped), out_file = out, check_that_out_file_exists = False)
+
+go_mockgen = macro(
+    implementation = _impl,
+    attrs = {
+        "importpath": attr.string(mandatory = True),
+        "out": attr.string(mandatory = True, configurable = False),
+        "prefix": attr.string(mandatory = True),
+        "src": attr.label(mandatory = True),
+    },
+)

--- a/pkg/proto/pbgo/mocks/core/BUILD.bazel
+++ b/pkg/proto/pbgo/mocks/core/BUILD.bazel
@@ -1,4 +1,26 @@
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go_mockgen:defs.bzl", "go_mockgen")
+
+filegroup(
+    name = "v1_go_proto_srcs",
+    srcs = ["//pkg/proto/datadog/api/v1:v1_go_proto"],
+    output_group = "go_generated_srcs",
+)
+
+select_file(
+    name = "api_grpc_pb_go",
+    srcs = ":v1_go_proto_srcs",
+    subpath = "api_grpc.pb.go",
+)
+
+go_mockgen(
+    name = "api_mockgen",
+    src = ":api_grpc_pb_go",
+    out = "api_mockgen.pb.go",
+    importpath = "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core",
+    prefix = "github.com/DataDog/datadog-agent",
+)
 
 go_library(
     name = "core",

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -141,7 +141,7 @@ class BazelTools:
 
     def __new__(cls, ctx):
         if not cls._paths:
-            labels = ("@com_github_golang_mock//mockgen", "@com_github_tinylib_msgp//:msgp", "@rules_go//go")
+            labels = ("@com_github_tinylib_msgp//:msgp", "@rules_go//go")
             bazel(ctx, "build", *labels)
             root = bazel(ctx, "info", "execution_root", capture_output=True).strip()
             for line in bazel(

--- a/tasks/protobuf.py
+++ b/tasks/protobuf.py
@@ -1,6 +1,5 @@
 import os
 import re
-from pathlib import Path
 
 from invoke import Exit, task
 
@@ -25,34 +24,18 @@ def generate(ctx, pre_commit=False):
     proto_root = os.path.join(repo_root, "pkg", "proto")
     pbgo_dir = os.path.join(proto_root, "pbgo")
 
-    with ctx.cd(repo_root):
-        # protobuf defs
-        print(f"generating protobuf code from: {proto_root}")
-        bazel(ctx, "run", "//pkg/proto/pbgo/core:write_pb_go")
-        bazel(ctx, "run", "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go")
-        bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
-        bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/actionsclient:write_pb_go")
-        bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/errorcode:write_pb_go")
-        bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/privateactions:write_pb_go")
-        bazel(ctx, "run", "//pkg/proto/pbgo/process:write_pb_go")
-        bazel(ctx, "run", "//pkg/proto/pbgo/sbom:write_pb_go")
-        bazel(ctx, "run", "//pkg/proto/pbgo/trace/idx:write_pb_go")
-        bazel(ctx, "run", "//pkg/proto/pbgo/trace:write_pb_go")
-
-        # Mockgen (not done in pre-commit as it is slow)
-        if not pre_commit:
-            mockgen_out = os.path.join(proto_root, "pbgo", "mocks")
-            pbgo_rel = Path(pbgo_dir).relative_to(repo_root).as_posix()
-            try:
-                os.mkdir(mockgen_out)
-            except FileExistsError:
-                print(f"{mockgen_out} folder already exists")
-
-            # Generate mocks from the gRPC file (api_grpc.pb.go) which contains the client/server interfaces
-            ctx.run(
-                f"{bt.mockgen} -source={pbgo_rel}/core/api_grpc.pb.go -destination={mockgen_out}/core/api_mockgen.pb.go",
-                env=bt.go_env,
-            )
+    print(f"generating protobuf code from: {proto_root}")
+    bazel(ctx, "run", "//pkg/proto/pbgo/core:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo/dogstatsdhttp:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo/languagedetection:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo/mocks/core:api_mockgen")
+    bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/actionsclient:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/errorcode:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo/privateactionrunner/privateactions:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo/process:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo/sbom:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo/trace:write_pb_go")
+    bazel(ctx, "run", "//pkg/proto/pbgo/trace/idx:write_pb_go")
 
     # Generate messagepack marshallers
     # msgp targets (file, io)


### PR DESCRIPTION
### What does this PR do?
Introduce a `go_mockgen` symbolic macro that wraps `@rules_go//extras:gomock` for **any Go source file**, and apply it to its first user in the repo, `pkg/proto/pbgo/mocks/core/api_mockgen.pb.go`, previously generated by a `mockgen` shell-out in `tasks/protobuf.py`.

`go_mockgen` is source-agnostic, where callers pass:
- `src`: any single-file label,
- `out`: destination filename in the source tree,
- `importpath`: Go importpath of `src`'s package,
- `prefix`: workspace's Go module prefix.

It chains three steps:
- `gomock`'s source mode produces a raw mock where `mockgen` records the sandbox-staged source path in the `// Source:` header, which varies by CPU/compilation_mode and would defeat reproducibility,
- a small private `_strip_sandbox_path` rule deletes the `<bin>/<pkg>/gopath/src/<prefix>/` prefix from the raw mock via `ctx.actions.expand_template`, leaving a workspace-relative path,
- `write_source_file` copies the stripped result back into the source tree and emits a `diff_test`.

The `pkg/proto/pbgo/mocks/core/BUILD.bazel` call extracts `api_grpc.pb.go` from `//pkg/proto/datadog/api/v1:v1_go_proto`'s `go_generated_srcs` output group via `filegroup` + `select_file`, then hands it to `go_mockgen`.

Because the mock pulls from the in-`bazel` output rather than from the committed `api_grpc.pb.go` copy, the order of `bazel run` lines in `tasks/protobuf.py` doesn't matter.

`tasks/protobuf.py` drops the `mockgen` shell-out, the `from pathlib import Path` import (only used there), the `if not pre_commit:` gate that worked around pre-commit slowness (`bazel` caches make it cheap), and the `with ctx.cd(repo_root):` wrapper that only existed to anchor `mockgen -source=<workspace-rel>` (`bazel` doesn't depend on CWD). `BazelTools` similarly sheds the now-orphan `@com_github_golang_mock//mockgen` label.

### Motivation
Bring `mockgen` code generator under `bazel`'s diff-test umbrella, by way of a generic `go_mockgen` macro that any future caller can reuse for any Go interface they want mocked.

### Describe how you validated your changes
- `bazel test //pkg/proto/pbgo/mocks/core:api_mockgen_test` passes (regenerated output is byte-equal to the committed file),
- `bazel run //:gazelle` leaves the hand-wired rules alone,
- `dda inv linter.python` is clean,
- `dda inv protobuf.generate` is a no-op on a clean tree.