### PR TITLE
feat(anomalydetection): add log source gates

### DIFF
--- a/comp/anomalydetection/logssource/impl/logssource.go
+++ b/comp/anomalydetection/logssource/impl/logssource.go
@@ -68,16 +68,19 @@ type logssourceComponent struct{}
 // NewComponent creates the logssource component.
 //
 // anomaly_detection.logs.enabled is the main toggle for all log ingestion:
-// setting it to false disables both container/AD logs (this component) and
-// agent-internal logs (observer's agent_logs tap). Defaults to false.
+// setting it to false disables container, kubelet, and agent-internal logs
+// (observer's agent_logs tap). Recording is unaffected.
+// anomaly_detection.logs.containers.enabled controls workloadmeta generic
+// container sources and AD-scheduled container log configs.
+// anomaly_detection.logs.kubelet.enabled controls the kubelet journald source.
 // anomaly_detection.agent_logs.enabled additionally controls the agent-internal
 // log tap and defaults to true when logs.enabled is true.
 //
 // The component is a no-op when any of these are true:
 //   - the observer is unavailable
-//   - workloadmeta is unavailable
 //   - anomaly_detection.enabled is false and anomaly_detection.recording.enabled is false
 //   - anomaly_detection.logs.enabled is false and anomaly_detection.recording.enabled is false
+//   - no enabled log source can start
 //
 // The component itself has no build-tag constraints. Capability differences
 // across builds are handled transparently by the underlying launchers:
@@ -90,14 +93,15 @@ func NewComponent(deps Requires) (Provides, error) {
 	wmeta, wmetaOk := deps.WMeta.Get()
 
 	analysisEnabled := deps.Config.GetBool("anomaly_detection.enabled")
-	logsEnabled := !deps.Config.IsConfigured("anomaly_detection.logs.enabled") || deps.Config.GetBool("anomaly_detection.logs.enabled")
+	logSourceSettings := newLogSourceSettings(deps.Config)
 	recordingEnabled := deps.Config.GetBool("anomaly_detection.recording.enabled")
 
-	// Skip when the observer is absent, workloadmeta is absent,
-	// or neither logs ingestion nor recording is requested.
-	if !obsOk || !wmetaOk || (!logsEnabled && !recordingEnabled) || (!analysisEnabled && !recordingEnabled) {
+	// Skip when the observer is absent, neither logs ingestion nor recording is
+	// requested, or no enabled source can start.
+	if !logSourceSettings.shouldStart(obsOk, wmetaOk, analysisEnabled, recordingEnabled) {
 		return Provides{Comp: &logssourceComponent{}}, nil
 	}
+	containerSourcesActive := logSourceSettings.containerSourcesEnabled && wmetaOk
 
 	observerHandle := obs.GetHandle("logs")
 
@@ -115,61 +119,74 @@ func NewComponent(deps Requires) (Provides, error) {
 	pipeline := newObserverPipeline(deps.Config, processingRules, deps.Hostname, observerHandle)
 	logSources := sources.NewLogSources()
 	tracker := tailers.NewTailerTracker()
-
-	fingerprintCfg, err := logsconfig.GlobalFingerprintConfig(deps.Config)
-	if err != nil {
-		deps.Log.Warnf("observer logssource: invalid fingerprint config, proceeding with defaults: %v", err)
-		fingerprintCfg = &types.FingerprintConfig{}
-	}
-	fileOpener := opener.NewFileOpener()
-	fileLauncher := filelauncher.NewLauncher(
-		deps.Config.GetInt("logs_config.open_files_limit"),
-		filelauncher.DefaultSleepDuration,
-		deps.Config.GetBool("logs_config.validate_pod_container_id"),
-		time.Duration(deps.Config.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
-		deps.Config.GetString("logs_config.file_wildcard_selection_mode"),
-		flare.NewFlareController(),
-		deps.Tagger,
-		fileOpener,
-		fileTailer.NewFingerprinter(*fingerprintCfg, fileOpener),
-	)
-
-	launcher := containerLauncher.NewLauncher(logSources, option.New(wmeta), deps.Tagger)
 	launchersMgr := launchers.NewLaunchers(logSources, pipeline, deps.Auditor, tracker)
-	launchersMgr.AddLauncher(fileLauncher)
-	launchersMgr.AddLauncher(launcher)
-	launchersMgr.AddLauncher(journaldlauncher.NewLauncher(flare.NewFlareController(), deps.Tagger))
 
-	registerKubeletJournaldSource(logSources, deps.Log)
-
-	sp := newSourceProvider(wmeta, logSources, pauseFilter)
-
-	services := service.NewServices()
-	adMgr := newADSourceManager(logSources, services, sp)
-
+	var sp *sourceProvider
+	var adMgr *adSourceManager
 	var adScheduler schedulers.Scheduler
-	if deps.Autodiscovery != nil {
-		adScheduler = logsadscheduler.NewNamed(deps.Autodiscovery, "observer-logssource AD scheduler")
+
+	if containerSourcesActive {
+		fingerprintCfg, err := logsconfig.GlobalFingerprintConfig(deps.Config)
+		if err != nil {
+			deps.Log.Warnf("observer logssource: invalid fingerprint config, proceeding with defaults: %v", err)
+			fingerprintCfg = &types.FingerprintConfig{}
+		}
+		fileOpener := opener.NewFileOpener()
+		fileLauncher := filelauncher.NewLauncher(
+			deps.Config.GetInt("logs_config.open_files_limit"),
+			filelauncher.DefaultSleepDuration,
+			deps.Config.GetBool("logs_config.validate_pod_container_id"),
+			time.Duration(deps.Config.GetFloat64("logs_config.file_scan_period")*float64(time.Second)),
+			deps.Config.GetString("logs_config.file_wildcard_selection_mode"),
+			flare.NewFlareController(),
+			deps.Tagger,
+			fileOpener,
+			fileTailer.NewFingerprinter(*fingerprintCfg, fileOpener),
+		)
+		launchersMgr.AddLauncher(fileLauncher)
+		launchersMgr.AddLauncher(containerLauncher.NewLauncher(logSources, option.New(wmeta), deps.Tagger))
+
+		sp = newSourceProvider(wmeta, logSources, pauseFilter)
+
+		services := service.NewServices()
+		adMgr = newADSourceManager(logSources, services, sp)
+
+		if deps.Autodiscovery != nil {
+			adScheduler = logsadscheduler.NewNamed(deps.Autodiscovery, "observer-logssource AD scheduler")
+		}
+	} else if logSourceSettings.containerSourcesEnabled {
+		deps.Log.Debugf("[observer/logssource] container log sources not started: workloadmeta unavailable")
+	}
+
+	if containerSourcesActive || logSourceSettings.kubeletSourceEnabled {
+		launchersMgr.AddLauncher(journaldlauncher.NewLauncher(flare.NewFlareController(), deps.Tagger))
+	}
+	if logSourceSettings.kubeletSourceEnabled {
+		registerKubeletJournaldSource(logSources, deps.Log)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	deps.Lc.Append(compdef.Hook{
 		OnStart: func(_ context.Context) error {
-			deps.Log.Infof("[observer/logssource] starting container log pipeline")
+			deps.Log.Infof("[observer/logssource] starting log pipeline")
 			pipeline.start()
 			launchersMgr.Start()
 			if adScheduler != nil {
 				adScheduler.Start(adMgr)
 			}
-			sp.run(ctx)
+			if sp != nil {
+				sp.run(ctx)
+			}
 			return nil
 		},
 		OnStop: func(_ context.Context) error {
 			// Shutdown ordering is load-bearing — do NOT reorder.
 			// 1. Cancel context and wait for source provider to exit fully.
 			cancel()
-			sp.wait()
+			if sp != nil {
+				sp.wait()
+			}
 			// 2. Stop the AD scheduler so it does not add more sources.
 			if adScheduler != nil {
 				adScheduler.Stop()

--- a/comp/anomalydetection/logssource/impl/logssource.go
+++ b/comp/anomalydetection/logssource/impl/logssource.go
@@ -69,7 +69,7 @@ type logssourceComponent struct{}
 //
 // anomaly_detection.logs.enabled is the main toggle for all log ingestion:
 // setting it to false disables container, kubelet, and agent-internal logs
-// (observer's agent_logs tap). Recording is unaffected.
+// (observer's agent_logs tap).
 // anomaly_detection.logs.containers.enabled controls workloadmeta generic
 // container sources and AD-scheduled container log configs.
 // anomaly_detection.logs.kubelet.enabled controls the kubelet journald source.
@@ -80,7 +80,8 @@ type logssourceComponent struct{}
 //   - the observer is unavailable
 //   - anomaly_detection.enabled is false and anomaly_detection.recording.enabled is false
 //   - anomaly_detection.logs.enabled is false and anomaly_detection.recording.enabled is false
-//   - no enabled log source can start
+//   - only container sources are enabled and workloadmeta is unavailable
+//   - all source-specific gates are disabled
 //
 // The component itself has no build-tag constraints. Capability differences
 // across builds are handled transparently by the underlying launchers:

--- a/comp/anomalydetection/logssource/impl/source_settings.go
+++ b/comp/anomalydetection/logssource/impl/source_settings.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logssourceimpl
+
+import config "github.com/DataDog/datadog-agent/comp/core/config"
+
+const (
+	anomalyDetectionLogsEnabledKey           = "anomaly_detection.logs.enabled"
+	anomalyDetectionLogsContainersEnabledKey = "anomaly_detection.logs.containers.enabled"
+	anomalyDetectionLogsKubeletEnabledKey    = "anomaly_detection.logs.kubelet.enabled"
+)
+
+type logSourceSettings struct {
+	logsEnabled             bool
+	containerSourcesEnabled bool
+	kubeletSourceEnabled    bool
+}
+
+func newLogSourceSettings(cfg config.Component) logSourceSettings {
+	return logSourceSettings{
+		logsEnabled:             configBoolDefaultTrue(cfg, anomalyDetectionLogsEnabledKey),
+		containerSourcesEnabled: configBoolDefaultTrue(cfg, anomalyDetectionLogsContainersEnabledKey),
+		kubeletSourceEnabled:    configBoolDefaultTrue(cfg, anomalyDetectionLogsKubeletEnabledKey),
+	}
+}
+
+func configBoolDefaultTrue(cfg config.Component, key string) bool {
+	return !cfg.IsConfigured(key) || cfg.GetBool(key)
+}
+
+func (s logSourceSettings) shouldStart(observerAvailable, workloadmetaAvailable, analysisEnabled, recordingEnabled bool) bool {
+	if !observerAvailable {
+		return false
+	}
+	if !recordingEnabled && (!analysisEnabled || !s.logsEnabled) {
+		return false
+	}
+	return s.kubeletSourceEnabled || (s.containerSourcesEnabled && workloadmetaAvailable)
+}

--- a/comp/anomalydetection/logssource/impl/source_settings_test.go
+++ b/comp/anomalydetection/logssource/impl/source_settings_test.go
@@ -1,0 +1,202 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logssourceimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	compConfig "github.com/DataDog/datadog-agent/comp/core/config"
+)
+
+func TestLogSourceSettings(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides map[string]interface{}
+		want      logSourceSettings
+	}{
+		{
+			name: "defaults",
+			want: logSourceSettings{
+				logsEnabled:             true,
+				containerSourcesEnabled: true,
+				kubeletSourceEnabled:    true,
+			},
+		},
+		{
+			name: "container sources disabled",
+			overrides: map[string]interface{}{
+				anomalyDetectionLogsContainersEnabledKey: false,
+			},
+			want: logSourceSettings{
+				logsEnabled:             true,
+				containerSourcesEnabled: false,
+				kubeletSourceEnabled:    true,
+			},
+		},
+		{
+			name: "kubelet source disabled",
+			overrides: map[string]interface{}{
+				anomalyDetectionLogsKubeletEnabledKey: false,
+			},
+			want: logSourceSettings{
+				logsEnabled:             true,
+				containerSourcesEnabled: true,
+				kubeletSourceEnabled:    false,
+			},
+		},
+		{
+			name: "parent logs disabled",
+			overrides: map[string]interface{}{
+				anomalyDetectionLogsEnabledKey: false,
+			},
+			want: logSourceSettings{
+				logsEnabled:             false,
+				containerSourcesEnabled: true,
+				kubeletSourceEnabled:    true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := compConfig.NewMockWithOverrides(t, tt.overrides)
+			assert.Equal(t, tt.want, newLogSourceSettings(cfg))
+		})
+	}
+}
+
+func TestLogSourceSettingsShouldStart(t *testing.T) {
+	defaultSettings := logSourceSettings{
+		logsEnabled:             true,
+		containerSourcesEnabled: true,
+		kubeletSourceEnabled:    true,
+	}
+
+	tests := []struct {
+		name                  string
+		settings              logSourceSettings
+		observerAvailable     bool
+		workloadmetaAvailable bool
+		analysisEnabled       bool
+		recordingEnabled      bool
+		want                  bool
+	}{
+		{
+			name:                  "all sources enabled",
+			settings:              defaultSettings,
+			observerAvailable:     true,
+			workloadmetaAvailable: true,
+			analysisEnabled:       true,
+			want:                  true,
+		},
+		{
+			name: "kubelet only does not require workloadmeta",
+			settings: logSourceSettings{
+				logsEnabled:             true,
+				containerSourcesEnabled: false,
+				kubeletSourceEnabled:    true,
+			},
+			observerAvailable: true,
+			analysisEnabled:   true,
+			want:              true,
+		},
+		{
+			name: "container only requires workloadmeta",
+			settings: logSourceSettings{
+				logsEnabled:             true,
+				containerSourcesEnabled: true,
+				kubeletSourceEnabled:    false,
+			},
+			observerAvailable:     true,
+			workloadmetaAvailable: true,
+			analysisEnabled:       true,
+			want:                  true,
+		},
+		{
+			name: "container only skips without workloadmeta",
+			settings: logSourceSettings{
+				logsEnabled:             true,
+				containerSourcesEnabled: true,
+				kubeletSourceEnabled:    false,
+			},
+			observerAvailable: true,
+			analysisEnabled:   true,
+			want:              false,
+		},
+		{
+			name: "both source gates disabled",
+			settings: logSourceSettings{
+				logsEnabled: true,
+			},
+			observerAvailable:     true,
+			workloadmetaAvailable: true,
+			analysisEnabled:       true,
+			want:                  false,
+		},
+		{
+			name: "parent logs disabled without recording",
+			settings: logSourceSettings{
+				containerSourcesEnabled: true,
+				kubeletSourceEnabled:    true,
+			},
+			observerAvailable:     true,
+			workloadmetaAvailable: true,
+			analysisEnabled:       true,
+			want:                  false,
+		},
+		{
+			name: "recording starts when parent logs are disabled",
+			settings: logSourceSettings{
+				containerSourcesEnabled: true,
+				kubeletSourceEnabled:    true,
+			},
+			observerAvailable:     true,
+			workloadmetaAvailable: true,
+			analysisEnabled:       true,
+			recordingEnabled:      true,
+			want:                  true,
+		},
+		{
+			name:                  "analysis disabled without recording",
+			settings:              defaultSettings,
+			observerAvailable:     true,
+			workloadmetaAvailable: true,
+			want:                  false,
+		},
+		{
+			name:                  "recording starts when analysis is disabled",
+			settings:              defaultSettings,
+			observerAvailable:     true,
+			workloadmetaAvailable: true,
+			recordingEnabled:      true,
+			want:                  true,
+		},
+		{
+			name: "recording starts when analysis and parent logs are disabled",
+			settings: logSourceSettings{
+				containerSourcesEnabled: true,
+				kubeletSourceEnabled:    true,
+			},
+			observerAvailable:     true,
+			workloadmetaAvailable: true,
+			recordingEnabled:      true,
+			want:                  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.settings.shouldStart(
+				tt.observerAvailable,
+				tt.workloadmetaAvailable,
+				tt.analysisEnabled,
+				tt.recordingEnabled,
+			))
+		})
+	}
+}

--- a/comp/anomalydetection/logssource/impl/source_settings_test.go
+++ b/comp/anomalydetection/logssource/impl/source_settings_test.go
@@ -150,31 +150,11 @@ func TestLogSourceSettingsShouldStart(t *testing.T) {
 			want:                  false,
 		},
 		{
-			name: "recording starts when parent logs are disabled",
-			settings: logSourceSettings{
-				containerSourcesEnabled: true,
-				kubeletSourceEnabled:    true,
-			},
-			observerAvailable:     true,
-			workloadmetaAvailable: true,
-			analysisEnabled:       true,
-			recordingEnabled:      true,
-			want:                  true,
-		},
-		{
 			name:                  "analysis disabled without recording",
 			settings:              defaultSettings,
 			observerAvailable:     true,
 			workloadmetaAvailable: true,
 			want:                  false,
-		},
-		{
-			name:                  "recording starts when analysis is disabled",
-			settings:              defaultSettings,
-			observerAvailable:     true,
-			workloadmetaAvailable: true,
-			recordingEnabled:      true,
-			want:                  true,
 		},
 		{
 			name: "recording starts when analysis and parent logs are disabled",

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2096,6 +2096,8 @@ func anomalyDetection(config pkgconfigmodel.Setup) {
 	// Log ingestion gate. When false, container/journald logs are not routed
 	// into the anomaly detection pipeline (recording is unaffected).
 	config.BindEnvAndSetDefault("anomaly_detection.logs.enabled", true)
+	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.enabled", true)
+	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.enabled", true)
 
 	// Metrics ingestion gate. When false, externally-ingested metrics
 	// (DogStatsD, check samplers) are dropped at the handle factory.


### PR DESCRIPTION
### What does this PR do?

Adds separate anomaly detection log source gates for container logs and kubelet logs:

- `anomaly_detection.logs.containers.enabled` controls workloadmeta generic container log sources and AD-scheduled container log configs.
- `anomaly_detection.logs.kubelet.enabled` controls the kubelet journald source.

Both options default to `true`, preserving existing behavior. The parent `anomaly_detection.logs.enabled` gate still disables anomaly detection log ingestion broadly.

### Motivation

This allows anomaly detection to run in kubelet-only mode, container-only mode, or the existing combined mode. The source gates make the intended collection surface explicit.

### Describe how you validated your changes

- `dda inv test --targets=./comp/anomalydetection/logssource/impl/`
- `git diff --check`
- Commit signature verified with `git log --show-signature -1`

### Additional Notes

No release note is included because this PR is labeled `changelog/no-changelog`.