### PR TITLE
Make .pyc files out of the python build reproducible

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -277,7 +277,9 @@ configure_make(
         # Build in parallel but install without parallel execution
         # (see https://github.com/python/cpython/issues/109796)
         "-j 16",
-        "install",
+        # Set compileall options for improved reproducibility of pyc files by enabling hash-based invalidation
+        # and removing the sandbox path from the paths recorded in them.
+        'install COMPILEALL_OPTS="--invalidation-mode checked-hash -s $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$"',
     ],
     target_compatible_with = select({
         "@platforms//os:macos": [],

--- a/deps/cpython/0004-Drop-hardcoded-d-LIBDEST-from-libinstall-compileall.patch
+++ b/deps/cpython/0004-Drop-hardcoded-d-LIBDEST-from-libinstall-compileall.patch
@@ -1,0 +1,38 @@
+From: Alex Lopez <alex.lopez@datadoghq.com>
+Subject: [PATCH] libinstall: drop hardcoded `-d $(LIBDEST)` from compileall
+
+The libinstall recipe passes `-d $(LIBDEST)` to compileall *after*
+$(COMPILEALL_OPTS). compileall's argument parser rejects the combination
+of `-d` with `-s` or `-p`, so any user attempt to control the `.pyc`
+embedded `co_filename` paths via COMPILEALL_OPTS (e.g. `-s STRIP -p
+PREPEND`) fails fast with:
+
+  compileall.py: error: -d cannot be used in combination with -s or -p
+
+In standard CPython installs LIBDEST is a stable, sensible path
+(e.g. /usr/local/lib/python3.13), so the hardcoded `-d` produced the
+right `co_filename` by default. In rules_foreign_cc-style builds, LIBDEST
+is the sandbox install root and varies per-machine, so the default isn't
+useful and we want to override it.
+
+Dropping `-d $(LIBDEST)` is a no-op for the default invocation: when no
+-d/-s/-p is provided, compileall falls back to using the positional
+source-directory prefix in `co_filename`, which is the same value
+`-d $(LIBDEST)` had been setting. The change only matters when
+COMPILEALL_OPTS supplies its own path-rewriting flags.
+
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -2572,10 +2572,10 @@
+ 	@ # Build PYC files for the 3 optimization levels (0, 1, 2)
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-o 0 -o 1 -o 2 $(COMPILEALL_OPTS) -d $(LIBDEST) -f \
++		-o 0 -o 1 -o 2 $(COMPILEALL_OPTS) -f \
+ 		-x 'bad_coding|badsyntax|site-packages' \
+ 		$(DESTDIR)$(LIBDEST)
+ 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
+ 		$(PYTHON_FOR_BUILD) -Wi $(DESTDIR)$(LIBDEST)/compileall.py \
+-		-o 0 -o 1 -o 2 $(COMPILEALL_OPTS) -d $(LIBDEST)/site-packages -f \
++		-o 0 -o 1 -o 2 $(COMPILEALL_OPTS) -f \
+ 		-x badsyntax $(DESTDIR)$(LIBDEST)/site-packages

--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -14,6 +14,7 @@ http_archive(
         "//deps/cpython:0001-customize-windows-build-script.patch",
         "//deps/cpython:0002-Set-the-install-name-to-use-rpath-instead-of-absolut.patch",
         "//deps/cpython:0003-propagate-pgo-test-exit-code.patch",
+        "//deps/cpython:0004-Drop-hardcoded-d-LIBDEST-from-libinstall-compileall.patch",
     ],
     sha256 = "f9cde7b0e2ec8165d7326e2a0f59ea2686ce9d0c617dbbb3d66a7e54d31b74b9",
     strip_prefix = "Python-{}".format(PYTHON_VERSION),


### PR DESCRIPTION
### What does this PR do?

Makes pyc files coming out of the unix python built with bazel more reproducible by:
- Using the deterministic invalidation method introduced by [PEP-552](https://peps.python.org/pep-0552/). This embeds a hash of the file instead of relying on timestamps to determine whether a .pyc file should be recompiled. See https://docs.python.org/3/library/compileall.html#cmdoption-compileall-invalidation-mode.
- Strips the sandbox's path from the path that gets encoded in the .pyc files, using the [available flag for doing so](https://docs.python.org/3/library/compileall.html#cmdoption-compileall-s). This conflicts with the hardcoded `-d` flag in the cpython makefile ([here](https://github.com/python/cpython/blob/661df25692fd3d56ccca715e38656fdb565b4661/Makefile.pre.in#L2823)), which is why a patch is needed in addition.

### Motivation

I'm working on making the Python we build usable within Bazel for the purposed of [ABLD-260](https://datadoghq.atlassian.net/browse/ABLD-260). I was observing that running my current prototype via `bazel run` dirtied the output folder, invalidating the cache.

Looking at what we're doing on windows, I realized that we're deleting them (https://github.com/DataDog/datadog-agent/pull/49338), making me aware of the encoding of the sandbox path in `co_filename`, driving the second reproducibility improvement.

### Describe how you validated your changes

CI plus extra confirmation:
- Confirmed `co_filename` no longer encodes the path to the sandbox:
```
>>> f = open("bazel-bin/external/+http_archive+cpython/python_unix/lib/python3.13/__pycache__/os.cpython-313.pyc", "rb")
>>> f.read(16); import marshal; print(marshal.load(f).co_filename)
b'\xf3\r\r\n\x03\x00\x00\x00\x06^\xfe\x82\x19\xfb\x01\xff'
lib/python3.13/os.py
```
- `bazel run` on my prototype runs without dirtying the output folder.

### Additional Notes

There's the very reasonable question of: why not just delete the __pycache__ folder as we're doing on Windows? The main reason is that I'm trying to affect existing behavior.

The simple most compelling answer is that there's code that depends on it on Linux:
https://github.com/DataDog/datadog-agent/blob/5181164f8270304ad727e91077e069fca084e6ed/omnibus/config/software/datadog-agent-finalize.rb#L111-L112

This actually deletes the pyc files, but it records them on a file that is used by installation-related code. Therefore, the proposed change:
- Avoids going deep into what the current setup does, its rationale, etc. for now.
- It gives us the option to ship pyc files that are actually usable (given that they're reproducible and won't be regenerated). Even though this seems unlikely due to the extra size (for the perhaps questionable startup time optimization).

On macos we don't seem to remove the files at all.

[ABLD-260]: https://datadoghq.atlassian.net/browse/ABLD-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ