### PR TITLE
chore(git): force LF for Bazel files to stop autocrlf churn on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,6 +32,9 @@ pkg/fleet/installer/fixtures/** text=auto eol=lf
 *.bzl text eol=lf
 MODULE.bazel.lock text eol=lf
 
+# Use LF for python files that need to pass Bazel's byte-exact diff_test
+tasks/core_checks.py text eol=lf
+
 # Fix `git diff` when running on the below file formats.
 # Our windows build image uses MinGit which tries to use the astextplain diff algorithm (https://git-scm.com/docs/gitattributes#_setting_the_internal_diff_algorithm).
 # The astextplain binary is not embedded in the docker image making the git diff command fail when one of the below file formats is in the diff.

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 *.gopatch text eol=lf
 # Same for go workspace files (root and testdata)
 *go.work text eol=lf
+go.mod text eol=lf
 go.sum -diff -merge linguist-generated=true
 *.pb.go -diff -merge
 *.pb.go linguist-generated=true
@@ -25,6 +26,11 @@ pkg/security/seclwin/** -diff -merge linguist-generated=true
 docs/cloud-workload-security/** text eol=lf
 # Fixtures should have LF line endings because they are checked against OCI packages built on Linux
 pkg/fleet/installer/fixtures/** text=auto eol=lf
+
+# Bazel writes LF; force LF on Windows too to avoid autocrlf churn after `bazel run` / `dda inv tidy`
+*.bazel text eol=lf
+*.bzl text eol=lf
+MODULE.bazel.lock text eol=lf
 
 # Fix `git diff` when running on the below file formats.
 # Our windows build image uses MinGit which tries to use the astextplain diff algorithm (https://git-scm.com/docs/gitattributes#_setting_the_internal_diff_algorithm).


### PR DESCRIPTION
### What does this PR do?

Adds `text eol=lf` rules to `.gitattributes` for Bazel-managed files (`*.bazel`, `*.bzl`, `MODULE.bazel.lock`) and `go.mod`.

### Motivation

On Windows with the default `core.autocrlf=true`, Bazel-generated files (BUILD.bazel, MODULE.bazel, `.bzl`, lockfile) create perpetual line-ending churn: Bazel/`dda inv tidy` writes LF, git's smudge filter would rewrite to CRLF on checkout, producing "LF will be replaced by CRLF" warnings and phantom modifications every time these files are touched. Pinning them to LF matches what Bazel actually emits and eliminates the round-trip.

### Describe how you validated your changes

Inspected blob and working-tree bytes of affected files after `dda inv tidy` on Windows; both are LF and `.gitattributes` rules suppress the CRLF smudge.