### PR TITLE
Remove telemetry-onboarding from /cmd/agent/macos/ CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -238,7 +238,7 @@
 /cmd/agent/dist/conf.d/win32_event_log.d/ @DataDog/windows-products
 /cmd/agent/dist/conf.d/windows_certificate.d/ @DataDog/windows-products
 /cmd/agent/install*.sh                  @DataDog/agent-build
-/cmd/agent/macos/                       @DataDog/windows-products @DataDog/telemetry-onboarding
+/cmd/agent/macos/                       @DataDog/windows-products
 /cmd/ai_prompt_logger/                  @DataDog/windows-products
 /cmd/cluster-agent/                     @DataDog/container-platform
 /cmd/cluster-agent/subcommands/autoscalerlist   @DataDog/container-autoscaling @DataDog/container-integrations


### PR DESCRIPTION
## Summary
- Removes `@DataDog/telemetry-onboarding` as a co-owner of `/cmd/agent/macos/` in `.github/CODEOWNERS`.
- `@DataDog/windows-products` remains the sole owner.


## Test plan
- [x] No code changes — CODEOWNERS metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)