### PR TITLE
[clusteragent/autoscaling] Defer workloadmeta pod collection until first DPA

### DIFF
--- a/cmd/cluster-agent/subcommands/check/command.go
+++ b/cmd/cluster-agent/subcommands/check/command.go
@@ -12,11 +12,13 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/check"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/autoscalinggate"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkgcommon "github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 
 	"github.com/spf13/cobra"
+	"go.uber.org/fx"
 )
 
 // Commands returns a slice of subcommands for the 'cluster-agent' command.
@@ -33,7 +35,12 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			ConfigName:   command.ConfigName,
 			LoggerName:   command.LoggerName,
 		}
-	}, wmcatalog.GetCatalog())
+	}, fx.Options(
+		wmcatalog.GetCatalog(),
+		// Required by the kubeapiserver collector, but never enabled in the
+		// "check" command because autoscaling doesn't run.
+		fx.Supply(autoscalinggate.New()),
+	))
 
 	return []*cobra.Command{cmd}
 }

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -562,7 +562,7 @@ func start(log log.Component,
 			log.Error("Admission controller is disabled, vertical autoscaling requires the admission controller to be enabled. Vertical scaling will be disabled.")
 		}
 
-		if patcher, err := provider.StartWorkloadAutoscaling(mainCtx, clusterID, clusterName, le.IsLeader, apiCl, rcClient, wmeta, taggerComp, demultiplexer); err == nil {
+		if patcher, err := provider.StartWorkloadAutoscaling(mainCtx, clusterID, clusterName, le.IsLeader, apiCl, rcClient, wmeta, taggerComp, demultiplexer, autoscalingGate); err == nil {
 			pp = patcher
 		} else {
 			return fmt.Errorf("Error while starting workload autoscaling: %v", err)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -91,6 +91,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection"
 	admissionpatch "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/patch"
 	apidca "github.com/DataDog/datadog-agent/pkg/clusteragent/api"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/autoscalinggate"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster"
 	clusterspot "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster/spot"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
@@ -180,6 +181,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					InitHelper: workloadmetainit.GetWorkloadmetaInit(),
 					AgentType:  workloadmeta.ClusterAgent,
 				}), // TODO(components): check what this must be for cluster-agent-cloudfoundry
+				fx.Supply(autoscalinggate.New()),
 				fx.Supply(context.Background()),
 				localTaggerfx.Module(),
 				workloadfilterfx.Module(),
@@ -290,6 +292,7 @@ func start(log log.Component,
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
 	healthPlatform option.Option[healthplatformdef.Component],
+	autoscalingGate *autoscalinggate.Gate,
 ) error {
 	stopCh := make(chan struct{})
 	validatingStopCh := make(chan struct{})

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"go.uber.org/fx"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -22,9 +21,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/autoscalinggate"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -37,18 +38,26 @@ const (
 type dependencies struct {
 	fx.In
 
-	Config config.Component
+	Config          config.Component
+	AutoscalingGate *autoscalinggate.Gate
 }
 
 // storeGenerator returns a new store specific to a given resource
 type storeGenerator func(context.Context, workloadmeta.Component, config.Reader, kubernetes.Interface) (*cache.Reflector, *reflectorStore)
 
 func shouldHavePodStore(cfg config.Reader) bool {
-	metadataAsTags := configutils.GetMetadataAsTags(cfg)
-	hasPodLabelsAsTags := len(metadataAsTags.GetPodLabelsAsTags()) > 0
-	hasPodAnnotationsAsTags := len(metadataAsTags.GetPodAnnotationsAsTags()) > 0
+	return podsRequiredAtStartup(cfg) || cfg.GetBool("autoscaling.workload.enabled")
+}
 
-	return cfg.GetBool("cluster_agent.collect_kubernetes_tags") || cfg.GetBool("autoscaling.workload.enabled") || cfg.GetBool("autoscaling.cluster.spot.enabled") || hasPodLabelsAsTags || hasPodAnnotationsAsTags
+// podsRequiredAtStartup returns true when some feature needs the pod store to
+// be available from startup. Workload autoscaling does not. It can defer the
+// start via the autoscaling gate.
+func podsRequiredAtStartup(cfg config.Reader) bool {
+	metadataAsTags := configutils.GetMetadataAsTags(cfg)
+	return cfg.GetBool("cluster_agent.collect_kubernetes_tags") ||
+		cfg.GetBool("autoscaling.cluster.spot.enabled") ||
+		len(metadataAsTags.GetPodLabelsAsTags()) > 0 ||
+		len(metadataAsTags.GetPodAnnotationsAsTags()) > 0
 }
 
 func shouldHaveDeploymentStore(cfg config.Reader) bool {
@@ -57,20 +66,6 @@ func shouldHaveDeploymentStore(cfg config.Reader) bool {
 	hasDeploymentsAnnotationsAsTags := len(metadataAsTags.GetResourcesAnnotationsAsTags()["deployments.apps"]) > 0
 
 	return cfg.GetBool("language_detection.enabled") && cfg.GetBool("language_detection.reporting.enabled") || hasDeploymentsLabelsAsTags || hasDeploymentsAnnotationsAsTags
-}
-
-func storeGenerators(cfg config.Reader) []storeGenerator {
-	var generators []storeGenerator
-
-	if shouldHavePodStore(cfg) {
-		generators = append(generators, newPodStore)
-	}
-
-	if shouldHaveDeploymentStore(cfg) {
-		generators = append(generators, newDeploymentStore)
-	}
-
-	return generators
 }
 
 func metadataCollectionGVRs(cfg config.Reader, discoveryClient discovery.DiscoveryInterface) ([]schema.GroupVersionResource, error) {
@@ -194,18 +189,20 @@ func resourcesForCSIDetection(cfg config.Reader) []string {
 }
 
 type collector struct {
-	id      string
-	catalog workloadmeta.AgentType
-	config  config.Reader
+	id              string
+	catalog         workloadmeta.AgentType
+	config          config.Reader
+	autoscalingGate *autoscalinggate.Gate
 }
 
 // NewCollector returns a kubeapiserver CollectorProvider that instantiates its colletor
 func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 	return workloadmeta.CollectorProvider{
 		Collector: &collector{
-			id:      collectorID,
-			catalog: workloadmeta.ClusterAgent,
-			config:  deps.Config,
+			id:              collectorID,
+			catalog:         workloadmeta.ClusterAgent,
+			config:          deps.Config,
+			autoscalingGate: deps.AutoscalingGate,
 		},
 	}, nil
 }
@@ -242,8 +239,26 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 		}
 	}
 
-	for _, storeBuilder := range storeGenerators(c.config) {
-		reflector, store := storeBuilder(ctx, wlmetaStore, c.config, client)
+	if shouldHavePodStore(c.config) {
+		autoscalingEnabled := c.config.GetBool("autoscaling.workload.enabled")
+		lazyStart := !podsRequiredAtStartup(c.config) && autoscalingEnabled
+
+		if lazyStart {
+			// The store is intentionally not added to objectStores. It would
+			// block the startup readiness check.
+			go c.startPodStoreOnGate(ctx, wlmetaStore, client, newPodStore)
+		} else {
+			reflector, store := newPodStore(ctx, wlmetaStore, c.config, client)
+			objectStores = append(objectStores, store)
+			go reflector.Run(ctx.Done())
+			if autoscalingEnabled {
+				go c.markPodCollectionSyncedWhenReady(ctx, store)
+			}
+		}
+	}
+
+	if shouldHaveDeploymentStore(c.config) {
+		reflector, store := newDeploymentStore(ctx, wlmetaStore, c.config, client)
 		objectStores = append(objectStores, store)
 		go reflector.Run(ctx.Done())
 	}
@@ -263,6 +278,27 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 	go runStartupCheck(ctx, objectStores)
 
 	return nil
+}
+
+// startPodStoreOnGate blocks until the autoscaling gate is enabled or the
+// context is cancelled. On gate enable, it starts the pod reflector.
+func (c *collector) startPodStoreOnGate(ctx context.Context, wlmetaStore workloadmeta.Component, client kubernetes.Interface, newStore storeGenerator) {
+	if !c.autoscalingGate.WaitForEnable(ctx) {
+		return
+	}
+
+	log.Debug("Autoscaling gate enabled, starting workloadmeta pod reflector lazily")
+	reflector, store := newStore(ctx, wlmetaStore, c.config, client)
+	go reflector.Run(ctx.Done())
+
+	c.markPodCollectionSyncedWhenReady(ctx, store)
+}
+
+func (c *collector) markPodCollectionSyncedWhenReady(ctx context.Context, store *reflectorStore) {
+	if !cache.WaitForCacheSync(ctx.Done(), store.HasSynced) {
+		return
+	}
+	c.autoscalingGate.MarkPodCollectionSynced()
 }
 
 func (c *collector) Pull(_ context.Context) error {

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -8,101 +8,178 @@
 package kubeapiserver
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/autoscalinggate"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestStoreGenerators(t *testing.T) {
-	// Define tests
+func TestShouldHaveDeploymentStore(t *testing.T) {
 	tests := []struct {
-		name                    string
-		cfg                     map[string]interface{}
-		expectedStoresGenerator []storeGenerator
+		name     string
+		cfg      map[string]interface{}
+		expected bool
 	}{
 		{
-			name: "All configurations disabled",
+			name: "language detection disabled",
 			cfg: map[string]interface{}{
-				"cluster_agent.collect_kubernetes_tags": false,
-				"language_detection.reporting.enabled":  false,
-				"language_detection.enabled":            false,
+				"language_detection.enabled": false,
 			},
-			expectedStoresGenerator: []storeGenerator{},
+			expected: false,
 		},
 		{
-			name: "All configurations disabled",
+			name: "language detection enabled but reporting disabled",
 			cfg: map[string]interface{}{
-				"cluster_agent.collect_kubernetes_tags": false,
-				"language_detection.reporting.enabled":  false,
-				"language_detection.enabled":            true,
+				"language_detection.enabled":           true,
+				"language_detection.reporting.enabled": false,
 			},
-			expectedStoresGenerator: []storeGenerator{},
+			expected: false,
 		},
 		{
-			name: "Kubernetes tags enabled",
+			name: "language detection and reporting enabled",
 			cfg: map[string]interface{}{
-				"cluster_agent.collect_kubernetes_tags": true,
-				"language_detection.reporting.enabled":  false,
-				"language_detection.enabled":            true,
+				"language_detection.reporting.enabled": true,
+				"language_detection.enabled":           true,
 			},
-			expectedStoresGenerator: []storeGenerator{newPodStore},
-		},
-		{
-			name: "Language detection enabled",
-			cfg: map[string]interface{}{
-				"cluster_agent.collect_kubernetes_tags": false,
-				"language_detection.reporting.enabled":  true,
-				"language_detection.enabled":            true,
-			},
-			expectedStoresGenerator: []storeGenerator{newDeploymentStore},
-		},
-		{
-			name: "Language detection enabled",
-			cfg: map[string]interface{}{
-				"cluster_agent.collect_kubernetes_tags": false,
-				"language_detection.reporting.enabled":  true,
-				"language_detection.enabled":            false,
-			},
-			expectedStoresGenerator: []storeGenerator{},
-		},
-		{
-			name: "All configurations enabled",
-			cfg: map[string]interface{}{
-				"cluster_agent.collect_kubernetes_tags": true,
-				"language_detection.reporting.enabled":  true,
-				"language_detection.enabled":            true,
-			},
-			expectedStoresGenerator: []storeGenerator{newPodStore, newDeploymentStore},
+			expected: true,
 		},
 	}
 
-	// Run test for each testcase
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := config.NewMockWithOverrides(t, tt.cfg)
-			expectedStores := collectResultStoreGenerator(tt.expectedStoresGenerator, cfg)
-			stores := collectResultStoreGenerator(storeGenerators(cfg), cfg)
-
-			assert.Equal(t, expectedStores, stores)
+			assert.Equal(t, tt.expected, shouldHaveDeploymentStore(cfg))
 		})
 	}
 }
 
-func collectResultStoreGenerator(funcs []storeGenerator, config config.Reader) []*reflectorStore {
-	var stores []*reflectorStore
-	client := fakeclientset.NewClientset()
-	for _, f := range funcs {
-		_, s := f(nil, nil, config, client)
-		stores = append(stores, s)
+func TestShouldHavePodStore(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      map[string]interface{}
+		expected bool
+	}{
+		{
+			name:     "no triggers",
+			cfg:      map[string]interface{}{},
+			expected: false,
+		},
+		{
+			name: "kubernetes tags collection",
+			cfg: map[string]interface{}{
+				"cluster_agent.collect_kubernetes_tags": true,
+			},
+			expected: true,
+		},
+		{
+			name: "spot scheduling",
+			cfg: map[string]interface{}{
+				"autoscaling.cluster.spot.enabled": true,
+			},
+			expected: true,
+		},
+		{
+			name: "pod labels as tags",
+			cfg: map[string]interface{}{
+				"kubernetes_pod_labels_as_tags": map[string]string{"app": "kube_app"},
+			},
+			expected: true,
+		},
+		{
+			name: "pod annotations as tags",
+			cfg: map[string]interface{}{
+				"kubernetes_pod_annotations_as_tags": map[string]string{"team": "kube_team"},
+			},
+			expected: true,
+		},
+		{
+			name: "workload autoscaling enabled",
+			cfg: map[string]interface{}{
+				"autoscaling.workload.enabled": true,
+			},
+			expected: true,
+		},
 	}
-	return stores
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := config.NewMockWithOverrides(t, test.cfg)
+			assert.Equal(t, test.expected, shouldHavePodStore(cfg))
+		})
+	}
+}
+
+func TestPodsRequiredAtStartup(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      map[string]interface{}
+		expected bool
+	}{
+		{
+			name:     "no triggers",
+			cfg:      map[string]interface{}{},
+			expected: false,
+		},
+		{
+			name: "kubernetes tags collection",
+			cfg: map[string]interface{}{
+				"cluster_agent.collect_kubernetes_tags": true,
+			},
+			expected: true,
+		},
+		{
+			name: "spot scheduling",
+			cfg: map[string]interface{}{
+				"autoscaling.cluster.spot.enabled": true,
+			},
+			expected: true,
+		},
+		{
+			name: "pod labels as tags",
+			cfg: map[string]interface{}{
+				"kubernetes_pod_labels_as_tags": map[string]string{"app": "kube_app"},
+			},
+			expected: true,
+		},
+		{
+			name: "pod annotations as tags",
+			cfg: map[string]interface{}{
+				"kubernetes_pod_annotations_as_tags": map[string]string{"team": "kube_team"},
+			},
+			expected: true,
+		},
+		{
+			name: "workload autoscaling alone is not a startup-time requirement",
+			cfg: map[string]interface{}{
+				"autoscaling.workload.enabled": true,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewMockWithOverrides(t, tt.cfg)
+			assert.Equal(t, tt.expected, podsRequiredAtStartup(cfg))
+		})
+	}
 }
 
 func Test_metadataCollectionGVRs_WithFunctionalDiscovery(t *testing.T) {
@@ -566,4 +643,60 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			assert.ElementsMatch(t, test.expectedResources, resourcesWithMetadataCollectionEnabled(cfg))
 		})
 	}
+}
+
+func TestStartPodStoreOnGate(t *testing.T) {
+	testPodUID := "test-pod-uid"
+
+	client := fakeclientset.NewClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       types.UID(testPodUID),
+		},
+	})
+
+	gate := autoscalinggate.New()
+
+	wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	testCollector := &collector{
+		id:              collectorID,
+		catalog:         workloadmeta.ClusterAgent,
+		config:          wmeta.GetConfig(),
+		autoscalingGate: gate,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		testCollector.startPodStoreOnGate(ctx, wmeta, client, newPodStoreWithTypedClient)
+		close(done)
+	}()
+
+	// Before enabling the gate, no pod should appear in workloadmeta.
+	assert.Never(t, func() bool {
+		_, err := wmeta.GetKubernetesPod(testPodUID)
+		return err == nil
+	}, 100*time.Millisecond, 20*time.Millisecond)
+
+	gate.Enable()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startPodStoreOnGate did not return after gate enabled")
+	}
+
+	// The pod reflector should eventually populate workloadmeta after enabling
+	// the gate.
+	require.Eventually(t, func() bool {
+		_, err := wmeta.GetKubernetesPod(testPodUID)
+		return err == nil
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/pkg/clusteragent/autoscaling/autoscalinggate/BUILD.bazel
+++ b/pkg/clusteragent/autoscaling/autoscalinggate/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "autoscalinggate",
+    srcs = ["gate.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/autoscalinggate",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "autoscalinggate_test",
+    srcs = ["gate_test.go"],
+    embed = [":autoscalinggate"],
+    gotags = ["test"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/pkg/clusteragent/autoscaling/autoscalinggate/gate.go
+++ b/pkg/clusteragent/autoscaling/autoscalinggate/gate.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package autoscalinggate provides a gate used to defer the start of pod
+// collection in workloadmeta for users that have workload autoscaling enabled
+// but no autoscalers configured yet.
+//
+// Pod collection can use a lot of memory on large clusters, and we'd like to
+// avoid that until it's needed.
+//
+// The gate is opened the first time the autoscaling stack observes a
+// DatadogPodAutoscaler, regardless of how it was created (Kubernetes, remote
+// config, profile-driven, etc.).
+package autoscalinggate
+
+import (
+	"context"
+	"sync"
+)
+
+// Gate coordinates the lazy startup of pod collection for workload autoscaling.
+type Gate struct {
+	enableCh   chan struct{}
+	enableOnce sync.Once
+	syncedCh   chan struct{}
+	syncedOnce sync.Once
+}
+
+// New returns a new Gate.
+func New() *Gate {
+	return &Gate{
+		enableCh: make(chan struct{}),
+		syncedCh: make(chan struct{}),
+	}
+}
+
+// Enable opens the gate. To be called when the autoscaling stack observes a
+// DatadogPodAutoscaler. Only the first call has any effect.
+func (g *Gate) Enable() {
+	g.enableOnce.Do(func() { close(g.enableCh) })
+}
+
+// MarkPodCollectionSynced marks the pod collection as synced. Only the first
+// call has any effect.
+func (g *Gate) MarkPodCollectionSynced() {
+	g.syncedOnce.Do(func() { close(g.syncedCh) })
+}
+
+// WaitForEnable blocks until Enable is called or ctx is cancelled. Returns true
+// if Enable was called, false if ctx was cancelled first.
+func (g *Gate) WaitForEnable(ctx context.Context) bool {
+	select {
+	case <-g.enableCh:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// WaitForPodCollectionSynced blocks until MarkPodCollectionSynced is called or
+// ctx is cancelled. Returns true if MarkPodCollectionSynced was called, false
+// if ctx was cancelled first.
+func (g *Gate) WaitForPodCollectionSynced(ctx context.Context) bool {
+	select {
+	case <-g.syncedCh:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}

--- a/pkg/clusteragent/autoscaling/autoscalinggate/gate_test.go
+++ b/pkg/clusteragent/autoscaling/autoscalinggate/gate_test.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoscalinggate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testTimeout = time.Second
+
+func TestEnable(t *testing.T) {
+	gate := New()
+
+	gate.Enable()
+	gate.Enable() // can be called multiple times safely
+
+	assert.True(t, gate.WaitForEnable(context.TODO()))
+}
+
+func TestMarkPodCollectionSynced(t *testing.T) {
+	gate := New()
+
+	gate.MarkPodCollectionSynced()
+	gate.MarkPodCollectionSynced() // can be called multiple times safely
+
+	assert.True(t, gate.WaitForPodCollectionSynced(context.TODO()))
+}
+
+func TestWaitForEnable(t *testing.T) {
+	t.Run("unblocks on Enable", func(t *testing.T) {
+		gate := New()
+
+		done := make(chan bool, 1)
+		go func() {
+			done <- gate.WaitForEnable(context.TODO())
+		}()
+
+		gate.Enable()
+
+		select {
+		case result := <-done:
+			assert.True(t, result)
+		case <-time.After(testTimeout):
+			t.Fatal("WaitForEnable did not unblock after Enable")
+		}
+	})
+
+	t.Run("returns false on cancelled context", func(t *testing.T) {
+		gate := New()
+
+		ctx, cancel := context.WithCancel(context.TODO())
+		cancel()
+
+		assert.False(t, gate.WaitForEnable(ctx))
+	})
+}
+
+func TestWaitForPodCollectionSynced(t *testing.T) {
+	t.Run("unblocks on MarkPodCollectionSynced", func(t *testing.T) {
+		gate := New()
+
+		done := make(chan bool, 1)
+		go func() {
+			done <- gate.WaitForPodCollectionSynced(context.TODO())
+		}()
+
+		gate.MarkPodCollectionSynced()
+
+		select {
+		case result := <-done:
+			assert.True(t, result)
+		case <-time.After(testTimeout):
+			t.Fatal("WaitForPodCollectionSynced did not unblock after MarkPodCollectionSynced")
+		}
+	})
+
+	t.Run("returns false on cancelled context", func(t *testing.T) {
+		gate := New()
+
+		ctx, cancel := context.WithCancel(context.TODO())
+		cancel()
+
+		assert.False(t, gate.WaitForPodCollectionSynced(ctx))
+	})
+}

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -48,6 +48,8 @@ const (
 	controllerID autoscaling.SenderID = "dpa-c"
 
 	defaultStaleTimestampThreshold = 30 * time.Minute // time to wait before considering a recommendation stale
+
+	podWatcherSyncRequeueAfter = 30 * time.Second
 )
 
 var (
@@ -146,7 +148,6 @@ func NewController(
 			DeleteFunc: func(key string, _ autoscaling.SenderID) { c.metricsStore.Delete(key) },
 		})
 
-	// TODO: Ensure that controllers do not take action before the podwatcher is synced
 	c.horizontalController = newHorizontalReconciler(c.clock, eventRecorder, c.scaler)
 
 	patchClient := workloadpatcher.NewPatcher(dynamicClient, nil) // let controller handle leader check
@@ -434,6 +435,13 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 		notFoundErr := autoscaling.NewConditionError(autoscaling.ConditionReasonTargetNotFound,
 			fmt.Errorf("target %s %s/%s not found", targetGVK.Kind, target.Namespace, target.Name))
 		return handleNonRetryableError(notFoundErr)
+	}
+
+	// The PodWatcher starts lazily and may not have indexed pods yet.
+	if !c.podWatcher.HasSynced() {
+		log.Debugf("PodWatcher not synced yet, requeuing %s in %s", key, podWatcherSyncRequeueAfter)
+		storeUnlock()
+		return autoscaling.Requeue.After(podWatcherSyncRequeueAfter), nil
 	}
 
 	// Now that everything is synced, we can perform the actual processing

--- a/pkg/clusteragent/autoscaling/workload/pod_watcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
@@ -43,6 +44,9 @@ type PodWatcher interface {
 	GetPodsForOwner(NamespacedPodOwner) []*workloadmeta.KubernetesPod
 	// GetReadyPodsForOwner returns the number of ready pods for the given owner.
 	GetReadyPodsForOwner(NamespacedPodOwner) int32
+	// HasSynced returns true once the PodWatcher has processed its initial
+	// workloadmeta bundle with pods
+	HasSynced() bool
 }
 
 // PodWatcherImpl is the implementation of the autoscaling PodWatcher
@@ -54,6 +58,7 @@ type PodWatcherImpl struct {
 	patcherChan          chan *workloadmeta.KubernetesPod
 	podsPerPodOwner      map[NamespacedPodOwner]map[string]*workloadmeta.KubernetesPod
 	readyPodsPerPodOwner map[NamespacedPodOwner]int32
+	synced               atomic.Bool
 }
 
 // NewPodWatcher creates a new PodWatcher
@@ -90,7 +95,7 @@ func (pw *PodWatcherImpl) GetReadyPodsForOwner(owner NamespacedPodOwner) int32 {
 
 // Run subscribes to workloadmeta events and indexes pods by their owner.
 func (pw *PodWatcherImpl) Run(ctx context.Context) {
-	log.Debug("Starting PodWatcher")
+	log.Info("Starting autoscaling PodWatcher, waiting for initial pod sync")
 
 	filter := workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindKubernetesPod).Build()
 	ch := pw.wlm.Subscribe(
@@ -119,8 +124,17 @@ func (pw *PodWatcherImpl) Run(ctx context.Context) {
 			for _, event := range eventBundle.Events {
 				pw.HandleEvent(event)
 			}
+			if pw.synced.CompareAndSwap(false, true) {
+				log.Info("Autoscaling PodWatcher synced")
+			}
 		}
 	}
+}
+
+// HasSynced returns true once the PodWatcher has processed its initial
+// workloadmeta bundle.
+func (pw *PodWatcherImpl) HasSynced() bool {
+	return pw.synced.Load()
 }
 
 // HandleEvent handles a workloadmeta event and updates the podwatcher state

--- a/pkg/clusteragent/autoscaling/workload/pod_watcher_fake.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher_fake.go
@@ -34,6 +34,10 @@ func (f *fakePodWatcher) GetReadyPodsForOwner(owner NamespacedPodOwner) int32 {
 	return f.Called(owner).Get(0).(int32)
 }
 
+func (f *fakePodWatcher) HasSynced() bool {
+	return true
+}
+
 func (f *fakePodWatcher) mockGetPodsForOwner(owner NamespacedPodOwner, pods []*workloadmeta.KubernetesPod) {
 	mockCall := f.On("GetPodsForOwner", owner)
 	mockCall.Return(pods)

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -25,6 +25,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/autoscalinggate"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/external"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/local"
@@ -50,6 +51,7 @@ func StartWorkloadAutoscaling(
 	wlm workloadmeta.Component,
 	taggerComp tagger.Component,
 	senderManager sender.SenderManager,
+	gate *autoscalinggate.Gate,
 ) (workload.PodPatcher, error) {
 	if apiCl == nil {
 		return nil, errors.New("Impossible to start workload autoscaling without valid APIClient")
@@ -61,6 +63,13 @@ func StartWorkloadAutoscaling(
 
 	store := autoscaling.NewStore[model.PodAutoscalerInternal]()
 	workload.InitDumper(store)
+
+	// Open the gate the first time a DPA enters the store. This catches every
+	// path that creates a DPA: Kubernetes informer, remote config, and the
+	// profile syncer.
+	store.RegisterObserver(autoscaling.Observer{
+		SetFunc: func(string, autoscaling.SenderID) { gate.Enable() },
+	})
 
 	patcher := workloadpatcher.NewPatcher(apiCl.DynamicCl, isLeaderFunc)
 	podPatcher := workload.NewPodPatcher(store, patcher, eventRecorder)
@@ -141,7 +150,7 @@ func StartWorkloadAutoscaling(
 	go profileController.Run(ctx, 1)
 	go workloadWatcher.Run(ctx)
 	go autoscalerSyncer.Run(ctx)
-	go podWatcher.Run(ctx)
+	go runPodWatcherWhenReady(ctx, gate, podWatcher.Run)
 	go controller.Run(ctx, dpaNumWorkers)
 
 	// Only start the local recommender if failover metrics collection is enabled
@@ -158,6 +167,18 @@ func StartWorkloadAutoscaling(
 	go externalRecommender.Run(ctx)
 
 	return podPatcher, nil
+}
+
+func runPodWatcherWhenReady(ctx context.Context, gate *autoscalinggate.Gate, run func(context.Context)) {
+	if !gate.WaitForEnable(ctx) || ctx.Err() != nil {
+		return
+	}
+
+	if !gate.WaitForPodCollectionSynced(ctx) || ctx.Err() != nil {
+		return
+	}
+
+	run(ctx)
 }
 
 func isArgoRolloutsAvailable(discoveryClient discovery.DiscoveryInterface) bool {

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -145,7 +145,6 @@ func StartWorkloadAutoscaling(
 	apiCl.InformerFactory.Start(ctx.Done())
 
 	dpaNumWorkers := pkgconfigsetup.Datadog().GetInt("autoscaling.workload.num_workers")
-	// TODO: Wait POD Watcher sync before running the controller
 	go builtinManager.Run(ctx)
 	go profileController.Run(ctx, 1)
 	go workloadWatcher.Run(ctx)

--- a/pkg/clusteragent/autoscaling/workload/provider/provider_test.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider_test.go
@@ -8,13 +8,17 @@
 package provider
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/autoscalinggate"
 )
 
 func TestIsArgoRolloutsAvailable(t *testing.T) {
@@ -71,4 +75,35 @@ func TestIsArgoRolloutsAvailable(t *testing.T) {
 
 		assert.False(t, isArgoRolloutsAvailable(fakeDiscovery))
 	})
+}
+
+func TestRunPodWatcherWhenReady(t *testing.T) {
+	gate := autoscalinggate.New()
+	ran := make(chan struct{})
+
+	go runPodWatcherWhenReady(context.TODO(), gate, func(context.Context) {
+		close(ran)
+	})
+
+	select {
+	case <-ran:
+		t.Fatal("run called before gate enabled")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	gate.Enable()
+
+	select {
+	case <-ran:
+		t.Fatal("run called before pod collection synced")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	gate.MarkPodCollectionSynced()
+
+	select {
+	case <-ran:
+	case <-time.After(time.Second):
+		t.Fatal("run not called after gate enabled and synced")
+	}
 }


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to reduce the memory cost of enabling workload autoscaling when it's not in use.

Right now, when autoscaling is enabled, the kubeapiserver workloadmeta collector starts a pod reflector. In large clusters, this can use a lot of memory. This happens even if no DPA is deployed.

We want to avoid this memory usage when no DPAs are deployed.

This will let us enable workload autoscaling by default at a much lower cost when it's not in use. Users who want it will be able to create DPAs directly, without having to enable the option in the Cluster Agent.

This PR does not flip the `autoscaling.workload.enabled` default to true. That will be done in a separate PR so it can be reverted independently if needed.

Note that this PR only gates the pod collection part instead of the whole autoscaling stack. That approach was tried in another PR (https://github.com/DataDog/datadog-agent/pull/50305) but it proved to be tricky. The problem is that parts of autoscaling need to be running to create DPAs in some cases (for example, when they come from remote config, or from profile-labelled workloads). So this PR reduces the cost of enabling autoscaling when there are no DPAs, but doesn't completely remove it. Some parts still run, like the metadata-only informers for deployments and statefulsets.

### Describe how you validated your changes

Unit tests plus tests on a local kind cluster.

For the kind tests, I used kwok to simulate a large number of pods so the memory impact of the pod reflector would be measurable. I ran 5 scenarios:

1. main, autoscaling disabled. Just to have a baseline.
2. main, autoscaling enabled, no DPAs. To have a baseline with autoscaling enabled.
3. This branch, autoscaling disabled. To confirm no regression with main. Memory usage is roughly the same as in scenario 1.
4. This branch, autoscaling enabled, no DPAs: memory higher than baseline but lower than scenarios 2 and 5. This is because some of the autoscaling components that are running as mentioned in the PR description.
5. This branch, autoscaling enabled, DPA deployed: memory went up to roughly the same as scenario 2.