### PR TITLE
[EBPF] gpu: simplify nvlink management in the spec

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1482,7 +1482,6 @@ workflow:
 
 .on_gpu_integration_tests:
   - !reference [.on_scheduled_main]
-  - !reference [.manual]
   # Run on GPU-related changes
   - changes:
       paths:
@@ -1492,6 +1491,7 @@ workflow:
         - .gitlab/build/source_test/linux.yml
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
+  - !reference [.manual]
 
 .on_installer_systemd_changes:
   - <<: *if_main_branch

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -958,7 +958,7 @@ func TestMetricsFollowSpec(t *testing.T) {
 		testName := fmt.Sprintf("arch=%s/mode=%s", config.Architecture, config.DeviceMode)
 		t.Run(testName, func(t *testing.T) {
 			archSpec := specs.Architectures.Architectures[config.Architecture]
-			emittedMetrics, knownTagValues := collectMetricSamples(t, config, archSpec)
+			emittedMetrics, knownTagValues := collectMetricSamples(t, config, specs.Architectures, archSpec)
 			validationOptions := gpuspec.ValidationOptions{
 				WorkloadActive: true,
 			}
@@ -970,10 +970,10 @@ func TestMetricsFollowSpec(t *testing.T) {
 // collectMetricSamples runs the GPU check with a capability-driven mock
 // for the given architecture and device mode, then returns emitted metrics (without "gpu." prefix)
 // and their tags.
-func collectMetricSamples(t *testing.T, config gpuspec.GPUConfig, archSpec gpuspec.ArchitectureSpec) (map[string][]gpuspec.MetricObservation, map[string]string) {
+func collectMetricSamples(t *testing.T, config gpuspec.GPUConfig, archSpecs *gpuspec.ArchitecturesSpec, archSpec gpuspec.ArchitectureSpec) (map[string][]gpuspec.MetricObservation, map[string]string) {
 	t.Helper()
 
-	collectionSetup := setupMockCheckForMetricCollection(t, config, archSpec)
+	collectionSetup := setupMockCheckForMetricCollection(t, config, archSpecs, archSpec)
 	collectionSetup.runCollection()
 
 	return GetEmittedGPUMetrics(collectionSetup.mockSender), collectionSetup.knownTagValues
@@ -1007,9 +1007,9 @@ func seedContainersForPIDMapping(wmeta workloadmetamock.Mock, fakeTagger taggerm
 	}
 }
 
-func setupMockCheckForMetricCollection(t *testing.T, config gpuspec.GPUConfig, archSpec gpuspec.ArchitectureSpec) metricCollectionSetup {
+func setupMockCheckForMetricCollection(t *testing.T, config gpuspec.GPUConfig, archSpecs *gpuspec.ArchitecturesSpec, archSpec gpuspec.ArchitectureSpec) metricCollectionSetup {
 	t.Helper()
-	opts := gpuspec.BuildMockOptionsForConfig(t, config, archSpec)
+	opts := gpuspec.BuildMockOptionsForConfig(t, config, archSpecs, archSpec)
 
 	senderManager := mocksender.CreateDefaultDemultiplexer()
 	mockSender := mocksender.NewMockSenderWithSenderManager("gpu", senderManager)

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -8,6 +8,7 @@
 package gpu
 
 import (
+	"encoding/binary"
 	"fmt"
 	"slices"
 	"strconv"
@@ -43,6 +44,23 @@ import (
 	ddmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
 	mock_containers "github.com/DataDog/datadog-agent/pkg/process/util/containers/mocks"
 )
+
+func mockNVLinkLinkCount(count uint64) func(*nvmlmock.Device) {
+	return func(d *nvmlmock.Device) {
+		getFieldValues := d.GetFieldValuesFunc
+		d.GetFieldValuesFunc = func(values []nvml.FieldValue) nvml.Return {
+			ret := getFieldValues(values)
+			for i := range values {
+				if values[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
+					values[i].NvmlReturn = uint32(nvml.SUCCESS)
+					values[i].ValueType = uint32(nvml.VALUE_TYPE_UNSIGNED_LONG_LONG)
+					binary.LittleEndian.PutUint64(values[i].Value[:], count)
+				}
+			}
+			return ret
+		}
+	}
+}
 
 func newMockContainerProvider(t *testing.T, pidToContainerID map[int]string) *mock_containers.MockContainerProvider {
 	t.Helper()
@@ -323,7 +341,7 @@ func TestCollectorsOnDeviceChanges(t *testing.T) {
 		testutil.WithProcessInfoCallback(func(_ string) ([]nvml.ProcessInfo, nvml.Return) {
 			return nil, nvml.SUCCESS // disable process info, we don't want to mock that part here
 		}),
-		testutil.WithCapabilities(testutil.Capabilities{GPM: true}),
+		testutil.WithCapabilities(testutil.Capabilities{GPM: true, NvLinkGenerationSupported: 6, NvLinkLinkCount: 2}),
 		testutil.WithMIGDisabled(),
 		testutil.WithArchitecture("blackwell"),
 	)
@@ -406,7 +424,7 @@ func TestCollectorsOnMIGDeviceChanges(t *testing.T) {
 			if index >= int(curMIGChildCount.Load()) {
 				return nil, nvml.ERROR_NOT_FOUND
 			}
-			return testutil.GetMIGDeviceMock(deviceIdx, index, testutil.WithMockAllDeviceFunctions()), nvml.SUCCESS
+			return testutil.GetMIGDeviceMock(deviceIdx, index, testutil.WithMockAllDeviceFunctions(), mockNVLinkLinkCount(2)), nvml.SUCCESS
 		}
 		d.GpmMigSampleGetFunc = func(_ int, _ nvml.GpmSample) nvml.Return {
 			return nvml.SUCCESS
@@ -414,6 +432,7 @@ func TestCollectorsOnMIGDeviceChanges(t *testing.T) {
 		d.GpmSampleGetFunc = func(_ nvml.GpmSample) nvml.Return {
 			return nvml.SUCCESS
 		}
+		mockNVLinkLinkCount(2)(d)
 	})
 
 	// Setup NVML mock with single parent device
@@ -422,7 +441,7 @@ func TestCollectorsOnMIGDeviceChanges(t *testing.T) {
 		testutil.WithProcessInfoCallback(func(_ string) ([]nvml.ProcessInfo, nvml.Return) {
 			return nil, nvml.SUCCESS
 		}),
-		testutil.WithCapabilities(testutil.Capabilities{GPM: true}),
+		testutil.WithCapabilities(testutil.Capabilities{GPM: true, NvLinkGenerationSupported: 6, NvLinkLinkCount: 2}),
 		testutil.WithArchitecture("blackwell"),
 	)
 	nvmlMock.DeviceGetCountFunc = func() (int, nvml.Return) { return 1, nvml.SUCCESS }

--- a/pkg/collector/corechecks/gpu/integrationtests/check_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/check_test.go
@@ -137,8 +137,8 @@ func TestCheckRunMatchesSpecForPhysicalDevices(t *testing.T) {
 
 		capabilities := archSpec.EffectiveCapabilities(gpuspec.DeviceModePhysical)
 		capabilities.NVLink = archSpec.SupportedNVLinkGeneration()
-		nvlinkLinkCount := linkCount(t, device, nvidia.GetNVLinkCount)
-		if linkCount(t, device, nvidia.GetC2CLinkCount) == 0 {
+		nvlinkLinkCount := linkCount(t, device, "NVLink", nvidia.GetNVLinkCount)
+		if linkCount(t, device, "C2C", nvidia.GetC2CLinkCount) == 0 {
 			capabilities.C2C = false
 		}
 		gpuConfig := gpuspec.GPUConfig{Architecture: archName, DeviceMode: gpuspec.DeviceModePhysical, Capabilities: capabilities, NVLinkLinkCount: nvlinkLinkCount}
@@ -151,11 +151,15 @@ func TestCheckRunMatchesSpecForPhysicalDevices(t *testing.T) {
 	}
 }
 
-func linkCount(t *testing.T, device safenvml.Device, countFunc func(safenvml.Device) (int, error)) int {
+func linkCount(t *testing.T, device safenvml.Device, name string, countFunc func(safenvml.Device) (int, error)) int {
 	t.Helper()
 
 	count, err := countFunc(device)
 	if err != nil {
+		if safenvml.IsAPIUnsupportedOnDevice(err, device) {
+			return 0
+		}
+		require.NoError(t, err, "%s link count probe failed for GPU %s", name, device.GetDeviceInfo().UUID)
 		return 0
 	}
 	return count

--- a/pkg/collector/corechecks/gpu/integrationtests/check_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/check_test.go
@@ -18,6 +18,7 @@ import (
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/nvidia"
 	gpuspec "github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/spec"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
@@ -134,7 +135,13 @@ func TestCheckRunMatchesSpecForPhysicalDevices(t *testing.T) {
 		deviceMetrics := metricsByUUID[deviceUUID]
 		require.NotEmpty(t, deviceMetrics, "expected emitted metrics for GPU %s", deviceUUID)
 
-		gpuConfig := gpuspec.GPUConfig{Architecture: archName, DeviceMode: gpuspec.DeviceModePhysical}
+		capabilities := archSpec.EffectiveCapabilities(gpuspec.DeviceModePhysical)
+		capabilities.NVLink = archSpec.SupportedNVLinkGeneration()
+		nvlinkLinkCount := linkCount(t, device, nvidia.GetNVLinkCount)
+		if linkCount(t, device, nvidia.GetC2CLinkCount) == 0 {
+			capabilities.C2C = false
+		}
+		gpuConfig := gpuspec.GPUConfig{Architecture: archName, DeviceMode: gpuspec.DeviceModePhysical, Capabilities: capabilities, NVLinkLinkCount: nvlinkLinkCount}
 		validationOptions := gpuspec.ValidationOptions{
 			WorkloadActive: false,
 		}
@@ -142,4 +149,14 @@ func TestCheckRunMatchesSpecForPhysicalDevices(t *testing.T) {
 			gpu.ValidateEmittedMetricsAgainstSpec(t, specs, gpuConfig, deviceMetrics, nil, validationOptions)
 		})
 	}
+}
+
+func linkCount(t *testing.T, device safenvml.Device, countFunc func(safenvml.Device) (int, error)) int {
+	t.Helper()
+
+	count, err := countFunc(device)
+	if err != nil {
+		return 0
+	}
+	return count
 }

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -142,7 +142,7 @@ func TestAllCollectorsWork(t *testing.T) {
 
 	nvmlMock := testutil.GetBasicNvmlMockWithOptions(
 		testutil.WithMIGDisabled(),
-		testutil.WithCapabilities(testutil.Capabilities{GPM: true}),
+		testutil.WithCapabilities(testutil.Capabilities{GPM: true, NvLinkGenerationSupported: 6, NvLinkLinkCount: 2}),
 		testutil.WithMockAllFunctions(),
 		testutil.WithArchitecture("blackwell")) // Ensure all functions are marked as supported
 
@@ -244,7 +244,7 @@ func TestDisabledCollectors(t *testing.T) {
 			nvmlMock := testutil.GetBasicNvmlMockWithOptions(
 				testutil.WithDeviceCount(1),
 				testutil.WithMIGDisabled(),
-				testutil.WithCapabilities(testutil.Capabilities{GPM: true}),
+				testutil.WithCapabilities(testutil.Capabilities{GPM: true, NvLinkGenerationSupported: 6, NvLinkLinkCount: 2}),
 				testutil.WithMockAllFunctions(),
 				testutil.WithArchitecture("blackwell"),
 			)

--- a/pkg/collector/corechecks/gpu/nvidia/helpers.go
+++ b/pkg/collector/corechecks/gpu/nvidia/helpers.go
@@ -215,22 +215,34 @@ func RemoveDuplicateMetrics(allMetrics map[CollectorName][]*Metric) []*Metric {
 	return result
 }
 
-// getNVLinkCount returns the number of NVLink ports on the device
-func getNVLinkCount(device ddnvml.Device) (int, error) {
+func fieldValueForField(device ddnvml.Device, fieldID uint32, fieldName string) (int, error) {
 	fields := []nvml.FieldValue{{
-		FieldId: nvml.FI_DEV_NVLINK_LINK_COUNT,
+		FieldId: fieldID,
 		ScopeId: 0,
 	}}
 
 	if err := device.GetFieldValues(fields); err != nil {
-		return 0, fmt.Errorf("get NVLink link count: %w", err)
+		return 0, fmt.Errorf("get %s: %w", fieldName, err)
+	}
+	if ret := nvml.Return(fields[0].NvmlReturn); ret != nvml.SUCCESS {
+		return 0, ddnvml.NewNvmlAPIErrorOrNil(fmt.Sprintf("GetFieldValues(%s)", fieldName), ret)
 	}
 
-	totalPorts, err := fieldValueToNumber[int](nvml.ValueType(fields[0].ValueType), fields[0].Value)
+	value, err := fieldValueToNumber[int](nvml.ValueType(fields[0].ValueType), fields[0].Value)
 	if err != nil {
-		return 0, fmt.Errorf("convert NVLink link count: %w", err)
+		return 0, fmt.Errorf("convert %s: %w", fieldName, err)
 	}
-	return totalPorts, nil
+	return value, nil
+}
+
+// GetNVLinkCount returns the number of NVLink ports on the device.
+func GetNVLinkCount(device ddnvml.Device) (int, error) {
+	return fieldValueForField(device, nvml.FI_DEV_NVLINK_LINK_COUNT, "FI_DEV_NVLINK_LINK_COUNT")
+}
+
+// GetC2CLinkCount returns the number of C2C links on the device.
+func GetC2CLinkCount(device ddnvml.Device) (int, error) {
+	return fieldValueForField(device, nvml.FI_DEV_C2C_LINK_COUNT, "FI_DEV_C2C_LINK_COUNT")
 }
 
 func nvlinkPortTag(port int) string {
@@ -243,7 +255,7 @@ func portIsAlwaysSupported(_ int) ([]*Metric, error) {
 }
 
 func getSupportedNvlinkPorts(device ddnvml.Device, metricCollector func(int) ([]*Metric, error)) ([]int, error) {
-	totalPorts, err := getNVLinkCount(device)
+	totalPorts, err := GetNVLinkCount(device)
 	if err != nil {
 		if ddnvml.IsAPIUnsupportedOnDevice(err, device) {
 			return nil, fmt.Errorf("%w: get NVLink link count: %w", errUnsupportedDevice, err)

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -23,7 +23,7 @@ import (
 
 // nvlinkSample handles NVLink metrics collection logic
 func nvlinkSample(device ddnvml.Device) ([]Metric, uint64, error) {
-	totalNVLinks, err := getNVLinkCount(device)
+	totalNVLinks, err := GetNVLinkCount(device)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get nvlink count: %w", err)
 	}

--- a/pkg/collector/corechecks/gpu/spec/README.md
+++ b/pkg/collector/corechecks/gpu/spec/README.md
@@ -2,8 +2,8 @@
 
 This directory contains the GPU corecheck specification files:
 
-- `gpu_metrics.yaml`: metric catalog (metric names, required tagsets/custom tags, and support matrix by architecture/device mode).
-- `architectures.yaml`: architecture capabilities (GPM support, unsupported NVML fields by mode, and unsupported device modes such as `mig`/`vgpu`).
+- `gpu_metrics.yaml`: metric catalog (metric names, required tagsets/custom tags, and support matrix by architecture/device mode/capability).
+- `architectures.yaml`: architecture capabilities (GPM, NVLink generation, C2C support, unsupported NVML fields by mode, and unsupported device modes such as `mig`/`vgpu`).
 - `tags.yaml`: reusable tag definitions (`tags`) and reusable tag groups (`tagsets`), including workload-only tagsets and regex validation for tag values.
 
 Each YAML file has headers describing the schema.

--- a/pkg/collector/corechecks/gpu/spec/architectures.yaml
+++ b/pkg/collector/corechecks/gpu/spec/architectures.yaml
@@ -87,16 +87,10 @@ architectures:
             - FI_DEV_PERF_POLICY_THERMAL
     support:
       - device_modes: [physical]
-        capabilities:
-          gpm: false
-          nvlink: 1
-          c2c: false
         unsupported_fields: []
       - device_modes: [mig, vgpu]
         capabilities:
-          gpm: false
           nvlink: 0
-          c2c: false
         unsupported_fields: []
     unsupported_device_modes:
       - mig
@@ -115,16 +109,10 @@ architectures:
             - FI_DEV_PERF_POLICY_THERMAL
     support:
       - device_modes: [physical]
-        capabilities:
-          gpm: false
-          nvlink: 2
-          c2c: false
         unsupported_fields: []
       - device_modes: [mig, vgpu]
         capabilities:
-          gpm: false
           nvlink: 0
-          c2c: false
         unsupported_fields: []
     unsupported_device_modes:
       - mig
@@ -143,16 +131,10 @@ architectures:
             - FI_DEV_PERF_POLICY_THERMAL
     support:
       - device_modes: [physical]
-        capabilities:
-          gpm: false
-          nvlink: 2
-          c2c: false
         unsupported_fields: []
       - device_modes: [mig, vgpu]
         capabilities:
-          gpm: false
           nvlink: 0
-          c2c: false
         unsupported_fields: []
     unsupported_device_modes:
       - mig
@@ -169,16 +151,10 @@ architectures:
             - FI_DEV_PERF_POLICY_THERMAL
     support:
       - device_modes: [physical]
-        capabilities:
-          gpm: false
-          nvlink: 3
-          c2c: false
         unsupported_fields: []
       - device_modes: [mig, vgpu]
         capabilities:
-          gpm: false
           nvlink: 0
-          c2c: false
         unsupported_fields: []
     unsupported_device_modes: []
   hopper:
@@ -194,14 +170,9 @@ architectures:
             - FI_DEV_PERF_POLICY_THERMAL
     support:
       - device_modes: [physical]
-        capabilities:
-          gpm: true
-          nvlink: 4
-          c2c: true
         unsupported_fields: []
       - device_modes: [mig]
         capabilities:
-          gpm: true
           nvlink: 0
           c2c: false
         unsupported_fields: []
@@ -227,16 +198,8 @@ architectures:
             - FI_DEV_PERF_POLICY_THERMAL
     support:
       - device_modes: [physical]
-        capabilities:
-          gpm: false
-          nvlink: 0
-          c2c: false
         unsupported_fields: []
       - device_modes: [mig, vgpu]
-        capabilities:
-          gpm: false
-          nvlink: 0
-          c2c: false
         unsupported_fields: []
     unsupported_device_modes:
       - mig
@@ -253,14 +216,9 @@ architectures:
             - FI_DEV_PERF_POLICY_THERMAL
     support:
       - device_modes: [physical]
-        capabilities:
-          gpm: true
-          nvlink: 5
-          c2c: true
         unsupported_fields: []
       - device_modes: [mig]
         capabilities:
-          gpm: true
           nvlink: 0
           c2c: false
         unsupported_fields: []

--- a/pkg/collector/corechecks/gpu/spec/architectures.yaml
+++ b/pkg/collector/corechecks/gpu/spec/architectures.yaml
@@ -407,9 +407,6 @@ architectures:
             - FI_DEV_NVLINK_COUNT_FEC_HISTORY_13
             - FI_DEV_NVLINK_COUNT_FEC_HISTORY_14
             - FI_DEV_NVLINK_COUNT_FEC_HISTORY_15
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
             - FI_DEV_NVLINK_COUNT_XMIT_PACKETS
             - FI_DEV_NVLINK_COUNT_RCV_PACKETS
             - FI_DEV_NVLINK_COUNT_XMIT_DISCARDS
@@ -442,9 +439,6 @@ architectures:
             - FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL
             - FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL
             - FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
     support:
       - device_modes: [physical]
         capabilities:
@@ -452,7 +446,13 @@ architectures:
           nvlink: 4
           c2c: true
         unsupported_fields: []
-      - device_modes: [mig, vgpu]
+      - device_modes: [mig]
+        capabilities:
+          gpm: true
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
+      - device_modes: [vgpu]
         capabilities:
           gpm: false
           nvlink: 0
@@ -547,9 +547,6 @@ architectures:
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
         - device_modes: [vgpu, mig]
           fields:
             - FI_DEV_NVLINK_COUNT_FEC_HISTORY_0
@@ -605,7 +602,13 @@ architectures:
           nvlink: 5
           c2c: true
         unsupported_fields: []
-      - device_modes: [mig, vgpu]
+      - device_modes: [mig]
+        capabilities:
+          gpm: true
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
+      - device_modes: [vgpu]
         capabilities:
           gpm: false
           nvlink: 0

--- a/pkg/collector/corechecks/gpu/spec/architectures.yaml
+++ b/pkg/collector/corechecks/gpu/spec/architectures.yaml
@@ -7,10 +7,72 @@
 #       - device_modes: [physical|mig|vgpu, ...]  (in which modes the fields are unsupported, for example some fields are not supported in vGPU mode. If not included, the fields are unsupported in all modes.)
 #       - fields: [<field_id>, ...] (the list of field IDs that are unsupported in the given modes. Check nvmlFieldNameToFieldID in spec_test.go for the mapping.)
 #   - unsupported_device_modes: [mig|physical|vgpu, ...] (the list of device modes that are unsupported on the architecture. For example, MIG is not supported on the Pascal architecture.)
+nvlink_generations:
+  1:
+    supported_fields:
+      - FI_DEV_NVLINK_LINK_COUNT
+      - FI_DEV_NVLINK_SPEED_MBPS_COMMON
+      - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
+      - FI_DEV_NVLINK_THROUGHPUT_DATA_TX
+      - FI_DEV_NVLINK_THROUGHPUT_RAW_RX
+      - FI_DEV_NVLINK_THROUGHPUT_RAW_TX
+      - FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL
+      - FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL
+      - FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL
+      - FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL
+      - FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL
+  2:
+    supported_fields: []
+  3:
+    supported_fields:
+      - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
+  4:
+    supported_fields: []
+  5:
+    supported_fields:
+      - FI_DEV_NVLINK_GET_SPEED
+      - FI_DEV_NVLINK_COUNT_EFFECTIVE_BER
+      - FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_0
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_1
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_2
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_3
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_4
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_5
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_6
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_7
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_8
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_9
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_10
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_11
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_12
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_13
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_14
+      - FI_DEV_NVLINK_COUNT_FEC_HISTORY_15
+      - FI_DEV_NVLINK_COUNT_SYMBOL_BER
+      - FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS
+      - FI_DEV_NVLINK_COUNT_XMIT_PACKETS
+      - FI_DEV_NVLINK_COUNT_RCV_PACKETS
+      - FI_DEV_NVLINK_COUNT_XMIT_DISCARDS
+      - FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS
+      - FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS
+      - FI_DEV_NVLINK_COUNT_RCV_ERRORS
+      - FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS
+      - FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS
+      - FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS
+      - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS
+      - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS
+c2c:
+  supported_fields:
+    - FI_DEV_C2C_LINK_ERROR_INTR
+    - FI_DEV_C2C_LINK_ERROR_REPLAY
+    - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
 architectures:
   pascal:
     capabilities:
       gpm: false
+      nvlink: 1
+      c2c: false
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
@@ -70,11 +132,26 @@ architectures:
             - FI_DEV_C2C_LINK_ERROR_INTR
             - FI_DEV_C2C_LINK_ERROR_REPLAY
             - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
+    support:
+      - device_modes: [physical]
+        capabilities:
+          gpm: false
+          nvlink: 1
+          c2c: false
+        unsupported_fields: []
+      - device_modes: [mig, vgpu]
+        capabilities:
+          gpm: false
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
     unsupported_device_modes:
       - mig
   volta:
     capabilities:
       gpm: false
+      nvlink: 2
+      c2c: false
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
@@ -134,11 +211,26 @@ architectures:
             - FI_DEV_C2C_LINK_ERROR_INTR
             - FI_DEV_C2C_LINK_ERROR_REPLAY
             - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
+    support:
+      - device_modes: [physical]
+        capabilities:
+          gpm: false
+          nvlink: 2
+          c2c: false
+        unsupported_fields: []
+      - device_modes: [mig, vgpu]
+        capabilities:
+          gpm: false
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
     unsupported_device_modes:
       - mig
   turing:
     capabilities:
       gpm: false
+      nvlink: 2
+      c2c: false
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
@@ -198,11 +290,26 @@ architectures:
             - FI_DEV_C2C_LINK_ERROR_INTR
             - FI_DEV_C2C_LINK_ERROR_REPLAY
             - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
+    support:
+      - device_modes: [physical]
+        capabilities:
+          gpm: false
+          nvlink: 2
+          c2c: false
+        unsupported_fields: []
+      - device_modes: [mig, vgpu]
+        capabilities:
+          gpm: false
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
     unsupported_device_modes:
       - mig
   ampere:
     capabilities:
       gpm: false
+      nvlink: 3
+      c2c: false
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
@@ -262,10 +369,25 @@ architectures:
             - FI_DEV_C2C_LINK_ERROR_INTR
             - FI_DEV_C2C_LINK_ERROR_REPLAY
             - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
+    support:
+      - device_modes: [physical]
+        capabilities:
+          gpm: false
+          nvlink: 3
+          c2c: false
+        unsupported_fields: []
+      - device_modes: [mig, vgpu]
+        capabilities:
+          gpm: false
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
     unsupported_device_modes: []
   hopper:
     capabilities:
       gpm: true
+      nvlink: 4
+      c2c: true
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
@@ -323,10 +445,25 @@ architectures:
             - FI_DEV_C2C_LINK_ERROR_INTR
             - FI_DEV_C2C_LINK_ERROR_REPLAY
             - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
+    support:
+      - device_modes: [physical]
+        capabilities:
+          gpm: true
+          nvlink: 4
+          c2c: true
+        unsupported_fields: []
+      - device_modes: [mig, vgpu]
+        capabilities:
+          gpm: false
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
     unsupported_device_modes: []
   ada:
     capabilities:
       gpm: false
+      nvlink: 0
+      c2c: false
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
@@ -387,11 +524,26 @@ architectures:
             - FI_DEV_C2C_LINK_ERROR_INTR
             - FI_DEV_C2C_LINK_ERROR_REPLAY
             - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
+    support:
+      - device_modes: [physical]
+        capabilities:
+          gpm: false
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
+      - device_modes: [mig, vgpu]
+        capabilities:
+          gpm: false
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
     unsupported_device_modes:
       - mig
   blackwell:
     capabilities:
       gpm: true
+      nvlink: 5
+      c2c: true
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
@@ -446,4 +598,17 @@ architectures:
             - FI_DEV_NVLINK_COUNT_EFFECTIVE_BER
             - FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS
             - FI_DEV_NVLINK_COUNT_SYMBOL_BER
+    support:
+      - device_modes: [physical]
+        capabilities:
+          gpm: true
+          nvlink: 5
+          c2c: true
+        unsupported_fields: []
+      - device_modes: [mig, vgpu]
+        capabilities:
+          gpm: false
+          nvlink: 0
+          c2c: false
+        unsupported_fields: []
     unsupported_device_modes: []

--- a/pkg/collector/corechecks/gpu/spec/architectures.yaml
+++ b/pkg/collector/corechecks/gpu/spec/architectures.yaml
@@ -1,8 +1,7 @@
 # GPU architecture capability matrix used by the GPU corecheck.
 # Schema:
-# - nvlink_generations.<generation>.supported_fields: field IDs supported by that NVLink generation and later generations
+# - nvlink_generations.<generation>.supported_fields: field IDs introduced in that NVLink generation; older generation fields are always supported
 # - c2c.supported_fields: field IDs supported when NVLink-C2C is available
-# - Root key: architectures
 # - architectures.<architecture_name>:
 #   - capabilities.gpm: bool  (whether the architecture supports GPU Performance Metrics or not)
 #   - capabilities.nvlink: int (highest NVLink generation supported by this architecture/mode, or 0)
@@ -81,62 +80,11 @@ architectures:
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_0
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_1
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_2
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_3
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_4
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_5
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_6
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_7
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_8
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_9
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_10
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_11
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_12
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_13
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_14
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_15
-            - FI_DEV_NVLINK_COUNT_XMIT_PACKETS
-            - FI_DEV_NVLINK_COUNT_RCV_PACKETS
-            - FI_DEV_NVLINK_COUNT_XMIT_DISCARDS
-            - FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS
-            - FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS
-            - FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_BER
-            - FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS
-            - FI_DEV_NVLINK_COUNT_SYMBOL_BER
-        - device_modes: [physical, mig, vgpu]
-          fields:
             - FI_DEV_MEMORY_TEMP
-            - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
-        - device_modes: [vgpu, mig]
+        - device_modes: [mig, vgpu]
           fields:
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_SPEED_MBPS_COMMON
-            - FI_DEV_NVLINK_GET_SPEED
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_TX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_RX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_TX
-            - FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
     support:
       - device_modes: [physical]
         capabilities:
@@ -160,62 +108,11 @@ architectures:
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_0
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_1
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_2
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_3
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_4
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_5
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_6
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_7
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_8
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_9
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_10
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_11
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_12
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_13
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_14
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_15
-            - FI_DEV_NVLINK_COUNT_XMIT_PACKETS
-            - FI_DEV_NVLINK_COUNT_RCV_PACKETS
-            - FI_DEV_NVLINK_COUNT_XMIT_DISCARDS
-            - FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS
-            - FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS
-            - FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_BER
-            - FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS
-            - FI_DEV_NVLINK_COUNT_SYMBOL_BER
-        - device_modes: [physical, mig, vgpu]
-          fields:
             - FI_DEV_MEMORY_TEMP
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
-        - device_modes: [vgpu, mig]
+        - device_modes: [mig, vgpu]
           fields:
-            - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_SPEED_MBPS_COMMON
-            - FI_DEV_NVLINK_GET_SPEED
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_TX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_RX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_TX
-            - FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
     support:
       - device_modes: [physical]
         capabilities:
@@ -239,62 +136,11 @@ architectures:
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_0
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_1
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_2
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_3
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_4
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_5
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_6
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_7
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_8
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_9
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_10
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_11
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_12
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_13
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_14
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_15
-            - FI_DEV_NVLINK_COUNT_XMIT_PACKETS
-            - FI_DEV_NVLINK_COUNT_RCV_PACKETS
-            - FI_DEV_NVLINK_COUNT_XMIT_DISCARDS
-            - FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS
-            - FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS
-            - FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_BER
-            - FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS
-            - FI_DEV_NVLINK_COUNT_SYMBOL_BER
-        - device_modes: [physical, mig, vgpu]
-          fields:
             - FI_DEV_MEMORY_TEMP
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
-        - device_modes: [vgpu, mig]
+        - device_modes: [mig, vgpu]
           fields:
-            - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_SPEED_MBPS_COMMON
-            - FI_DEV_NVLINK_GET_SPEED
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_TX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_RX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_TX
-            - FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
     support:
       - device_modes: [physical]
         capabilities:
@@ -316,64 +162,11 @@ architectures:
       nvlink: 3
       c2c: false
       unsupported_fields_by_device_mode:
-        - device_modes: [physical, mig, vgpu]
-          fields:
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_0
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_1
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_2
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_3
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_4
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_5
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_6
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_7
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_8
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_9
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_10
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_11
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_12
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_13
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_14
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_15
-            - FI_DEV_NVLINK_COUNT_XMIT_PACKETS
-            - FI_DEV_NVLINK_COUNT_RCV_PACKETS
-            - FI_DEV_NVLINK_COUNT_XMIT_DISCARDS
-            - FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS
-            - FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS
-            - FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_BER
-            - FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS
-            - FI_DEV_NVLINK_COUNT_SYMBOL_BER
-        - device_modes: [physical]
-          fields:
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
-        - device_modes: [vgpu, mig]
+        - device_modes: [mig, vgpu]
           fields:
             - FI_DEV_MEMORY_TEMP
-            - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_SPEED_MBPS_COMMON
-            - FI_DEV_NVLINK_GET_SPEED
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_TX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_RX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_TX
-            - FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
     support:
       - device_modes: [physical]
         capabilities:
@@ -394,56 +187,11 @@ architectures:
       nvlink: 4
       c2c: true
       unsupported_fields_by_device_mode:
-        - device_modes: [physical, mig, vgpu]
-          fields:
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_0
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_1
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_2
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_3
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_4
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_5
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_6
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_7
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_8
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_9
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_10
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_11
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_12
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_13
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_14
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_15
-            - FI_DEV_NVLINK_COUNT_XMIT_PACKETS
-            - FI_DEV_NVLINK_COUNT_RCV_PACKETS
-            - FI_DEV_NVLINK_COUNT_XMIT_DISCARDS
-            - FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS
-            - FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS
-            - FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_BER
-            - FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS
-            - FI_DEV_NVLINK_COUNT_SYMBOL_BER
-        - device_modes: [vgpu, mig]
+        - device_modes: [mig, vgpu]
           fields:
             - FI_DEV_MEMORY_TEMP
-            - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_SPEED_MBPS_COMMON
-            - FI_DEV_NVLINK_GET_SPEED
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_TX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_RX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_TX
-            - FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL
     support:
       - device_modes: [physical]
         capabilities:
@@ -472,63 +220,11 @@ architectures:
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_0
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_1
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_2
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_3
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_4
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_5
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_6
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_7
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_8
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_9
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_10
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_11
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_12
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_13
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_14
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_15
-            - FI_DEV_NVLINK_SPEED_MBPS_COMMON
-            - FI_DEV_NVLINK_GET_SPEED
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_TX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_RX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_TX
-            - FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL
             - FI_DEV_MEMORY_TEMP
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
-            - FI_DEV_NVLINK_COUNT_XMIT_PACKETS
-            - FI_DEV_NVLINK_COUNT_RCV_PACKETS
-            - FI_DEV_NVLINK_COUNT_XMIT_DISCARDS
-            - FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS
-            - FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS
-            - FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_BER
-            - FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS
-            - FI_DEV_NVLINK_COUNT_SYMBOL_BER
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
-        - device_modes: [vgpu, mig]
+        - device_modes: [mig, vgpu]
           fields:
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
-            - FI_DEV_C2C_LINK_ERROR_INTR
-            - FI_DEV_C2C_LINK_ERROR_REPLAY
-            - FI_DEV_C2C_LINK_ERROR_REPLAY_B2B
     support:
       - device_modes: [physical]
         capabilities:
@@ -550,56 +246,11 @@ architectures:
       nvlink: 5
       c2c: true
       unsupported_fields_by_device_mode:
-        - device_modes: [physical, mig, vgpu]
+        - device_modes: [mig, vgpu]
           fields:
-        - device_modes: [vgpu, mig]
-          fields:
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_0
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_1
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_2
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_3
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_4
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_5
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_6
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_7
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_8
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_9
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_10
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_11
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_12
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_13
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_14
-            - FI_DEV_NVLINK_COUNT_FEC_HISTORY_15
             - FI_DEV_MEMORY_TEMP
-            - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_SPEED_MBPS_COMMON
-            - FI_DEV_NVLINK_GET_SPEED
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
-            - FI_DEV_NVLINK_THROUGHPUT_DATA_TX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_RX
-            - FI_DEV_NVLINK_THROUGHPUT_RAW_TX
-            - FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL
-            - FI_DEV_NVLINK_COUNT_XMIT_PACKETS
-            - FI_DEV_NVLINK_COUNT_RCV_PACKETS
-            - FI_DEV_NVLINK_COUNT_XMIT_DISCARDS
-            - FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS
-            - FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS
-            - FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS
-            - FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS
-            - FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS
-            - FI_DEV_NVLINK_COUNT_EFFECTIVE_BER
-            - FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS
-            - FI_DEV_NVLINK_COUNT_SYMBOL_BER
     support:
       - device_modes: [physical]
         capabilities:

--- a/pkg/collector/corechecks/gpu/spec/architectures.yaml
+++ b/pkg/collector/corechecks/gpu/spec/architectures.yaml
@@ -1,11 +1,16 @@
 # GPU architecture capability matrix used by the GPU corecheck.
 # Schema:
+# - nvlink_generations.<generation>.supported_fields: field IDs supported by that NVLink generation and later generations
+# - c2c.supported_fields: field IDs supported when NVLink-C2C is available
 # - Root key: architectures
 # - architectures.<architecture_name>:
 #   - capabilities.gpm: bool  (whether the architecture supports GPU Performance Metrics or not)
+#   - capabilities.nvlink: int (highest NVLink generation supported by this architecture/mode, or 0)
+#   - capabilities.c2c: bool (whether this architecture/mode supports NVLink-C2C)
 #   - capabilities.unsupported_fields_by_device_mode (list of conditional exclusions for the GetFields API)
 #       - device_modes: [physical|mig|vgpu, ...]  (in which modes the fields are unsupported, for example some fields are not supported in vGPU mode. If not included, the fields are unsupported in all modes.)
 #       - fields: [<field_id>, ...] (the list of field IDs that are unsupported in the given modes. Check nvmlFieldNameToFieldID in spec_test.go for the mapping.)
+#   - support (optional): mode-specific capabilities and additional unsupported_fields entries
 #   - unsupported_device_modes: [mig|physical|vgpu, ...] (the list of device modes that are unsupported on the architecture. For example, MIG is not supported on the Pascal architecture.)
 nvlink_generations:
   1:

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -670,14 +670,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: true
+      capabilities_required:
+        nvlink: 1
   nvlink.count.inactive:
     metadata:
       metric_type: gauge
@@ -685,14 +684,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: true
+      capabilities_required:
+        nvlink: 1
   nvlink.count.total:
     metadata:
       metric_type: gauge
@@ -700,14 +698,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: true
+      capabilities_required:
+        nvlink: 1
   nvlink.ber.effective:
     metadata:
       metric_type: gauge
@@ -715,20 +712,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.ber.symbol:
     metadata:
       metric_type: gauge
@@ -736,20 +726,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.errors.crc.data:
     metadata:
       metric_type: gauge
@@ -761,15 +744,13 @@ metrics:
         min: 0
         max: 1000000000000000
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.errors.crc.flit:
     metadata:
       metric_type: gauge
@@ -781,15 +762,13 @@ metrics:
         min: 0
         max: 1000000000000000
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.errors.buffer.overrun:
     metadata:
       metric_type: gauge
@@ -797,20 +776,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.errors.ecc:
     metadata:
       metric_type: gauge
@@ -822,15 +794,13 @@ metrics:
         min: 0
         max: 1000000000000000
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.errors.effective:
     metadata:
       metric_type: gauge
@@ -838,20 +808,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.errors.local.link.integrity:
     metadata:
       metric_type: gauge
@@ -859,20 +822,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.errors.malformed.packet:
     metadata:
       metric_type: gauge
@@ -880,20 +836,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.errors.recovery:
     metadata:
       metric_type: gauge
@@ -905,15 +854,13 @@ metrics:
         min: 0
         max: 1000000000000000
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.errors.replay:
     metadata:
       metric_type: gauge
@@ -925,15 +872,13 @@ metrics:
         min: 0
         max: 1000000000000000
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.errors.rx:
     metadata:
       metric_type: gauge
@@ -941,20 +886,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.errors.rx.general:
     metadata:
       metric_type: gauge
@@ -962,20 +900,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.errors.rx.remote:
     metadata:
       metric_type: gauge
@@ -983,20 +914,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.errors.symbol:
     metadata:
       metric_type: gauge
@@ -1004,20 +928,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.nvswitch_connected:
     metadata:
       metric_type: gauge
@@ -1025,15 +942,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 3
   nvlink.plr.codes_loss:
     metadata:
       metric_type: gauge
@@ -1278,15 +1193,13 @@ metrics:
         min: 0
         max: 5000000000000 # 5 TB/s (bytes/second)
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.recovery.events.failed:
     metadata:
       metric_type: gauge
@@ -1294,20 +1207,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.recovery.events.successful:
     metadata:
       metric_type: gauge
@@ -1315,20 +1221,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.rx.packets:
     metadata:
       metric_type: gauge
@@ -1336,20 +1235,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.throughput.data.rx:
     metadata:
       metric_type: gauge
@@ -1362,15 +1254,13 @@ metrics:
         min: 0
         max: 3000000000000 # 3 TB/s (bytes/second)
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.throughput.data.tx:
     metadata:
       metric_type: gauge
@@ -1383,15 +1273,13 @@ metrics:
         min: 0
         max: 3000000000000 # 3 TB/s (bytes/second)
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.throughput.raw.rx:
     metadata:
       metric_type: gauge
@@ -1404,15 +1292,13 @@ metrics:
         min: 0
         max: 3000000000000 # 3 TB/s (bytes/second)
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.throughput.raw.tx:
     metadata:
       metric_type: gauge
@@ -1425,15 +1311,13 @@ metrics:
         min: 0
         max: 3000000000000 # 3 TB/s (bytes/second)
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 1
   nvlink.tx.discards:
     metadata:
       metric_type: gauge
@@ -1441,20 +1325,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.tx.packets:
     metadata:
       metric_type: gauge
@@ -1462,20 +1339,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - maxwell
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   c2c.errors.interrupt:
     metadata:
       metric_type: gauge
@@ -1483,21 +1353,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - blackwell
-        - hopper
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        c2c: true
   c2c.errors.replay:
     metadata:
       metric_type: gauge
@@ -1505,21 +1367,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - blackwell
-        - hopper
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        c2c: true
   c2c.errors.replay.b2b:
     metadata:
       metric_type: gauge
@@ -1527,21 +1381,13 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures:
-        - blackwell
-        - hopper
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        c2c: true
   pci.replay_counter:
     metadata:
       metric_type: gauge

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -952,6 +952,8 @@ metrics:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 3
   nvlink.plr.codes_loss:
     metadata:
       metric_type: gauge

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -943,13 +943,15 @@ metrics:
     tagsets:
       - device
     support:
-      unsupported_architectures: []
+      unsupported_architectures:
+        - fermi
+        - kepler
+        - maxwell
+        - pascal
       device_modes:
         mig: false
         physical: true
         vgpu: false
-      capabilities_required:
-        nvlink: 3
   nvlink.plr.codes_loss:
     metadata:
       metric_type: gauge
@@ -959,20 +961,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
-        - hopper
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.plr.rx.code_err:
     metadata:
       metric_type: gauge
@@ -982,20 +977,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
-        - hopper
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.plr.rx.codes:
     metadata:
       metric_type: gauge
@@ -1005,20 +993,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
-        - hopper
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.plr.rx.uncorrectable_code:
     metadata:
       metric_type: gauge
@@ -1028,20 +1009,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
-        - hopper
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.plr.tx.sync_events:
     metadata:
       metric_type: gauge
@@ -1051,20 +1025,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
-        - hopper
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.plr.tx.codes:
     metadata:
       metric_type: gauge
@@ -1074,20 +1041,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
-        - hopper
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.plr.tx.retry_codes:
     metadata:
       metric_type: gauge
@@ -1097,20 +1057,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
-        - hopper
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.plr.tx.retry_events:
     metadata:
       metric_type: gauge
@@ -1120,20 +1073,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
-        - hopper
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.plr.tx.retry_events_within_t_sec_max:
     metadata:
       metric_type: gauge
@@ -1143,20 +1089,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - ada
-        - hopper
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.errors.fec:
     metadata:
       metric_type: histogram
@@ -1168,20 +1107,13 @@ metrics:
     custom_tags:
       - nvlink_port
     support:
-      unsupported_architectures:
-        - fermi
-        - kepler
-        - maxwell
-        - pascal
-        - volta
-        - turing
-        - ampere
-        - hopper
-        - ada
+      unsupported_architectures: []
       device_modes:
         mig: false
         physical: true
         vgpu: false
+      capabilities_required:
+        nvlink: 5
   nvlink.speed:
     metadata:
       metric_type: gauge

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -12,6 +12,7 @@
 #   - support:
 #       - unsupported_architectures: [<architecture_name>, ...] (the list of architectures that do not support the metric)
 #       - device_modes: {mig: bool, physical: bool, vgpu: bool} (a map describing whether each device mode supports the metric)
+#       - capabilities_required (optional): {nvlink: <min_generation>, c2c: <bool>} (hardware capabilities required for the metric)
 metric_prefix: gpu
 metrics:
   clock.speed.graphics:

--- a/pkg/collector/corechecks/gpu/spec/spec.go
+++ b/pkg/collector/corechecks/gpu/spec/spec.go
@@ -248,6 +248,13 @@ type ArchitectureCapabilities struct {
 	UnsupportedFieldsByDeviceMode []UnsupportedFieldsByDeviceModeSpec `yaml:"unsupported_fields_by_device_mode"`
 }
 
+// ArchitectureCapabilitiesOverride defines mode-specific capability overrides.
+type ArchitectureCapabilitiesOverride struct {
+	GPM    *bool `yaml:"gpm,omitempty"`
+	NVLink *int  `yaml:"nvlink,omitempty"`
+	C2C    *bool `yaml:"c2c,omitempty"`
+}
+
 // UnsupportedFieldsByDeviceModeSpec groups unsupported fields by device modes.
 type UnsupportedFieldsByDeviceModeSpec struct {
 	DeviceModes []DeviceMode `yaml:"device_modes"`
@@ -264,7 +271,7 @@ type ArchitectureSupportSpec struct {
 	// DeviceModes lists the device modes covered by this support entry.
 	DeviceModes []DeviceMode `yaml:"device_modes"`
 	// Capabilities describes which hardware/API capabilities are available for those modes.
-	Capabilities ArchitectureCapabilities `yaml:"capabilities"`
+	Capabilities ArchitectureCapabilitiesOverride `yaml:"capabilities"`
 	// UnsupportedFields lists additional GetFieldValues fields unsupported for those modes.
 	UnsupportedFields []string `yaml:"unsupported_fields"`
 }
@@ -281,12 +288,26 @@ type ArchitectureSpec struct {
 
 // EffectiveCapabilities returns the capabilities for a device mode.
 func (a ArchitectureSpec) EffectiveCapabilities(mode DeviceMode) ArchitectureCapabilities {
+	capabilities := a.Capabilities
 	for _, support := range a.Support {
 		if slices.Contains(support.DeviceModes, mode) {
-			return support.Capabilities
+			capabilities.applyOverride(support.Capabilities)
+			return capabilities
 		}
 	}
-	return a.Capabilities
+	return capabilities
+}
+
+func (c *ArchitectureCapabilities) applyOverride(override ArchitectureCapabilitiesOverride) {
+	if override.GPM != nil {
+		c.GPM = *override.GPM
+	}
+	if override.NVLink != nil {
+		c.NVLink = *override.NVLink
+	}
+	if override.C2C != nil {
+		c.C2C = *override.C2C
+	}
 }
 
 // UnsupportedFieldsForMode returns fields unsupported for a device mode and capability set.
@@ -336,7 +357,9 @@ func (a ArchitectureSpec) UnsupportedFieldsForMode(mode DeviceMode, archSpecs *A
 func (a ArchitectureSpec) SupportedNVLinkGeneration() int {
 	maxGeneration := a.Capabilities.NVLink
 	for _, support := range a.Support {
-		maxGeneration = max(maxGeneration, support.Capabilities.NVLink)
+		if support.Capabilities.NVLink != nil {
+			maxGeneration = max(maxGeneration, *support.Capabilities.NVLink)
+		}
 	}
 	return maxGeneration
 }

--- a/pkg/collector/corechecks/gpu/spec/spec.go
+++ b/pkg/collector/corechecks/gpu/spec/spec.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 
 	"regexp"
 
@@ -214,13 +215,22 @@ func (v *MetricValidator) validateDefinition() error {
 
 // MetricSupportSpec defines where a metric is supported.
 type MetricSupportSpec struct {
-	UnsupportedArchitectures []string            `yaml:"unsupported_architectures"`
-	DeviceModes              map[DeviceMode]bool `yaml:"device_modes"`
+	UnsupportedArchitectures []string                   `yaml:"unsupported_architectures"`
+	DeviceModes              map[DeviceMode]bool        `yaml:"device_modes"`
+	CapabilitiesRequired     MetricCapabilitiesRequired `yaml:"capabilities_required,omitempty"`
+}
+
+// MetricCapabilitiesRequired defines hardware capabilities required for a metric.
+type MetricCapabilitiesRequired struct {
+	NVLink *int  `yaml:"nvlink,omitempty"`
+	C2C    *bool `yaml:"c2c,omitempty"`
 }
 
 // ArchitecturesSpec is the YAML architecture capability specification.
 type ArchitecturesSpec struct {
-	Architectures map[string]ArchitectureSpec `yaml:"architectures"`
+	NVLinkGenerations map[int]FieldSupportSpec    `yaml:"nvlink_generations"`
+	C2C               FieldSupportSpec            `yaml:"c2c"`
+	Architectures     map[string]ArchitectureSpec `yaml:"architectures"`
 }
 
 // Specs bundles all GPU spec files used by validation and tests.
@@ -233,6 +243,8 @@ type Specs struct {
 // ArchitectureCapabilities defines capabilities and unsupported fields.
 type ArchitectureCapabilities struct {
 	GPM                           bool                                `yaml:"gpm"`
+	NVLink                        int                                 `yaml:"nvlink"`
+	C2C                           bool                                `yaml:"c2c"`
 	UnsupportedFieldsByDeviceMode []UnsupportedFieldsByDeviceModeSpec `yaml:"unsupported_fields_by_device_mode"`
 }
 
@@ -242,10 +254,91 @@ type UnsupportedFieldsByDeviceModeSpec struct {
 	Fields      []string     `yaml:"fields"`
 }
 
+// FieldSupportSpec defines fields made available by a capability.
+type FieldSupportSpec struct {
+	SupportedFields []string `yaml:"supported_fields"`
+}
+
+// ArchitectureSupportSpec defines architecture support for a set of device modes.
+type ArchitectureSupportSpec struct {
+	// DeviceModes lists the device modes covered by this support entry.
+	DeviceModes []DeviceMode `yaml:"device_modes"`
+	// Capabilities describes which hardware/API capabilities are available for those modes.
+	Capabilities ArchitectureCapabilities `yaml:"capabilities"`
+	// UnsupportedFields lists additional GetFieldValues fields unsupported for those modes.
+	UnsupportedFields []string `yaml:"unsupported_fields"`
+}
+
 // ArchitectureSpec defines architecture capabilities and unsupported device modes.
 type ArchitectureSpec struct {
-	Capabilities           ArchitectureCapabilities `yaml:"capabilities"`
-	UnsupportedDeviceModes []DeviceMode             `yaml:"unsupported_device_modes"`
+	// Capabilities is the default capability set used when no mode-specific support entry matches.
+	Capabilities ArchitectureCapabilities `yaml:"capabilities"`
+	// Support contains mode-specific capability and unsupported-field overrides.
+	Support []ArchitectureSupportSpec `yaml:"support"`
+	// UnsupportedDeviceModes lists device modes that should not be validated for this architecture.
+	UnsupportedDeviceModes []DeviceMode `yaml:"unsupported_device_modes"`
+}
+
+// EffectiveCapabilities returns the capabilities for a device mode.
+func (a ArchitectureSpec) EffectiveCapabilities(mode DeviceMode) ArchitectureCapabilities {
+	for _, support := range a.Support {
+		if slices.Contains(support.DeviceModes, mode) {
+			return support.Capabilities
+		}
+	}
+	return a.Capabilities
+}
+
+// UnsupportedFieldsForMode returns fields unsupported for a device mode and capability set.
+func (a ArchitectureSpec) UnsupportedFieldsForMode(mode DeviceMode, archSpecs *ArchitecturesSpec) []string {
+	unsupported := make(map[string]struct{})
+	capabilities := a.EffectiveCapabilities(mode)
+	for _, support := range a.Support {
+		if !slices.Contains(support.DeviceModes, mode) {
+			continue
+		}
+		for _, field := range support.UnsupportedFields {
+			unsupported[field] = struct{}{}
+		}
+	}
+	for _, group := range a.Capabilities.UnsupportedFieldsByDeviceMode {
+		if len(group.DeviceModes) > 0 && !slices.Contains(group.DeviceModes, mode) {
+			continue
+		}
+		for _, name := range group.Fields {
+			unsupported[name] = struct{}{}
+		}
+	}
+	if archSpecs != nil {
+		for generation, support := range archSpecs.NVLinkGenerations {
+			if generation <= capabilities.NVLink {
+				continue
+			}
+			for _, field := range support.SupportedFields {
+				unsupported[field] = struct{}{}
+			}
+		}
+		if !capabilities.C2C {
+			for _, field := range archSpecs.C2C.SupportedFields {
+				unsupported[field] = struct{}{}
+			}
+		}
+	}
+	names := make([]string, 0, len(unsupported))
+	for name := range unsupported {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// SupportedNVLinkGeneration returns the highest NVLink generation this architecture can support.
+func (a ArchitectureSpec) SupportedNVLinkGeneration() int {
+	maxGeneration := a.Capabilities.NVLink
+	for _, support := range a.Support {
+		maxGeneration = max(maxGeneration, support.Capabilities.NVLink)
+	}
+	return maxGeneration
 }
 
 // SupportsArchitecture returns true if the metric is supported on this architecture.
@@ -271,6 +364,17 @@ func (m MetricSpec) SupportsDeviceMode(mode DeviceMode) bool {
 // SupportsConfig returns true if the metric is supported for the given GPU config.
 func (m MetricSpec) SupportsConfig(config GPUConfig) bool {
 	return m.SupportsArchitecture(config.Architecture) && m.SupportsDeviceMode(config.DeviceMode)
+}
+
+// SupportsCapabilities returns true if the metric's capability requirements are met.
+func (m MetricSpec) SupportsCapabilities(capabilities ArchitectureCapabilities) bool {
+	if m.Support.CapabilitiesRequired.NVLink != nil && capabilities.NVLink < *m.Support.CapabilitiesRequired.NVLink {
+		return false
+	}
+	if m.Support.CapabilitiesRequired.C2C != nil && capabilities.C2C != *m.Support.CapabilitiesRequired.C2C {
+		return false
+	}
+	return true
 }
 
 // IsModeSupportedByArchitecture returns true when the architecture supports the device mode.

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 
+func ptrTo[T any](v T) *T {
+	return &v
+}
+
 func TestLoadSpecNotEmpty(t *testing.T) {
 	specs, err := LoadSpecs()
 	require.NoError(t, err)
@@ -232,9 +236,9 @@ func TestUnsupportedFieldsForModeIncludesHigherNVLinkGenerations(t *testing.T) {
 		Support: []ArchitectureSupportSpec{
 			{
 				DeviceModes: []DeviceMode{DeviceModePhysical},
-				Capabilities: ArchitectureCapabilities{
-					NVLink: 1,
-					C2C:    false,
+				Capabilities: ArchitectureCapabilitiesOverride{
+					NVLink: ptrTo(1),
+					C2C:    ptrTo(false),
 				},
 				UnsupportedFields: []string{"FI_DEV_MEMORY_TEMP"},
 			},

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -296,6 +296,19 @@ func TestMockCapabilitiesMatchArchitectureSpec(t *testing.T) {
 				require.True(t, ddnvml.IsUnsupported(err), "GpmSampleGet should return an API_UNSUPPORTED_ON_DEVICE error")
 			}
 
+			nvlinkState, err := dev.GetNvLinkState(0)
+			if effectiveCapabilities.NVLink > 0 {
+				require.NoError(t, err, "GetNvLinkState should not return an error")
+				if config.NVLinkLinkCount > 0 {
+					assert.Equal(t, nvml.FEATURE_ENABLED, nvlinkState, "GetNvLinkState should report enabled when NVLink links are active")
+				} else {
+					assert.Equal(t, nvml.FEATURE_DISABLED, nvlinkState, "GetNvLinkState should report disabled when no NVLink links are active")
+				}
+			} else {
+				require.Error(t, err, "GetNvLinkState should return an error")
+				require.True(t, ddnvml.IsUnsupported(err), "GetNvLinkState should return an API_UNSUPPORTED_ON_DEVICE error")
+			}
+
 			unsupportedIDs := UnsupportedFieldIDsForConfig(t, specs.Architectures, archSpec, config.DeviceMode)
 			unsupportedSet := make(map[uint32]struct{}, len(unsupportedIDs))
 			for _, id := range unsupportedIDs {

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -219,6 +219,37 @@ func TestLoadedMetricsIncludeMetadata(t *testing.T) {
 	}
 }
 
+func TestUnsupportedFieldsForModeIncludesHigherNVLinkGenerations(t *testing.T) {
+	archSpecs := &ArchitecturesSpec{
+		NVLinkGenerations: map[int]FieldSupportSpec{
+			1: {SupportedFields: []string{"FI_DEV_NVLINK_LINK_COUNT"}},
+			2: {SupportedFields: []string{"FI_DEV_NVLINK_THROUGHPUT_DATA_RX"}},
+			3: {SupportedFields: []string{"FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT"}},
+		},
+		C2C: FieldSupportSpec{SupportedFields: []string{"FI_DEV_C2C_LINK_ERROR_INTR"}},
+	}
+	archSpec := ArchitectureSpec{
+		Support: []ArchitectureSupportSpec{
+			{
+				DeviceModes: []DeviceMode{DeviceModePhysical},
+				Capabilities: ArchitectureCapabilities{
+					NVLink: 1,
+					C2C:    false,
+				},
+				UnsupportedFields: []string{"FI_DEV_MEMORY_TEMP"},
+			},
+		},
+	}
+
+	unsupported := archSpec.UnsupportedFieldsForMode(DeviceModePhysical, archSpecs)
+
+	assert.Contains(t, unsupported, "FI_DEV_MEMORY_TEMP")
+	assert.NotContains(t, unsupported, "FI_DEV_NVLINK_LINK_COUNT")
+	assert.Contains(t, unsupported, "FI_DEV_NVLINK_THROUGHPUT_DATA_RX")
+	assert.Contains(t, unsupported, "FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT")
+	assert.Contains(t, unsupported, "FI_DEV_C2C_LINK_ERROR_INTR")
+}
+
 // TestMockCapabilitiesMatchArchitectureSpec ensures that for each architecture and supported device mode,
 // the NVML mock configured from architectures.yaml returns API behavior that matches the capability flags
 // (gpm, unsupported_fields_by_device_mode). This validates that the mock actually applies the spec.
@@ -231,7 +262,7 @@ func TestMockCapabilitiesMatchArchitectureSpec(t *testing.T) {
 		subtestName := fmt.Sprintf("arch=%s/mode=%s", config.Architecture, config.DeviceMode)
 		t.Run(subtestName, func(t *testing.T) {
 			archSpec := specs.Architectures.Architectures[config.Architecture]
-			opts := BuildMockOptionsForConfig(t, config, archSpec)
+			opts := BuildMockOptionsForConfig(t, config, specs.Architectures, archSpec)
 
 			ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(opts...))
 
@@ -244,7 +275,8 @@ func TestMockCapabilitiesMatchArchitectureSpec(t *testing.T) {
 			support, err := dev.GpmQueryDeviceSupport()
 			require.NoError(t, err, "GpmQueryDeviceSupport should not report an error")
 			expected := uint32(0)
-			if archSpec.Capabilities.GPM {
+			effectiveCapabilities := archSpec.EffectiveCapabilities(config.DeviceMode)
+			if effectiveCapabilities.GPM {
 				expected = 1
 			}
 			if config.DeviceMode == DeviceModeVGPU {
@@ -252,19 +284,19 @@ func TestMockCapabilitiesMatchArchitectureSpec(t *testing.T) {
 				// where physical devices support GPM.
 				expected = 0
 			}
-			assert.Equal(t, expected, support.IsSupportedDevice, "GpmQueryDeviceSupport.IsSupportedDevice should be %d when gpm=%v", expected, archSpec.Capabilities.GPM)
+			assert.Equal(t, expected, support.IsSupportedDevice, "GpmQueryDeviceSupport.IsSupportedDevice should be %d when gpm=%v", expected, effectiveCapabilities.GPM)
 
 			// Check also that GpmSampleGet returns NOT_SUPPORTED when GPM is not supported
 			var sample testutil.MockGpmSample
 			err = dev.GpmSampleGet(sample)
-			if archSpec.Capabilities.GPM && config.DeviceMode != DeviceModeVGPU {
+			if effectiveCapabilities.GPM && config.DeviceMode != DeviceModeVGPU {
 				require.NoError(t, err, "GpmSampleGet should not return an error")
 			} else {
 				require.Error(t, err, "GpmSampleGet should return an error")
 				require.True(t, ddnvml.IsUnsupported(err), "GpmSampleGet should return an API_UNSUPPORTED_ON_DEVICE error")
 			}
 
-			unsupportedIDs := UnsupportedFieldIDsForMode(t, archSpec, config.DeviceMode)
+			unsupportedIDs := UnsupportedFieldIDsForConfig(t, specs.Architectures, archSpec, config.DeviceMode)
 			unsupportedSet := make(map[uint32]struct{}, len(unsupportedIDs))
 			for _, id := range unsupportedIDs {
 				unsupportedSet[id] = struct{}{}
@@ -297,8 +329,9 @@ func TestBuildMockOptionsCreatesCorrectDevices(t *testing.T) {
 		require.True(t, IsModeSupportedByArchitecture(arch, mode))
 
 		t.Run(string(mode), func(t *testing.T) {
-			config := GPUConfig{Architecture: archName, DeviceMode: mode}
-			opts := BuildMockOptionsForConfig(t, config, arch)
+			capabilities := arch.EffectiveCapabilities(mode)
+			config := GPUConfig{Architecture: archName, DeviceMode: mode, Capabilities: capabilities}
+			opts := BuildMockOptionsForConfig(t, config, archSpec, arch)
 			ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(opts...))
 
 			lib, err := ddnvml.GetSafeNvmlLib()

--- a/pkg/collector/corechecks/gpu/spec/testutil.go
+++ b/pkg/collector/corechecks/gpu/spec/testutil.go
@@ -82,35 +82,31 @@ func unsupportedFieldIDsFromNames(t *testing.T, names []string) []uint32 {
 	return ids
 }
 
+// UnsupportedFieldIDsForConfig computes unsupported NVML field IDs for an architecture+mode.
+func UnsupportedFieldIDsForConfig(t *testing.T, archSpecs *ArchitecturesSpec, archSpec ArchitectureSpec, mode DeviceMode) []uint32 {
+	t.Helper()
+
+	return unsupportedFieldIDsFromNames(t, archSpec.UnsupportedFieldsForMode(mode, archSpecs))
+}
+
 // UnsupportedFieldIDsForMode computes unsupported NVML field IDs for an architecture+mode.
 func UnsupportedFieldIDsForMode(t *testing.T, archSpec ArchitectureSpec, mode DeviceMode) []uint32 {
 	t.Helper()
 
-	unsupportedNameSet := make(map[string]struct{})
-	for _, group := range archSpec.Capabilities.UnsupportedFieldsByDeviceMode {
-		if len(group.DeviceModes) > 0 && !slices.Contains(group.DeviceModes, mode) {
-			continue
-		}
-		for _, name := range group.Fields {
-			unsupportedNameSet[name] = struct{}{}
-		}
-	}
-
-	unsupportedNames := make([]string, 0, len(unsupportedNameSet))
-	for name := range unsupportedNameSet {
-		unsupportedNames = append(unsupportedNames, name)
-	}
-	return unsupportedFieldIDsFromNames(t, unsupportedNames)
+	return unsupportedFieldIDsFromNames(t, archSpec.UnsupportedFieldsForMode(mode, nil))
 }
 
 // BuildMockOptionsForArchAndMode creates canonical NVML mock options from spec capabilities.
-func BuildMockOptionsForConfig(t *testing.T, config GPUConfig, archSpec ArchitectureSpec) []testutil.NvmlMockOption {
+func BuildMockOptionsForConfig(t *testing.T, config GPUConfig, archSpecs *ArchitecturesSpec, archSpec ArchitectureSpec) []testutil.NvmlMockOption {
 	t.Helper()
 
 	testMode := testutil.DeviceFeatureMode(config.DeviceMode)
 	caps := testutil.Capabilities{
-		GPM:               archSpec.Capabilities.GPM,
-		UnsupportedFields: UnsupportedFieldIDsForMode(t, archSpec, config.DeviceMode),
+		GPM:                       archSpec.EffectiveCapabilities(config.DeviceMode).GPM,
+		NvLinkGenerationSupported: config.Capabilities.NVLink,
+		NvLinkLinkCount:           config.NVLinkLinkCount,
+		C2C:                       config.Capabilities.C2C,
+		UnsupportedFields:         UnsupportedFieldIDsForConfig(t, archSpecs, archSpec, config.DeviceMode),
 	}
 	opts := []testutil.NvmlMockOption{
 		testutil.WithArchitecture(config.Architecture),

--- a/pkg/collector/corechecks/gpu/spec/validation.go
+++ b/pkg/collector/corechecks/gpu/spec/validation.go
@@ -168,6 +168,7 @@ func KnownGPUConfigs(specs *Specs) []GPUConfig {
 			}
 			capabilities := archSpec.EffectiveCapabilities(mode)
 			nvlinkLinkCount := 0
+			// Use a nonzero mock link count whenever the spec says this mode is NVLink-capable.
 			if capabilities.NVLink > 0 {
 				nvlinkLinkCount = 2
 			}

--- a/pkg/collector/corechecks/gpu/spec/validation.go
+++ b/pkg/collector/corechecks/gpu/spec/validation.go
@@ -191,7 +191,7 @@ func ExpectedMetricsForConfig(specs *Specs, config GPUConfig, options Validation
 		if !metricSpec.SupportsConfig(config) {
 			continue
 		}
-		if strings.HasPrefix(metricName, "nvlink.") && config.NVLinkLinkCount == 0 {
+		if suppressInactiveNVLinkMetric(metricName, config) {
 			continue
 		}
 		if !metricSpec.SupportsCapabilities(config.Capabilities) {
@@ -338,7 +338,7 @@ func ValidateEmittedMetricsAgainstSpec(specs *Specs, config GPUConfig, emittedMe
 			continue
 		}
 
-		if (strings.HasPrefix(metricName, "nvlink.") && config.NVLinkLinkCount == 0) || !metricSpec.SupportsCapabilities(config.Capabilities) {
+		if suppressInactiveNVLinkMetric(metricName, config) || !metricSpec.SupportsCapabilities(config.Capabilities) {
 			results.getMetricStatus(metricName).Unsupported++
 		}
 	}
@@ -376,4 +376,11 @@ func ValidateEmittedMetricsAgainstSpec(specs *Specs, config GPUConfig, emittedMe
 	}
 
 	return results, nil
+}
+
+func suppressInactiveNVLinkMetric(metricName string, config GPUConfig) bool {
+	return strings.HasPrefix(metricName, "nvlink.") &&
+		// NVSwitch connectivity can be reported as zero even when no active NVLink ports are present.
+		metricName != "nvlink.nvswitch_connected" &&
+		config.NVLinkLinkCount == 0
 }

--- a/pkg/collector/corechecks/gpu/spec/validation.go
+++ b/pkg/collector/corechecks/gpu/spec/validation.go
@@ -12,10 +12,12 @@ import (
 	"strings"
 )
 
-// GPUConfig identifies an architecture + device mode pair from the spec.
+// GPUConfig identifies a GPU configuration used for spec validation.
 type GPUConfig struct {
-	Architecture string     `json:"architecture"`
-	DeviceMode   DeviceMode `json:"device_mode"`
+	Architecture    string                   `json:"architecture"`
+	DeviceMode      DeviceMode               `json:"device_mode"`
+	Capabilities    ArchitectureCapabilities `json:"capabilities,omitempty"`
+	NVLinkLinkCount int                      `json:"nvlink_link_count,omitempty"`
 }
 
 // ValidationOptions controls which spec failures should be enforced.
@@ -25,7 +27,12 @@ type ValidationOptions struct {
 
 // Equals checks if two GPU configs are equal.
 func (c *GPUConfig) Equals(other GPUConfig) bool {
-	return c.Architecture == other.Architecture && c.DeviceMode == other.DeviceMode
+	return c.Architecture == other.Architecture &&
+		c.DeviceMode == other.DeviceMode &&
+		c.Capabilities.GPM == other.Capabilities.GPM &&
+		c.Capabilities.NVLink == other.Capabilities.NVLink &&
+		c.Capabilities.C2C == other.Capabilities.C2C &&
+		c.NVLinkLinkCount == other.NVLinkLinkCount
 }
 
 // TagFilter returns the Datadog tag filter expression for a GPU config.
@@ -159,9 +166,16 @@ func KnownGPUConfigs(specs *Specs) []GPUConfig {
 			if !IsModeSupportedByArchitecture(archSpec, mode) {
 				continue
 			}
+			capabilities := archSpec.EffectiveCapabilities(mode)
+			nvlinkLinkCount := 0
+			if capabilities.NVLink > 0 {
+				nvlinkLinkCount = 2
+			}
 			configs = append(configs, GPUConfig{
-				Architecture: strings.ToLower(archName),
-				DeviceMode:   mode,
+				Architecture:    strings.ToLower(archName),
+				DeviceMode:      mode,
+				Capabilities:    capabilities,
+				NVLinkLinkCount: nvlinkLinkCount,
 			})
 		}
 	}
@@ -174,6 +188,12 @@ func ExpectedMetricsForConfig(specs *Specs, config GPUConfig, options Validation
 	expected := make(map[string]MetricSpec)
 	for metricName, metricSpec := range specs.Metrics.Metrics {
 		if !metricSpec.SupportsConfig(config) {
+			continue
+		}
+		if strings.HasPrefix(metricName, "nvlink.") && config.NVLinkLinkCount == 0 {
+			continue
+		}
+		if !metricSpec.SupportsCapabilities(config.Capabilities) {
 			continue
 		}
 		if metricSpec.WorkloadOnly && !options.WorkloadActive {
@@ -313,6 +333,11 @@ func ValidateEmittedMetricsAgainstSpec(specs *Specs, config GPUConfig, emittedMe
 		}
 
 		if !metricSpec.SupportsConfig(config) {
+			results.getMetricStatus(metricName).Unsupported++
+			continue
+		}
+
+		if (strings.HasPrefix(metricName, "nvlink.") && config.NVLinkLinkCount == 0) || !metricSpec.SupportsCapabilities(config.Capabilities) {
 			results.getMetricStatus(metricName).Unsupported++
 		}
 	}

--- a/pkg/collector/corechecks/gpu/spec/validation_test.go
+++ b/pkg/collector/corechecks/gpu/spec/validation_test.go
@@ -34,3 +34,61 @@ func TestValidateMetricType(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestExpectedMetricsSuppressesInactiveNVLinkMetrics(t *testing.T) {
+	specs := &Specs{
+		Metrics: &MetricsSpec{
+			Metrics: map[string]MetricSpec{
+				"nvlink.count.active": {
+					Support: MetricSupportSpec{
+						DeviceModes: map[DeviceMode]bool{DeviceModePhysical: true},
+					},
+				},
+				"nvlink.nvswitch_connected": {
+					Support: MetricSupportSpec{
+						DeviceModes: map[DeviceMode]bool{DeviceModePhysical: true},
+					},
+				},
+			},
+		},
+	}
+	config := GPUConfig{
+		Architecture: "hopper",
+		DeviceMode:   DeviceModePhysical,
+		Capabilities: ArchitectureCapabilities{NVLink: 4},
+	}
+
+	expected := ExpectedMetricsForConfig(specs, config, ValidationOptions{})
+
+	require.NotContains(t, expected, "nvlink.count.active")
+	require.Contains(t, expected, "nvlink.nvswitch_connected")
+}
+
+func TestValidateEmittedMetricsAllowsZeroNVSwitchWithNoActiveNVLink(t *testing.T) {
+	specs := &Specs{
+		Metrics: &MetricsSpec{
+			Metrics: map[string]MetricSpec{
+				"nvlink.nvswitch_connected": {
+					Support: MetricSupportSpec{
+						DeviceModes: map[DeviceMode]bool{DeviceModePhysical: true},
+					},
+				},
+			},
+		},
+		Tags: &TagsSpec{},
+	}
+	config := GPUConfig{
+		Architecture: "hopper",
+		DeviceMode:   DeviceModePhysical,
+		Capabilities: ArchitectureCapabilities{NVLink: 4},
+	}
+	value := float64(0)
+	emittedMetrics := map[string][]MetricObservation{
+		"nvlink.nvswitch_connected": {{Value: &value}},
+	}
+
+	result, err := ValidateEmittedMetricsAgainstSpec(specs, config, emittedMetrics, nil, ValidationOptions{})
+
+	require.NoError(t, err)
+	require.False(t, result.HasFailures())
+}

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -131,6 +131,9 @@ type deviceOptions struct {
 	computeMinor       int
 	processInfoCB      func(uuid string) ([]nvml.ProcessInfo, nvml.Return)
 	gpmSupported       *bool
+	nvlinkGeneration   int
+	nvlinkLinkCount    int
+	c2cSupported       bool
 	unsupportedFields  map[uint32]struct{}
 	migChildCount      int
 }
@@ -161,6 +164,10 @@ func (o deviceOptions) hasUnsupportedField(fieldID uint32) bool {
 	}
 	_, found := o.unsupportedFields[fieldID]
 	return found
+}
+
+func (o deviceOptions) nvlinkSupported() bool {
+	return o.nvlinkGeneration > 0
 }
 
 func (o deviceOptions) effectiveArchitecture() (nvml.DeviceArchitecture, int, int) {
@@ -421,19 +428,22 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 			return nvml.RepairStatus{}, nvml.SUCCESS
 		},
 		GetNvLinkStateFunc: func(_ int) (nvml.EnableState, nvml.Return) {
-			if isMIGUnsupported {
+			if isMIGUnsupported || !opts.nvlinkSupported() {
 				return 0, nvml.ERROR_NOT_SUPPORTED
+			}
+			if opts.nvlinkLinkCount == 0 {
+				return nvml.FEATURE_DISABLED, nvml.SUCCESS
 			}
 			return nvml.FEATURE_ENABLED, nvml.SUCCESS
 		},
 		GetNvLinkUtilizationCounterFunc: func(_, _ int) (uint64, uint64, nvml.Return) {
-			if isMIGOrVGPUUnsupported {
+			if isMIGOrVGPUUnsupported || !opts.nvlinkSupported() || opts.nvlinkLinkCount == 0 {
 				return 0, 0, nvml.ERROR_NOT_SUPPORTED
 			}
 			return 100, 200, nvml.SUCCESS
 		},
 		GetNvLinkErrorCounterFunc: func(_ int, _ nvml.NvLinkErrorCounter) (uint64, nvml.Return) {
-			if isMIGOrVGPUUnsupported {
+			if isMIGOrVGPUUnsupported || !opts.nvlinkSupported() || opts.nvlinkLinkCount == 0 {
 				return 0, nvml.ERROR_NOT_SUPPORTED
 			}
 			return 0, nvml.SUCCESS
@@ -520,6 +530,9 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 				value := fieldValuesCounter + uint64(i)
 				if defaultValue, ok := DefaultFieldValues[values[i].FieldId]; ok {
 					value = defaultValue
+				}
+				if values[i].FieldId == nvml.FI_DEV_NVLINK_LINK_COUNT {
+					value = uint64(opts.nvlinkLinkCount)
 				}
 
 				var encoded [8]byte
@@ -778,8 +791,11 @@ func WithDeviceFeatureMode(mode DeviceFeatureMode) NvmlMockOption {
 // (e.g. from spec/architectures.yaml capabilities).
 // process_detail_list is derived from architecture (Hopper+ only) and is not a capability.
 type Capabilities struct {
-	GPM               bool
-	UnsupportedFields []uint32
+	GPM                       bool
+	NvLinkGenerationSupported int
+	NvLinkLinkCount           int
+	C2C                       bool
+	UnsupportedFields         []uint32
 }
 
 // WithCapabilities configures the mock so that architecture-gated APIs return
@@ -787,6 +803,9 @@ type Capabilities struct {
 func WithCapabilities(caps Capabilities) NvmlMockOption {
 	return func(o *nvmlMockOptions) {
 		o.deviceOptions.gpmSupported = &caps.GPM
+		o.deviceOptions.nvlinkGeneration = caps.NvLinkGenerationSupported
+		o.deviceOptions.nvlinkLinkCount = caps.NvLinkLinkCount
+		o.deviceOptions.c2cSupported = caps.C2C
 		if len(caps.UnsupportedFields) == 0 {
 			o.deviceOptions.unsupportedFields = nil
 			return


### PR DESCRIPTION
### What does this PR do?

Formalizes how NVLink fields are considered in the metric specification. We define NVLink generations, where fields are supported incrementally, and then assign generations to each architecture. We also allow GPUs to not have nvlink support. 

There's also a fix in the CI to ensure that the `tests_gpu` job runs on PRs that modify GPU code.

### Motivation

Simplify nvlink management in the specification and ensure tests take into account the fact that some GPUs do not have NVLink. This was causing integration tests like `tests_gpu` to fail.

### Describe how you validated your changes

CI passing.

### Additional Notes

Mock creation should be refactored later as there's a variety of places where mocks are instantiated in different forms.

The `tests_gpu` job is still failing despite these changes. A subsequent PR will fix it later.