### PR TITLE
fix(cws): include last approver event type in stats reset loop

### DIFF
--- a/pkg/security/probe/monitors/approver/approver_monitor.go
+++ b/pkg/security/probe/monitors/approver/approver_monitor.go
@@ -126,7 +126,7 @@ func (d *Monitor) SendStats() error {
 			_ = d.statsdClient.Count(metrics.MetricEventApproved, int64(stats.EventApprovedByInUpperLayer), tagsForInUpperLayerApprovedEvents, 1.0)
 		}
 	}
-	for i := uint32(0); i != uint32(model.LastApproverEventType); i++ {
+	for i := uint32(0); i <= uint32(model.LastApproverEventType); i++ {
 		_ = buffer.Put(i, d.statsZero)
 	}
 


### PR DESCRIPTION
## Summary

The approver monitor stats reset loop in `pkg/security/probe/monitors/approver/approver_monitor.go` used `i != uint32(model.LastApproverEventType)`, which excluded the last key from being reset on every flush. Approver stats for the last event type therefore accumulated across flushes instead of being interval-based, skewing observability whenever a new event type was appended.

Changing the loop bound to `i <= uint32(model.LastApproverEventType)` ensures every approver event type (including the last) has its stats buffer reset to zero each flush.

Split out from #43523 per review feedback so the fix can be tracked independently.

## Test plan
- [ ] Existing CWS tests in `pkg/security/probe/monitors/approver/` continue to pass
- [ ] Manual verification that approver monitor metrics no longer drift for the last event type