### PR TITLE
fix(anomalydetection): skip agent AD log sources

### DIFF
--- a/comp/anomalydetection/logssource/impl/ad_source_manager.go
+++ b/comp/anomalydetection/logssource/impl/ad_source_manager.go
@@ -36,10 +36,14 @@ func newADSourceManager(logSources *sources.LogSources, services *service.Servic
 }
 
 // AddSource implements schedulers.SourceManager.
-// For container-runtime sources with an identifier, it adds to LogSources first
-// so the AD source is always active before suppression evicts any generic source.
-// This eliminates the TOCTOU window where neither source would be active.
+// Agent container sources are dropped so AD/CCA cannot bypass the internal log
+// tap gate. Other container-runtime sources are added to LogSources before
+// suppression evicts any generic source, eliminating the TOCTOU window where
+// neither source would be active.
 func (m *adSourceManager) AddSource(src *sources.LogSource) {
+	if isContainerSource(src) && m.sp.isAgentContainerID(src.Config.Identifier) {
+		return
+	}
 	m.logSources.AddSource(src)
 	if isContainerSource(src) {
 		m.sp.suppressIdentifier(src.Config.Identifier)

--- a/comp/anomalydetection/logssource/impl/ad_source_manager_test.go
+++ b/comp/anomalydetection/logssource/impl/ad_source_manager_test.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logssourceimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+func newContainerADSource(containerID string) *sources.LogSource {
+	return sources.NewLogSource("container_collect_all", &logsconfig.LogsConfig{
+		Type:       logsconfig.ContainerdType,
+		Identifier: containerID,
+	})
+}
+
+func isSuppressed(sp *sourceProvider, containerID string) bool {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	_, suppressed := sp.suppressedIDs[containerID]
+	return suppressed
+}
+
+func TestADSourceManagerAddSourceSkipsAgentContainer(t *testing.T) {
+	wmeta := newWMetaMock(t)
+	wmeta.Set(runningContainer("agent-container", "gcr.io/datadoghq/datadog-agent"))
+
+	logSources := sources.NewLogSources()
+	sp := newSourceProvider(wmeta, logSources, nil)
+	mgr := newADSourceManager(logSources, service.NewServices(), sp)
+
+	mgr.AddSource(newContainerADSource("agent-container"))
+
+	assert.Empty(t, logSources.GetSources(), "AD/CCA must not bypass the agent-internal log tap gate")
+	assert.False(t, isSuppressed(sp, "agent-container"), "skipped Agent AD sources should not suppress future generic decisions")
+}
+
+func TestADSourceManagerAddSourceKeepsNonAgentContainer(t *testing.T) {
+	wmeta := newWMetaMock(t)
+	wmeta.Set(runningContainer("app-container", "nginx"))
+
+	logSources := sources.NewLogSources()
+	sp := newSourceProvider(wmeta, logSources, nil)
+	mgr := newADSourceManager(logSources, service.NewServices(), sp)
+
+	src := newContainerADSource("app-container")
+	mgr.AddSource(src)
+
+	got := logSources.GetSources()
+	require.Len(t, got, 1)
+	assert.Same(t, src, got[0])
+	assert.True(t, isSuppressed(sp, "app-container"), "active AD source should still suppress generic fallback collection")
+}
+
+func TestADSourceManagerAddSourceKeepsUnknownContainer(t *testing.T) {
+	wmeta := newWMetaMock(t)
+
+	logSources := sources.NewLogSources()
+	sp := newSourceProvider(wmeta, logSources, nil)
+	mgr := newADSourceManager(logSources, service.NewServices(), sp)
+
+	src := newContainerADSource("not-yet-in-workloadmeta")
+	mgr.AddSource(src)
+
+	got := logSources.GetSources()
+	require.Len(t, got, 1)
+	assert.Same(t, src, got[0])
+}

--- a/comp/anomalydetection/logssource/impl/source_provider.go
+++ b/comp/anomalydetection/logssource/impl/source_provider.go
@@ -168,6 +168,20 @@ func isAgentContainer(c *workloadmeta.Container) bool {
 	return strings.Contains(strings.ToLower(c.Image.ShortName), "agent")
 }
 
+// isAgentContainerID returns true when workloadmeta identifies containerID as
+// an Agent container. Lookup failures are treated as non-Agent so AD collection
+// is not accidentally disabled while workloadmeta is still catching up.
+func (sp *sourceProvider) isAgentContainerID(containerID string) bool {
+	if sp == nil || sp.wmeta == nil || containerID == "" {
+		return false
+	}
+	container, err := sp.wmeta.GetContainer(containerID)
+	if err != nil {
+		return false
+	}
+	return isAgentContainer(container)
+}
+
 // suppressIdentifier marks containerID as owned by an AD source.
 // If a generic source for that container is already active, it is removed so
 // the AD source becomes the sole collector for this container.

--- a/releasenotes/notes/anomaly-logssource-skip-agent-ad-da91b0ad9ccf1bd8.yaml
+++ b/releasenotes/notes/anomaly-logssource-skip-agent-ad-da91b0ad9ccf1bd8.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Fixes anomaly detection log ingestion so container autodiscovery does not collect Datadog Agent container logs when container collect-all log collection is enabled.

--- a/releasenotes/notes/anomaly-logssource-skip-agent-ad-da91b0ad9ccf1bd8.yaml
+++ b/releasenotes/notes/anomaly-logssource-skip-agent-ad-da91b0ad9ccf1bd8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes anomaly detection log ingestion so container autodiscovery does not collect Datadog Agent container logs when container collect-all log collection is enabled.


### PR DESCRIPTION
### What does this PR do?

Skips Datadog Agent container log sources in the anomaly detection log autodiscovery source manager. This prevents container collect-all autodiscovery from feeding Agent container logs into the anomaly observer pipeline and bypassing the dedicated agent-internal log tap configuration.

### Motivation

The generic anomaly log source provider already avoids tailing Datadog Agent containers, but the autodiscovery path used by `logs_config.container_collect_all` could create a normal container log source before that generic guard ran. As a result, disabling `anomaly_detection.agent_logs.enabled` did not fully prevent Agent logs from reaching anomaly detection when container collect-all was enabled.

Lookup misses in workloadmeta continue to fall through so regular AD log collection is not disabled while workloadmeta catches up.

### Describe how you validated your changes

- Added unit tests for Agent container AD sources, non-Agent container AD sources, and workloadmeta lookup misses.
- Ran `dda inv test --targets=./comp/anomalydetection/logssource/impl/` successfully.
- Ran `dda inv linter.releasenote`; it exited successfully and skipped PR-specific release note checks because the PR did not exist yet.
- Commit and push hooks passed, including gofmt, releasenote RST, go-test, and go-linter.

### Additional Notes

Includes a `fixes` reno note for the behavior change.