### PR TITLE
[auto-jira][AGNTLOG-502] Add remote_agent and source COAT tags to logs.sent metric

### DIFF
--- a/comp/logs-library/client/http/destination.go
+++ b/comp/logs-library/client/http/destination.go
@@ -311,8 +311,14 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 			metrics.DestinationLogsDropped.Add(d.host, payload.Count())
 			metrics.TlmLogsDropped.Add(float64(payload.Count()), d.host)
 		} else {
+			var sourceTag string
+			if strings.Contains(d.Metadata().TelemetryName(), "logs") {
+				sourceTag = "logs"
+			} else {
+				sourceTag = "epforwarder"
+			}
 			metrics.LogsSent.Add(payload.Count())
-			metrics.TlmLogsSent.Add(float64(payload.Count()))
+			metrics.TlmLogsSent.Add(float64(payload.Count()), metrics.GetAgentIdentityTag(), sourceTag)
 		}
 
 		output <- payload

--- a/comp/logs-library/client/http/sync_destination.go
+++ b/comp/logs-library/client/http/sync_destination.go
@@ -6,6 +6,7 @@
 package http
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -87,8 +88,14 @@ func (d *SyncDestination) run(input chan *message.Payload, output chan *message.
 			senderDoneWg.Done()
 		}
 
+		var sourceTag string
+		if strings.Contains(d.destination.Metadata().TelemetryName(), "logs") {
+			sourceTag = "logs"
+		} else {
+			sourceTag = "epforwarder"
+		}
 		metrics.LogsSent.Add(p.Count())
-		metrics.TlmLogsSent.Add(float64(p.Count()))
+		metrics.TlmLogsSent.Add(float64(p.Count()), metrics.GetAgentIdentityTag(), sourceTag)
 		output <- p
 
 		inUse := float64(time.Since(startInUse) / time.Millisecond)

--- a/comp/logs-library/client/tcp/destination.go
+++ b/comp/logs-library/client/tcp/destination.go
@@ -121,12 +121,11 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 
 		d.updateRetryState(nil, isRetrying)
 
-		metrics.LogsSent.Add(1)
-		metrics.TlmLogsSent.Inc()
-		metrics.BytesSent.Add(int64(payload.UnencodedSize))
-
 		// TCP is only used for logs data, so we always use "logs" as the source tag
 		sourceTag := "logs"
+		metrics.LogsSent.Add(1)
+		metrics.TlmLogsSent.Add(1, metrics.GetAgentIdentityTag(), sourceTag)
+		metrics.BytesSent.Add(int64(payload.UnencodedSize))
 		// Default Compression for TCP is none
 		compressionKind := "none"
 

--- a/comp/logs-library/metrics/metrics.go
+++ b/comp/logs-library/metrics/metrics.go
@@ -29,8 +29,11 @@ var (
 	// LogsSent is the total number of sent logs.
 	LogsSent = expvar.Int{}
 	// TlmLogsSent is the total number of sent logs.
+	// The remote_agent tag identifies which agent sent the logs. Use GetAgentIdentityTag()
+	// to get the correct value for the current agent. This tag is used by COAT to partition
+	// log counts by agent type. The source tag distinguishes logs from epforwarder payloads.
 	TlmLogsSent = telemetryimpl.GetCompatComponent().NewCounter("logs", "sent",
-		nil, "Total number of sent logs")
+		[]string{"remote_agent", "source"}, "Total number of sent logs")
 	// DestinationErrors is the total number of network errors.
 	DestinationErrors = expvar.Int{}
 	// TlmDestinationErrors is the total number of network errors.


### PR DESCRIPTION
## What

`TlmLogsSent` (the `logs.sent` telemetry counter) was already tracking log counts but lacked the `remote_agent` and `source` tags that other COAT metrics carry. This made it impossible to partition log counts by agent type or data source in COAT dashboards.

This PR updates `TlmLogsSent` to carry the same `remote_agent` and `source` tags as `TlmBytesSent` and `TlmEncodedBytesSent`, and passes those tags at all three call sites.

## Changes

- `comp/logs-library/metrics/metrics.go` — add `remote_agent` and `source` tag labels to `TlmLogsSent` counter definition
- `comp/logs-library/client/http/destination.go` — pass `GetAgentIdentityTag()` and computed `sourceTag` to `TlmLogsSent.Add()`
- `comp/logs-library/client/http/sync_destination.go` — same, derives `sourceTag` from destination metadata
- `comp/logs-library/client/tcp/destination.go` — same; TCP always uses `sourceTag = "logs"`

## Manual QA

To verify the metric is emitted with COAT tags after this change:

1. Build the agent:
   ```bash
   dda inv agent.build --build-exclude=systemd
   ```
2. Add a file log source to `datadog.yaml`:
   ```yaml
   api_key: <your-key>
   logs_enabled: true
   logs_config:
     logs_dd_url: <intake-or-local-forwarder>
   ```
3. Run the agent and send some log lines to a watched file.
4. Query the expvar endpoint to confirm `LogsSent` increments:
   ```bash
   curl -s http://localhost:5000/expvar | python3 -m json.tool | grep -A2 '"logs-agent"'
   ```
5. In a Datadog metrics explorer (or via the agent's internal telemetry), confirm `logs.sent` now appears with `remote_agent` and `source` tags.

## Jira

[AGNTLOG-502](https://datadoghq.atlassian.net/browse/AGNTLOG-502)

---

_Created by [Auto-JIRA](https://github.com/DataDog/datadog-agent/blob/main/.claude/skills/auto-jira/SKILL.md)._

[AGNTLOG-502]: https://datadoghq.atlassian.net/browse/AGNTLOG-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ