### PR TITLE
omnibus: migrate leftover raw 'invoke' callsites to 'dda inv -- -e'

### DIFF
--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -30,7 +30,7 @@ build do
   end
 
   # we assume the go deps are already installed before running omnibus
-  command "invoke dogstatsd.build", env: env, :live_stream => Omnibus.logger.live_stream(:info)
+  command "dda inv -- -e dogstatsd.build", env: env, :live_stream => Omnibus.logger.live_stream(:info)
 
   mkdir "#{install_dir}/etc/datadog-dogstatsd"
   unless windows_target?

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -42,7 +42,7 @@ build do
   end
 
   if linux_target?
-    command "invoke agent.build --flavor iot --no-development", env: env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "dda inv -- -e agent.build --flavor iot --no-development", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     mkdir "#{install_dir}/bin"
     mkdir "#{install_dir}/run/"
 
@@ -60,7 +60,7 @@ build do
     if windows_target?
       # just builds the trace-agent, this should be moved to a separate package as it's not related to the iot agent
 
-      command "invoke trace-agent.build", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
+      command "dda inv -- -e trace-agent.build", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
 
       mkdir "#{Omnibus::Config.source_dir()}/datadog-iot-agent/src/github.com/DataDog/datadog-agent/bin/agent"
       copy 'bin/trace-agent/trace-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-iot-agent/src/github.com/DataDog/datadog-agent/bin/agent/trace-agent.exe"

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -42,7 +42,7 @@ build do
   bazel_flags = "--config=release --//:install_dir=#{install_dir}"
 
   if linux_target?
-    command "invoke installer.build --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "dda inv -- -e installer.build --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     mkdir "#{install_dir}/bin"
     copy 'bin/installer', "#{install_dir}/bin/"
 


### PR DESCRIPTION
### What does this PR do?

Aligns four omnibus software configs that were still shelling out to raw
`invoke ...` with the convention used by the rest of the codebase
(`dda inv -- -e <task> ...`).

### Motivation

Align iot-agent builds with the other flavors.

This ensures we can use dda everywhere (which we can't today, dda fails to install on the armhf build image)

### Describe how you validated your changes

CI

### Additional Notes
