### PR TITLE
persist resolved IPC paths so configstream snapshot carries them

### DIFF
--- a/comp/core/ipc/impl/ipc.go
+++ b/comp/core/ipc/impl/ipc.go
@@ -60,6 +60,9 @@ func NewReadOnlyComponent(reqs Requires) (Provides, error) {
 		return Provides{}, fmt.Errorf("unable to fetch IPC certificate (please check that the Agent is running, this file is normally generated during the first run of the Agent service): %s", err)
 	}
 
+	pkgtoken.PersistAuthTokenFilepath(reqs.Conf)
+	cert.PersistCertFilepath(reqs.Conf)
+
 	return buildIPCComponent(reqs, token, clientConfig, serverConfig, clusterClientConfig)
 }
 
@@ -82,6 +85,9 @@ func NewReadWriteComponent(reqs Requires) (Provides, error) {
 	if err != nil {
 		return Provides{}, fmt.Errorf("error while creating or fetching IPC cert: %w", err)
 	}
+
+	pkgtoken.PersistAuthTokenFilepath(reqs.Conf)
+	cert.PersistCertFilepath(reqs.Conf)
 
 	return buildIPCComponent(reqs, token, clientConfig, serverConfig, clusterClientConfig)
 }

--- a/pkg/api/security/cert/cert_getter.go
+++ b/pkg/api/security/cert/cert_getter.go
@@ -40,6 +40,20 @@ func getCertFilepath(config configModel.Reader) string {
 	return filepath.Join(filepath.Dir(config.ConfigFileUsed()), defaultCertFileName)
 }
 
+// PersistCertFilepath stores the resolved ipc_cert_file_path back into the config when the
+// setting was left at its empty default, so the configstream snapshot carries a concrete
+// absolute path that remote agents can resolve regardless of their own cwd.
+func PersistCertFilepath(config configModel.ReaderWriter) {
+	if config.GetString("ipc_cert_file_path") != "" {
+		return
+	}
+	resolved := getCertFilepath(config)
+	if abs, err := filepath.Abs(resolved); err == nil {
+		resolved = abs
+	}
+	config.Set("ipc_cert_file_path", resolved, configModel.SourceConfigPostInit)
+}
+
 type certificateFactory struct {
 	caCert             *x509.Certificate
 	caPrivKey          any // x509.ParsePKCS8PrivateKey returns as the private key any, and x509.CreateCertificate takes any as the private key argument

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -140,6 +140,22 @@ func GetAuthTokenFilepath(config configModel.Reader) string {
 	return filepath.Join(filepath.Dir(config.ConfigFileUsed()), authTokenName)
 }
 
+// PersistAuthTokenFilepath stores the resolved auth_token_file_path back into the config when
+// the setting was left at its empty default, so downstream readers (notably the configstream
+// snapshot producer) see a concrete absolute path rather than re-deriving the fallback on
+// each call. Absolute is required because remote agents consuming the snapshot may run from
+// a different cwd than the core agent.
+func PersistAuthTokenFilepath(config configModel.ReaderWriter) {
+	if config.GetString("auth_token_file_path") != "" {
+		return
+	}
+	resolved := GetAuthTokenFilepath(config)
+	if abs, err := filepath.Abs(resolved); err == nil {
+		resolved = abs
+	}
+	config.Set("auth_token_file_path", resolved, configModel.SourceConfigPostInit)
+}
+
 // FetchAuthToken gets the authentication token from the auth token file
 // Requires that the config has been set up before calling
 func FetchAuthToken(config configModel.Reader) (string, error) {


### PR DESCRIPTION
### What does this PR do?

The IPC component now writes the resolved `auth_token_file_path` and `ipc_cert_file_path` back to the config at `SourceConfigPostInit` when the setting was left at its empty default. The values are made absolute via `filepath.Abs` before being written so remote agents that consume the configstream snapshot can resolve them regardless of their own working directory.

Two small persisters are added:
- `pkg/api/security/security.PersistAuthTokenFilepath(config)`
- `pkg/api/security/cert.PersistCertFilepath(config)`

Both are called from `comp/core/ipc/impl/ipc.go` in `NewReadOnlyComponent` and `NewReadWriteComponent`, immediately after the IPC artifacts have been fetched or created. The write is a no-op when the setting is already non-empty, so explicit `auth_token_file_path` / `ipc_cert_file_path` values from file or env on the core agent still win.

### Motivation

`auth_token_file_path` and `ipc_cert_file_path` are registered in `pkg/config/setup/common_settings.go` with empty-string defaults. The resolved fallback paths are computed on demand by `GetAuthTokenFilepath` and `getCertFilepath` and never written back to the config. So a core agent that hasn't been given explicit overrides reports these keys as `""` in `cs.config.AllFlattenedSettingsWithSequenceID()`, and the configstream snapshot streams them as empty strings.

On the consumer side, the saluki `IpcAuthConfiguration` parses an empty string as "unset" and falls back to `PlatformSettings::get_auth_token_path()` / `PlatformSettings::get_config_dir_path()`. On macOS that's `/opt/datadog-agent/etc/`, which on most developer machines (and any host with a second Datadog install) contains a different `ipc_cert.pem` than the one the running Core Agent serves. The byte-equality TLS verifier in `lib/datadog-agent-commons/src/ipc/tls.rs` then rejects the server's cert with `UnknownIssuer`, the retry budget exhausts, and ADP exits.

Concretely, before this PR:

- Bootstrap-phase cert read: `/etc/datadog-agent/ipc_cert.pem` (from `DD_IPC_CERT_FILE_PATH`), 453 bytes — matches what the Core Agent serves.
- Steady-state cert read: `/opt/datadog-agent/etc/ipc_cert.pem` (platform default), 454 bytes — different cert.
- ADP loop: `Successfully registered` → `Initial configuration received.` → 10× `Failed to create Datadog Agent API client ... invalid peer certificate: UnknownIssuer` → exit.

After this PR, the snapshot carries the resolved absolute paths the Core Agent is itself using, so the consumer reads the right cert and the steady-state TLS handshake succeeds.

The persistence is gated on the setting being empty, so this is a no-op on any deployment where the operator has set `DD_AUTH_TOKEN_FILE_PATH` / `DD_IPC_CERT_FILE_PATH` (or the equivalent YAML keys). It only fills in the implicit fallback case where the consumer would otherwise have to re-derive a path it has no reliable way to compute.

### Describe how you validated your changes

`dda inv linter.go --targets=./pkg/api/security,./pkg/api/security/cert,./comp/core/ipc/impl` — clean.

`dda inv test --targets=./pkg/api/security,./pkg/api/security/cert,./comp/core/ipc/impl` — 25/25 passed.

`dda inv agent.build` — succeeds.

Inspected the resolved config dump on the rebuilt agent:

```
$ ./bin/agent/agent -c bin/agent/dist/datadog.yaml config | grep -E 'auth_token_file_path|ipc_cert_file_path'
auth_token_file_path: /Users/<redacted>/datadog-agent/bin/agent/dist/auth_token
ipc_cert_file_path: /Users/<redacted>/datadog-agent/bin/agent/dist/ipc_cert.pem
```

Before this PR, both keys reported empty.

End-to-end repro of the original bug + verification it's fixed:

1. Started the patched Core Agent with the configstream consumer enabled.
2. Ran ADP (saluki `main`) with `DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT=true`, `DD_CMD_PORT`, `DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth_token`, `DD_IPC_CERT_FILE_PATH=/etc/datadog-agent/ipc_cert.pem`.

Before this PR (against an agent on `main`):

```
DATAPLANE | INFO  | Successfully registered with the Datadog Agent.
DATAPLANE | INFO  | Waiting for initial configuration from Datadog Agent...
DATAPLANE | INFO  | Initial configuration received.
DATAPLANE | WARN  | Failed to create Datadog Agent API client. Retrying in 2s...
... (10 retries) ...
DATAPLANE | ERROR | Failed to create Datadog Agent API client.
Caused by:
    0: Failed to connect to Datadog Agent API at 'https://127.0.0.1:5001/'.
    1: transport error
    2: invalid peer certificate: UnknownIssuer
```

After this PR (against the patched agent):

```
DATAPLANE | INFO  | Successfully registered with the Datadog Agent.
DATAPLANE | INFO  | Waiting for initial configuration from Datadog Agent...
DATAPLANE | INFO  | Initial configuration received.
DATAPLANE | INFO  | Internal supervisor healthy.
DATAPLANE | INFO  | Topology healthy. Waiting for interrupt...
```

ADP's effective config after startup confirms the streamed values are what it's using:

```
$ target/devel/agent-data-plane config | grep -E 'auth_token_file_path|ipc_cert_file_path'
  "auth_token_file_path": "/Users/<redacted>/datadog-agent/bin/agent/dist/auth_token",
  "ipc_cert_file_path": "/Users/<redacted>/datadog-agent/bin/agent/dist/ipc_cert.pem",
```

The Core Agent log also shows the subscriber joining the config stream and staying for the lifetime of the ADP process, with no `removeSubscriber` until ADP is killed.

### Additional Notes

- This is a server-side fix; saluki / ADP requires no changes to benefit from it.
- The persistence happens at `SourceConfigPostInit` (priority 6, above `SourceEnvVar`), but only when the existing value is empty. Operator-provided values via file (priority 3) or env (priority 4) on the Core Agent still flow through unchanged.
- The same paths are now visible to any Go-based remote agent that consumes the configstream snapshot (system-probe and the trace/process/security adopters scheduled for follow-up), not just ADP.