### PR TITLE
[SLES-2866] fix(serverless): move evp_proxy/ol_proxy defaults into setupAPM

### DIFF
--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -173,4 +173,25 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.ParseEnvJSON("apm_config.span_derived_primary_tags", []string{})
 
 	config.BindEnvAndSetDefault("apm_config.mode", "", "DD_APM_MODE")
+
+	// trace-agent's evp_proxy. Registered here (in setupAPM, which is part of
+	// initCommonConfigComponents) so the defaults are reachable under both the
+	// regular and `serverless` build tags. comp/trace/config reads these
+	// unconditionally; previously the defaults lived only in initCoreAgentFull
+	// and silently became false under serverless.
+	config.BindEnvAndSetDefault("evp_proxy_config.enabled", true)
+	config.BindEnvAndSetDefault("evp_proxy_config.dd_url", "")
+	config.BindEnvAndSetDefault("evp_proxy_config.api_key", "")
+	config.BindEnvAndSetDefault("evp_proxy_config.additional_endpoints", map[string][]string{})
+	config.BindEnvAndSetDefault("evp_proxy_config.max_payload_size", int64(10*1024*1024))
+	config.BindEnvAndSetDefault("evp_proxy_config.receiver_timeout", 0)
+	bindDelegatedAuthConfig(config, "evp_proxy_config")
+
+	// trace-agent's ol_proxy. Same rationale as evp_proxy above.
+	config.BindEnvAndSetDefault("ol_proxy_config.enabled", true)
+	config.BindEnvAndSetDefault("ol_proxy_config.dd_url", "")
+	config.BindEnvAndSetDefault("ol_proxy_config.api_key", "")
+	config.BindEnvAndSetDefault("ol_proxy_config.additional_endpoints", map[string][]string{})
+	config.BindEnvAndSetDefault("ol_proxy_config.api_version", 2)
+	bindDelegatedAuthConfig(config, "ol_proxy_config")
 }

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1597,6 +1597,21 @@ func serverless(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("serverless.trace_managed_services", true, "DD_TRACE_MANAGED_SERVICES")
 	config.BindEnvAndSetDefault("serverless.service_mapping", "", "DD_SERVICE_MAPPING")
 
+	// trace-agent EVPProxy / OpenLineageProxy defaults. Mirrors the registrations in initCoreAgentFull.
+	config.BindEnvAndSetDefault("evp_proxy_config.enabled", true)
+	config.BindEnvAndSetDefault("evp_proxy_config.dd_url", "")
+	config.BindEnvAndSetDefault("evp_proxy_config.api_key", "")
+	config.BindEnvAndSetDefault("evp_proxy_config.additional_endpoints", map[string][]string{})
+	config.BindEnvAndSetDefault("evp_proxy_config.max_payload_size", int64(10*1024*1024))
+	config.BindEnvAndSetDefault("evp_proxy_config.receiver_timeout", 0)
+	bindDelegatedAuthConfig(config, "evp_proxy_config")
+	config.BindEnvAndSetDefault("ol_proxy_config.enabled", true)
+	config.BindEnvAndSetDefault("ol_proxy_config.dd_url", "")
+	config.BindEnvAndSetDefault("ol_proxy_config.api_key", "")
+	config.BindEnvAndSetDefault("ol_proxy_config.additional_endpoints", map[string][]string{})
+	config.BindEnvAndSetDefault("ol_proxy_config.api_version", 2)
+	bindDelegatedAuthConfig(config, "ol_proxy_config")
+
 	// Set defaults for config keys that may be accessed but aren't relevant in serverless environments
 	// to avoid "config key is unknown" and "unable to cast nil" warnings
 	config.SetDefault("checks_tag_cardinality", "low")

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -950,25 +950,6 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.direct_send_from_system_probe", false)
 	config.BindEnvAndSetDefault("runtime_security_config.event_grpc_server", "")
 
-	// trace-agent's evp_proxy
-	config.BindEnvAndSetDefault("evp_proxy_config.enabled", true)
-	config.BindEnvAndSetDefault("evp_proxy_config.dd_url", "")
-	config.BindEnvAndSetDefault("evp_proxy_config.api_key", "")
-	config.BindEnvAndSetDefault("evp_proxy_config.additional_endpoints", map[string][]string{})
-	config.BindEnvAndSetDefault("evp_proxy_config.max_payload_size", int64(10*1024*1024))
-	config.BindEnvAndSetDefault("evp_proxy_config.receiver_timeout", 0)
-	// Delegated authentication for evp_proxy
-	bindDelegatedAuthConfig(config, "evp_proxy_config")
-
-	// trace-agent's ol_proxy
-	config.BindEnvAndSetDefault("ol_proxy_config.enabled", true)
-	config.BindEnvAndSetDefault("ol_proxy_config.dd_url", "")
-	config.BindEnvAndSetDefault("ol_proxy_config.api_key", "")
-	config.BindEnvAndSetDefault("ol_proxy_config.additional_endpoints", map[string][]string{})
-	config.BindEnvAndSetDefault("ol_proxy_config.api_version", 2)
-	// Delegated authentication for ol_proxy_config
-	bindDelegatedAuthConfig(config, "ol_proxy_config")
-
 	// command line options
 	config.SetDefault("cmd.check.fullsketches", false)
 
@@ -1596,21 +1577,6 @@ func serverless(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("serverless.trace_enabled", true, "DD_TRACE_ENABLED")
 	config.BindEnvAndSetDefault("serverless.trace_managed_services", true, "DD_TRACE_MANAGED_SERVICES")
 	config.BindEnvAndSetDefault("serverless.service_mapping", "", "DD_SERVICE_MAPPING")
-
-	// trace-agent EVPProxy / OpenLineageProxy defaults. Mirrors the registrations in initCoreAgentFull.
-	config.BindEnvAndSetDefault("evp_proxy_config.enabled", true)
-	config.BindEnvAndSetDefault("evp_proxy_config.dd_url", "")
-	config.BindEnvAndSetDefault("evp_proxy_config.api_key", "")
-	config.BindEnvAndSetDefault("evp_proxy_config.additional_endpoints", map[string][]string{})
-	config.BindEnvAndSetDefault("evp_proxy_config.max_payload_size", int64(10*1024*1024))
-	config.BindEnvAndSetDefault("evp_proxy_config.receiver_timeout", 0)
-	bindDelegatedAuthConfig(config, "evp_proxy_config")
-	config.BindEnvAndSetDefault("ol_proxy_config.enabled", true)
-	config.BindEnvAndSetDefault("ol_proxy_config.dd_url", "")
-	config.BindEnvAndSetDefault("ol_proxy_config.api_key", "")
-	config.BindEnvAndSetDefault("ol_proxy_config.additional_endpoints", map[string][]string{})
-	config.BindEnvAndSetDefault("ol_proxy_config.api_version", 2)
-	bindDelegatedAuthConfig(config, "ol_proxy_config")
 
 	// Set defaults for config keys that may be accessed but aren't relevant in serverless environments
 	// to avoid "config key is unknown" and "unable to cast nil" warnings

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1509,6 +1509,13 @@ func TestServerlessConfigInit(t *testing.T) {
 	// ensure some non-serverless configs are not declared
 	assert.False(t, conf.IsKnown("sbom.enabled"))
 	assert.False(t, conf.IsKnown("inventories_enabled"))
+
+	// comp/trace/config reads these unconditionally; serverless builds only run
+	// initCommonConfigComponents, so the defaults must be reachable from here.
+	assert.True(t, conf.GetBool("evp_proxy_config.enabled"))
+	assert.Equal(t, int64(10*1024*1024), conf.GetInt64("evp_proxy_config.max_payload_size"))
+	assert.True(t, conf.GetBool("ol_proxy_config.enabled"))
+	assert.Equal(t, 2, conf.GetInt("ol_proxy_config.api_version"))
 }
 
 func TestDisableCoreAgent(t *testing.T) {

--- a/releasenotes/notes/fix-serverless-evp-proxy-default-a8c1d2e3f4b5e6d7.yaml
+++ b/releasenotes/notes/fix-serverless-evp-proxy-default-a8c1d2e3f4b5e6d7.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fixes a regression in serverless-init and the Lambda extension where the
+    trace-agent's EVPProxy was disabled at startup, producing
+    "EVPProxy is disabled: Has been disabled in config" 405 responses to
+    clients sending LLM Observability spans (and other EVP-routed payloads).
+    The ``evp_proxy_config.*`` and ``ol_proxy_config.*`` default registrations
+    were only reachable under the non-serverless build, so the trace-agent's
+    unconditional read of ``evp_proxy_config.enabled`` returned ``false`` and
+    clobbered the package-level ``true`` default. The defaults are now also
+    registered in the serverless config init path so they take effect under
+    the ``serverless`` build tag.

--- a/releasenotes/notes/fix-serverless-evp-proxy-default-a8c1d2e3f4b5e6d7.yaml
+++ b/releasenotes/notes/fix-serverless-evp-proxy-default-a8c1d2e3f4b5e6d7.yaml
@@ -8,6 +8,6 @@ fixes:
     The ``evp_proxy_config.*`` and ``ol_proxy_config.*`` default registrations
     were only reachable under the non-serverless build, so the trace-agent's
     unconditional read of ``evp_proxy_config.enabled`` returned ``false`` and
-    clobbered the package-level ``true`` default. The defaults are now also
-    registered in the serverless config init path so they take effect under
-    the ``serverless`` build tag.
+    clobbered the package-level ``true`` default. The defaults have been moved
+    into the shared APM config setup so they take effect under both the
+    regular and ``serverless`` build tags.


### PR DESCRIPTION
### What does this PR do?

Moves the canonical `evp_proxy_config.*` and `ol_proxy_config.*` default registrations from `initCoreAgentFull` into `setupAPM` (`pkg/config/setup/apm.go`). `setupAPM` is part of `commonConfigComponents`, which runs under both the regular and `serverless` build tags, so the defaults are now reachable from both code paths without duplication.

### Motivation

See https://datadoghq.atlassian.net/browse/SLES-2866

PR #49239 paired a `BindEnv → BindEnvAndSetDefault` migration with an unconditional read of `evp_proxy_config.enabled` (and `ol_proxy_config.enabled`) in `comp/trace/config/impl/setup.go`. That assumes the `true` default is reachable through viper. It was — but only under the non-serverless build, which calls `InitConfig` → `initCoreAgentFull`. Under the `serverless` build tag, `initConfig` only runs `initCommonConfigComponents` and **never calls `initCoreAgentFull`**, so the `BindEnvAndSetDefault("evp_proxy_config.enabled", true)` call never executed.

Net result starting with `serverless-init-1.9.12`: the trace-agent's EVPProxy is disabled at startup. Customers running sidecar-mode tracers see:

```
failed to send N LLMObs span events to http://127.0.0.1:8126/evp_proxy/v2/api/v2/llmobs,
got response code 405, status: b'EVPProxy is disabled: Has been disabled in config\n'
```

This affects all EVP-routed payloads in serverless: LLM Observability, CI Visibility, & OpenFeature.

### Why setupAPM

EVPProxy and OpenLineageProxy are trace-agent features, and their consumer (`comp/trace/config/impl/setup.go`) is built under both tags, so `setupAPM` is both the semantically correct home and solves the build-tag gap without duplicating registrations.

The first commit on this branch registered the defaults defensively inside the `serverless` function (which also runs under both tags). The follow-up commit consolidates by moving the canonical registration to `setupAPM` and removing both the original `initCoreAgentFull` block and the defensive mirror, leaving a single source of truth.

### Describe how you validated your changes

- `go build ./pkg/config/setup/... ./comp/trace/config/...` (non-serverless build)
- `go build -tags "serverless otlp" ./cmd/serverless-init/...` (serverless build)
- `go test -tags=test ./pkg/config/setup/ ./comp/trace/config/impl/`
- `go test -tags="test serverless otlp" ./cmd/serverless-init/ ./pkg/serverless/trace/`
- Extended `TestServerlessConfigInit` with regression assertions on `evp_proxy_config.enabled`, `evp_proxy_config.max_payload_size`, `ol_proxy_config.enabled`, and `ol_proxy_config.api_version`
- New integration test: https://github.com/DataDog/serverless-e2e-serverless-init-gcp-tests/pull/318

E2E Test Results:
| Version | EVP status  | OL status | Test result |
|---------|-------------|-----------|-----------|
| `gcr.io/datadoghq/serverless-init:1.9.11` (working) | 202 | 201 | **PASSED** in 52s |
| `gcr.io/datadoghq/serverless-init:1.9.12` (broken) | 405 |  500 | **FAILED** in 41s |