### PR TITLE
Revert "flake: mark TestRevertsConfigExperimentWhenTimeout as flaky"

### DIFF
--- a/test/new-e2e/tests/installer/windows/agent_config_test.go
+++ b/test/new-e2e/tests/installer/windows/agent_config_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cenkalti/backoff/v5"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
@@ -272,7 +271,6 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 // TestRevertsConfigExperimentWhenTimeout tests that the watchdog will revert
 // to stable config when the timeout expires.
 func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
-	flake.Mark(s.T()) // TODO: https://datadoghq.atlassian.net/browse/incident-54741
 	// Arrange
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()


### PR DESCRIPTION
Reverts DataDog/datadog-agent#51006

fixed by https://github.com/DataDog/datadog-agent/pull/50980