### PR TITLE
packaging/aix: add bare pip symlink to embedded Python

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -10,6 +10,8 @@
 
 <!-- Add entries here for changes not yet in a release. -->
 
+- Add bare `pip` symlink to embedded Python (`embedded/bin/pip`)
+
 ---
 
 > **Note:** `datadog-agent-7.80.0-devel.git.446.66c9b62-18.aix.ppc64.bff` and all older builds

--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -464,9 +464,10 @@ fi
 
 # ─── Step 8: Convenience symlinks ────────────────────────────────────────────
 
-log "Creating convenience symlinks python3 -> python${PYTHON_MAJ_MIN} and pip3 -> pip${PYTHON_MAJ_MIN}"
+log "Creating convenience symlinks python3 -> python${PYTHON_MAJ_MIN}, pip3 -> pip${PYTHON_MAJ_MIN}, pip -> pip${PYTHON_MAJ_MIN}"
 ln -sf "python${PYTHON_MAJ_MIN}" "$EMBEDDED_DESTDIR/bin/python3"
 ln -sf "pip${PYTHON_MAJ_MIN}"    "$EMBEDDED_DESTDIR/bin/pip3"
+ln -sf "pip${PYTHON_MAJ_MIN}"    "$EMBEDDED_DESTDIR/bin/pip"
 log "Symlinks created."
 
 # ─── Step 9: Remove test directories to save space ───────────────────────────


### PR DESCRIPTION
### What does this PR do?
Adds a `pip` symlink (alongside the existing `pip3`) in the embedded Python `bin/` directory.

### Motivation
The `pip` bare command documented in integration install instructions (e.g. `ibm_db2`) was missing from the package. Only `pip3` and `pip3.13` were present.

### Describe how you validated your changes
Validated as part of a combined build (see related PRs).

### Additional Notes
N/A