### PR TITLE
fix(testwasher): skip blank lines

### DIFF
--- a/tasks/libs/testing/result_json.py
+++ b/tasks/libs/testing/result_json.py
@@ -61,6 +61,9 @@ class ResultJson:
         warning_logged = False
         with open(file) as f:
             for line in f:
+                line = line.strip()
+                if not line:
+                    continue
                 data = json.loads(line)
                 try:
                     res.append(ResultJsonLine.from_dict(data))


### PR DESCRIPTION
### What does this PR do?

I had an issue when running e2e tests, it's possible to have JSONDecodeError in some cases.
This ignores empty lines from the result json to avoid that.

### Motivation

### Describe how you validated your changes

### Additional Notes
