### PR TITLE
[compliance] skip CIS Docker rules on non-Docker CRI kubelet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -862,6 +862,7 @@
 /test/new-e2e/tests/containers                @DataDog/container-integrations @DataDog/container-platform
 /test/new-e2e/tests/containers/cluster_agent_sgc_binary_test.go    @DataDog/agent-configuration
 /test/new-e2e/tests/containers/ecs_test.go    @DataDog/ecs-experiences
+/test/new-e2e/tests/cspm                      @DataDog/agent-cspm @DataDog/agent-security
 /test/new-e2e/tests/discovery                 @DataDog/agent-discovery
 /test/new-e2e/tests/fips-compliance           @DataDog/agent-runtimes
 /test/new-e2e/tests/ha-agent                  @DataDog/network-device-monitoring-core

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -1185,6 +1185,7 @@ new-e2e-cspm:
     - !reference [.needs_new_e2e_template]
     - qa_agent_linux
     - qa_dca
+    - agent_deb-x64-a7
   variables:
     TARGETS: ./tests/cspm
     TEAM: cspm

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math/rand"
+	"os"
 	"sync"
 	"time"
 
@@ -139,13 +140,38 @@ var seclRuleFilterError error
 // will exclude rules based on the evaluation context / environment running
 // the benchmark.
 func MakeDefaultRuleFilter(hostname string) RuleFilter {
-	isK8s := env.IsKubernetes()
+	hostroot := os.Getenv("HOST_ROOT")
+	return makeDefaultRuleFilter(hostname, env.IsKubernetes, func() string {
+		return getKubeletCRIRuntime(context.Background(), hostroot)
+	})
+}
+
+// makeDefaultRuleFilter is the testable inner helper; injected functions let
+// tests drive isK8s and the CRI runtime without touching the host.
+func makeDefaultRuleFilter(hostname string, isK8sFn func() bool, kubeletCRIFn func() string) RuleFilter {
+	isK8s := isK8sFn()
 	xccdfEnabled := xccdfEnabled()
+
+	var kubeletCRIOnce sync.Once
+	var kubeletCRI string
+	resolveCRI := func() string {
+		kubeletCRIOnce.Do(func() {
+			kubeletCRI = kubeletCRIFn()
+		})
+		return kubeletCRI
+	}
 
 	return func(r *Rule) bool {
 		if isK8s {
 			if r.SkipOnK8s {
 				return false
+			}
+			// GKE COS ships dockerd alongside containerd; CIS Docker doesn't
+			// apply when the kubelet's CRI is not Docker. Unknown => fail open.
+			if r.HasScope(DockerScope) {
+				if cri := resolveCRI(); cri != "" && cri != criRuntimeDocker {
+					return false
+				}
 			}
 		} else {
 			if r.HasScope(KubernetesNodeScope) || r.HasScope(KubernetesClusterScope) {

--- a/pkg/compliance/agent_test.go
+++ b/pkg/compliance/agent_test.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package compliance
+
+import "testing"
+
+func TestMakeDefaultRuleFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		isK8s    bool
+		cri      string
+		rule     *Rule
+		wantKept bool
+	}{
+		{"non-k8s + k8s-scoped rule", false, "", &Rule{Scopes: []RuleScope{KubernetesNodeScope}}, false},
+		{"non-k8s + docker rule", false, "", &Rule{Scopes: []RuleScope{DockerScope}}, true},
+		{"k8s + SkipOnK8s rule", true, "", &Rule{SkipOnK8s: true}, false},
+		{"k8s + docker rule + unknown CRI", true, "", &Rule{Scopes: []RuleScope{DockerScope}}, true},
+		{"k8s + docker rule + docker CRI", true, "docker", &Rule{Scopes: []RuleScope{DockerScope}}, true},
+		{"k8s + docker rule + containerd CRI", true, "containerd", &Rule{Scopes: []RuleScope{DockerScope}}, false},
+		{"k8s + k8s-scoped rule + containerd CRI", true, "containerd", &Rule{Scopes: []RuleScope{KubernetesNodeScope}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := makeDefaultRuleFilter(
+				"test-host",
+				func() bool { return tt.isK8s },
+				func() string { return tt.cri },
+			)
+			if got := filter(tt.rule); got != tt.wantKept {
+				t.Errorf("filter(rule) = %v, want %v", got, tt.wantKept)
+			}
+		})
+	}
+}

--- a/pkg/compliance/cri.go
+++ b/pkg/compliance/cri.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package compliance
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/process"
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	criRuntimeContainerd = "containerd"
+	criRuntimeDocker     = "docker"
+	criRuntimeCRIO       = "crio"
+)
+
+// getKubeletCRIRuntime returns "containerd", "docker", "crio", or "" by
+// inspecting the running kubelet. hostroot is the agent's view of the host
+// filesystem; kubelet --config paths are resolved relative to it.
+func getKubeletCRIRuntime(ctx context.Context, hostroot string) string {
+	return criRuntimeFromEndpoint(findKubeletCRIEndpoint(ctx, hostroot))
+}
+
+// findKubeletCRIEndpoint reads --container-runtime-endpoint from the kubelet
+// process, falling back to containerRuntimeEndpoint in its --config YAML.
+func findKubeletCRIEndpoint(ctx context.Context, hostroot string) string {
+	procs, err := process.ProcessesWithContext(ctx)
+	if err != nil {
+		return ""
+	}
+	for _, p := range procs {
+		name, _ := p.Name()
+		cmdline, err := p.CmdlineSlice()
+		if err != nil || len(cmdline) == 0 {
+			continue
+		}
+		isKubelet := name == "kubelet" || (name == "hyperkube" && len(cmdline) >= 2 && cmdline[1] == "kubelet")
+		if !isKubelet {
+			continue
+		}
+		flags := parseCmdlineFlags(cmdline)
+		if v := flags["--container-runtime-endpoint"]; v != "" {
+			return v
+		}
+		if cfgPath := flags["--config"]; cfgPath != "" {
+			return readCRIEndpointFromConfig(filepath.Join(hostroot, cfgPath))
+		}
+		return ""
+	}
+	return ""
+}
+
+// readCRIEndpointFromConfig returns the containerRuntimeEndpoint value from
+// the kubelet config YAML at path, or "" if unset or unreadable.
+func readCRIEndpointFromConfig(path string) string {
+	const maxConfigSize = 1 << 19 // 512 KiB
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || info.Size() > maxConfigSize {
+		return ""
+	}
+	var cfg struct {
+		ContainerRuntimeEndpoint string `yaml:"containerRuntimeEndpoint"`
+	}
+	if err := yaml.NewDecoder(f).Decode(&cfg); err != nil {
+		return ""
+	}
+	return cfg.ContainerRuntimeEndpoint
+}
+
+// criRuntimeFromEndpoint maps an endpoint URI to a runtime tag. cri-dockerd
+// and dockershim shim Docker, so they must match before "containerd".
+func criRuntimeFromEndpoint(endpoint string) string {
+	e := strings.ToLower(endpoint)
+	switch {
+	case e == "":
+		return ""
+	case strings.Contains(e, "cri-dockerd"),
+		strings.Contains(e, "dockershim"),
+		strings.Contains(e, "docker.sock"):
+		return criRuntimeDocker
+	case strings.Contains(e, "containerd"):
+		return criRuntimeContainerd
+	case strings.Contains(e, "crio"):
+		return criRuntimeCRIO
+	default:
+		return ""
+	}
+}

--- a/pkg/compliance/cri_stub.go
+++ b/pkg/compliance/cri_stub.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package compliance
+
+import "context"
+
+const criRuntimeDocker = "docker"
+
+func getKubeletCRIRuntime(_ context.Context, _ string) string {
+	return ""
+}

--- a/pkg/compliance/cri_test.go
+++ b/pkg/compliance/cri_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package compliance
+
+import "testing"
+
+func TestCRIRuntimeFromEndpoint(t *testing.T) {
+	tests := []struct {
+		endpoint string
+		want     string
+	}{
+		{"unix:///run/containerd/containerd.sock", "containerd"},
+		{"unix:///var/run/dockershim.sock", "docker"},
+		{"unix:///run/cri-dockerd.sock", "docker"},
+		{"unix:///var/run/docker.sock", "docker"},
+		{"unix:///var/run/crio/crio.sock", "crio"},
+		{"", ""},
+		{"unix:///foo/bar.sock", ""},
+		{"UNIX:///RUN/CONTAINERD/CONTAINERD.SOCK", "containerd"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.endpoint, func(t *testing.T) {
+			if got := criRuntimeFromEndpoint(tt.endpoint); got != tt.want {
+				t.Errorf("criRuntimeFromEndpoint(%q) = %q, want %q", tt.endpoint, got, tt.want)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/compliance-skip-cis-docker-on-non-docker-cri-fb09408e02a1b38d.yaml
+++ b/releasenotes/notes/compliance-skip-cis-docker-on-non-docker-cri-fb09408e02a1b38d.yaml
@@ -1,0 +1,9 @@
+enhancements:
+  - |
+    Compliance: CIS Docker rules (``scope: docker``) are no longer evaluated
+    on Kubernetes nodes where the kubelet's CRI runtime is not Docker (e.g.
+    containerd, CRI-O), avoiding false positives on GKE Container-Optimized
+    OS which ships dockerd alongside containerd. The runtime is read from
+    the kubelet's ``--container-runtime-endpoint`` flag or the
+    ``containerRuntimeEndpoint`` field of its ``--config`` YAML; if it
+    cannot be determined the rules continue to evaluate.

--- a/test/e2e-framework/components/kubernetes/kind-cluster.yaml
+++ b/test/e2e-framework/components/kubernetes/kind-cluster.yaml
@@ -5,6 +5,10 @@ nodes:
   extraMounts:
   - hostPath: /proc
     containerPath: /host/proc
+{{- if .MountDockerSocket }}
+  - hostPath: /var/run/docker.sock
+    containerPath: /var/run/docker.sock
+{{- end }}
 {{- if .NewContainerdRegistryConfig }}
   - hostPath: ./certs.d
     containerPath: /etc/containerd/certs.d
@@ -14,6 +18,10 @@ nodes:
   extraMounts:
   - hostPath: /proc
     containerPath: /host/proc
+{{- if $.MountDockerSocket }}
+  - hostPath: /var/run/docker.sock
+    containerPath: /var/run/docker.sock
+{{- end }}
 {{- if $.NewContainerdRegistryConfig }}
   - hostPath: ./certs.d
     containerPath: /etc/containerd/certs.d

--- a/test/e2e-framework/components/kubernetes/kind_versions.go
+++ b/test/e2e-framework/components/kubernetes/kind_versions.go
@@ -29,6 +29,7 @@ type KindConfig struct {
 type KindConfigFlags struct {
 	NewContainerdRegistryConfig bool             // whether to use the new containerd registry mirror config format (for containerd >= 2.2, used in kubernetes >= v1.32)
 	KubeProxyReplacement        bool             // whether to set kubeProxyMode to "none" in the kind config
+	MountDockerSocket           bool             // whether to bind-mount /var/run/docker.sock from the host into each kind node
 	WorkerNodes                 []KindWorkerNode // additional worker nodes beyond the control-plane
 }
 

--- a/test/e2e-framework/scenarios/aws/kindvm/run.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run.go
@@ -111,7 +111,7 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resAws.Environment, env outputs.Kube
 		kindCluster, err = cilium.NewKindCluster(&awsEnv, host, params.Name, awsEnv.KubernetesVersion(), params.ciliumOptions, utils.PulumiDependsOn(installEcrCredsHelperCmd))
 	} else {
 		kindCluster, err = kubeComp.NewKindClusterWithConfig(&awsEnv, host, params.Name, awsEnv.KubernetesVersion(),
-			kubeComp.KindConfigFlags{WorkerNodes: params.workerNodes},
+			kubeComp.KindConfigFlags{WorkerNodes: params.workerNodes, MountDockerSocket: params.mountDockerSocket},
 			utils.PulumiDependsOn(installEcrCredsHelperCmd))
 	}
 

--- a/test/e2e-framework/scenarios/aws/kindvm/run_args.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run_args.go
@@ -48,6 +48,10 @@ type RunParams struct {
 	// workerNodes configures the kind cluster worker nodes with custom labels and taints.
 	// When empty the cluster uses the default single worker node.
 	workerNodes []kubecomp.KindWorkerNode
+
+	// mountDockerSocket bind-mounts /var/run/docker.sock from the EC2 host into
+	// each kind node, surfacing the host's dockerd inside the cluster.
+	mountDockerSocket bool
 }
 
 type RunOption = func(*RunParams) error
@@ -210,4 +214,11 @@ func WithKindWorkerNodes(nodes ...kubecomp.KindWorkerNode) RunOption {
 		p.workerNodes = append(p.workerNodes, nodes...)
 		return nil
 	}
+}
+
+// WithMountDockerSocket bind-mounts /var/run/docker.sock from the EC2 host into
+// each kind node. Use this to reproduce environments (e.g. GKE COS) where the
+// kubelet runs on containerd but a separate dockerd is still reachable.
+func WithMountDockerSocket() RunOption {
+	return func(p *RunParams) error { p.mountDockerSocket = true; return nil }
 }

--- a/test/new-e2e/tests/cspm/cspm_test.go
+++ b/test/new-e2e/tests/cspm/cspm_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -179,6 +180,10 @@ func TestCSPM(t *testing.T) {
 		provkindvm.Provisioner(
 			provkindvm.WithRunOptions(
 				scenkindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(values)),
+				// Surface the EC2 host's dockerd inside the kind nodes so
+				// TestDockerRulesFilteredOnContainerdCRI can reproduce the
+				// GKE-COS shape (containerd CRI alongside dockerd).
+				scenkindvm.WithMountDockerSocket(),
 			),
 		),
 	))
@@ -241,6 +246,60 @@ func isContainerReady(pod *corev1.Pod, containerName string) bool {
 		}
 	}
 	return false
+}
+
+// TestDockerRulesFilteredOnContainerdCRI reproduces the GKE-COS shape -
+// kubelet on containerd with a reachable dockerd - and asserts the filter
+// suppresses CIS Docker rules while keeping CIS Kubernetes rules.
+func (s *cspmTestSuite) TestDockerRulesFilteredOnContainerdCRI() {
+	pods, err := s.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.Background(), metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("app", s.Env().Agent.LinuxNodeAgent.LabelSelectors["app"]).String(),
+	})
+	require.NoError(s.T(), err)
+	require.Len(s.T(), pods.Items, 1)
+	agentPod := s.waitForSecurityAgentPodReady("datadog", pods.Items[0].Name)
+
+	// Without a reachable dockerd the scope gate would skip docker rules
+	// on its own, so the test would pass for the wrong reason.
+	info, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+		"datadog", agentPod, "security-agent",
+		[]string{"curl", "-sS", "--unix-socket", "/host/var/run/docker.sock", "http://localhost/info"})
+	require.NoError(s.T(), err, "agent pod must be able to reach dockerd via /host/var/run/docker.sock")
+	require.Contains(s.T(), info, `"ServerVersion"`, "/info response from the agent pod must look like a real Docker daemon")
+
+	_, _, err = s.Env().KubernetesCluster.KubernetesClient.PodExec(
+		"datadog", agentPod, "security-agent",
+		[]string{"security-agent", "compliance", "check", "--dump-reports", "/tmp/reports", "--report"})
+	require.NoError(s.T(), err)
+	dump, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+		"datadog", agentPod, "security-agent",
+		[]string{"cat", "/tmp/reports"})
+	require.NoError(s.T(), err)
+	findings, err := parseFindingOutput(dump)
+	require.NoError(s.T(), err)
+
+	for rule := range findings {
+		assert.NotContains(s.T(), rule, "cis-docker-1.2.0-",
+			"CIS Docker rule %q must be filtered when kubelet's CRI runtime is containerd", rule)
+	}
+
+	seenKubernetesRule := false
+	for rule, results := range findings {
+		if !strings.HasPrefix(rule, "cis-kubernetes-1.5.1-") {
+			continue
+		}
+		for _, r := range results {
+			if r["result"] == "passed" || r["result"] == "failed" {
+				seenKubernetesRule = true
+				break
+			}
+		}
+		if seenKubernetesRule {
+			break
+		}
+	}
+	assert.True(s.T(), seenKubernetesRule,
+		"expected at least one cis-kubernetes-1.5.1-* finding with result passed or failed; the filter must not be over-greedy")
 }
 
 func (s *cspmTestSuite) TestMetrics() {

--- a/test/new-e2e/tests/cspm/docker_host_test.go
+++ b/test/new-e2e/tests/cspm/docker_host_test.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cspm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+const dockerHostSecurityAgentConfig = `compliance_config:
+  enabled: true
+`
+
+type dockerHostCSPMSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+// TestDockerHostCSPM is the symmetric counter-test of
+// TestDockerRulesFilteredOnContainerdCRI: on a non-K8s Docker host the
+// benchmark must still fire. Catches an over-greedy filter.
+func TestDockerHostCSPM(t *testing.T) {
+	e2e.Run(t, &dockerHostCSPMSuite{},
+		e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(
+			awshost.WithRunOptions(
+				scenec2.WithDocker(),
+				scenec2.WithAgentOptions(
+					agentparams.WithSecurityAgentConfig(dockerHostSecurityAgentConfig),
+				),
+			),
+		)),
+	)
+}
+
+func (s *dockerHostCSPMSuite) TestDockerRulesFireOnDockerHost() {
+	host := s.Env().RemoteHost
+
+	host.MustExecute("sudo /opt/datadog-agent/embedded/bin/security-agent compliance check --dump-reports /tmp/reports")
+	dump := host.MustExecute("sudo cat /tmp/reports")
+
+	findings, err := parseFindingOutput(dump)
+	require.NoError(s.T(), err)
+
+	seenDockerRule := false
+	for rule, results := range findings {
+		if !strings.HasPrefix(rule, "cis-docker-1.2.0-") {
+			continue
+		}
+		for _, r := range results {
+			if r["result"] == "passed" || r["result"] == "failed" {
+				seenDockerRule = true
+				break
+			}
+		}
+		if seenDockerRule {
+			break
+		}
+	}
+	assert.True(s.T(), seenDockerRule,
+		"expected at least one cis-docker-1.2.0-* finding with result passed or failed on a non-K8s Docker host; the filter must not suppress rules outside Kubernetes")
+}

--- a/test/new-e2e/tests/cspm/values.yaml
+++ b/test/new-e2e/tests/cspm/values.yaml
@@ -1,4 +1,7 @@
 datadog:
+  # Exposes the EC2 host's dockerd into the agent pod, reproducing the
+  # GKE-COS shape (containerd CRI alongside dockerd) the filter targets.
+  dockerSocketPath: /var/run/docker.sock
   securityAgent:
     compliance:
       enabled: true


### PR DESCRIPTION
### What does this PR do?

GKE COS ships dockerd alongside containerd. CIS Docker rules then fire
false positives on every K8s node not using Docker for workloads.
MakeDefaultRuleFilter now drops scope: docker rules when the kubelet's
--container-runtime-endpoint resolves to something other than Docker.
cri-dockerd and dockershim still map to "docker" so real Docker-CRI hosts
are unaffected. Unknown endpoints fail open.

E2E coverage in test/new-e2e/tests/cspm:
TestDockerRulesFilteredOnContainerdCRI (KinD-on-EC2, with docker.sock
surfaced via the new kindvm WithMountDockerSocket scenario option and
the dockerSocketPath helm value) asserts no cis-docker-1.2.0-* keys and
at least one cis-kubernetes-1.5.1-* finding. TestDockerHostCSPM
(awshost) is the counter-test: on a non-K8s Docker host the benchmark
must still fire.

### Motivation

### Describe how you validated your changes

### Additional Notes
