### PR TITLE
docs: add AIX changelog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,10 +39,10 @@
 
 /CHANGELOG.rst                          @DataDog/agent-delivery
 /CHANGELOG-DCA.rst                      @DataDog/container-integrations @DataDog/container-platform
-/CHANGELOG-AIX.md                       @DataDog/agent-runtimes
 /CHANGELOG-INSTALLSCRIPT.rst            @DataDog/agent-delivery
 
 /*.md                                   @DataDog/agent-devx
+/CHANGELOG-AIX.md                       @DataDog/agent-runtimes
 /NOTICE                                 @DataDog/agent-delivery
 
 /LICENSE*                               # do not notify anyone

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,6 +39,7 @@
 
 /CHANGELOG.rst                          @DataDog/agent-delivery
 /CHANGELOG-DCA.rst                      @DataDog/container-integrations @DataDog/container-platform
+/CHANGELOG-AIX.md                       @DataDog/agent-runtimes
 /CHANGELOG-INSTALLSCRIPT.rst            @DataDog/agent-delivery
 
 /*.md                                   @DataDog/agent-devx

--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -1,0 +1,18 @@
+# AIX Changelog
+
+<!-- This file tracks changes to the Datadog Agent on AIX.
+     It is maintained manually until AIX is officially supported and released
+     through the same process as other platforms, at which point it will be
+     replaced by the standard release notes mechanism. Each PR that affects
+     AIX should add an entry to the current (unreleased) section below. -->
+
+## Unreleased
+
+- Initial AIX packaging pipeline supporting AIX 7.3 (ppc64)
+- Agent binary, trace-agent, and process-agent built from source on AIX 7.3
+- Embedded Python 3.13 with pip, supporting Go and Python checks
+- Bundled integrations: `lparstats` (LPAR performance metrics)
+- IBM integrations available: `ibm_ace`, `ibm_db2`, `ibm_i`, `ibm_mq`, `ibm_spectrum_lsf`, `ibm_was`
+- installp (BFF) packaging with pre/post install scripts, service management via SRC
+- Static linking of libstdc++ in rtloader for compatibility with AIX 7.2+
+- jellyfish Python package built from source using the IBM Rust SDK

--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -8,11 +8,9 @@
 
 ## Unreleased
 
-- Initial AIX packaging pipeline supporting AIX 7.3 (ppc64)
-- Agent binary, trace-agent, and process-agent built from source on AIX 7.3
-- Embedded Python 3.13 with pip, supporting Go and Python checks
-- Bundled integrations: `lparstats` (LPAR performance metrics)
-- IBM integrations available: `ibm_ace`, `ibm_db2`, `ibm_i`, `ibm_mq`, `ibm_spectrum_lsf`, `ibm_was`
-- installp (BFF) packaging with pre/post install scripts, service management via SRC
-- Static linking of libstdc++ in rtloader for compatibility with AIX 7.2+
-- jellyfish Python package built from source using the IBM Rust SDK
+<!-- Add entries here for changes not yet in a release. -->
+
+---
+
+> **Note:** `datadog-agent-7.80.0-devel.git.446.66c9b62-18.aix.ppc64.bff` and all older builds
+> predate this changelog and do not have entries.


### PR DESCRIPTION
### What does this PR do?
Adds `CHANGELOG-AIX.md` at the repo root with an initial unreleased section, and sets `@DataDog/agent-runtimes` as CODEOWNERS.

### Motivation
AIX is not yet officially supported and does not go through the standard release process. This file tracks AIX-specific changes per release until it does.

### Describe how you validated your changes
N/A, documentation only.

### Additional Notes
